### PR TITLE
Update SD3 init parameters (replacing `height`, `width` with `image_shape`)

### DIFF
--- a/keras_hub/src/models/image_to_image.py
+++ b/keras_hub/src/models/image_to_image.py
@@ -234,7 +234,7 @@ class ImageToImage(Task):
                 input_is_scalar = True
             x = ops.image.resize(
                 x,
-                (self.backbone.height, self.backbone.width),
+                (self.backbone.image_shape[0], self.backbone.image_shape[1]),
                 interpolation="nearest",
                 data_format=data_format,
             )

--- a/keras_hub/src/models/inpaint.py
+++ b/keras_hub/src/models/inpaint.py
@@ -202,7 +202,7 @@ class Inpaint(Task):
                 input_is_scalar = True
             x = ops.image.resize(
                 x,
-                (self.backbone.height, self.backbone.width),
+                (self.backbone.image_shape[0], self.backbone.image_shape[1]),
                 interpolation="nearest",
                 data_format=data_format,
             )
@@ -240,7 +240,7 @@ class Inpaint(Task):
                 x = ops.cast(x, "float32")
             x = ops.image.resize(
                 x,
-                (self.backbone.height, self.backbone.width),
+                (self.backbone.image_shape[0], self.backbone.image_shape[1]),
                 interpolation="nearest",
                 data_format=data_format,
             )
@@ -303,7 +303,7 @@ class Inpaint(Task):
                 input_is_scalar = True
             x = ops.image.resize(
                 x,
-                (self.backbone.height, self.backbone.width),
+                (self.backbone.image_shape[0], self.backbone.image_shape[1]),
                 interpolation="nearest",
                 data_format=data_format,
             )
@@ -323,7 +323,7 @@ class Inpaint(Task):
                 x = ops.cast(x, "float32")
             x = ops.image.resize(
                 x,
-                (self.backbone.height, self.backbone.width),
+                (self.backbone.image_shape[0], self.backbone.image_shape[1]),
                 interpolation="nearest",
                 data_format=data_format,
             )
@@ -384,8 +384,8 @@ class Inpaint(Task):
 
         Typically, `inputs` is a dict with `"images"` `"masks"` and `"prompts"`
         keys. `"images"` are reference images within a value range of
-        `[-1.0, 1.0]`, which will be resized to `self.backbone.height` and
-        `self.backbone.width`, then encoded into latent space by the VAE
+        `[-1.0, 1.0]`, which will be resized to height and width from
+        `self.backbone.image_shape`, then encoded into latent space by the VAE
         encoder. `"masks"` are mask images with a boolean dtype, where white
         pixels are repainted while black pixels are preserved. `"prompts"` are
         strings that will be tokenized and encoded by the text encoder.

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
@@ -11,7 +11,8 @@ from keras_hub.src.tests.test_case import TestCase
 
 class StableDiffusion3BackboneTest(TestCase):
     def setUp(self):
