### PR TITLE
[Object Detection] Add YOLOv11 Architecture and Presets

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -176,6 +176,10 @@ from keras_hub.src.models.image_classifier import ImageClassifier
 from keras_hub.src.models.image_classifier_preprocessor import (
     ImageClassifierPreprocessor,
 )
+from keras_hub.src.models.image_object_detector import ImageObjectDetector
+from keras_hub.src.models.image_object_detector_preprocessor import (
+    ImageObjectDetectorPreprocessor,
+)
 from keras_hub.src.models.image_segmenter import ImageSegmenter
 from keras_hub.src.models.image_segmenter_preprocessor import (
     ImageSegmenterPreprocessor,

--- a/keras_hub/src/bounding_box/iou.py
+++ b/keras_hub/src/bounding_box/iou.py
@@ -249,3 +249,86 @@ def compute_ciou(boxes1, boxes2, bounding_box_format):
     return iou - (
         centers_distance_squared / convex_diagonal_squared + v * alpha
     )
+
+
+class CIoULoss(keras.losses.Loss):
+    """
+    Implements the Complete IoU (CIoU) Loss as a class.
+
+    CIoU loss is an extension of GIoU loss, which further improves the IoU
+    optimization for object detection. CIoU loss not only penalizes the
+    bounding box coordinates but also considers the aspect ratio and center
+    distance of the boxes. The length of the last dimension should be 4 to
+    represent the bounding boxes. Based on https://arxiv.org/pdf/2005.03572.pdf.
+
+    Args:
+        bounding_box_format: string. A case-insensitive string (for example, "xyxy").
+            Each bounding box is defined by these 4 values. For detailed
+            information on the supported formats, see the [KerasCV bounding box
+            documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
+        epsilon: float. A small value added to avoid division by zero and stabilize
+            calculations.
+
+    Example usage:
+
+    ```python
+    y_true = np.random.uniform(
+        size=(5, 10, 5),
+        low=0,
+        high=10)
+    y_pred = np.random.uniform(
+        (5, 10, 4),
+        low=0,
+        high=10)
+
+    loss = keras_hub.src.models.yolo_v8.ciou_loss.CIoULoss("xyxy")
+    loss(y_true, y_pred).numpy()
+    ```
+
+    Usage with the `compile()` API:
+
+    ```python
+    model.compile(optimizer='adam', loss=CIoULoss())
+    ```
+    """
+
+    def __init__(self, bounding_box_format, epsilon=1e-7, **kwargs):
+        super().__init__(**kwargs)
+        self.epsilon = epsilon
+        self.bounding_box_format = bounding_box_format
+
+    def call(self, y_true, y_pred):
+        y_pred = ops.convert_to_tensor(y_pred)
+        y_true = ops.cast(y_true, y_pred.dtype)
+
+        if y_pred.shape[-1] != 4:
+            raise ValueError(
+                "CIoULoss expects y_pred.shape[-1] to be 4 to represent the "
+                f"bounding boxes. Received y_pred.shape[-1]={y_pred.shape[-1]}."
+            )
+
+        if y_true.shape[-1] != 4:
+            raise ValueError(
+                "CIoULoss expects y_true.shape[-1] to be 4 to represent the "
+                f"bounding boxes. Received y_true.shape[-1]={y_true.shape[-1]}."
+            )
+
+        if y_true.shape[-2] != y_pred.shape[-2]:
+            raise ValueError(
+                "CIoULoss expects number of boxes in y_pred to be equal to the "
+                "number of boxes in y_true. Received number of boxes in "
+                f"y_true={y_true.shape[-2]} and number of boxes in "
+                f"y_pred={y_pred.shape[-2]}."
+            )
+
+        ciou = compute_ciou(y_true, y_pred, self.bounding_box_format)
+        return 1 - ciou
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "epsilon": self.epsilon,
+            }
+        )
+        return config

