### PR TITLE
Allow backbone to be any functional, preprocessor any callable

### DIFF
--- a/keras_hub/src/layers/preprocessing/audio_converter.py
+++ b/keras_hub/src/layers/preprocessing/audio_converter.py
@@ -2,11 +2,10 @@ from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
-from keras_hub.src.utils.preset_utils import AUDIO_CONVERTER_CONFIG_FILE
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_preset_loader
-from keras_hub.src.utils.preset_utils import save_serialized_object
+from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 
 
@@ -101,8 +100,5 @@ class AudioConverter(PreprocessingLayer):
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(
-            self,
-            preset_dir,
-            config_file=AUDIO_CONVERTER_CONFIG_FILE,
-        )
+        saver = get_preset_saver(preset_dir)
+        saver.save_audio_converter(self)

--- a/keras_hub/src/layers/preprocessing/image_converter.py
+++ b/keras_hub/src/layers/preprocessing/image_converter.py
@@ -2,11 +2,10 @@ from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
-from keras_hub.src.utils.preset_utils import IMAGE_CONVERTER_CONFIG_FILE
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_preset_loader
-from keras_hub.src.utils.preset_utils import save_serialized_object
+from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 
 
@@ -110,8 +109,5 @@ class ImageConverter(PreprocessingLayer):
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(
-            self,
-            preset_dir,
-            config_file=IMAGE_CONVERTER_CONFIG_FILE,
-        )
+        saver = get_preset_saver(preset_dir)
+        saver.save_image_converter(self)

--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -1,15 +1,10 @@
-import os
-
 import keras
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.utils.keras_utils import assert_quantization_support
-from keras_hub.src.utils.preset_utils import CONFIG_FILE
-from keras_hub.src.utils.preset_utils import MODEL_WEIGHTS_FILE
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import get_preset_loader
-from keras_hub.src.utils.preset_utils import save_metadata
-from keras_hub.src.utils.preset_utils import save_serialized_object
+from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 
 
