### PR TITLE
Added Support for Returning Attention Scores in TransformerEncoder call

### DIFF
--- a/keras_hub/src/layers/modeling/transformer_encoder.py
+++ b/keras_hub/src/layers/modeling/transformer_encoder.py
@@ -184,7 +184,12 @@ class TransformerEncoder(keras.layers.Layer):
         self.built = True
 
     def call(
-        self, inputs, padding_mask=None, attention_mask=None, training=None, return_attention_scores=False
+        self,
+        inputs,
+        padding_mask=None,
+        attention_mask=None,
+        training=None,
+        return_attention_scores=False,
     ):
         """Forward pass of the TransformerEncoder.
 
@@ -199,6 +204,7 @@ class TransformerEncoder(keras.layers.Layer):
                 [batch_size, sequence_length, sequence_length].
             training: a boolean indicating whether the layer should behave in
                 training mode or in inference mode.
+            return_attention_scores: a boolean indicating whether the output should be `(attention_output, attention_scores)` if `True` or `attention_output` if `False`. Defaults to `False`.
 
         Returns:
             A Tensor of the same shape as the `inputs`.
@@ -232,7 +238,6 @@ class TransformerEncoder(keras.layers.Layer):
                 training=training,
             )
 
-
         x = self._self_attention_dropout(x, training=training)
         x = x + residual
         if not self.normalize_first:
@@ -248,7 +253,7 @@ class TransformerEncoder(keras.layers.Layer):
         x = x + residual
         if not self.normalize_first:
             x = self._feedforward_layer_norm(x)
-        
+
         if return_attention_scores:
             return x, attention_scores
 

--- a/keras_hub/src/layers/modeling/transformer_encoder_test.py
+++ b/keras_hub/src/layers/modeling/transformer_encoder_test.py
@@ -116,7 +116,7 @@ class TransformerEncoderTest(TestCase):
         outputs, attention_scores = encoder(
             inputs, return_attention_scores=True
         )
-        print(attention_scores)
-        assert outputs.shape == inputs.shape
+        self.assertAllEqual(outputs.shape,inputs.shape)
+        
         # attention scores shape (batch_size, num_of_attn_heads, seq_length, seq_length)
-        assert attention_scores.shape == [1, 2, 4, 4]
+        self.assertAllEqual(attention_scores.shape, [1, 2, 4, 4])

--- a/keras_hub/src/layers/modeling/transformer_encoder_test.py
+++ b/keras_hub/src/layers/modeling/transformer_encoder_test.py
@@ -116,7 +116,7 @@ class TransformerEncoderTest(TestCase):
         outputs, attention_scores = encoder(
             inputs, return_attention_scores=True
         )
-        self.assertAllEqual(outputs.shape,inputs.shape)
-        
+        self.assertAllEqual(outputs.shape, inputs.shape)
+
         # attention scores shape (batch_size, num_of_attn_heads, seq_length, seq_length)
         self.assertAllEqual(attention_scores.shape, [1, 2, 4, 4])

--- a/keras_hub/src/layers/modeling/transformer_encoder_test.py
+++ b/keras_hub/src/layers/modeling/transformer_encoder_test.py
@@ -109,3 +109,14 @@ class TransformerEncoderTest(TestCase):
         inputs._keras_mask = mask
         outputs = encoder(inputs)
         self.assertAllEqual(outputs._keras_mask, mask)
+
+    def test_attention_scores(self):
+        encoder = TransformerEncoder(intermediate_dim=4, num_heads=2)
+        inputs = random.uniform(shape=[1, 4, 6])
+        outputs, attention_scores = encoder(
+            inputs, return_attention_scores=True
+        )
+        print(attention_scores)
+        assert outputs.shape == inputs.shape
+        # attention scores shape (batch_size, num_of_attn_heads, seq_length, seq_length)
+        assert attention_scores.shape == [1, 2, 4, 4]


### PR DESCRIPTION
**Summary:** This pull request introduces a new feature that adds support for optionally returning attention scores in the `TransformerEncoder` class. This is controlled by the `return_attention_scores` flag, which when set to `True`, returns both the output and the attention scores from the attention mechanism.

**Changes Introduced:**
- Updated the call method in the `TransformerEncoder` to handle the `return_attention_scores` flag.
- Refactored the code to ensure that the attention scores are computed and returned when required.
- Updated the documentation in the `call` method to reflect the changes.
- Added unit tests to ensure the correctness of this feature using pytest.

**Testing:**
Ran the unit tests to verify that the `return_attention_scores` flag works as expected.
`return_attention_scores=True` (verifies that attention scores are returned and the shapes are correct).
Related Issue: https://github.com/keras-team/keras-hub/issues/1644