### PR TITLE
Expunge include_rescaling from backbones

### DIFF
--- a/keras_hub/src/layers/preprocessing/resizing_image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/resizing_image_converter_test.py
@@ -22,22 +22,57 @@ from keras_hub.src.tests.test_case import TestCase
 
 
 class ResizingImageConverterTest(TestCase):
+    def test_resize_simple(self):
+        converter = ResizingImageConverter(height=4, width=4)
+        inputs = np.ones((10, 10, 3))
+        outputs = converter(inputs)
+        self.assertAllClose(outputs, ops.ones((4, 4, 3)))
+
     def test_resize_one(self):
-        converter = ResizingImageConverter(22, 22)
-        test_image = np.random.rand(10, 10, 3) * 255
-        shape = ops.shape(converter(test_image))
-        self.assertEqual(shape, (22, 22, 3))
+        converter = ResizingImageConverter(
+            height=4,
+            width=4,
+            mean=(0.5, 0.7, 0.3),
+            variance=(0.25, 0.1, 0.5),
+            scale=1 / 255.0,
+        )
+        inputs = np.ones((10, 10, 3)) * 128
+        outputs = converter(inputs)
+        self.assertEqual(ops.shape(outputs), (4, 4, 3))
+        self.assertAllClose(outputs[:, :, 0], np.ones((4, 4)) * 0.003922)
+        self.assertAllClose(outputs[:, :, 1], np.ones((4, 4)) * -0.626255)
+        self.assertAllClose(outputs[:, :, 2], np.ones((4, 4)) * 0.285616)
 
     def test_resize_batch(self):
-        converter = ResizingImageConverter(12, 12)
-        test_batch = np.random.rand(4, 10, 20, 3) * 255
-        shape = ops.shape(converter(test_batch))
-        self.assertEqual(shape, (4, 12, 12, 3))
+        converter = ResizingImageConverter(
+            height=4,
+            width=4,
+            mean=(0.5, 0.7, 0.3),
+            variance=(0.25, 0.1, 0.5),
+            scale=1 / 255.0,
+        )
+        inputs = np.ones((2, 10, 10, 3)) * 128
+        outputs = converter(inputs)
+        self.assertEqual(ops.shape(outputs), (2, 4, 4, 3))
+        self.assertAllClose(outputs[:, :, :, 0], np.ones((2, 4, 4)) * 0.003922)
+        self.assertAllClose(outputs[:, :, :, 1], np.ones((2, 4, 4)) * -0.626255)
+        self.assertAllClose(outputs[:, :, :, 2], np.ones((2, 4, 4)) * 0.285616)
+
+    def test_errors(self):
+        with self.assertRaises(ValueError):
+            ResizingImageConverter(
+                height=4,
+                width=4,
+                mean=(0.5, 0.7, 0.3),
+            )
 
     def test_config(self):
         converter = ResizingImageConverter(
             width=12,
             height=20,
+            mean=(0.5, 0.7, 0.3),
+            variance=(0.25, 0.1, 0.5),
+            scale=1 / 255.0,
             crop_to_aspect_ratio=False,
             interpolation="nearest",
         )

--- a/keras_hub/src/models/csp_darknet/csp_darknet_backbone.py
+++ b/keras_hub/src/models/csp_darknet/csp_darknet_backbone.py
@@ -31,9 +31,6 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
             level in the model.
         stackwise_depth: A list of ints, the depth for each dark level in the
             model.
-        include_rescaling: boolean. If `True`, rescale the input using
-            `Rescaling(1 / 255.0)` layer. If `False`, do nothing. Defaults to
-            `True`.
         block_type: str. One of `"basic_block"` or `"depthwise_block"`.
             Use `"depthwise_block"` for depthwise conv block
             `"basic_block"` for basic conv block.
