### PR TITLE
Two fixes for image resizing in preprocessing

### DIFF
--- a/keras_hub/src/models/preprocessor.py
+++ b/keras_hub/src/models/preprocessor.py
@@ -71,6 +71,22 @@ class Preprocessor(PreprocessingLayer):
     def image_converter(self, value):
         self._image_converter = value
 
+    @property
+    def image_size(self):
+        """Shortcut to get/set the image size of the image converter."""
+        if self.image_converter is None:
+            return None
+        return self.image_converter.image_size
+
+    @image_size.setter
+    def image_size(self, value):
+        if self.image_converter is None:
+            raise ValueError(
+                "Cannot set `image_size` on preprocessor if `image_converter` "
+                " is `None`."
+            )
+        self.image_converter.image_size = value
+
     def get_config(self):
         config = super().get_config()
         if self.tokenizer:

--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -280,7 +280,7 @@ class Task(PipelineModel):
 
         def highlight_number(x):
             if x is None:
-                f"[color(45)]{x}[/]"
+                return f"[color(45)]{x}[/]"
             return f"[color(34)]{x:,}[/]"  # Format number with commas.
 
         def highlight_symbol(x):
@@ -339,7 +339,10 @@ class Task(PipelineModel):
                         add_layer(layer, info)
                     elif isinstance(layer, ImageConverter):
                         info = "Image size: "
-                        info += highlight_shape(layer.image_size)
+                        image_size = layer.image_size
+                        if image_size is None:
+                            image_size = (None, None)
+                        info += highlight_shape(image_size)
                         add_layer(layer, info)
                     elif isinstance(layer, AudioConverter):
                         info = "Audio shape: "


### PR DESCRIPTION
1. Properly display when are not resizing the input image in `model.summary()`
2. Allow setting the `image_size` directly on a preprocessing layer.

`2.` is just to allow a more consistent way to set the input shape across tasks. We now have:

```python
text_classifier = keras_hub.models.TextClassifer.from_preset(
    "bert_base_en",
)
text_classifier.preprocessor.sequence_length = 256

image_classifier = keras_hub.models.TextClassifer.from_preset(
    "bert_base_en",
)
image_classifier.preprocessor.image_size = (256, 256)

multi_modal_lm = keras_hub.models.CausalLM.from_preset(
    "some_preset",
)
multi_modal_lm.preprocessor.sequence_length = 256
multi_modal_lm.preprocessor.image_size = (256, 256)
```