### PR TITLE
Minor bug fix to image_converter.image_size

### DIFF
--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -339,7 +339,7 @@ class Task(PipelineModel):
                         add_layer(layer, info)
                     elif isinstance(layer, ImageConverter):
                         info = "Image size: "
-                        info += highlight_shape(layer.image_size())
+                        info += highlight_shape(layer.image_size)
                         add_layer(layer, info)
                     elif isinstance(layer, AudioConverter):
                         info = "Audio shape: "


### PR DESCRIPTION
Change to` image_converter.image_size` since it is a tuple and it's not a callable function.