### PR TITLE
Fix image_converter bug.

### DIFF
--- a/keras_hub/src/layers/preprocessing/image_converter.py
+++ b/keras_hub/src/layers/preprocessing/image_converter.py
@@ -149,7 +149,9 @@ class ImageConverter(PreprocessingLayer):
         if self.image_size is not None:
             x = self.resizing(x)
         if self.scale is not None:
-            x = x * self._expand_non_channel_dims(self.scale, x)
+            x = ops.cast(x, self.dtype) * self._expand_non_channel_dims(
+                self.scale, x
+            )
         if self.offset is not None:
             x = x + self._expand_non_channel_dims(self.offset, x)
         return x

--- a/keras_hub/src/utils/timm/preset_loader.py
+++ b/keras_hub/src/utils/timm/preset_loader.py
@@ -53,10 +53,11 @@ class TimmPresetLoader(PresetLoader):
 
     def load_image_converter(self, cls, **kwargs):
         pretrained_cfg = self.config.get("pretrained_cfg", None)
-        if not pretrained_cfg:
+        if not pretrained_cfg or "input_size" not in pretrained_cfg:
             return None
         # This assumes the same basic setup for all timm preprocessing, We may
         # need to extend this as we cover more model types.
+        input_size = pretrained_cfg["input_size"]
         mean = pretrained_cfg["mean"]
         std = pretrained_cfg["std"]
         scale = [1.0 / 255.0 / s for s in std]
@@ -65,6 +66,7 @@ class TimmPresetLoader(PresetLoader):
         if interpolation not in ("bilinear", "nearest", "bicubic"):
             interpolation = "bilinear"  # Unsupported interpolation type.
         return cls(
+            image_size=input_size[1:],
             scale=scale,
             offset=offset,
             interpolation=interpolation,


### PR DESCRIPTION
testing the resnet classifier preset was resulting in the following error
this PR will fix it.
```
 File "/workspaces/keras-nlp/keras_hub/src/models/image_classifier_preprocessor.py", line 69, in call
    x = self.image_converter(x)
  File "/workspaces/keras-nlp/keras_hub/src/utils/tensor_utils.py", line 48, in wrapper
    x = fn(self, x, **kwargs)
  File "/workspaces/keras-nlp/keras_hub/src/layers/preprocessing/image_converter.py", line 152, in call
    x = x * self._expand_non_channel_dims(self.scale, x)
tensorflow.python.framework.errors_impl.InvalidArgumentError: Exception encountered when calling ResNetImageConverter.call().

cannot compute Mul as input #1(zero-based) was expected to be a uint8 tensor but is a float tensor [Op:Mul] name: 
```