### PR TITLE
Only publish KerasNLP if we have a release tag

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -40,6 +40,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN_HUB }}
           verbose: true
       - name: Publish KerasNLP to PyPI
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: keras_nlp/dist/


### PR DESCRIPTION
We accidentally just published 0.16.0 😬 because we were missing this line (just yanked the release, so no one will get it now).