### PR TITLE
Add presets for CLIP and fix some minor bugs

### DIFF
--- a/keras_hub/src/models/clip/__init__.py
+++ b/keras_hub/src/models/clip/__init__.py
@@ -1,0 +1,5 @@
+from keras_hub.src.models.clip.clip_backbone import CLIPBackbone
+from keras_hub.src.models.clip.clip_presets import backbone_presets
+from keras_hub.src.utils.preset_utils import register_presets
+
+register_presets(backbone_presets, CLIPBackbone)

--- a/keras_hub/src/models/clip/clip_backbone.py
+++ b/keras_hub/src/models/clip/clip_backbone.py
@@ -19,8 +19,10 @@ class CLIPVisionPooler(layers.Layer):
     """
 
     def call(self, vision_embeddings):
-        pooled_outputs = vision_embeddings[:, 0, :]
-        return pooled_outputs
+        return vision_embeddings[:, 0, :]
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], input_shape[-1])
 
 
 class CLIPTextPooler(layers.Layer):
@@ -40,8 +42,10 @@ class CLIPTextPooler(layers.Layer):
         eos_index = ops.argmax(token_ids, axis=-1, keepdims=True)
         eos_index = ops.expand_dims(eos_index, axis=-1)
         pooled_outputs = ops.take_along_axis(text_embeddings, eos_index, axis=1)
-        pooled_outputs = ops.squeeze(pooled_outputs, axis=1)
-        return pooled_outputs
+        return ops.squeeze(pooled_outputs, axis=1)
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], input_shape[-1])
 
 
 class CLIPHead(layers.Layer):

--- a/keras_hub/src/models/clip/clip_backbone.py
+++ b/keras_hub/src/models/clip/clip_backbone.py
@@ -39,7 +39,9 @@ class CLIPTextPooler(layers.Layer):
     """
 
     def call(self, text_embeddings, token_ids):
-        eos_index = ops.argmax(token_ids, axis=-1, keepdims=True)
+        # `keepdims` is not supported in `keras<=3.1`.
+        eos_index = ops.argmax(token_ids, axis=-1)
+        eos_index = ops.expand_dims(eos_index, axis=-1)
         eos_index = ops.expand_dims(eos_index, axis=-1)
         pooled_outputs = ops.take_along_axis(text_embeddings, eos_index, axis=1)
         return ops.squeeze(pooled_outputs, axis=1)

--- a/keras_hub/src/models/clip/clip_backbone.py
+++ b/keras_hub/src/models/clip/clip_backbone.py
@@ -138,7 +138,7 @@ class CLIPBackbone(Backbone):
     }
 
     # Pretrained CLIP model.
-    model = keras_hub.models.CLIPBackbone.from_preset("clip-vit-base-patch32")
+    model = keras_hub.models.CLIPBackbone.from_preset("clip_vit_base_patch32")
     model(input_data)
 
     # Randomly initialized CLIP model with custom config.
@@ -159,8 +159,8 @@ class CLIPBackbone(Backbone):
         intermediate_dim=2048,
     )
     model = keras_hub.models.CLIPBackbone(
-        vision_encoder=50257,
-        text_encoder=12,
+        vision_encoder=vision_encoder,
+        text_encoder=text_encoder,
         projection_dim=256,
     )
     model(input_data)

--- a/keras_hub/src/models/clip/clip_backbone_test.py
+++ b/keras_hub/src/models/clip/clip_backbone_test.py
@@ -1,0 +1,54 @@
+import pytest
+from keras import ops
+
+from keras_hub.src.models.clip.clip_backbone import CLIPBackbone
+from keras_hub.src.models.clip.clip_text_encoder import CLIPTextEncoder
+from keras_hub.src.models.clip.clip_vision_encoder import CLIPVisionEncoder
+from keras_hub.src.tests.test_case import TestCase
+
+
+class CLIPBackboneTest(TestCase):
+    def setUp(self):
+        vision_encoder = CLIPVisionEncoder(
+            16, 64, 2, 2, 128, name="vision_encoder"
+        )
+        text_encoder = CLIPTextEncoder(
+            64, 64, 64, 2, 2, 128, name="text_encoder"
+        )
+        self.init_kwargs = {
+            "vision_encoder": vision_encoder,
+            "text_encoder": text_encoder,
+            "projection_dim": 64,
+        }
+        self.input_data = {
+            "images": ops.ones((2, 224, 224, 3)),
+            "token_ids": ops.ones((2, 77), dtype="int32"),
+        }
+
+    def test_backbone_basics(self):
+        self.run_backbone_test(
+            cls=CLIPBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_output_shape={
+                "vision_logits": (2, 2),
+                "text_logits": (2, 2),
+            },
+        )
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=CLIPBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )
+
+    @pytest.mark.extra_large
+    def test_all_presets(self):
+        for preset in CLIPBackbone.presets:
+            self.run_preset_test(
+                cls=CLIPBackbone,
+                preset=preset,
+                input_data=self.input_data,
+            )

