### PR TITLE
Update docstring

### DIFF
--- a/keras_hub/src/models/whisper/whisper_audio_converter.py
+++ b/keras_hub/src/models/whisper/whisper_audio_converter.py
@@ -39,7 +39,7 @@ class WhisperAudioConverter(AudioConverter):
     audio_tensor = tf.ones((8000,), dtype="float32")
 
     # Compute the log-mel spectrogram.
-    audio_converter = keras_hub.models.WhisperAudioConverter.from_preset(
+    audio_converter = keras_hub.layers.WhisperAudioConverter.from_preset(
         "whisper_base_en",
     )
     audio_converter(audio_tensor)


### PR DESCRIPTION
AudioConverter is registered as "keras_hub.layers.WhisperAudioConverter" and not as part of models.