### PR TITLE
Task models fix

### DIFF
--- a/keras_hub/src/models/llama/llama_causal_lm.py
+++ b/keras_hub/src/models/llama/llama_causal_lm.py
@@ -42,7 +42,9 @@ class LlamaCausalLM(CausalLM):
         self.preprocessor = preprocessor
 
         # === Functional Model ===
-        inputs = backbone.inputs
+        # This must be "backbone.input" i.e. the full input structure,
+        # rather than "backbone.inputs" which is the flattened list of inputs.
+        inputs = backbone.input
         hidden_states = backbone(inputs)
         outputs = backbone.token_embedding(hidden_states, reverse=True)
         super().__init__(

--- a/keras_hub/src/models/mistral/mistral_causal_lm.py
+++ b/keras_hub/src/models/mistral/mistral_causal_lm.py
@@ -42,7 +42,9 @@ class MistralCausalLM(CausalLM):
         self.preprocessor = preprocessor
 
         # === Functional Model ===
-        inputs = backbone.inputs
+        # This must be "backbone.input" i.e. the full input structure,
+        # rather than "backbone.inputs" which is the flattened list of inputs.
+        inputs = backbone.input
         hidden_states = backbone(inputs)
         outputs = backbone.token_embedding(hidden_states, reverse=True)
         super().__init__(

--- a/keras_hub/src/models/pali_gemma/pali_gemma_causal_lm.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_causal_lm.py
@@ -110,7 +110,9 @@ class PaliGemmaCausalLM(CausalLM):
         self.backbone = backbone
 
         # === Functional Model ===
-        inputs = backbone.inputs
+        # This must be "backbone.input" i.e. the full input structure,
+        # rather than "backbone.inputs" which is the flattened list of inputs.
+        inputs = backbone.input
         hidden_state = backbone(inputs=inputs)
         outputs = backbone.token_embedding(hidden_state, reverse=True)
         outputs = outputs[:, backbone.image_sequence_length :, :]

--- a/keras_hub/src/models/phi3/phi3_causal_lm.py
+++ b/keras_hub/src/models/phi3/phi3_causal_lm.py
@@ -41,7 +41,9 @@ class Phi3CausalLM(CausalLM):
         self.preprocessor = preprocessor
 
         # === Functional Model ===
-        inputs = backbone.inputs
+        # This must be "backbone.input" i.e. the full input structure,
+        # rather than "backbone.inputs" which is the flattened list of inputs.
+        inputs = backbone.input
         hidden_states = backbone(inputs)
         outputs = backbone.token_embedding(hidden_states, reverse=True)
         super().__init__(

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -569,7 +569,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         ds = tf.data.Dataset.from_tensor_slices(train_data).batch(batch_size)
         x, y, sw = keras.utils.unpack_x_y_sample_weight(train_data)
 
-        # Test: shapes output by the preprocessor must match what model expects.
+        # Test: the tree struct output by the
+        # preprocessor must match what model expects.
         preprocessed_data = preprocessor(*train_data)[0]
         tree.assert_same_structure(
             preprocessed_data,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -569,6 +569,14 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         ds = tf.data.Dataset.from_tensor_slices(train_data).batch(batch_size)
         x, y, sw = keras.utils.unpack_x_y_sample_weight(train_data)
 
+        # Test: shapes output by the preprocessor must match what model expects.
+        preprocessed_data = preprocessor(*train_data)[0]
+        tree.assert_same_structure(
+            preprocessed_data,
+            task._inputs_struct,
+            check_types=False,
+        )
+
         # Test predict.
         output = task.predict(x)
         if expected_output_shape is not None:

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
@@ -15,7 +15,6 @@ MERGE_PATH = keras.utils.get_file(
 )
 
 
-# @pytest.mark.large
 class BytePairTokenizerTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -115,11 +114,11 @@ class BytePairTokenizerTest(TestCase):
         # templates: \n\n must be tokenized as a single token
         input_data = "Hello\n\nHello"
         encoded = self.tokenizer(input_data)
-        # self.assertAllEqual(encoded, [31414, 50140, 31414])
+        self.assertAllEqual(encoded, [31414, 50140, 31414])
 
         input_data = "Hello\n\n\n\nHello"
         encoded = self.tokenizer(input_data)
-        # self.assertAllEqual(encoded, [31414, 50140, 50140, 31414])
+        self.assertAllEqual(encoded, [31414, 50140, 50140, 31414])
 
         input_data = "Hello\n\n"
         encoded = self.tokenizer(input_data)

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
@@ -1,5 +1,4 @@
 import keras
-import pytest
 import tensorflow as tf
 
 from keras_hub.src.tests.test_case import TestCase

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
@@ -15,7 +15,7 @@ MERGE_PATH = keras.utils.get_file(
 )
 
 
-@pytest.mark.large
+# @pytest.mark.large
 class BytePairTokenizerTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -110,6 +110,24 @@ class BytePairTokenizerTest(TestCase):
         input_data = "  \n\n\ns"
         encoded = self.tokenizer(input_data)
         self.assertAllEqual(encoded, [1437, 1437, 50140, 50118, 29])
+
+        # This is important for Llama3 which uses the \n\n sequence in chat
+        # templates: \n\n must be tokenized as a single token
+        input_data = "Hello\n\nHello"
+        encoded = self.tokenizer(input_data)
+        # self.assertAllEqual(encoded, [31414, 50140, 31414])
+
+        input_data = "Hello\n\n\n\nHello"
+        encoded = self.tokenizer(input_data)
+        # self.assertAllEqual(encoded, [31414, 50140, 50140, 31414])
+
+        input_data = "Hello\n\n"
+        encoded = self.tokenizer(input_data)
+        self.assertAllEqual(encoded, [31414, 50140])
+
+        input_data = "Hello\n\n\n\n"
+        encoded = self.tokenizer(input_data)
+        self.assertAllEqual(encoded, [31414, 50140, 50140])
 
     def test_special_whitespace(self):
         input_data = "\xa0 \xa0 \x3000 s"


### PR DESCRIPTION
Some task models (not all) were initialized from "inputs", i.e. the flattened list of input vectors, rather than "input", which is the full input structure. This caused a mismatched between the data structure generated by the preprocessor and the one expected by the model. Since [Keras PR 20170](https://github.com/keras-team/keras/pull/20170), this throws a warning when the model is applied to data coming from the preprocessor.

I suspect that this can also lead to an inversion between token_ids and padding_mask when the input structure is flattened.

This PR fixes the issues for the affected models and adds a test for task models ensuring that the structure returned by the preprocessor always matched the structure expected by the model.