@@ -193,9 +188,8 @@ class Backbone(keras.Model):
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(self, preset_dir, config_file=CONFIG_FILE)
-        self.save_weights(os.path.join(preset_dir, MODEL_WEIGHTS_FILE))
-        save_metadata(self, preset_dir)
+        saver = get_preset_saver(preset_dir)
+        saver.save_backbone(self)
 
     def enable_lora(self, rank):
         """Enable Lora on the backbone.

--- a/keras_hub/src/models/preprocessor.py
+++ b/keras_hub/src/models/preprocessor.py
@@ -8,7 +8,7 @@ from keras_hub.src.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_preset_loader
-from keras_hub.src.utils.preset_utils import save_serialized_object
+from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 
 
@@ -209,7 +209,5 @@ class Preprocessor(PreprocessingLayer):
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(self, preset_dir, config_file=self.config_name)
-        for layer in self._flatten_layers(include_self=False):
-            if hasattr(layer, "save_to_preset"):
-                layer.save_to_preset(preset_dir)
+        saver = get_preset_saver(preset_dir)
+        saver.save_preprocessor(self)

--- a/keras_hub/src/models/resnet/resnet_image_classifier.py
+++ b/keras_hub/src/models/resnet/resnet_image_classifier.py
@@ -96,17 +96,18 @@ class ResNetImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
         self.backbone = backbone
         self.preprocessor = preprocessor
         if pooling == "avg":
             self.pooler = keras.layers.GlobalAveragePooling2D(
-                data_format=backbone.data_format, dtype=head_dtype
+                data_format=data_format, dtype=head_dtype
             )
         elif pooling == "max":
             self.pooler = keras.layers.GlobalAveragePooling2D(
-                data_format=backbone.data_format, dtype=head_dtype
+                data_format=data_format, dtype=head_dtype
             )
         else:
             raise ValueError(

--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -1,19 +1,17 @@
-import os
-
 import keras
 from rich import console as rich_console
 from rich import markup
 from rich import table as rich_table
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.preprocessor import Preprocessor
 from keras_hub.src.utils.keras_utils import print_msg
 from keras_hub.src.utils.pipeline_model import PipelineModel
-from keras_hub.src.utils.preset_utils import TASK_CONFIG_FILE
-from keras_hub.src.utils.preset_utils import TASK_WEIGHTS_FILE
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_preset_loader
-from keras_hub.src.utils.preset_utils import save_serialized_object
+from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 
 
@@ -58,10 +56,15 @@ class Task(PipelineModel):
             self.compile()
 
     def preprocess_samples(self, x, y=None, sample_weight=None):
-        if self.preprocessor is not None:
+        # If `preprocessor` is `None`, return inputs unaltered.
+        if self.preprocessor is None:
+            return keras.utils.pack_x_y_sample_weight(x, y, sample_weight)
+        # If `preprocessor` is `Preprocessor` subclass, pass labels as a kwarg.
+        if isinstance(self.preprocessor, Preprocessor):
             return self.preprocessor(x, y=y, sample_weight=sample_weight)
-        else:
-            return super().preprocess_samples(x, y, sample_weight)
+        # For other layers and callable, do not pass the label.
+        x = self.preprocessor(x)
+        return keras.utils.pack_x_y_sample_weight(x, y, sample_weight)
 
     def __setattr__(self, name, value):
         # Work around setattr issues for Keras 2 and Keras 3 torch backend.
@@ -178,7 +181,10 @@ class Task(PipelineModel):
         loader = get_preset_loader(preset)
         backbone_cls = loader.check_backbone_class()
         # Detect the correct subclass if we need to.
-        if cls.backbone_cls != backbone_cls:
+        if (
+            issubclass(backbone_cls, Backbone)
+            and cls.backbone_cls != backbone_cls
+        ):
             cls = find_subclass(preset, cls, backbone_cls)
         # Specifically for classifiers, we never load task weights if
         # num_classes is supplied. We handle this in the task base class because
@@ -232,17 +238,8 @@ class Task(PipelineModel):
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        if self.preprocessor is None:
-            raise ValueError(
-                "Cannot save `task` to preset: `Preprocessor` is not initialized."
-            )
-
-        save_serialized_object(self, preset_dir, config_file=TASK_CONFIG_FILE)
-        if self.has_task_weights():
-            self.save_task_weights(os.path.join(preset_dir, TASK_WEIGHTS_FILE))
-
-        self.preprocessor.save_to_preset(preset_dir)
-        self.backbone.save_to_preset(preset_dir)
+        saver = get_preset_saver(preset_dir)
+        saver.save_task(self)
 
     @property
     def layers(self):
@@ -327,24 +324,25 @@ class Task(PipelineModel):
                     info,
                 )
 
-            tokenizer = self.preprocessor.tokenizer
+            preprocessor = self.preprocessor
+            tokenizer = getattr(preprocessor, "tokenizer", None)
             if tokenizer:
                 info = "Vocab size: "
                 info += highlight_number(tokenizer.vocabulary_size())
                 add_layer(tokenizer, info)
-            image_converter = self.preprocessor.image_converter
+            image_converter = getattr(preprocessor, "image_converter", None)
             if image_converter:
                 info = "Image size: "
                 info += highlight_shape(image_converter.image_size())
                 add_layer(image_converter, info)
-            audio_converter = self.preprocessor.audio_converter
+            audio_converter = getattr(preprocessor, "audio_converter", None)
             if audio_converter:
                 info = "Audio shape: "
                 info += highlight_shape(audio_converter.audio_shape())
                 add_layer(audio_converter, info)
 
             # Print the to the console.
-            preprocessor_name = markup.escape(self.preprocessor.name)
+            preprocessor_name = markup.escape(preprocessor.name)
             console.print(bold_text(f'Preprocessor: "{preprocessor_name}"'))
             console.print(table)
 

--- a/keras_hub/src/tokenizers/tokenizer.py
+++ b/keras_hub/src/tokenizers/tokenizer.py
@@ -10,7 +10,7 @@ from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_file
 from keras_hub.src.utils.preset_utils import get_preset_loader
-from keras_hub.src.utils.preset_utils import save_serialized_object
+from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
@@ -189,11 +189,8 @@ class Tokenizer(PreprocessingLayer):
         Args:
             preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(self, preset_dir, config_file=self.config_name)
-        subdir = self.config_name.split(".")[0]
-        asset_dir = os.path.join(preset_dir, ASSET_DIR, subdir)
-        os.makedirs(asset_dir, exist_ok=True)
-        self.save_assets(asset_dir)
+        saver = get_preset_saver(preset_dir)
+        saver.save_tokenizer(self)
 
     @preprocessing_function
     def call(self, inputs, *args, training=None, **kwargs):

--- a/keras_hub/src/utils/preset_utils_test.py
+++ b/keras_hub/src/utils/preset_utils_test.py
@@ -13,7 +13,6 @@ from keras_hub.src.models.bert.bert_tokenizer import BertTokenizer
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.keras_utils import has_quantization_support
 from keras_hub.src.utils.preset_utils import CONFIG_FILE
-from keras_hub.src.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_hub.src.utils.preset_utils import load_serialized_object
 from keras_hub.src.utils.preset_utils import upload_preset
 
@@ -66,9 +65,8 @@ class PresetUtilsTest(TestCase):
         with self.assertRaisesRegex(FileNotFoundError, "is missing"):
             upload_preset("kaggle://user/model/keras/variant", local_preset_dir)
 
-    @parameterized.parameters((TOKENIZER_CONFIG_FILE), (CONFIG_FILE))
     @pytest.mark.large
-    def test_upload_with_invalid_json(self, json_file):
+    def test_upload_with_invalid_json(self):
         # Load a model from Kaggle to use as a test model.
         preset = "bert_tiny_en_uncased"
         backbone = BertBackbone.from_preset(preset)
@@ -81,7 +79,7 @@ class PresetUtilsTest(TestCase):
         tokenizer.save_to_preset(local_preset_dir)
 
         # Re-write json file content to an invalid format.
-        json_path = os.path.join(local_preset_dir, json_file)
+        json_path = os.path.join(local_preset_dir, CONFIG_FILE)
         with open(json_path, "w") as file:
             file.write("Invalid!")
 

--- a/keras_hub/src/utils/timm/preset_loader.py
+++ b/keras_hub/src/utils/timm/preset_loader.py
@@ -14,7 +14,7 @@ class TimmPresetLoader(PresetLoader):
         architecture = self.config["architecture"]
         if "resnet" in architecture:
             self.converter = convert_resnet
-        if "densenet" in architecture:
+        elif "densenet" in architecture:
             self.converter = convert_densenet
         else:
             raise ValueError(


### PR DESCRIPTION
The main change this allows is passing arbitrary functional models as a backbone to a task and arbitrary callables as preprocessing for a task. This should allow a lot more flexible API usage.

* Passing `Rescaling` layer or a [Pipeline](https://github.com/keras-team/keras/blob/084b7e113d0aa9984af5318e29a19d235c19de6f/keras/src/layers/preprocessing/pipeline.py#L8) as preprocessing for a `ImageClassifier` task.
* Running augmentation on the GPU by retracing the backbone with augmentation layers included.
* Doing more custom surgery of a backbone.

I also moved our saving routines to a `PresetSaver` class, but this is really just to be parallel with the `PresetLoader` we added for transformers/timm conversion. You can still override `save_to_preset` on a model if you need to. Probably more cleanups to do.