@@ -55,7 +52,6 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
     model = keras_hub.models.CSPDarkNetBackbone(
         stackwise_num_filters=[128, 256, 512, 1024],
         stackwise_depth=[3, 9, 9, 3],
-        include_rescaling=False,
     )
     model(input_data)
     ```
@@ -65,7 +61,6 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
         self,
         stackwise_num_filters,
         stackwise_depth,
-        include_rescaling=True,
         block_type="basic_block",
         image_shape=(None, None, 3),
         **kwargs,
@@ -82,10 +77,7 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
         base_channels = stackwise_num_filters[0] // 2
 
         image_input = layers.Input(shape=image_shape)
-        x = image_input
-        if include_rescaling:
-            x = layers.Rescaling(scale=1 / 255.0)(x)
-
+        x = image_input  # Intermediate result.
         x = apply_focus(channel_axis, name="stem_focus")(x)
         x = apply_darknet_conv_block(
             base_channels,
@@ -130,7 +122,6 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
         # === Config ===
         self.stackwise_num_filters = stackwise_num_filters
         self.stackwise_depth = stackwise_depth
-        self.include_rescaling = include_rescaling
         self.block_type = block_type
         self.image_shape = image_shape
         self.pyramid_outputs = pyramid_outputs
@@ -141,7 +132,6 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
             {
                 "stackwise_num_filters": self.stackwise_num_filters,
                 "stackwise_depth": self.stackwise_depth,
-                "include_rescaling": self.include_rescaling,
                 "block_type": self.block_type,
                 "image_shape": self.image_shape,
             }

--- a/keras_hub/src/models/csp_darknet/csp_darknet_image_classifier.py
+++ b/keras_hub/src/models/csp_darknet/csp_darknet_image_classifier.py
@@ -76,7 +76,6 @@ class CSPDarkNetImageClassifier(ImageClassifier):
     backbone = keras_hub.models.CSPDarkNetBackbone(
         stackwise_num_filters=[128, 256, 512, 1024],
         stackwise_depth=[3, 9, 9, 3],
-        include_rescaling=False,
         block_type="basic_block",
         image_shape = (224, 224, 3),
     )

--- a/keras_hub/src/models/csp_darknet/csp_darknet_image_classifier_test.py
+++ b/keras_hub/src/models/csp_darknet/csp_darknet_image_classifier_test.py
@@ -31,7 +31,6 @@ class CSPDarkNetImageClassifierTest(TestCase):
         self.backbone = CSPDarkNetBackbone(
             stackwise_num_filters=[2, 16, 16],
             stackwise_depth=[1, 3, 3, 1],
-            include_rescaling=False,
             block_type="basic_block",
             image_shape=(16, 16, 3),
         )

--- a/keras_hub/src/models/densenet/densenet_backbone.py
+++ b/keras_hub/src/models/densenet/densenet_backbone.py
@@ -31,9 +31,6 @@ class DenseNetBackbone(FeaturePyramidBackbone):
     Args:
         stackwise_num_repeats: list of ints, number of repeated convolutional
             blocks per dense block.
-        include_rescaling: bool, whether to rescale the inputs. If set
-            to `True`, inputs will be passed through a `Rescaling(1/255.0)`
-            layer. Defaults to `True`.
         image_shape: optional shape tuple, defaults to (None, None, 3).
         compression_ratio: float, compression rate at transition layers,
             defaults to 0.5.
@@ -51,7 +48,6 @@ class DenseNetBackbone(FeaturePyramidBackbone):
     # Randomly initialized backbone with a custom config
     model = keras_hub.models.DenseNetBackbone(
         stackwise_num_repeats=[6, 12, 24, 16],
-        include_rescaling=False,
     )
     model(input_data)
     ```