--- a/keras_hub/src/models/image_object_detector.py
+++ b/keras_hub/src/models/image_object_detector.py
@@ -1,0 +1,51 @@
+import keras
+from keras.losses import BinaryCrossentropy
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.task import Task
+
+
+@keras_hub_export("keras_hub.models.ImageObjectDetector")
+class ImageObjectDetector(Task):
+    """Base class for object detection tasks."""
+
+    def compile(
+        self,
+        optimizer="auto",
+        box_loss="auto",
+        classification_loss="auto",
+        metrics=None,
+        **kwargs,
+    ):
+        """Configures the `ObjectDetector` task for training.
+        The `ObjectDetector` task extends the default compilation signature of
+        `keras.Model.compile` with a default `optimizer`, default loss
+        functions `box_loss`, and `classification_loss` and default loss weights
+        "box_loss_weight" and "classification_loss_weight".
+        `compile()` mirrors the standard Keras `compile()` method, but has one
+        key distinction -- two losses must be provided: `box_loss` and
+        `classification_loss`.
+        Args:
+            box_loss: a Keras loss to use for box offset regression. A
+                preconfigured loss is provided when the string "ciou" is passed.
+            classification_loss: a Keras loss to use for box classification. A
+                preconfigured loss is provided when the string
+                "binary_crossentropy" is passed.
+            kwargs: most other `keras.Model.compile()` arguments are supported
+                and propagated to the `keras.Model` class.
+        """
+        if optimizer == "auto":
+            optimizer = keras.optimizers.Adam(0.001)
+        if box_loss == "auto":
+            box_loss = CIoULoss(bounding_box_format="xyxy", reduction="sum")
+        if classification_loss == "auto":
+            classification_loss = BinaryCrossentropy(reduction="sum")
+        if metrics is not None:
+            raise ValueError("User metrics not yet supported")
+        self.box_loss = box_loss
+        self.classification_loss = classification_loss
+        losses = {
+            "box": self.box_loss,
+            "class": self.classification_loss,
+        }
+        super().compile(loss=losses, **kwargs)

--- a/keras_hub/src/models/image_object_detector.py
+++ b/keras_hub/src/models/image_object_detector.py
@@ -37,7 +37,8 @@ class ImageObjectDetector(Task):
         if optimizer == "auto":
             optimizer = keras.optimizers.Adam(0.001)
         if box_loss == "auto":
-            box_loss = CIoULoss(bounding_box_format="xyxy", reduction="sum")
+            # box_loss = CIoULoss(bounding_box_format="xyxy", reduction="sum")
+            pass
         if classification_loss == "auto":
             classification_loss = BinaryCrossentropy(reduction="sum")
         if metrics is not None:

--- a/keras_hub/src/models/image_object_detector_preprocessor.py
+++ b/keras_hub/src/models/image_object_detector_preprocessor.py
@@ -1,0 +1,74 @@
+import keras
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.preprocessor import Preprocessor
+from keras_hub.src.utils.tensor_utils import preprocessing_function
+
+
+@keras_hub_export("keras_hub.models.ImageObjectDetectorPreprocessor")
+class ImageObjectDetectorPreprocessor(Preprocessor):
+    """Base class for image segmentation preprocessing layers.
+
+    `ImageObjectDetectorPreprocessor` wraps a
+    `keras_hub.layers.ImageConverter` to create a preprocessing layer for
+    image object detection tasks. It is intended to be paired with a
+    `keras_hub.models.ImageObjectDetector` task.
+
+    All `ImageObjectDetectorPreprocessor` instances take three inputs: `x`, `y`, and
+    `sample_weight`.
+
+    - `x`: The first input, should always be included. It can be an image or
+      a batch of images.
+    - `y`: (Optional) Usually the bounding boxes, if `resize_bboxes`
+        is set to `True` this will be resized to input image shape else will be
+        passed through unaltered.
+    - `sample_weight`: (Optional) Will be passed through unaltered.
+
+    The layer will output either `x`, an `(x, y)` tuple if labels were provided,
+    or an `(x, y, sample_weight)` tuple if labels and sample weight were
+    provided. `x` will be the input images after all model preprocessing has
+    been applied.
+
+    All `ImageObjectDetectorPreprocessor` tasks include a `from_preset()`
+    constructor which can be used to load a pre-trained config.
+    You can call the `from_preset()` constructor directly on this base class, in
+    which case the correct class for your model will be automatically
+    instantiated.
+
+    Examples.
+    ```python
+    preprocessor = keras_hub.models.ImageObjectDetectorPreprocessor.from_preset(
+        "yolov11_n",
+    )
+
+    # Resize a single image for the model.
+    x = np.ones((512, 512, 3))
+    x = preprocessor(x)
+    ```
+
+    """
+
+    def __init__(
+        self,
+        image_converter=None,
+        resize_bboxes=False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.image_converter = image_converter
+        self.resize_bboxes = resize_bboxes
+
+    @preprocessing_function
+    def call(self, x, y=None, sample_weight=None):
+        original_shape = x.shape
+        if self.image_converter:
+            x = self.image_converter(x)
+
+        if y is not None and self.image_converter and self.resize_bboxes:
+            # resize the bboxes
+            # 1. Use the original shape for this
+            # 2. Compute the would-be locations in the new size
+            # 3. Scale to the new sizes
+            print(original_shape)
+
+        return keras.utils.pack_x_y_sample_weight(x, y, sample_weight)

--- a/keras_hub/src/models/yolov11/yolov11_layers.py
+++ b/keras_hub/src/models/yolov11/yolov11_layers.py
@@ -209,7 +209,8 @@ class PSABlock(layers.Layer):
     """
 
     def __init__(self, c, attn_ratio=0.5, num_heads=4, shortcut=True) -> None:
-        """Initializes the PSABlock with attention and feed-forward layers for enhanced feature extraction."""
+        """Initializes the PSABlock with attention and feed-forward
+        layers for enhanced feature extraction."""
         super().__init__()
 
         self.attn = Attention(c, attn_ratio=attn_ratio, num_heads=num_heads)
@@ -219,7 +220,8 @@ class PSABlock(layers.Layer):
         self.add = shortcut
 
     def call(self, x):
-        """Executes a forward pass through PSABlock, applying attention and feed-forward layers to the input tensor."""
+        """Executes a forward pass through PSABlock, applying attention
+        and feed-forward layers to the input tensor."""
         x = x + self.attn(x) if self.add else self.attn(x)
         x = x + self.ffn(x) if self.add else self.ffn(x)
         return x
@@ -245,7 +247,8 @@ class Attention(layers.Layer):
     """
 
     def __init__(self, dim, num_heads=8, attn_ratio=0.5):
-        """Initializes multi-head attention module with query, key, and value convolutions and positional encoding."""
+        """Initializes multi-head attention module with query, key,
+        and value convolutions and positional encoding."""
         super().__init__()
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
@@ -267,7 +270,7 @@ class Attention(layers.Layer):
         Returns:
             KerasTensor. The output tensor after self-attention.
         """
-        B, C, H, W = ops.shape(x)
+        B, H, W, _ = ops.shape(x)
         N = H * W
         qkv = self.qkv(x)
 
@@ -279,7 +282,6 @@ class Attention(layers.Layer):
         attn = (ops.transpose(q, (0, 1, 3, 2)) @ k) * self.scale
         attn = ops.softmax(attn, axis=-1)
         x = v @ ops.transpose(attn, (0, 1, 3, 2))
-        x = ops.reshape(x, (B, C, H, W))
-        x = x + self.pe(ops.reshape(v, (B, C, H, W)))
+        x = x + self.pe(v)
         x = self.proj(x)
         return x

--- a/keras_hub/src/models/yolov11/yolov11_layers.py
+++ b/keras_hub/src/models/yolov11/yolov11_layers.py
@@ -1,4 +1,5 @@
 from keras import layers
+from keras import ops
 
 
 class ConvBNAct(layers.Layer):
@@ -52,9 +53,47 @@ class Bottleneck(layers.Layer):
         return out
 
 
-class C3f(layers.Layer):
+class CSPBottleneck3C(layers.Layer):
+    """CSP Bottleneck with 3 convolutions."""
+
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5, **kwargs):
+        """Initialize the CSP Bottleneck with given channels, number, shortcut, groups, and expansion values."""
+        super().__init__(**kwargs)
+        c_ = int(c2 * e)  # hidden channels
+        self.cv1 = ConvBNAct(c1, c_, 1, 1)
+        self.cv2 = ConvBNAct(c1, c_, 1, 1)
+        self.cv3 = ConvBNAct(2 * c_, c2, 1)  # optional act=FReLU(c2)
+        self.m = [
+            Bottleneck(c_, c_, shortcut, g, k=((1, 1), (3, 3)), e=1.0)
+            for _ in range(n)
+        ]
+
+    def forward(self, x):
+        """Forward pass through the CSP bottleneck with 2 convolutions."""
+        return self.cv3(
+            ops.concatenate((self.m(self.cv1(x)), self.cv2(x)), axis=1)
+        )
+
+
+class C3k(CSPBottleneck3C):
+    """C3k is a CSP bottleneck module with customizable kernel sizes for feature extraction in neural networks."""
+
+    def __init__(self, c2, n=1, shortcut=True, g=1, e=0.5, k=3, **kwargs):
+        super().__init__(c2=c2, n=1, shortcut=shortcut, g=g, e=e, k=k, **kwargs)
+        c_ = int(c2 * e)  # hidden channels
+        self.m = [Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)]
+
+    def call(self, x, training=False):
+        for m in self.m:
+            x = m(x, training=training)
+        return x
+
+
+class CSPBottleneck3CFast(layers.Layer):
+    """Faster Implementation of CSP Bottleneck with 2 convolutions."""
+
     def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5, **kwargs):
-        super(C3f, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         c_ = int(c2 * e)  # hidden channels
         self.cv1 = ConvBNAct(c_, kernel_size=1)
         self.cv2 = ConvBNAct(c_, kernel_size=1)
@@ -68,11 +107,13 @@ class C3f(layers.Layer):
         return self.cv3(layers.Concatenate(axis=-1)(y), training=training)
 
 
-class C3k2(C3f):
+class C3k2(CSPBottleneck3CFast):
+    """Faster Implementation of CSP Bottleneck with 2 convolutions."""
+
     def __init__(
         self, c1, c2, n=1, c3k=False, e=0.5, g=1, shortcut=True, **kwargs
     ):
-        super(C3k2, self).__init__(c1, c2, n, shortcut, g, e, **kwargs)
+        super().__init__(c1, c2, n, shortcut, g, e, **kwargs)
         c_ = int(c2 * e)  # hidden channels
         self.m = [
             (
@@ -82,15 +123,3 @@ class C3k2(C3f):
             )
             for _ in range(n)
         ]
-
-
-class C3k(layers.Layer):
-    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5, k=3, **kwargs):
-        super(C3k, self).__init__(**kwargs)
-        c_ = int(c2 * e)  # hidden channels
-        self.m = [Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)]
-
-    def call(self, x, training=False):
-        for m in self.m:
-            x = m(x, training=training)
-        return x

--- a/keras_hub/src/models/yolov11/yolov11_layers.py
+++ b/keras_hub/src/models/yolov11/yolov11_layers.py
@@ -1,3 +1,4 @@
+from keras import Sequential
 from keras import layers
 from keras import ops
 
@@ -10,29 +11,36 @@ class ConvBNAct(layers.Layer):
         stride=1,
         padding="same",
         activation="swish",
+        apply_act=True,
+        groups=1,
         **kwargs
     ):
-        super(ConvBNAct, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.conv = layers.Conv2D(
             out_channels,
             kernel_size,
             strides=stride,
             padding=padding,
             use_bias=False,
+            groups=groups,
         )
         self.bn = layers.BatchNormalization(epsilon=0.001, momentum=0.03)
         self.act = layers.Activation(activation)
+        self.apply_act = apply_act
 
     def call(self, inputs, training=False):
         x = self.conv(inputs)
         x = self.bn(x, training=training)
-        return self.act(x)
+        if self.apply_act:
+            return self.act(x)
+        else:
+            return x
 
 
 class Bottleneck(layers.Layer):
     """Standard bottleneck layer with optional shortcut connection."""
 
-    def __init__(self, c1, c2, shortcut=True, g=1, k=(3, 3), e=0.5, **kwargs):
+    def __init__(self, c2, shortcut=True, groups=1, k=(3, 3), e=0.5, **kwargs):
         super(Bottleneck, self).__init__(**kwargs)
         c_ = int(c2 * e)  # hidden channels
         # First convolution with customizable kernel size k[0]
@@ -41,14 +49,14 @@ class Bottleneck(layers.Layer):
         self.cv2 = ConvBNAct(c2, kernel_size=k[1], stride=1, activation="swish")
 
         # Determine if a residual connection (shortcut) should be added
-        self.add = shortcut and (c1 == c2)
+        self.shortcut = shortcut
 
     def call(self, x, training=False):
         out = self.cv1(x, training=training)
         out = self.cv2(out, training=training)
 
         # If shortcut is enabled, add input x to the output
-        if self.add:
+        if self.shortcut and (out.shape[-1] == x.shape[-1]):
             return layers.Add()([x, out])
         return out
 
@@ -56,15 +64,15 @@ class Bottleneck(layers.Layer):
 class CSPBottleneck3C(layers.Layer):
     """CSP Bottleneck with 3 convolutions."""
 
-    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5, **kwargs):
+    def __init__(self, c2, n=1, shortcut=True, groups=1, e=0.5, **kwargs):
         """Initialize the CSP Bottleneck with given channels, number, shortcut, groups, and expansion values."""
         super().__init__(**kwargs)
         c_ = int(c2 * e)  # hidden channels
-        self.cv1 = ConvBNAct(c1, c_, 1, 1)
-        self.cv2 = ConvBNAct(c1, c_, 1, 1)
-        self.cv3 = ConvBNAct(2 * c_, c2, 1)  # optional act=FReLU(c2)
+        self.cv1 = ConvBNAct(c_, 1, 1)
+        self.cv2 = ConvBNAct(c_, 1, 1)
+        self.cv3 = ConvBNAct(c2, 1)  # optional act=FReLU(c2)
         self.m = [
-            Bottleneck(c_, c_, shortcut, g, k=((1, 1), (3, 3)), e=1.0)
+            Bottleneck(c_, shortcut, groups, k=((1, 1), (3, 3)), e=1.0)
             for _ in range(n)
         ]
 
@@ -75,30 +83,16 @@ class CSPBottleneck3C(layers.Layer):
         )
 
 
-class C3k(CSPBottleneck3C):
-    """C3k is a CSP bottleneck module with customizable kernel sizes for feature extraction in neural networks."""
-
-    def __init__(self, c2, n=1, shortcut=True, g=1, e=0.5, k=3, **kwargs):
-        super().__init__(c2=c2, n=1, shortcut=shortcut, g=g, e=e, k=k, **kwargs)
-        c_ = int(c2 * e)  # hidden channels
-        self.m = [Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)]
-
-    def call(self, x, training=False):
-        for m in self.m:
-            x = m(x, training=training)
-        return x
-
-
 class CSPBottleneck3CFast(layers.Layer):
     """Faster Implementation of CSP Bottleneck with 2 convolutions."""
 
-    def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5, **kwargs):
+    def __init__(self, c2, n=1, shortcut=False, groups=1, e=0.5, **kwargs):
         super().__init__(**kwargs)
         c_ = int(c2 * e)  # hidden channels
         self.cv1 = ConvBNAct(c_, kernel_size=1)
         self.cv2 = ConvBNAct(c_, kernel_size=1)
         self.cv3 = ConvBNAct(c2, kernel_size=1)
-        self.m = [Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)]
+        self.m = [Bottleneck(c_, shortcut, groups, e=1.0) for _ in range(n)]
 
     def call(self, x, training=False):
         y = [self.cv2(x, training=training), self.cv1(x, training=training)]
@@ -107,19 +101,187 @@ class CSPBottleneck3CFast(layers.Layer):
         return self.cv3(layers.Concatenate(axis=-1)(y), training=training)
 
 
+class C3k(CSPBottleneck3C):
+    """C3k is a CSP bottleneck module with customizable kernel sizes for feature extraction in neural networks."""
+
+    def __init__(self, c2, n=1, shortcut=True, groups=1, e=0.5, k=3, **kwargs):
+        super().__init__(
+            c2=c2, n=1, shortcut=shortcut, groups=groups, e=e, **kwargs
+        )
+        c_ = int(c2 * e)  # hidden channels
+        self.m = [Bottleneck(c_, shortcut, groups, e=1.0) for _ in range(n)]
+
+    def call(self, x, training=False):
+        for m in self.m:
+            x = m(x, training=training)
+        return x
+
+
 class C3k2(CSPBottleneck3CFast):
     """Faster Implementation of CSP Bottleneck with 2 convolutions."""
 
     def __init__(
-        self, c1, c2, n=1, c3k=False, e=0.5, g=1, shortcut=True, **kwargs
+        self, c2, n=1, c3k=False, e=0.5, groups=1, shortcut=True, **kwargs
     ):
-        super().__init__(c1, c2, n, shortcut, g, e, **kwargs)
+        super().__init__(c2, n, shortcut, groups, e, **kwargs)
         c_ = int(c2 * e)  # hidden channels
         self.m = [
             (
-                C3k(c_, c_, 2, shortcut, g)
+                C3k(c_, 2, shortcut, groups)
                 if c3k
-                else Bottleneck(c_, c_, shortcut, g)
+                else Bottleneck(c_, shortcut, groups)
             )
             for _ in range(n)
         ]
+
+
+class SPPF(layers.Layer):
+    """Spatial Pyramid Pooling - Fast (SPPF) layer for YOLOv5 by Glenn Jocher."""
+
+    def __init__(self, c1, c2, k=5):
+        """
+        Initializes the SPPF layer with given input/output channels and kernel size.
+
+        This module is equivalent to SPP(k=(5, 9, 13)).
+        """
+        super().__init__()
+        c_ = c1 // 2  # hidden channels
+        self.cv1 = ConvBNAct(c_, 1, 1)
+        self.cv2 = ConvBNAct(c2, 1, 1)
+        self.m = layers.MaxPooling2D(
+            pool_size=k, strides=1, padding="same"
+        )  # padding should be k//2
+
+    def call(self, x):
+        """Forward pass through Ghost Convolution block."""
+        y = [self.cv1(x)]
+        y.extend(self.m(y[-1]) for _ in range(3))
+        return self.cv2(ops.concatenate(y, axis=1))
+
+
+class C2PSA(layers.Layer):
+    """
+    C2PSA module with attention mechanism for enhanced feature extraction and processing.
+
+    This module implements a convolutional block with attention
+    mechanisms to enhance feature extraction and processing
+    capabilities. It includes a series of PSABlock modules
+    for self-attention and feed-forward operations.
+
+    Attributes:
+        c (int): Number of hidden channels.
+        cv1 (ConvBNAct): 1x1 convolution layer to reduce the number of input channels to 2*c.
+        cv2 (ConvBNAct): 1x1 convolution layer to reduce the number of output channels to c.
+        m (keras.Sequential): Sequential container of PSABlock modules for attention and feed-forward operations.
+
+    """
+
+    def __init__(self, c, n=1, e=0.5):
+        """Initializes the C2PSA module with specified input/output channels, number of layers, and expansion ratio."""
+        super().__init__()
+        self.c = int(c * e)
+        self.cv1 = ConvBNAct(2 * self.c, 1, 1)
+        self.cv2 = ConvBNAct(c, 1)
+
+        self.m = Sequential(
+            [
+                PSABlock(self.c, attn_ratio=0.5, num_heads=self.c // 64)
+                for _ in range(n)
+            ]
+        )
+
+    def call(self, x):
+        """Processes the input tensor 'x' through a series of PSA blocks and returns the transformed tensor."""
+        a, b = ops.split(self.cv1(x), indices_or_sections=(self.c), axis=1)
+        b = self.m(b)
+        return self.cv2(ops.concatenate((a, b), axis=1))
+
+
+class PSABlock(layers.Layer):
+    """
+    PSABlock class implementing a Position-Sensitive Attention block for neural networks.
+
+    This class encapsulates the functionality for applying multi-head
+    attention and feed-forward neural network layers
+    with optional shortcut connections.
+
+    Attributes:
+    """
+
+    def __init__(self, c, attn_ratio=0.5, num_heads=4, shortcut=True) -> None:
+        """Initializes the PSABlock with attention and feed-forward layers for enhanced feature extraction."""
+        super().__init__()
+
+        self.attn = Attention(c, attn_ratio=attn_ratio, num_heads=num_heads)
+        self.ffn = Sequential(
+            [ConvBNAct(c * 2, 1), ConvBNAct(c, 1, apply_act=False)]
+        )
+        self.add = shortcut
+
+    def call(self, x):
+        """Executes a forward pass through PSABlock, applying attention and feed-forward layers to the input tensor."""
+        x = x + self.attn(x) if self.add else self.attn(x)
+        x = x + self.ffn(x) if self.add else self.ffn(x)
+        return x
+
+
+class Attention(layers.Layer):
+    """
+    Attention module that performs self-attention on the input tensor.
+
+    Args:
+        dim (int): The input tensor dimension.
+        num_heads (int): The number of attention heads.
+        attn_ratio (float): The ratio of the attention key dimension to the head dimension.
+
+    Attributes:
+        num_heads (int): The number of attention heads.
+        head_dim (int): The dimension of each attention head.
+        key_dim (int): The dimension of the attention key.
+        scale (float): The scaling factor for the attention scores.
+        qkv (ConvBNAct): Convolutional layer for computing the query, key, and value.
+        proj (ConvBNAct): Convolutional layer for projecting the attended values.
+        pe (ConvBNAct): Convolutional layer for positional encoding.
+    """
+
+    def __init__(self, dim, num_heads=8, attn_ratio=0.5):
+        """Initializes multi-head attention module with query, key, and value convolutions and positional encoding."""
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.key_dim = int(self.head_dim * attn_ratio)
+        self.scale = self.key_dim**-0.5
+        nh_kd = self.key_dim * num_heads
+        h = dim + nh_kd * 2
+        self.qkv = ConvBNAct(h, 1, apply_act=False)
+        self.proj = ConvBNAct(dim, 1, apply_act=False)
+        self.pe = ConvBNAct(dim, 3, 1, groups=dim, apply_act=False)
+
+    def call(self, x):
+        """
+        Forward pass of the Attention module.
+
+        Args:
+            x: KerasTensor. The input tensor.
+
+        Returns:
+            KerasTensor. The output tensor after self-attention.
+        """
+        B, C, H, W = x.shape
+        N = H * W
+        qkv = self.qkv(x)
+
+        qkv = ops.reshape(
+            B, self.num_heads, self.key_dim * 2 + self.head_dim, N
+        )
+        q, k, v = ops.split(
+            qkv, [self.key_dim, self.key_dim, self.head_dim], axis=2
+        )
+
+        attn = (ops.transpose(q, (0, 1, 3, 2)) @ k) * self.scale
+        attn = ops.softmax(attn, axis=-1)
+        x = v @ ops.transpose(attn, (0, 1, 3, 2))
+        x = ops.reshape(x, (B, C, H, W))
+        x = x + self.pe(ops.reshape(v, (B, C, H, W)))
+        x = self.proj(x)
+        return x

--- a/keras_hub/src/models/yolov11/yolov11_layers.py
+++ b/keras_hub/src/models/yolov11/yolov11_layers.py
@@ -274,7 +274,7 @@ class YOLOAttention(layers.Layer):
         Returns:
             KerasTensor. The output tensor after self-attention.
         """
-        B, H, W, _ = ops.shape(x)
+        B, H, W, C = ops.shape(x)
         N = H * W
         qkv = self.qkv(x)
 
@@ -287,5 +287,6 @@ class YOLOAttention(layers.Layer):
         attn = ops.softmax(attn, axis=-1)
         x = v @ ops.transpose(attn, (0, 1, 3, 2))
         x = x + self.pe(v)
+        x = ops.reshape(x, (B, H, W, C))
         x = self.proj(x)
         return x

--- a/keras_hub/src/models/yolov11/yolov11_layers.py
+++ b/keras_hub/src/models/yolov11/yolov11_layers.py
@@ -1,0 +1,96 @@
+from keras import layers
+
+
+class ConvBNAct(layers.Layer):
+    def __init__(
+        self,
+        out_channels,
+        kernel_size,
+        stride=1,
+        padding="same",
+        activation="swish",
+        **kwargs
+    ):
+        super(ConvBNAct, self).__init__(**kwargs)
+        self.conv = layers.Conv2D(
+            out_channels,
+            kernel_size,
+            strides=stride,
+            padding=padding,
+            use_bias=False,
+        )
+        self.bn = layers.BatchNormalization(epsilon=0.001, momentum=0.03)
+        self.act = layers.Activation(activation)
+
+    def call(self, inputs, training=False):
+        x = self.conv(inputs)
+        x = self.bn(x, training=training)
+        return self.act(x)
+
+
+class Bottleneck(layers.Layer):
+    """Standard bottleneck layer with optional shortcut connection."""
+
+    def __init__(self, c1, c2, shortcut=True, g=1, k=(3, 3), e=0.5, **kwargs):
+        super(Bottleneck, self).__init__(**kwargs)
+        c_ = int(c2 * e)  # hidden channels
+        # First convolution with customizable kernel size k[0]
+        self.cv1 = ConvBNAct(c_, kernel_size=k[0], stride=1, activation="swish")
+        # Second convolution with customizable kernel size k[1] and optional groups for grouped convolution
+        self.cv2 = ConvBNAct(c2, kernel_size=k[1], stride=1, activation="swish")
+
+        # Determine if a residual connection (shortcut) should be added
+        self.add = shortcut and (c1 == c2)
+
+    def call(self, x, training=False):
+        out = self.cv1(x, training=training)
+        out = self.cv2(out, training=training)
+
+        # If shortcut is enabled, add input x to the output
+        if self.add:
+            return layers.Add()([x, out])
+        return out
+
+
+class C3f(layers.Layer):
+    def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5, **kwargs):
+        super(C3f, self).__init__(**kwargs)
+        c_ = int(c2 * e)  # hidden channels
+        self.cv1 = ConvBNAct(c_, kernel_size=1)
+        self.cv2 = ConvBNAct(c_, kernel_size=1)
+        self.cv3 = ConvBNAct(c2, kernel_size=1)
+        self.m = [Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)]
+
+    def call(self, x, training=False):
+        y = [self.cv2(x, training=training), self.cv1(x, training=training)]
+        for m in self.m:
+            y.append(m(y[-1], training=training))
+        return self.cv3(layers.Concatenate(axis=-1)(y), training=training)
+
+
+class C3k2(C3f):
+    def __init__(
+        self, c1, c2, n=1, c3k=False, e=0.5, g=1, shortcut=True, **kwargs
+    ):
+        super(C3k2, self).__init__(c1, c2, n, shortcut, g, e, **kwargs)
+        c_ = int(c2 * e)  # hidden channels
+        self.m = [
+            (
+                C3k(c_, c_, 2, shortcut, g)
+                if c3k
+                else Bottleneck(c_, c_, shortcut, g)
+            )
+            for _ in range(n)
+        ]
+
+
+class C3k(layers.Layer):
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5, k=3, **kwargs):
+        super(C3k, self).__init__(**kwargs)
+        c_ = int(c2 * e)  # hidden channels
+        self.m = [Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)]
+
+    def call(self, x, training=False):
+        for m in self.m:
+            x = m(x, training=training)
+        return x