-        height, width = 64, 64
+        image_shape = (64, 64, 3)
+        height, width = image_shape[0], image_shape[1]
         vae = VAEBackbone(
             [32, 32, 32, 32],
             [1, 1, 1, 1],
@@ -36,8 +37,7 @@ class StableDiffusion3BackboneTest(TestCase):
             "vae": vae,
             "clip_l": clip_l,
             "clip_g": clip_g,
-            "height": height,
-            "width": width,
+            "image_shape": image_shape,
         }
         self.input_data = {
             "images": ops.ones((2, height, width, 3)),

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
@@ -82,7 +82,6 @@ class StableDiffusion3BackboneTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
                 init_kwargs={
-                    "height": self.init_kwargs["height"],
-                    "width": self.init_kwargs["width"],
+                    "image_shape": self.init_kwargs["image_shape"],
                 },
             )

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image.py
@@ -27,7 +27,7 @@ class StableDiffusion3ImageToImage(ImageToImage):
     Use `generate()` to do image generation.
     ```python
     image_to_image = keras_hub.models.StableDiffusion3ImageToImage.from_preset(
-        "stable_diffusion_3_medium", image_shape=(512, 512, 3),
+        "stable_diffusion_3_medium", image_shape=(512, 512, 3)
     )
     image_to_image.generate(
         {

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image.py
@@ -27,7 +27,7 @@ class StableDiffusion3ImageToImage(ImageToImage):
     Use `generate()` to do image generation.
     ```python
     image_to_image = keras_hub.models.StableDiffusion3ImageToImage.from_preset(
-        "stable_diffusion_3_medium", height=512, width=512
+        "stable_diffusion_3_medium", image_shape=(512, 512, 3),
     )
     image_to_image.generate(
         {

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image_test.py
@@ -55,8 +55,7 @@ class StableDiffusion3ImageToImageTest(TestCase):
             clip_g=CLIPTextEncoder(
                 20, 128, 128, 2, 2, 256, "gelu", -2, name="clip_g"
             ),
-            height=64,
-            width=64,
+            image_shape=(64, 64, 3),
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint.py
@@ -29,7 +29,7 @@ class StableDiffusion3Inpaint(Inpaint):
     reference_image = np.ones((1024, 1024, 3), dtype="float32")
     reference_mask = np.ones((1024, 1024), dtype="float32")
     inpaint = keras_hub.models.StableDiffusion3Inpaint.from_preset(
-        "stable_diffusion_3_medium", image_shape=(512, 512, 3),
+        "stable_diffusion_3_medium", image_shape=(512, 512, 3)
     )
     inpaint.generate(
         reference_image,

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint.py
@@ -29,7 +29,7 @@ class StableDiffusion3Inpaint(Inpaint):
     reference_image = np.ones((1024, 1024, 3), dtype="float32")
     reference_mask = np.ones((1024, 1024), dtype="float32")
     inpaint = keras_hub.models.StableDiffusion3Inpaint.from_preset(
-        "stable_diffusion_3_medium", height=512, width=512
+        "stable_diffusion_3_medium", image_shape=(512, 512, 3),
     )
     inpaint.generate(
         reference_image,

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint_test.py
@@ -55,8 +55,7 @@ class StableDiffusion3InpaintTest(TestCase):
             clip_g=CLIPTextEncoder(
                 20, 128, 128, 2, 2, 256, "gelu", -2, name="clip_g"
             ),
-            height=64,
-            width=64,
+            image_shape=(64, 64, 3),
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_presets.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_presets.py
@@ -13,6 +13,6 @@ backbone_presets = {
             "path": "stable_diffusion_3",
             "model_card": "https://arxiv.org/abs/2110.00476",
         },
-        "kaggle_handle": "kaggle://keras/stablediffusion3/keras/stable_diffusion_3_medium/2",
+        "kaggle_handle": "kaggle://keras/stablediffusion3/keras/stable_diffusion_3_medium/3",
     }
 }

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image.py
@@ -27,7 +27,7 @@ class StableDiffusion3TextToImage(TextToImage):
     Use `generate()` to do image generation.
     ```python
     text_to_image = keras_hub.models.StableDiffusion3TextToImage.from_preset(
-        "stable_diffusion_3_medium", image_shape=(512, 512, 3),
+        "stable_diffusion_3_medium", image_shape=(512, 512, 3)
     )
     text_to_image.generate(
         "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image.py
@@ -27,7 +27,7 @@ class StableDiffusion3TextToImage(TextToImage):
     Use `generate()` to do image generation.
     ```python
     text_to_image = keras_hub.models.StableDiffusion3TextToImage.from_preset(
-        "stable_diffusion_3_medium", height=512, width=512
+        "stable_diffusion_3_medium", image_shape=(512, 512, 3),
     )
     text_to_image.generate(
         "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_test.py
@@ -55,8 +55,7 @@ class StableDiffusion3TextToImageTest(TestCase):
             clip_g=CLIPTextEncoder(
                 20, 128, 128, 2, 2, 256, "gelu", -2, name="clip_g"
             ),
-            height=64,
-            width=64,
+            image_shape=(64, 64, 3),
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -563,10 +563,8 @@ class PresetLoader:
         backbone_kwargs["dtype"] = kwargs.pop("dtype", None)
 
         # Forward `height` and `width` to backbone when using `TextToImage`.
-        if "height" in kwargs:
-            backbone_kwargs["height"] = kwargs.pop("height", None)
-        if "width" in kwargs:
-            backbone_kwargs["width"] = kwargs.pop("width", None)
+        if "image_shape" in kwargs:
+            backbone_kwargs["image_shape"] = kwargs.pop("image_shape", None)
 
         return backbone_kwargs, kwargs
 

--- a/tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py
@@ -113,8 +113,7 @@ def convert_model(preset, height, width):
             vae,
             clip_l,
             clip_g,
-            height=height,
-            width=width,
+            image_shape=(height, width, 3),
             name="stable_diffusion_3_backbone",
         )
     return backbone
@@ -532,8 +531,7 @@ def main(_):
 
     keras_preprocessor.save_to_preset(preset)
     # Set the image size to 1024, the same as in huggingface/diffusers.
-    keras_model.height = 1024
-    keras_model.width = 1024
+    keras_model.image_shape = (1024, 1024, 3)
     keras_model.save_to_preset(preset)
     print(f"🏁 Preset saved to ./{preset}.")
 

--- a/tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py
@@ -4,7 +4,7 @@ export KAGGLE_USERNAME=XXX
 export KAGGLE_KEY=XXX
 
 python tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py \
-    --preset stable_diffusion_3_medium --upload_uri kaggle://kerashub/stablediffusion3/keras/stable_diffusion_3_medium
+    --preset stable_diffusion_3_medium --upload_uri kaggle://keras/stablediffusion3/keras/stable_diffusion_3_medium
 """
 
 import os

--- a/tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py
@@ -4,7 +4,7 @@ export KAGGLE_USERNAME=XXX
 export KAGGLE_KEY=XXX
 
 python tools/checkpoint_conversion/convert_stable_diffusion_3_checkpoints.py \
-    --preset stable_diffusion_3_medium --upload_uri kaggle://keras/stablediffusion3/keras/stable_diffusion_3_medium
+    --preset stable_diffusion_3_medium --upload_uri kaggle://kerashub/stablediffusion3/keras/stable_diffusion_3_medium
 """
 
 import os


### PR DESCRIPTION
@divyashreepathihalli @mattdangerw 

I have changed the `kaggle_handle` in this PR as well. We need to move the weights from KerasHub page to Keras page to pass the `large`  and `extra_large` tests.