@@ -60,7 +56,6 @@ class DenseNetBackbone(FeaturePyramidBackbone):
     def __init__(
         self,
         stackwise_num_repeats,
-        include_rescaling=True,
         image_shape=(None, None, 3),
         compression_ratio=0.5,
         growth_rate=32,
@@ -71,10 +66,7 @@ class DenseNetBackbone(FeaturePyramidBackbone):
         channel_axis = -1 if data_format == "channels_last" else 1
         image_input = keras.layers.Input(shape=image_shape)
 
-        x = image_input
-        if include_rescaling:
-            x = keras.layers.Rescaling(1 / 255.0)(x)
-
+        x = image_input  # Intermediate result.
         x = keras.layers.Conv2D(
             64,
             7,
@@ -124,7 +116,6 @@ class DenseNetBackbone(FeaturePyramidBackbone):
 
         # === Config ===
         self.stackwise_num_repeats = stackwise_num_repeats
-        self.include_rescaling = include_rescaling
         self.compression_ratio = compression_ratio
         self.growth_rate = growth_rate
         self.image_shape = image_shape
@@ -135,7 +126,6 @@ class DenseNetBackbone(FeaturePyramidBackbone):
         config.update(
             {
                 "stackwise_num_repeats": self.stackwise_num_repeats,
-                "include_rescaling": self.include_rescaling,
                 "compression_ratio": self.compression_ratio,
                 "growth_rate": self.growth_rate,
                 "image_shape": self.image_shape,

--- a/keras_hub/src/models/densenet/densenet_image_classifier.py
+++ b/keras_hub/src/models/densenet/densenet_image_classifier.py
@@ -74,7 +74,6 @@ class DenseNetImageClassifier(ImageClassifier):
     backbone = keras_hub.models.DenseNetBackbone(
         stackwise_num_filters=[128, 256, 512, 1024],
         stackwise_depth=[3, 9, 9, 3],
-        include_rescaling=False,
         block_type="basic_block",
         image_shape = (224, 224, 3),
     )

--- a/keras_hub/src/models/densenet/densenet_image_classifier_test.py
+++ b/keras_hub/src/models/densenet/densenet_image_classifier_test.py
@@ -28,7 +28,6 @@ class DenseNetImageClassifierTest(TestCase):
         self.labels = [0, 3]
         self.backbone = DenseNetBackbone(
             stackwise_num_repeats=[6, 12, 24, 16],
-            include_rescaling=True,
             compression_ratio=0.5,
             growth_rate=32,
             image_shape=(224, 224, 3),

--- a/keras_hub/src/models/efficientnet/efficientnet_backbone_test.py
+++ b/keras_hub/src/models/efficientnet/efficientnet_backbone_test.py
@@ -42,7 +42,6 @@ class EfficientNetBackboneTest(TestCase):
             "stackwise_block_types": ["fused"] * 3 + ["unfused"] * 3,
             "width_coefficient": 1.0,
             "depth_coefficient": 1.0,
-            "include_rescaling": False,
         }
         self.input_data = keras.ops.ones(shape=(8, 224, 224, 3))
 
@@ -86,7 +85,6 @@ class EfficientNetBackboneTest(TestCase):
             ],
             "width_coefficient": 1.0,
             "depth_coefficient": 1.0,
-            "include_rescaling": False,
             "stackwise_block_types": ["v1"] * 7,
             "min_depth": None,
             "include_initial_padding": True,
@@ -96,12 +94,6 @@ class EfficientNetBackboneTest(TestCase):
             "batch_norm_momentum": 0.99,
         }
         model = EfficientNetBackbone(**original_v1_kwargs)
-        model(self.input_data)
-
-    def test_valid_call_with_rescaling(self):
-        test_kwargs = self.init_kwargs.copy()
-        test_kwargs["include_rescaling"] = True
-        model = EfficientNetBackbone(**test_kwargs)
         model(self.input_data)
 
     def test_feature_pyramid_outputs(self):

--- a/keras_hub/src/models/mix_transformer/mix_transformer_backbone.py
+++ b/keras_hub/src/models/mix_transformer/mix_transformer_backbone.py
@@ -36,7 +36,6 @@ class MiTBackbone(FeaturePyramidBackbone):
         end_value,
         patch_sizes,
         strides,
-        include_rescaling=True,
         image_shape=(None, None, 3),
         hidden_dims=None,
         **kwargs,
@@ -60,9 +59,6 @@ class MiTBackbone(FeaturePyramidBackbone):
                 value projections. If set to > 1, a `Conv2D` layer is used to
                 reduce the length of the sequence.
             end_value: The end value of the sequence.
-            include_rescaling: bool, whether to rescale the inputs. If set
-                to `True`, inputs will be passed through a `Rescaling(1/255.0)`
-                layer. Defaults to `True`.
             image_shape: optional shape tuple, defaults to (None, None, 3).
             hidden_dims: the embedding dims per hierarchical layer, used as
                 the levels of the feature pyramid.
@@ -123,11 +119,7 @@ class MiTBackbone(FeaturePyramidBackbone):
 
         # === Functional Model ===
         image_input = keras.layers.Input(shape=image_shape)
-        x = image_input
-
-        if include_rescaling:
-            x = keras.layers.Rescaling(scale=1 / 255)(x)
-
+        x = image_input  # Intermediate result.
         pyramid_outputs = {}
         for i in range(num_layers):
             # Compute new height/width after the `proj`
@@ -151,7 +143,6 @@ class MiTBackbone(FeaturePyramidBackbone):
 
         # === Config ===
         self.depths = depths
-        self.include_rescaling = include_rescaling
         self.image_shape = image_shape
         self.hidden_dims = hidden_dims
         self.pyramid_outputs = pyramid_outputs
@@ -167,7 +158,6 @@ class MiTBackbone(FeaturePyramidBackbone):
         config.update(
             {
                 "depths": self.depths,
-                "include_rescaling": self.include_rescaling,
                 "hidden_dims": self.hidden_dims,
                 "image_shape": self.image_shape,
                 "num_layers": self.num_layers,

--- a/keras_hub/src/models/mix_transformer/mix_transformer_backbone_test.py
+++ b/keras_hub/src/models/mix_transformer/mix_transformer_backbone_test.py
@@ -25,7 +25,6 @@ class MiTBackboneTest(TestCase):
     def setUp(self):
         self.init_kwargs = {
             "depths": [2, 2],
-            "include_rescaling": True,
             "image_shape": (16, 16, 3),
             "hidden_dims": [4, 8],
             "num_layers": 2,

--- a/keras_hub/src/models/mix_transformer/mix_transformer_classifier.py
+++ b/keras_hub/src/models/mix_transformer/mix_transformer_classifier.py
@@ -76,7 +76,6 @@ class MiTImageClassifier(ImageClassifier):
     backbone = keras_hub.models.MiTBackbone(
         stackwise_num_filters=[128, 256, 512, 1024],
         stackwise_depth=[3, 9, 9, 3],
-        include_rescaling=False,
         block_type="basic_block",
         image_shape = (224, 224, 3),
     )

--- a/keras_hub/src/models/mix_transformer/mix_transformer_classifier_test.py
+++ b/keras_hub/src/models/mix_transformer/mix_transformer_classifier_test.py
@@ -30,7 +30,6 @@ class MiTImageClassifierTest(TestCase):
         self.labels = [0, 3]
         self.backbone = MiTBackbone(
             depths=[2, 2, 2, 2],
-            include_rescaling=True,
             image_shape=(16, 16, 3),
             hidden_dims=[4, 8],
             num_layers=2,

--- a/keras_hub/src/models/mobilenet/mobilenet_backbone_test.py
+++ b/keras_hub/src/models/mobilenet/mobilenet_backbone_test.py
@@ -28,7 +28,6 @@ class MobileNetBackboneTest(TestCase):
             "stackwise_num_strides": [2, 2, 1],
             "stackwise_se_ratio": [0.25, None, 0.25],
             "stackwise_activation": ["relu", "relu", "hard_swish"],
-            "include_rescaling": False,
             "output_num_filters": 1280,
             "input_activation": "hard_swish",
             "output_activation": "hard_swish",

--- a/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
+++ b/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
@@ -56,7 +56,6 @@ class MobileNetImageClassifier(ImageClassifier):
         stackwise_stride = [2, 2, 1],
         stackwise_se_ratio = [ 0.25, None, 0.25],
         stackwise_activation = ["relu", "relu", "hard_swish"],
-        include_rescaling = False,
         output_filter=1280,
         activation="hard_swish",
         inverted_res_block=True,

--- a/keras_hub/src/models/mobilenet/mobilenet_image_classifier_test.py
+++ b/keras_hub/src/models/mobilenet/mobilenet_image_classifier_test.py
@@ -33,7 +33,6 @@ class MobileNetImageClassifierTest(TestCase):
             stackwise_num_strides=[2, 2, 1],
             stackwise_se_ratio=[0.25, None, 0.25],
             stackwise_activation=["relu", "relu", "hard_swish"],
-            include_rescaling=False,
             output_num_filters=1280,
             input_activation="hard_swish",
             output_activation="hard_swish",

--- a/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
@@ -476,6 +476,9 @@ class PaliGemmaVit(keras.Model):
             shape=(image_size, image_size, 3), name="images"
         )
         x = image_input  # Intermediate result.
+        # TODO we have moved this rescaling to preprocessing layers for most
+        # models. We should consider removing it here, though it would break
+        # compatibility.
         if include_rescaling:
             rescaling = keras.layers.Rescaling(
                 scale=1.0 / 127.5, offset=-1.0, name="rescaling"

--- a/keras_hub/src/models/resnet/resnet_image_classifier.py
+++ b/keras_hub/src/models/resnet/resnet_image_classifier.py
@@ -85,7 +85,6 @@ class ResNetImageClassifier(ImageClassifier):
         stackwise_num_strides=[1, 2, 2],
         block_type="basic_block",
         use_pre_activation=True,
-        include_rescaling=False,
         pooling="avg",
     )
     classifier = keras_hub.models.ResNetImageClassifier(

--- a/keras_hub/src/models/resnet/resnet_image_classifier_test.py
+++ b/keras_hub/src/models/resnet/resnet_image_classifier_test.py
@@ -34,7 +34,6 @@ class ResNetImageClassifierTest(TestCase):
             block_type="basic_block",
             use_pre_activation=True,
             image_shape=(16, 16, 3),
-            include_rescaling=False,
         )
         self.init_kwargs = {
             "backbone": self.backbone,
@@ -62,7 +61,7 @@ class ResNetImageClassifierTest(TestCase):
     @pytest.mark.large
     def test_smallest_preset(self):
         # Test that our forward pass is stable!
-        image_batch = self.load_test_image()[None, ...]
+        image_batch = self.load_test_image()[None, ...] / 255.0
         self.run_preset_test(
             cls=ResNetImageClassifier,
             preset="resnet_18_imagenet",

--- a/keras_hub/src/models/resnet/resnet_presets.py
+++ b/keras_hub/src/models/resnet/resnet_presets.py
@@ -25,7 +25,7 @@ backbone_presets = {
             "path": "resnet",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_18_imagenet/2",
+        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_18_imagenet/3",
     },
     "resnet_50_imagenet": {
         "metadata": {
@@ -38,7 +38,7 @@ backbone_presets = {
             "path": "resnet",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_50_imagenet/2",
+        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_50_imagenet/3",
     },
     "resnet_101_imagenet": {
         "metadata": {
@@ -51,7 +51,7 @@ backbone_presets = {
             "path": "resnet",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_101_imagenet/2",
+        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_101_imagenet/3",
     },
     "resnet_152_imagenet": {
         "metadata": {
@@ -64,7 +64,7 @@ backbone_presets = {
             "path": "resnet",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_152_imagenet/2",
+        "kaggle_handle": "kaggle://kerashub/resnetv1/keras/resnet_152_imagenet/3",
     },
     "resnet_v2_50_imagenet": {
         "metadata": {
@@ -77,7 +77,7 @@ backbone_presets = {
             "path": "resnet",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://kerashub/resnetv2/keras/resnet_v2_50_imagenet/2",
+        "kaggle_handle": "kaggle://kerashub/resnetv2/keras/resnet_v2_50_imagenet/3",
     },
     "resnet_v2_101_imagenet": {
         "metadata": {
@@ -90,6 +90,6 @@ backbone_presets = {
             "path": "resnet",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://kerashub/resnetv2/keras/resnet_v2_101_imagenet/2",
+        "kaggle_handle": "kaggle://kerashub/resnetv2/keras/resnet_v2_101_imagenet/3",
     },
 }

--- a/keras_hub/src/models/vgg/vgg_backbone.py
+++ b/keras_hub/src/models/vgg/vgg_backbone.py
@@ -33,8 +33,6 @@ class VGGBackbone(Backbone):
       stackwise_num_filters: list of ints, filter size for convolutional
             blocks per VGG block. For both VGG16 and VGG19 this is [
             64, 128, 256, 512, 512].
-      include_rescaling: bool, whether to rescale the inputs. If set to
-        True, inputs will be passed through a `Rescaling(1/255.0)` layer.
       image_shape: tuple, optional shape tuple, defaults to (224, 224, 3).
       pooling: bool, Optional pooling mode for feature extraction
         when `include_top` is `False`.
@@ -61,7 +59,6 @@ class VGGBackbone(Backbone):
         stackwise_num_repeats = [2, 2, 3, 3, 3],
         stackwise_num_filters = [64, 128, 256, 512, 512],
         image_shape = (224, 224, 3),
-        include_rescaling = False,
         pooling = "avg",
     )
     model(input_data)
@@ -72,7 +69,6 @@ class VGGBackbone(Backbone):
         self,
         stackwise_num_repeats,
         stackwise_num_filters,
-        include_rescaling,
         image_shape=(224, 224, 3),
         pooling="avg",
         **kwargs,
@@ -82,8 +78,6 @@ class VGGBackbone(Backbone):
         img_input = keras.layers.Input(shape=image_shape)
         x = img_input
 
-        if include_rescaling:
-            x = layers.Rescaling(scale=1 / 255.0)(x)
         for stack_index in range(len(stackwise_num_repeats) - 1):
             x = apply_vgg_block(
                 x=x,
@@ -105,7 +99,6 @@ class VGGBackbone(Backbone):
         # === Config ===
         self.stackwise_num_repeats = stackwise_num_repeats
         self.stackwise_num_filters = stackwise_num_filters
-        self.include_rescaling = include_rescaling
         self.image_shape = image_shape
         self.pooling = pooling
 
@@ -113,7 +106,6 @@ class VGGBackbone(Backbone):
         return {
             "stackwise_num_repeats": self.stackwise_num_repeats,
             "stackwise_num_filters": self.stackwise_num_filters,
-            "include_rescaling": self.include_rescaling,
             "image_shape": self.image_shape,
             "pooling": self.pooling,
         }

--- a/keras_hub/src/models/vgg/vgg_backbone_test.py
+++ b/keras_hub/src/models/vgg/vgg_backbone_test.py
@@ -25,7 +25,6 @@ class VGGBackboneTest(TestCase):
             "stackwise_num_repeats": [2, 3, 3],
             "stackwise_num_filters": [8, 64, 64],
             "image_shape": (16, 16, 3),
-            "include_rescaling": False,
             "pooling": "avg",
         }
         self.input_data = np.ones((2, 16, 16, 3), dtype="float32")

--- a/keras_hub/src/models/vgg/vgg_image_classifier.py
+++ b/keras_hub/src/models/vgg/vgg_image_classifier.py
@@ -66,7 +66,6 @@ class VGGImageClassifier(ImageClassifier):
         stackwise_num_repeats = [2, 2, 3, 3, 3],
         stackwise_num_filters = [64, 128, 256, 512, 512],
         image_shape = (224, 224, 3),
-        include_rescaling = False,
         pooling = "avg",
     )
     classifier = keras_hub.models.VGGImageClassifier(

--- a/keras_hub/src/models/vgg/vgg_image_classifier_test.py
+++ b/keras_hub/src/models/vgg/vgg_image_classifier_test.py
@@ -28,7 +28,6 @@ class VGGImageClassifierTest(TestCase):
             stackwise_num_repeats=[2, 4, 4],
             stackwise_num_filters=[2, 16, 16],
             image_shape=(4, 4, 3),
-            include_rescaling=False,
             pooling="max",
         )
         self.init_kwargs = {

--- a/keras_hub/src/models/vit_det/vit_det_backbone.py
+++ b/keras_hub/src/models/vit_det/vit_det_backbone.py
@@ -46,9 +46,6 @@ class ViTDetBackbone(Backbone):
             global attention.
         image_shape (tuple[int], optional): The size of the input image in
             `(H, W, C)` format. Defaults to `(1024, 1024, 3)`.
-        include_rescaling (bool, optional): Whether to rescale the inputs. If
-            set to `True`, inputs will be passed through a
-            `Rescaling(1/255.0)` layer. Defaults to `False`.
         patch_size (int, optional): the patch size to be supplied to the
             Patching layer to turn input images into a flattened sequence of
             patches. Defaults to `16`.
@@ -96,7 +93,6 @@ class ViTDetBackbone(Backbone):
         intermediate_dim,
         num_heads,
         global_attention_layer_indices,
-        include_rescaling=True,
         image_shape=(1024, 1024, 3),
         patch_size=16,
         num_output_channels=256,
@@ -123,9 +119,6 @@ class ViTDetBackbone(Backbone):
             )
         img_size = img_input.shape[-3]
         x = img_input
-        if include_rescaling:
-            # Use common rescaling strategy across keras_cv
-            x = keras.layers.Rescaling(1.0 / 255.0)(x)
         # VITDet scales inputs based on the standard ImageNet mean/stddev.
         x = (x - ops.array([0.485, 0.456, 0.406], dtype=x.dtype)) / (
             ops.array([0.229, 0.224, 0.225], dtype=x.dtype)
@@ -179,14 +172,12 @@ class ViTDetBackbone(Backbone):
         self.window_size = window_size
         self.global_attention_layer_indices = global_attention_layer_indices
         self.layer_norm_epsilon = layer_norm_epsilon
-        self.include_rescaling = include_rescaling
 
     def get_config(self):
         config = super().get_config()
         config.update(
             {
                 "image_shape": self.image_shape,
-                "include_rescaling": self.include_rescaling,
                 "patch_size": self.patch_size,
                 "hidden_size": self.hidden_size,
                 "num_layers": self.num_layers,

--- a/keras_hub/src/models/vit_det/vit_det_backbone_test.py
+++ b/keras_hub/src/models/vit_det/vit_det_backbone_test.py
@@ -22,7 +22,6 @@ from keras_hub.src.tests.test_case import TestCase
 class ViTDetBackboneTest(TestCase):
     def setUp(self):
         self.init_kwargs = {
-            "include_rescaling": True,
             "image_shape": (16, 16, 3),
             "patch_size": 2,
             "hidden_size": 4,

--- a/keras_hub/src/utils/timm/convert_resnet.py
+++ b/keras_hub/src/utils/timm/convert_resnet.py
@@ -151,14 +151,6 @@ def convert_weights(backbone, loader, timm_config):
     if version == "v2":
         port_batch_normalization("post_bn", "norm")
 
-    # Rebuild normalization layer with pretrained mean & std
-    mean = timm_config["pretrained_cfg"]["mean"]
-    std = timm_config["pretrained_cfg"]["std"]
-    normalization_layer = backbone.get_layer("normalization")
-    normalization_layer.input_mean = mean
-    normalization_layer.input_variance = [s**2 for s in std]
-    normalization_layer.build(normalization_layer._build_input_shape)
-
 
 def convert_head(task, loader, timm_config):
     v2 = "resnetv2_" in timm_config["architecture"]

--- a/keras_hub/src/utils/timm/preset_loader.py
+++ b/keras_hub/src/utils/timm/preset_loader.py
@@ -62,5 +62,20 @@ class TimmPresetLoader(PresetLoader):
         pretrained_cfg = self.config.get("pretrained_cfg", None)
         if not pretrained_cfg or "input_size" not in pretrained_cfg:
             return None
+        # This assumes the same basic setup for all timm preprocessing, and that
+        # all our image conversion will be via a `ResizingImageConverter. We may
+        # need to extend this as we cover more model types.
         input_size = pretrained_cfg["input_size"]
-        return cls(width=input_size[1], height=input_size[2])
+        mean = pretrained_cfg["mean"]
+        variance = [s**2 for s in pretrained_cfg["std"]]
+        interpolation = pretrained_cfg["interpolation"]
+        if interpolation not in ("bilinear", "nearest", "bicubic"):
+            interpolation = "bilinear"  # Unsupported interpolation type.
+        return cls(
+            width=input_size[1],
+            height=input_size[2],
+            scale=1 / 255.0,
+            mean=mean,
+            variance=variance,
+            interpolation=interpolation,
+        )

--- a/tools/checkpoint_conversion/convert_resnet_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_resnet_checkpoints.py
@@ -75,21 +75,36 @@ def validate_output(keras_model, timm_model):
     image = PIL.Image.open(file)
     batch = np.array([image])
 
-    # Call with Timm.
-    timm_batch = keras_model.preprocessor(batch)
-    timm_batch = keras.ops.transpose(timm_batch, axes=(0, 3, 1, 2)) / 255.0
+    # Preprocess with Timm.
+    data_config = timm.data.resolve_model_data_config(timm_model)
+    data_config["crop_pct"] = 1.0  # Stop timm from cropping.
+    transforms = timm.data.create_transform(**data_config, is_training=False)
+    timm_preprocessed = transforms(image)
+    timm_preprocessed = keras.ops.transpose(timm_preprocessed, axes=(1, 2, 0))
+    timm_preprocessed = keras.ops.expand_dims(timm_preprocessed, 0)
+
+    # Preprocess with Keras.
+    keras_preprocessed = keras_model.preprocessor(batch)
+
+    # Call with Timm. Use the keras preprocessed image so we can keep modeling
+    # and preprocessing comparisons independent.
+    timm_batch = keras.ops.transpose(keras_preprocessed, axes=(0, 3, 1, 2))
     timm_batch = torch.from_numpy(np.array(timm_batch))
     timm_outputs = timm_model(timm_batch).detach().numpy()
     timm_label = np.argmax(timm_outputs[0])
+
     # Call with Keras.
     keras_outputs = keras_model.predict(batch)
     keras_label = np.argmax(keras_outputs[0])
 
     print("🔶 Keras output:", keras_outputs[0, :10])
     print("🔶 TIMM output:", timm_outputs[0, :10])
-    print("🔶 Difference:", np.mean(np.abs(keras_outputs - timm_outputs)))
     print("🔶 Keras label:", keras_label)
     print("🔶 TIMM label:", timm_label)
+    modeling_diff = np.mean(np.abs(keras_outputs - timm_outputs))
+    print("🔶 Modeling difference:", modeling_diff)
+    preprocessing_diff = np.mean(np.abs(keras_preprocessed - timm_preprocessed))
+    print("🔶 Preprocessing difference:", preprocessing_diff)
 
 
 def main(_):


### PR DESCRIPTION
Since our models include built in preprocessing, it is much clearer for this rescaling to happen in the preprocessing layers.