### PR DESCRIPTION
Draft PR for transparency.

### Done

- [x] Basic components
- [x] CIoU Loss
- [x] ImageObjectDetector Task
- [x] ImageObjectDetectorPreprocessor  

### Planned

- [] YOLOv11 Architecture
- [] Object detection workflow
- [] Weight conversion script
- [] Utils for bounding boxes
- [] Presets (n...xl)

### Out of Scope

- Instance segmentation
- Pose estimation
- Oriented Object Detection (i.e. rotated bounding boxes)

These will be exported as separate tasks (i.e. `ImagePoseEstimator`, `ImageInstanceSegmentor`, their respective preprocessors, etc.) in separate PRs.

### API Considerations

There will be lots of reusability between YOLOv11 OD, YOLOv11 Pose, etc. Some functions such as the non-max-supression can be wrapped into generic public layers and reused between object detectors. We could benefit from refactoring these into general utils in KerasHub (currently, they belong to models, such as in the case of RetinaNet).

Some YOLO models are consistent with the same architecture but rely on a different config. Enabling v11 will enable v8 as well, for example. These can be handled through presets. We could turn YOLOv11 into a generic YOLO class, which is configurable through presets and layers. This lets us support multiple versions, but also easily port and publish YOLOv{N} and subsequent versions in the future with minimal code changes (i.e. a layer or two + config).

/cc @divyashreepathihalli @mattdangerw @fchollet for API discussions and considerations.