### PR TITLE
[DRAFT] Support multiple tokenizers and other layers with assets

### DIFF
--- a/keras_hub/src/tokenizers/tokenizer.py
+++ b/keras_hub/src/tokenizers/tokenizer.py
@@ -17,14 +17,12 @@ from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
-from keras_hub.src.utils.preset_utils import TOKENIZER_ASSET_DIR
-from keras_hub.src.utils.preset_utils import TOKENIZER_CONFIG_FILE
+from keras_hub.src.utils.preset_utils import ASSET_DIR
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_file
 from keras_hub.src.utils.preset_utils import get_preset_loader
 from keras_hub.src.utils.preset_utils import save_serialized_object
-from keras_hub.src.utils.preset_utils import save_tokenizer_assets
 from keras_hub.src.utils.python_utils import classproperty
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
@@ -80,6 +78,7 @@ class Tokenizer(PreprocessingLayer):
     backbone_cls = None
 
     def __init__(self, *args, **kwargs):
+        self.config_name = kwargs.pop("config_name", "tokenizer.json")
         super().__init__(*args, **kwargs)
         self.file_assets = None
 
@@ -187,18 +186,26 @@ class Tokenizer(PreprocessingLayer):
             token = getattr(self, attr)
             setattr(self, f"{attr}_id", self.token_to_id(token))
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "config_name": self.config_name,
+            }
+        )
+        return config
+
     def save_to_preset(self, preset_dir):
         """Save tokenizer to a preset directory.
 
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(
-            self,
-            preset_dir,
-            config_file=TOKENIZER_CONFIG_FILE,
-        )
-        save_tokenizer_assets(self, preset_dir)
+        save_serialized_object(self, preset_dir, config_file=self.config_name)
+        subdir = self.config_name.split(".")[0]
+        asset_dir = os.path.join(preset_dir, ASSET_DIR, subdir)
+        os.makedirs(asset_dir, exist_ok=True)
+        self.save_assets(asset_dir)
 
     @preprocessing_function
     def call(self, inputs, *args, training=None, **kwargs):
@@ -207,11 +214,11 @@ class Tokenizer(PreprocessingLayer):
     def load_preset_assets(self, preset):
         asset_path = None
         for asset in self.file_assets:
-            asset_path = get_file(
-                preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
-            )
-        tokenizer_asset_dir = os.path.dirname(asset_path)
-        self.load_assets(tokenizer_asset_dir)
+            subdir = self.config_name.split(".")[0]
+            preset_path = os.path.join(ASSET_DIR, subdir, asset)
+            asset_path = get_file(preset, preset_path)
+        tokenizer_config_name = os.path.dirname(asset_path)
+        self.load_assets(tokenizer_config_name)
 
     @classproperty
     def presets(cls):
@@ -222,6 +229,7 @@ class Tokenizer(PreprocessingLayer):
     def from_preset(
         cls,
         preset,
+        config_name="tokenizer.json",
         **kwargs,
     ):
         """Instantiate a `keras_hub.models.Tokenizer` from a model preset.
@@ -267,4 +275,4 @@ class Tokenizer(PreprocessingLayer):
         backbone_cls = loader.check_backbone_class()
         if cls.backbone_cls != backbone_cls:
             cls = find_subclass(preset, cls, backbone_cls)
-        return loader.load_tokenizer(cls, **kwargs)
+        return loader.load_tokenizer(cls, config_name, **kwargs)

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -69,7 +69,7 @@ class TransformersPresetLoader(PresetLoader):
                 self.converter.convert_weights(backbone, loader, self.config)
         return backbone
 
-    def load_tokenizer(self, cls, **kwargs):
+    def load_tokenizer(self, cls, config_name="tokenizer.json", **kwargs):
         return self.converter.convert_tokenizer(cls, self.preset, **kwargs)
 
     def load_image_converter(self, cls, **kwargs):


### PR DESCRIPTION
Preset saving and loading does not currently generalize to multiple tokenizers (or other preprocessor with static assets), this is a work in progress PR towards adding it, specifically for stable diffusion.

The high-level api would allow something like this

```python
# High-level loading.
image_to_text = keras_hub.models.ImageToText.from_preset(
    "sd3_preset_name",
)
# Low-level tokenizer loading.
clip_l_tokenizer = kersa_hub.tokenizers.Tokenizer.from_preset(
    "sd3_preset_name", config_file="clip_l_tokenizer.json",
)
clip_g_tokenizer = kersa_hub.tokenizers.Tokenizer.from_preset(
    "sd3_preset_name", config_file="clip_g_tokenizer.json",
)
```

During conversion, we would need to make sure each tokenizer was created with a separate `config_file` passed to the constructor. Then when calling `task.save_to_preset("path")`, you would get the following structure.

```
assets/clip_l_tokenizer/...
assets/clip_g_tokenizer/...
assets/t5_tokenizer/...
clip_l_tokenizer.json
clip_g_tokenizer.json
t5_tokenizer.json
```

This is just a WIP commit to share with @james77777778 , tests will not pass yet.