--- a/keras_hub/src/models/clip/clip_encoder_block.py
+++ b/keras_hub/src/models/clip/clip_encoder_block.py
@@ -7,6 +7,33 @@ def quick_gelu(x):
     return x * ops.sigmoid(1.702 * x)
 
 
+# TODO: Deprecate this in favor of `keras.layers.MultiHeadAttention` once the
+# dtype compatibility issue is resolved.
+class CLIPMultiHeadAttention(layers.MultiHeadAttention):
+    def _compute_attention(
+        self, query, key, value, attention_mask=None, training=None
+    ):
+        query = ops.multiply(
+            query, ops.cast(self._inverse_sqrt_key_dim, query.dtype)
+        )
+        attention_scores = ops.einsum(self._dot_product_equation, key, query)
+        attention_scores = self._masked_softmax(
+            attention_scores, attention_mask
+        )
+        # Fix the dtype compatibility.
+        attention_scores = ops.cast(attention_scores, value.dtype)
+        if self.dropout:
+            final_attn_scores = self._dropout_layer(
+                attention_scores, training=training
+            )
+        else:
+            final_attn_scores = attention_scores
+        attention_output = ops.einsum(
+            self._combine_equation, final_attn_scores, value
+        )
+        return attention_output, attention_scores
+
+
 class CLIPEncoderBlock(layers.Layer):
     def __init__(
         self,
@@ -35,7 +62,7 @@ class CLIPEncoderBlock(layers.Layer):
         self.layer_norm_1 = layers.LayerNormalization(
             epsilon=1e-5, dtype=self.dtype_policy, name="layer_norm_1"
         )
-        self.attention = layers.MultiHeadAttention(
+        self.attention = CLIPMultiHeadAttention(
             num_heads,
             hidden_dim // num_heads,
             dtype=self.dtype_policy,

--- a/keras_hub/src/models/clip/clip_encoder_block.py
+++ b/keras_hub/src/models/clip/clip_encoder_block.py
@@ -33,7 +33,7 @@ class CLIPEncoderBlock(layers.Layer):
             intermediate_activation = quick_gelu
 
         self.layer_norm_1 = layers.LayerNormalization(
-            epsilon=1e-5, dtype="float32", name="layer_norm_1"
+            epsilon=1e-5, dtype=self.dtype_policy, name="layer_norm_1"
         )
         self.attention = layers.MultiHeadAttention(
             num_heads,
@@ -42,7 +42,7 @@ class CLIPEncoderBlock(layers.Layer):
             name="attention",
         )
         self.layer_norm_2 = layers.LayerNormalization(
-            epsilon=1e-5, dtype="float32", name="layer_norm_2"
+            epsilon=1e-5, dtype=self.dtype_policy, name="layer_norm_2"
         )
         self.dense_1 = layers.Dense(
             self.intermediate_dim, dtype=self.dtype_policy, name="dense_1"

--- a/keras_hub/src/models/clip/clip_presets.py
+++ b/keras_hub/src/models/clip/clip_presets.py
@@ -1,0 +1,109 @@
+"""CLIP model preset configurations."""
+
+# Metadata for loading pretrained model weights.
+backbone_presets = {
+    "clip_vit_base_patch16": {
+        "metadata": {
+            "description": (
+                "150 million parameter, 12-layer for vision and 12-layer for "
+                "text, patch size of 16, CLIP model."
+            ),
+            "params": 149620934,
+            "official_name": "CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_base_patch16/1",
+    },
+    "clip_vit_base_patch32": {
+        "metadata": {
+            "description": (
+                "151 million parameter, 12-layer for vision and 12-layer for "
+                "text, patch size of 32, CLIP model."
+            ),
+            "params": 151277363,
+            "official_name": "CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_base_patch32/1",
+    },
+    "clip_vit_large_patch14": {
+        "metadata": {
+            "description": (
+                "428 million parameter, 24-layer for vision and 12-layer for "
+                "text, patch size of 14, CLIP model."
+            ),
+            "params": 427616770,
+            "official_name": "CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_large_patch14/1",
+    },
+    "clip_vit_large_patch14_336": {
+        "metadata": {
+            "description": (
+                "428 million parameter, 24-layer for vision and 12-layer for "
+                "text, patch size of 14, image size of 336, CLIP model."
+            ),
+            "params": 427944770,
+            "official_name": "CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_large_patch14_336/1",
+    },
+    "clip_vit_b_32_laion2b_s34b_b79k": {
+        "metadata": {
+            "description": (
+                "151 million parameter, 12-layer for vision and 12-layer for "
+                "text, patch size of 32, Open CLIP model."
+            ),
+            "params": 151277363,
+            "official_name": "Open CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/mlfoundations/open_clip",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_b_32_laion2b_s34b_b79k/1",
+    },
+    "clip_vit_h_14_laion2b_s32b_b79k": {
+        "metadata": {
+            "description": (
+                "986 million parameter, 32-layer for vision and 24-layer for "
+                "text, patch size of 14, Open CLIP model."
+            ),
+            "params": 986109698,
+            "official_name": "Open CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/mlfoundations/open_clip",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_h_14_laion2b_s32b_b79k/1",
+    },
+    "clip_vit_g_14_laion2b_s12b_b42k": {
+        "metadata": {
+            "description": (
+                "1.4 billion parameter, 40-layer for vision and 24-layer for "
+                "text, patch size of 14, Open CLIP model."
+            ),
+            "params": 1366678530,
+            "official_name": "Open CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/mlfoundations/open_clip",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_g_14_laion2b_s12b_b42k/1",
+    },
+    "clip_vit_bigg_14_laion2b_39b_b160k": {
+        "metadata": {
+            "description": (
+                "2.5 billion parameter, 48-layer for vision and 32-layer for "
+                "text, patch size of 14, Open CLIP model."
+            ),
+            "params": 2539567362,
+            "official_name": "Open CLIP",
+            "path": "clip",
+            "model_card": "https://github.com/mlfoundations/open_clip",
+        },
+        "kaggle_handle": "kaggle://kerashub/clip/keras/clip_vit_bigg_14_laion2b_39b_b160k/1",
+    },
+}

--- a/keras_hub/src/models/clip/clip_text_encoder.py
+++ b/keras_hub/src/models/clip/clip_text_encoder.py
@@ -82,7 +82,7 @@ class CLIPTextEncoder(Backbone):
             for i in range(num_layers)
         ]
         self.layer_norm = layers.LayerNormalization(
-            epsilon=1e-6, dtype="float32", name=f"{prefix}layer_norm"
+            epsilon=1e-6, dtype=dtype, name=f"{prefix}layer_norm"
         )
 
         # === Functional Model ===
@@ -108,6 +108,7 @@ class CLIPTextEncoder(Backbone):
         super().__init__(
             inputs={"token_ids": token_id_input},
             outputs=outputs,
+            dtype=dtype,
             name=name,
             **kwargs,
         )

--- a/keras_hub/src/models/clip/clip_tokenizer.py
+++ b/keras_hub/src/models/clip/clip_tokenizer.py
@@ -1,4 +1,5 @@
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.clip.clip_backbone import CLIPBackbone
 from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 from keras_hub.src.tokenizers.byte_pair_tokenizer import convert_to_ragged_batch
 from keras_hub.src.tokenizers.byte_pair_tokenizer import split_strings_for_bpe
@@ -39,11 +40,25 @@ class CLIPTokenizer(BytePairTokenizer):
             should have one merge rule per line. Every merge rule contains
             merge entities separated by a space.
         pad_with_end_token: bool. Whether to pad the output with `end_token`.
+
+    Examples:
+
+    ```python
+    # Unbatched input.
+    tokenizer = keras_hub.models.CLIPTokenizer.from_preset(
+        "clip_vit_base_patch32"
+    )
+    tokenizer("The quick brown fox jumped.")
+
+    # Batched input.
+    tokenizer(["The quick brown fox jumped.", "The fox slept."])
+
+    # Detokenization.
+    tokenizer.detokenize(tokenizer("The quick brown fox jumped."))
+    ```
     """
 
-    # TODO: Add example and `backbone_cls` once we have a CLIP model.
-
-    backbone_cls = None
+    backbone_cls = CLIPBackbone
 
     def __init__(
         self,

--- a/keras_hub/src/models/clip/clip_tokenizer_test.py
+++ b/keras_hub/src/models/clip/clip_tokenizer_test.py
@@ -37,21 +37,15 @@ class CLIPTokenizerTest(TestCase):
 
     @pytest.mark.large
     def test_smallest_preset(self):
-        self.skipTest(
-            "TODO: Add preset from `hf://openai/clip-vit-large-patch14`"
-        )
         self.run_preset_test(
             cls=CLIPTokenizer,
-            preset="llama3_8b_en",
+            preset="clip_vit_base_patch16",
             input_data=["The quick brown fox."],
-            expected_output=[[791, 4062, 14198, 39935, 13]],
+            expected_output=[[51, 797, 3712, 2866, 3240, 269]],
         )
 
     @pytest.mark.extra_large
     def test_all_presets(self):
-        self.skipTest(
-            "TODO: Add preset from `hf://openai/clip-vit-large-patch14`"
-        )
         for preset in CLIPTokenizer.presets:
             self.run_preset_test(
                 cls=CLIPTokenizer,

--- a/keras_hub/src/models/clip/clip_vision_embedding.py
+++ b/keras_hub/src/models/clip/clip_vision_embedding.py
@@ -6,9 +6,15 @@ from keras_hub.src.utils.keras_utils import standardize_data_format
 
 class CLIPVisionEmbedding(layers.Layer):
     def __init__(
-        self, hidden_dim, patch_size, image_size, data_format=None, **kwargs
+        self,
+        hidden_dim,
+        patch_size,
+        image_size,
+        data_format=None,
+        dtype=None,
+        **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(dtype=dtype, **kwargs)
         self.hidden_dim = int(hidden_dim)
         self.patch_size = int(patch_size)
         self.image_size = int(image_size)
@@ -23,10 +29,11 @@ class CLIPVisionEmbedding(layers.Layer):
             strides=patch_size,
             data_format=data_format,
             use_bias=False,
+            dtype=dtype,
             name="patch_embedding",
         )
         self.position_embedding = layers.Embedding(
-            num_patches + 1, hidden_dim, name="position_embedding"
+            num_patches + 1, hidden_dim, dtype=dtype, name="position_embedding"
         )
 
     def build(self, input_shape):

--- a/keras_hub/src/models/clip/clip_vision_embedding.py
+++ b/keras_hub/src/models/clip/clip_vision_embedding.py
@@ -46,7 +46,10 @@ class CLIPVisionEmbedding(layers.Layer):
         self.position_ids = self.add_weight(
             shape=(1, self.num_positions),
             initializer="zeros",
-            dtype="int32",
+            # Let the backend determine the int dtype. For example, tf
+            # requires int64 for correct device placement, whereas jax and torch
+            # don't.
+            dtype=int,
             trainable=False,
             name="position_ids",
         )

--- a/keras_hub/src/models/clip/clip_vision_encoder.py
+++ b/keras_hub/src/models/clip/clip_vision_encoder.py
@@ -88,7 +88,7 @@ class CLIPVisionEncoder(Backbone):
             name=f"{prefix}embedding",
         )
         self.pre_layer_norm = layers.LayerNormalization(
-            epsilon=1e-5, dtype="float32", name=f"{prefix}pre_layer_norm"
+            epsilon=1e-5, dtype=dtype, name=f"{prefix}pre_layer_norm"
         )
         self.encoder_layers = [
             CLIPEncoderBlock(
@@ -103,7 +103,7 @@ class CLIPVisionEncoder(Backbone):
             for i in range(num_layers)
         ]
         self.layer_norm = layers.LayerNormalization(
-            epsilon=1e-5, dtype="float32", name=f"{prefix}layer_norm"
+            epsilon=1e-5, dtype=dtype, name=f"{prefix}layer_norm"
         )
 
         # === Functional Model ===
@@ -127,6 +127,7 @@ class CLIPVisionEncoder(Backbone):
         super().__init__(
             inputs={"images": image_input},
             outputs=outputs,
+            dtype=dtype,
             name=name,
             **kwargs,
         )

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -313,6 +313,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
         for policy in ["mixed_float16", "mixed_bfloat16", "bfloat16"]:
             policy = keras.mixed_precision.Policy(policy)
+            # Ensure we set the proper `dtype` for sublayers or submodels.
+            original_init_kwargs = init_kwargs.copy()
+            for k, v in init_kwargs.items():
+                if isinstance(v, keras.Layer):
+                    config = v.get_config()
+                    config["dtype"] = policy
+                    init_kwargs[k] = v.__class__.from_config(config)
             layer = cls(**{**init_kwargs, "dtype": policy})
             if isinstance(layer, keras.Model):
                 output_data = layer(input_data)
@@ -343,6 +350,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     continue
                 self.assertEqual(policy.compute_dtype, sublayer.compute_dtype)
                 self.assertEqual(policy.variable_dtype, sublayer.variable_dtype)
+            # Restore `init_kwargs`.
+            init_kwargs = original_init_kwargs
 
     def run_quantization_test(self, instance, cls, init_kwargs, input_data):
         def _get_supported_layers(mode):
@@ -361,6 +370,14 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     policy_map[layer.path] = keras.dtype_policies.get(
                         f"{mode}_from_float32"
                     )
+            # Ensure the correct `dtype` is set for sublayers or submodels in
+            # `init_kwargs`.
+            original_init_kwargs = init_kwargs.copy()
+            for k, v in init_kwargs.items():
+                if isinstance(v, keras.Layer):
+                    config = v.get_config()
+                    config["dtype"] = policy_map
+                    init_kwargs[k] = v.__class__.from_config(config)
             # Instantiate the layer.
             model = cls(**{**init_kwargs, "dtype": policy_map})
             # Call layer eagerly.
@@ -382,6 +399,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             # Check weights loading.
             weights = model.get_weights()
             revived_model.set_weights(weights)
+            # Restore `init_kwargs`.
+            init_kwargs = original_init_kwargs
 
     def run_model_saving_test(
         self,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -313,7 +313,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
         for policy in ["mixed_float16", "mixed_bfloat16", "bfloat16"]:
             policy = keras.mixed_precision.Policy(policy)
-            # Ensure we set the proper `dtype` for sublayers or submodels.
+            # Ensure the correct `dtype` is set for sublayers or submodels in
+            # `init_kwargs`.
             original_init_kwargs = init_kwargs.copy()
             for k, v in init_kwargs.items():
                 if isinstance(v, keras.Layer):

--- a/tools/checkpoint_conversion/convert_clip_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_clip_checkpoints.py
@@ -1,0 +1,413 @@
+"""Convert CLIP checkpoints.
+
+export KAGGLE_USERNAME=XXX
+export KAGGLE_KEY=XXX
+
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_base_patch16 --upload_uri kaggle://kerashub/clip/keras/clip_vit_base_patch16
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_base_patch32 --upload_uri kaggle://kerashub/clip/keras/clip_vit_base_patch32
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_large_patch14 --upload_uri kaggle://kerashub/clip/keras/clip_vit_large_patch14
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_large_patch14_336 --upload_uri kaggle://kerashub/clip/keras/clip_vit_large_patch14_336
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_b_32_laion2b_s34b_b79k --upload_uri kaggle://kerashub/clip/keras/clip_vit_b_32_laion2b_s34b_b79k
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_h_14_laion2b_s32b_b79k --upload_uri kaggle://kerashub/clip/keras/clip_vit_h_14_laion2b_s32b_b79k
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_g_14_laion2b_s12b_b42k --upload_uri kaggle://kerashub/clip/keras/clip_vit_g_14_laion2b_s12b_b42k
+python tools/checkpoint_conversion/convert_clip_checkpoints.py \
+    --preset clip_vit_bigg_14_laion2b_39b_b160k --upload_uri kaggle://kerashub/clip/keras/clip_vit_bigg_14_laion2b_39b_b160k
+"""
+
+import json
+import os
+import shutil
+
+import keras
+import numpy as np
+import torch
+from absl import app
+from absl import flags
+from huggingface_hub import hf_hub_download
+from PIL import Image
+from transformers import CLIPModel
+from transformers import CLIPProcessor
+
+import keras_hub
+from keras_hub.src.models.clip.clip_backbone import CLIPBackbone
+from keras_hub.src.models.clip.clip_image_converter import CLIPImageConverter
+from keras_hub.src.models.clip.clip_preprocessor import CLIPPreprocessor
+from keras_hub.src.models.clip.clip_text_encoder import CLIPTextEncoder
+from keras_hub.src.models.clip.clip_tokenizer import CLIPTokenizer
+from keras_hub.src.models.clip.clip_vision_encoder import CLIPVisionEncoder
+
+FLAGS = flags.FLAGS
+
+PRESET_MAP = {
+    "clip_vit_base_patch16": "openai/clip-vit-base-patch16",
+    "clip_vit_base_patch32": "openai/clip-vit-base-patch32",
+    "clip_vit_large_patch14": "openai/clip-vit-large-patch14",
+    "clip_vit_large_patch14_336": "openai/clip-vit-large-patch14-336",
+    "clip_vit_b_32_laion2b_s34b_b79k": "laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+    "clip_vit_h_14_laion2b_s32b_b79k": "laion/CLIP-ViT-H-14-laion2B-s32B-b79K",
+    "clip_vit_g_14_laion2b_s12b_b42k": "laion/CLIP-ViT-g-14-laion2B-s12B-b42K",
+    # "clip_vit_g_14_laion2b_s34b_b88k": "laion/CLIP-ViT-g-14-laion2B-s34B-b88K",  # No config.json
+    "clip_vit_bigg_14_laion2b_39b_b160k": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+}
+
+flags.DEFINE_string(
+    "preset",
+    None,
+    f'Must be one of {",".join(PRESET_MAP.keys())}',
+    required=True,
+)
+flags.DEFINE_string(
+    "upload_uri",
+    None,
+    'Could be "kaggle://keras/{variant}/keras/{preset}"',
+    required=False,
+)
+
+
+def convert_model(hf_model):
+    vision_encoder_config = hf_model.vision_model.config.to_dict()
+    text_encoder_config = hf_model.text_model.config.to_dict()
+    projection_dim = hf_model.config.to_dict().get("projection_dim", None)
+    if projection_dim is None:
+        assert (
+            vision_encoder_config["projection_dim"]
+            == text_encoder_config["projection_dim"]
+        )
+        projection_dim = vision_encoder_config["projection_dim"]
+    image_size = vision_encoder_config["image_size"]
+    vision_encoder = CLIPVisionEncoder(
+        patch_size=vision_encoder_config["patch_size"],
+        hidden_dim=vision_encoder_config["hidden_size"],
+        num_layers=vision_encoder_config["num_hidden_layers"],
+        num_heads=vision_encoder_config["num_attention_heads"],
+        intermediate_dim=vision_encoder_config["intermediate_size"],
+        intermediate_activation=vision_encoder_config["hidden_act"],
+        image_shape=(image_size, image_size, 3),
+    )
+    text_encoder = CLIPTextEncoder(
+        vocabulary_size=text_encoder_config["vocab_size"],
+        embedding_dim=text_encoder_config["hidden_size"],
+        hidden_dim=text_encoder_config["hidden_size"],
+        num_layers=text_encoder_config["num_hidden_layers"],
+        num_heads=text_encoder_config["num_attention_heads"],
+        intermediate_dim=text_encoder_config["intermediate_size"],
+        intermediate_activation=text_encoder_config["hidden_act"],
+        max_sequence_length=text_encoder_config["max_position_embeddings"],
+    )
+    return CLIPBackbone(
+        vision_encoder, text_encoder, projection_dim=projection_dim
+    )
+
+
+def convert_weights(keras_hub_model, hf_model):
+    # Get `state_dict` from `hf_model`.
+    state_dict = hf_model.state_dict()
+    state_dict.update(hf_model.named_buffers())  # Add buffers.
+
+    # Helper functions.
+    def port_weights(keras_variable, weight_key, hook_fn=None):
+        torch_tensor = state_dict[weight_key].cpu().numpy()
+        if hook_fn:
+            torch_tensor = hook_fn(torch_tensor, list(keras_variable.shape))
+        keras_variable.assign(torch_tensor)
+
+    def port_ln(keras_variable, weight_key):
+        port_weights(keras_variable.gamma, f"{weight_key}.weight")
+        port_weights(keras_variable.beta, f"{weight_key}.bias")
+
+    def port_dense(keras_variable, weight_key):
+        port_weights(
+            keras_variable.kernel,
+            f"{weight_key}.weight",
+            hook_fn=lambda x, _: x.T,
+        )
+        if keras_variable.bias is not None:
+            port_weights(keras_variable.bias, f"{weight_key}.bias")
+
+    def port_mha(keras_variable, weight_key, num_heads, hidden_dim):
+        # query
+        port_weights(
+            keras_variable.query_dense.kernel,
+            f"{weight_key}.q_proj.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (hidden_dim, num_heads, hidden_dim // num_heads)
+            ),
+        )
+        port_weights(
+            keras_variable.query_dense.bias,
+            f"{weight_key}.q_proj.bias",
+            hook_fn=lambda x, _: np.reshape(
+                x, (num_heads, hidden_dim // num_heads)
+            ),
+        )
+        # key
+        port_weights(
+            keras_variable.key_dense.kernel,
+            f"{weight_key}.k_proj.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (hidden_dim, num_heads, hidden_dim // num_heads)
+            ),
+        )
+        port_weights(
+            keras_variable.key_dense.bias,
+            f"{weight_key}.k_proj.bias",
+            hook_fn=lambda x, _: np.reshape(
+                x, (num_heads, hidden_dim // num_heads)
+            ),
+        )
+        # value
+        port_weights(
+            keras_variable.value_dense.kernel,
+            f"{weight_key}.v_proj.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (hidden_dim, num_heads, hidden_dim // num_heads)
+            ),
+        )
+        port_weights(
+            keras_variable.value_dense.bias,
+            f"{weight_key}.v_proj.bias",
+            hook_fn=lambda x, _: np.reshape(
+                x, (num_heads, hidden_dim // num_heads)
+            ),
+        )
+        # output
+        port_weights(
+            keras_variable.output_dense.kernel,
+            f"{weight_key}.out_proj.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (num_heads, hidden_dim // num_heads, hidden_dim)
+            ),
+        )
+        port_weights(
+            keras_variable.output_dense.bias, f"{weight_key}.out_proj.bias"
+        )
+
+    # Port vision encoder.
+    port_weights(
+        keras_hub_model.vision_encoder.embedding.patch_embedding.kernel,
+        "vision_model.embeddings.patch_embedding.weight",
+        hook_fn=lambda x, _: np.transpose(x, (2, 3, 1, 0)),
+    )
+    port_weights(
+        keras_hub_model.vision_encoder.embedding.position_embedding.embeddings,
+        "vision_model.embeddings.position_embedding.weight",
+    )
+    port_weights(
+        keras_hub_model.vision_encoder.embedding.class_embedding,
+        "vision_model.embeddings.class_embedding",
+    )
+    port_weights(
+        keras_hub_model.vision_encoder.embedding.position_ids,
+        "vision_model.embeddings.position_ids",
+    )
+    port_ln(
+        keras_hub_model.vision_encoder.pre_layer_norm,
+        "vision_model.pre_layrnorm",
+    )
+    encoder_layers = keras_hub_model.vision_encoder.encoder_layers
+    for i in range(len(encoder_layers)):
+        prefix = "vision_model.encoder.layers"
+        num_heads = encoder_layers[i].num_heads
+        hidden_dim = encoder_layers[i].hidden_dim
+        port_mha(
+            encoder_layers[i].attention,
+            f"{prefix}.{i}.self_attn",
+            num_heads,
+            hidden_dim,
+        )
+        port_ln(
+            encoder_layers[i].layer_norm_1,
+            f"{prefix}.{i}.layer_norm1",
+        )
+        port_ln(
+            encoder_layers[i].layer_norm_2,
+            f"{prefix}.{i}.layer_norm2",
+        )
+        port_dense(encoder_layers[i].dense_1, f"{prefix}.{i}.mlp.fc1")
+        port_dense(encoder_layers[i].dense_2, f"{prefix}.{i}.mlp.fc2")
+    port_ln(
+        keras_hub_model.vision_encoder.layer_norm, "vision_model.post_layernorm"
+    )
+    port_dense(keras_hub_model.vision_projection, "visual_projection")
+
+    # Port text encoder.
+    port_weights(
+        keras_hub_model.text_encoder.embedding.token_embedding._embeddings,
+        "text_model.embeddings.token_embedding.weight",
+    )
+    port_weights(
+        keras_hub_model.text_encoder.embedding.position_embedding.position_embeddings,
+        "text_model.embeddings.position_embedding.weight",
+    )
+    encoder_layers = keras_hub_model.text_encoder.encoder_layers
+    for i in range(len(encoder_layers)):
+        prefix = "text_model.encoder.layers"
+        num_heads = encoder_layers[i].num_heads
+        hidden_dim = encoder_layers[i].hidden_dim
+        port_mha(
+            encoder_layers[i].attention,
+            f"{prefix}.{i}.self_attn",
+            num_heads,
+            hidden_dim,
+        )
+        port_ln(
+            encoder_layers[i].layer_norm_1,
+            f"{prefix}.{i}.layer_norm1",
+        )
+        port_ln(
+            encoder_layers[i].layer_norm_2,
+            f"{prefix}.{i}.layer_norm2",
+        )
+        port_dense(encoder_layers[i].dense_1, f"{prefix}.{i}.mlp.fc1")
+        port_dense(encoder_layers[i].dense_2, f"{prefix}.{i}.mlp.fc2")
+    port_ln(
+        keras_hub_model.text_encoder.layer_norm, "text_model.final_layer_norm"
+    )
+    port_dense(keras_hub_model.text_projection, "text_projection")
+
+    # Port logit scale.
+    port_weights(keras_hub_model.clip_head.logit_scale, "logit_scale")
+
+
+def convert_image_converter(hf_image_processor):
+    config = hf_image_processor.to_dict()
+    image_size = (config["crop_size"]["height"], config["crop_size"]["width"])
+    std = config["image_std"]
+    mean = config["image_mean"]
+    return CLIPImageConverter(
+        image_size=image_size,
+        scale=[1.0 / 255.0 / s for s in std],
+        offset=[-m / s for m, s in zip(mean, std)],
+        interpolation="bicubic",  # CLIP defaults to bicubic resampling.
+    )
+
+
+def convert_tokenizer(hf_preset):
+    tokenizer_path = hf_hub_download(hf_preset, "tokenizer.json", token=True)
+    with open(tokenizer_path, "r") as tokenizer_file:
+        tokenizer_content = json.load(tokenizer_file)
+    vocabulary = tokenizer_content["model"]["vocab"]
+    merges = tokenizer_content["model"]["merges"]
+    return CLIPTokenizer(
+        vocabulary,
+        merges,
+        pad_with_end_token=True,
+    )
+
+
+def validate_output(
+    keras_model,
+    keras_image_converter,
+    keras_tokenizer,
+    hf_model,
+    hf_model_processor,
+):
+    file = keras.utils.get_file(
+        origin=("http://images.cocodataset.org/val2017/000000039769.jpg")
+    )
+    image = Image.open(file)
+    text = ["a photo of a cat", "a photo of a dog"]
+
+    # Preprocess with hf.
+    hf_inputs = hf_model_processor(
+        text=text,
+        images=[image, image],
+        return_tensors="pt",
+        padding="max_length",
+    )
+    hf_preprocessed = hf_inputs["pixel_values"].detach().cpu().numpy()
+
+    # Preprocess with keras.
+    images = np.expand_dims(np.array(image).astype("float32"), axis=0)
+    images = np.concatenate([images, images], axis=0)
+    images = keras_image_converter(images)
+    keras_preprocessed = keras.ops.convert_to_numpy(images)
+
+    # Call with hf. Use the keras preprocessed image so we can keep modeling
+    # and preprocessing comparisons independent.
+    hf_inputs["pixel_values"] = torch.from_numpy(
+        keras.ops.convert_to_numpy(
+            keras.ops.transpose(keras_preprocessed, (0, 3, 1, 2))
+        )
+    )
+    hf_outputs = hf_model(**hf_inputs)
+    hf_vision_logits = hf_outputs.logits_per_image.detach().cpu().numpy()
+
+    # Call with keras.
+    keras_preprocessor = CLIPPreprocessor(keras_tokenizer)
+    token_ids = keras_preprocessor(text)["token_ids"]
+    keras_outputs = keras_model.predict(
+        {"images": images, "token_ids": token_ids}, verbose=0
+    )
+    keras_vision_logits = keras.ops.convert_to_numpy(
+        keras_outputs["vision_logits"]
+    )
+
+    print("🔶 Keras output:", keras_vision_logits[0, :10])
+    print("🔶 HF output:", hf_vision_logits[0, :10])
+    modeling_diff = np.mean(np.abs(keras_vision_logits - hf_vision_logits))
+    print("🔶 Modeling difference:", modeling_diff)
+    preprocessing_diff = np.mean(
+        np.abs(keras_preprocessed - np.transpose(hf_preprocessed, (0, 2, 3, 1)))
+    )
+    print("🔶 Preprocessing difference:", preprocessing_diff)
+
+
+def main(_):
+    if FLAGS.preset not in PRESET_MAP.keys():
+        raise ValueError(
+            f"Invalid preset {FLAGS.preset}. Must be one "
+            f"of {','.join(PRESET_MAP.keys())}"
+        )
+    preset = FLAGS.preset
+    hf_preset = PRESET_MAP[preset]
+    if os.path.exists(preset):
+        shutil.rmtree(preset)
+    os.makedirs(preset)
+
+    print(f"🏃 Coverting {preset}")
+
+    # Load huggingface model.
+    hf_model = CLIPModel.from_pretrained(hf_preset)
+    hf_preprocessor = CLIPProcessor.from_pretrained(hf_preset)
+    hf_model.eval()
+
+    keras_model = convert_model(hf_model)
+    keras_image_converter = convert_image_converter(
+        hf_preprocessor.image_processor
+    )
+    keras_tokenizer = convert_tokenizer(hf_preset)
+    print("✅ KerasHub model loaded.")
+
+    convert_weights(keras_model, hf_model)
+    print("✅ Weights converted.")
+
+    validate_output(
+        keras_model,
+        keras_image_converter,
+        keras_tokenizer,
+        hf_model,
+        hf_preprocessor,
+    )
+    print("✅ Output validated.")
+
+    keras_model.save_to_preset(f"./{preset}")
+    keras_image_converter.save_to_preset(f"./{preset}")
+    keras_tokenizer.save_to_preset(f"./{preset}")
+    print(f"🏁 Preset saved to ./{preset}.")
+
+    upload_uri = FLAGS.upload_uri
+    if upload_uri:
+        keras_hub.upload_preset(uri=upload_uri, preset=f"./{preset}")
+        print(f"🏁 Preset uploaded to {upload_uri}")
+
+
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
This PR:
- Add tests for `CLIPBackbone`
- Add conversion script for CLIP
- Introduces 8 presets for CLIP from OpenAI and OpenCLIP repo
- Fixes several dtype bugs in CLIP
- Adds support for sublayer and submodel in `init_kwargs` in `run_backbone_test`

@divyashreepathihalli 

Some results (from conversion script):

|Preset|Modeling difference|
|-|-|
|clip_vit_base_patch16|0.009210587|
|clip_vit_base_patch32|0.0061130524|
|clip_vit_large_patch14|0.008178234|
|clip_vit_large_patch14_336|0.004854679|
|clip_vit_b_32_laion2b_s34b_b79k|0.02490139|
|clip_vit_h_14_laion2b_s32b_b79k|0.0014100075|
|clip_vit_g_14_laion2b_s12b_b42k|1.2397766e-05|
|clip_vit_bigg_14_laion2b_39b_b160k|1.04904175e-05|

Preprocessing difference: 0.095298484