### PR TITLE
Reduce the metadata we track per preset

### DIFF
--- a/keras_hub/src/models/albert/albert_presets.py
+++ b/keras_hub/src/models/albert/albert_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 11683584,
-            "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/albert/keras/albert_base_en_uncased/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 17683968,
-            "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/albert/keras/albert_large_en_uncased/2",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 58724864,
-            "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/albert/keras/albert_extra_large_en_uncased/2",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 222595584,
-            "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/albert/keras/albert_extra_extra_large_en_uncased/2",
     },

--- a/keras_hub/src/models/bart/bart_presets.py
+++ b/keras_hub/src/models/bart/bart_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on BookCorpus, English Wikipedia and CommonCrawl."
             ),
             "params": 139417344,
-            "official_name": "BART",
             "path": "bart",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/bart/README.md",
         },
         "kaggle_handle": "kaggle://keras/bart/keras/bart_base_en/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on BookCorpus, English Wikipedia and CommonCrawl."
             ),
             "params": 406287360,
-            "official_name": "BART",
             "path": "bart",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/bart/README.md",
         },
         "config": {
             "vocabulary_size": 50265,
@@ -43,9 +39,7 @@ backbone_presets = {
                 "summarization dataset."
             ),
             "params": 406287360,
-            "official_name": "BART",
             "path": "bart",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/bart/README.md",
         },
         "config": {
             "vocabulary_size": 50264,

--- a/keras_hub/src/models/bert/bert_presets.py
+++ b/keras_hub/src/models/bert/bert_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 4385920,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_tiny_en_uncased/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 28763648,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_small_en_uncased/2",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 41373184,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_medium_en_uncased/2",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 109482240,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_base_en_uncased/2",
     },
@@ -60,9 +52,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 108310272,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_base_en/2",
     },
@@ -72,9 +62,7 @@ backbone_presets = {
                 "12-layer BERT model. Trained on Chinese Wikipedia."
             ),
             "params": 102267648,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_base_zh/2",
     },
@@ -84,9 +72,7 @@ backbone_presets = {
                 "12-layer BERT model where case is maintained. Trained on trained on Wikipedias of 104 languages"
             ),
             "params": 177853440,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_base_multi/2",
     },
@@ -97,9 +83,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 335141888,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_large_en_uncased/2",
     },
@@ -110,9 +94,7 @@ backbone_presets = {
                 "Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 333579264,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_large_en/2",
     },
@@ -122,9 +104,7 @@ backbone_presets = {
                 "The bert_tiny_en_uncased backbone model fine-tuned on the SST-2 sentiment analysis dataset."
             ),
             "params": 4385920,
-            "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "kaggle_handle": "kaggle://keras/bert/keras/bert_tiny_en_uncased_sst2/4",
     },

--- a/keras_hub/src/models/bloom/bloom_presets.py
+++ b/keras_hub/src/models/bloom/bloom_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "trained on 45 natural languages and 12 programming languages."
             ),
             "params": 559214592,
-            "official_name": "BLOOM",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloom-560m",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloom_560m_multi/3",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "trained on 45 natural languages and 12 programming languages."
             ),
             "params": 1065314304,
-            "official_name": "BLOOM",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloom-1b1",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloom_1.1b_multi/1",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "trained on 45 natural languages and 12 programming languages."
             ),
             "params": 1722408960,
-            "official_name": "BLOOM",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloom-1b7",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloom_1.7b_multi/1",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "trained on 45 natural languages and 12 programming languages."
             ),
             "params": 3002557440,
-            "official_name": "BLOOM",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloom-3b",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloom_3b_multi/1",
     },
@@ -60,9 +52,7 @@ backbone_presets = {
                 "finetuned on crosslingual task mixture (xP3) dataset."
             ),
             "params": 559214592,
-            "official_name": "BLOOMZ",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloomz-560m",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloomz_560m_multi/1",
     },
@@ -73,9 +63,7 @@ backbone_presets = {
                 "finetuned on crosslingual task mixture (xP3) dataset."
             ),
             "params": 1065314304,
-            "official_name": "BLOOMZ",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloomz-1b1",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloomz_1.1b_multi/1",
     },
@@ -86,9 +74,7 @@ backbone_presets = {
                 "finetuned on crosslingual task mixture (xP3) dataset."
             ),
             "params": 1722408960,
-            "official_name": "BLOOMZ",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloomz-1b7",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloomz_1.7b_multi/1",
     },
@@ -99,9 +85,7 @@ backbone_presets = {
                 "finetuned on crosslingual task mixture (xP3) dataset."
             ),
             "params": 3002557440,
-            "official_name": "BLOOMZ",
             "path": "bloom",
-            "model_card": "https://huggingface.co/bigscience/bloomz-3b",
         },
         "kaggle_handle": "kaggle://keras/bloom/keras/bloomz_3b_multi/1",
     },

--- a/keras_hub/src/models/clip/clip_presets.py
+++ b/keras_hub/src/models/clip/clip_presets.py
@@ -9,9 +9,7 @@ backbone_presets = {
                 "text, patch size of 16, CLIP model."
             ),
             "params": 149620934,
-            "official_name": "CLIP",
             "path": "clip",
-            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_base_patch16/1",
     },
@@ -22,9 +20,7 @@ backbone_presets = {
                 "text, patch size of 32, CLIP model."
             ),
             "params": 151277363,
-            "official_name": "CLIP",
             "path": "clip",
-            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_base_patch32/1",
     },
@@ -35,9 +31,7 @@ backbone_presets = {
                 "text, patch size of 14, CLIP model."
             ),
             "params": 427616770,
-            "official_name": "CLIP",
             "path": "clip",
-            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_large_patch14/1",
     },
@@ -48,9 +42,7 @@ backbone_presets = {
                 "text, patch size of 14, image size of 336, CLIP model."
             ),
             "params": 427944770,
-            "official_name": "CLIP",
             "path": "clip",
-            "model_card": "https://github.com/openai/CLIP/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_large_patch14_336/1",
     },
@@ -61,9 +53,7 @@ backbone_presets = {
                 "text, patch size of 32, Open CLIP model."
             ),
             "params": 151277363,
-            "official_name": "Open CLIP",
             "path": "clip",
-            "model_card": "https://github.com/mlfoundations/open_clip",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_b_32_laion2b_s34b_b79k/1",
     },
@@ -74,9 +64,7 @@ backbone_presets = {
                 "text, patch size of 14, Open CLIP model."
             ),
             "params": 986109698,
-            "official_name": "Open CLIP",
             "path": "clip",
-            "model_card": "https://github.com/mlfoundations/open_clip",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_h_14_laion2b_s32b_b79k/1",
     },
@@ -87,9 +75,7 @@ backbone_presets = {
                 "text, patch size of 14, Open CLIP model."
             ),
             "params": 1366678530,
-            "official_name": "Open CLIP",
             "path": "clip",
-            "model_card": "https://github.com/mlfoundations/open_clip",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_g_14_laion2b_s12b_b42k/1",
     },
@@ -100,9 +86,7 @@ backbone_presets = {
                 "text, patch size of 14, Open CLIP model."
             ),
             "params": 2539567362,
-            "official_name": "Open CLIP",
             "path": "clip",
-            "model_card": "https://github.com/mlfoundations/open_clip",
         },
         "kaggle_handle": "kaggle://keras/clip/keras/clip_vit_bigg_14_laion2b_39b_b160k/1",
     },

--- a/keras_hub/src/models/deberta_v3/deberta_v3_presets.py
+++ b/keras_hub/src/models/deberta_v3/deberta_v3_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on English Wikipedia, BookCorpus and OpenWebText."
             ),
             "params": 70682112,
-            "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/deberta-v3-xsmall",
         },
         "kaggle_handle": "kaggle://keras/deberta_v3/keras/deberta_v3_extra_small_en/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on English Wikipedia, BookCorpus and OpenWebText."
             ),
             "params": 141304320,
-            "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/deberta-v3-small",
         },
         "kaggle_handle": "kaggle://keras/deberta_v3/keras/deberta_v3_small_en/2",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "Trained on English Wikipedia, BookCorpus and OpenWebText."
             ),
             "params": 183831552,
-            "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/deberta-v3-base",
         },
         "kaggle_handle": "kaggle://keras/deberta_v3/keras/deberta_v3_base_en/2",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "Trained on English Wikipedia, BookCorpus and OpenWebText."
             ),
             "params": 434012160,
-            "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/deberta-v3-large",
         },
         "kaggle_handle": "kaggle://keras/deberta_v3/keras/deberta_v3_large_en/2",
     },
@@ -60,9 +52,7 @@ backbone_presets = {
                 "Trained on the 2.5TB multilingual CC100 dataset."
             ),
             "params": 278218752,
-            "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/mdeberta-v3-base",
         },
         "kaggle_handle": "kaggle://keras/deberta_v3/keras/deberta_v3_base_multi/2",
     },

--- a/keras_hub/src/models/deeplab_v3/deeplab_v3_presets.py
+++ b/keras_hub/src/models/deeplab_v3/deeplab_v3_presets.py
@@ -9,9 +9,7 @@ backbone_presets = {
                 "which is having categorical accuracy of 90.01 and 0.63 Mean IoU."
             ),
             "params": 39190656,
-            "official_name": "DeepLabV3",
             "path": "deeplab_v3",
-            "model_card": "https://arxiv.org/abs/1802.02611",
         },
         "kaggle_handle": "kaggle://keras/deeplabv3plus/keras/deeplab_v3_plus_resnet50_pascalvoc/3",
     },

--- a/keras_hub/src/models/densenet/densenet_presets.py
+++ b/keras_hub/src/models/densenet/densenet_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 7037504,
-            "official_name": "DenseNet",
             "path": "densenet",
-            "model_card": "https://arxiv.org/abs/1608.06993",
         },
         "kaggle_handle": "kaggle://keras/densenet/keras/densenet_121_imagenet/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 12642880,
-            "official_name": "DenseNet",
             "path": "densenet",
-            "model_card": "https://arxiv.org/abs/1608.06993",
         },
         "kaggle_handle": "kaggle://keras/densenet/keras/densenet_169_imagenet/2",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 18321984,
-            "official_name": "DenseNet",
             "path": "densenet",
-            "model_card": "https://arxiv.org/abs/1608.06993",
         },
         "kaggle_handle": "kaggle://keras/densenet/keras/densenet_201_imagenet/2",
     },

--- a/keras_hub/src/models/distil_bert/distil_bert_presets.py
+++ b/keras_hub/src/models/distil_bert/distil_bert_presets.py
@@ -9,9 +9,7 @@ backbone_presets = {
                 "teacher model."
             ),
             "params": 66362880,
-            "official_name": "DistilBERT",
             "path": "distil_bert",
-            "model_card": "https://huggingface.co/distilbert-base-uncased",
         },
         "kaggle_handle": "kaggle://keras/distil_bert/keras/distil_bert_base_en_uncased/2",
     },
@@ -23,9 +21,7 @@ backbone_presets = {
                 "teacher model."
             ),
             "params": 65190912,
-            "official_name": "DistilBERT",
             "path": "distil_bert",
-            "model_card": "https://huggingface.co/distilbert-base-cased",
         },
         "kaggle_handle": "kaggle://keras/distil_bert/keras/distil_bert_base_en/2",
     },
@@ -35,9 +31,7 @@ backbone_presets = {
                 "6-layer DistilBERT model where case is maintained. Trained on Wikipedias of 104 languages"
             ),
             "params": 134734080,
-            "official_name": "DistilBERT",
             "path": "distil_bert",
-            "model_card": "https://huggingface.co/distilbert-base-multilingual-cased",
         },
         "kaggle_handle": "kaggle://keras/distil_bert/keras/distil_bert_base_multi/2",
     },

--- a/keras_hub/src/models/efficientnet/efficientnet_presets.py
+++ b/keras_hub/src/models/efficientnet/efficientnet_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "with RandAugment recipe."
             ),
             "params": 5288548,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b0_ra_imagenet/1",
     },
@@ -23,9 +21,7 @@ backbone_presets = {
                 'from timm and "ResNet Strikes Back".'
             ),
             "params": 5288548,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b0_ra4_e3600_r224_imagenet/1",
     },
@@ -35,9 +31,7 @@ backbone_presets = {
                 "EfficientNet B1 model fine-tuned on the ImageNet 1k dataset."
             ),
             "params": 7794184,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b1_ft_imagenet/1",
     },
@@ -50,9 +44,7 @@ backbone_presets = {
                 'from timm and "ResNet Strikes Back".'
             ),
             "params": 7794184,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b1_ra4_e3600_r240_imagenet/1",
     },
@@ -63,9 +55,7 @@ backbone_presets = {
                 "with RandAugment recipe."
             ),
             "params": 9109994,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b2_ra_imagenet/1",
     },
@@ -76,9 +66,7 @@ backbone_presets = {
                 "with RandAugment2 recipe."
             ),
             "params": 12233232,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b3_ra2_imagenet/1",
     },
@@ -89,9 +77,7 @@ backbone_presets = {
                 "with RandAugment2 recipe."
             ),
             "params": 19341616,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b4_ra2_imagenet/1",
     },
@@ -103,9 +89,7 @@ backbone_presets = {
                 "recipe with modifications (related to both DeiT and ConvNeXt recipes)."
             ),
             "params": 30389784,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b5_sw_imagenet/1",
     },
@@ -118,9 +102,7 @@ backbone_presets = {
                 "(related to both DeiT and ConvNeXt recipes)."
             ),
             "params": 30389784,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_b5_sw_ft_imagenet/1",
     },
@@ -131,9 +113,7 @@ backbone_presets = {
                 "dataset with RandAugment recipe."
             ),
             "params": 10589712,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_el_ra_imagenet/1",
     },
@@ -144,9 +124,7 @@ backbone_presets = {
                 "dataset with RandAugment2 recipe."
             ),
             "params": 6899496,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_em_ra2_imagenet/1",
     },
@@ -157,9 +135,7 @@ backbone_presets = {
                 "dataset with RandAugment recipe."
             ),
             "params": 5438392,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_es_ra_imagenet/1",
     },
@@ -170,9 +146,7 @@ backbone_presets = {
                 "with RandAugment recipe."
             ),
             "params": 4652008,
-            "official_name": "EfficientNet",
             "path": "efficientnet",
-            "model_card": "https://arxiv.org/abs/1905.11946",
         },
         "kaggle_handle": "kaggle://keras/efficientnet/keras/efficientnet_lite0_ra_imagenet",
     },

--- a/keras_hub/src/models/electra/electra_presets.py
+++ b/keras_hub/src/models/electra/electra_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "lowercased. Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 13548800,
-            "official_name": "ELECTRA",
             "path": "electra",
-            "model_card": "https://github.com/google-research/electra",
         },
         "kaggle_handle": "kaggle://keras/electra/keras/electra_small_discriminator_uncased_en/1",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "lowercased. Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 13548800,
-            "official_name": "ELECTRA",
             "path": "electra",
-            "model_card": "https://github.com/google-research/electra",
         },
         "kaggle_handle": "kaggle://keras/electra/keras/electra_small_generator_uncased_en/1",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "lowercased. Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 109482240,
-            "official_name": "ELECTRA",
             "path": "electra",
-            "model_card": "https://github.com/google-research/electra",
         },
         "kaggle_handle": "kaggle://keras/electra/keras/electra_base_discriminator_uncased_en/1",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "lowercased. Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 33576960,
-            "official_name": "ELECTRA",
             "path": "electra",
-            "model_card": "https://github.com/google-research/electra",
         },
         "kaggle_handle": "kaggle://keras/electra/keras/electra_base_generator_uncased_en/1",
     },
@@ -60,9 +52,7 @@ backbone_presets = {
                 "lowercased. Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 335141888,
-            "official_name": "ELECTRA",
             "path": "electra",
-            "model_card": "https://github.com/google-research/electra",
         },
         "kaggle_handle": "kaggle://keras/electra/keras/electra_large_discriminator_uncased_en/1",
     },
@@ -73,9 +63,7 @@ backbone_presets = {
                 "lowercased. Trained on English Wikipedia + BooksCorpus."
             ),
             "params": 51065344,
-            "official_name": "ELECTRA",
             "path": "electra",
-            "model_card": "https://github.com/google-research/electra",
         },
         "kaggle_handle": "kaggle://keras/electra/keras/electra_large_generator_uncased_en/1",
     },

--- a/keras_hub/src/models/f_net/f_net_presets.py
+++ b/keras_hub/src/models/f_net/f_net_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on the C4 dataset."
             ),
             "params": 82861056,
-            "official_name": "FNet",
             "path": "f_net",
-            "model_card": "https://github.com/google-research/google-research/blob/master/f_net/README.md",
         },
         "kaggle_handle": "kaggle://keras/f_net/keras/f_net_base_en/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on the C4 dataset."
             ),
             "params": 236945408,
-            "official_name": "FNet",
             "path": "f_net",
-            "model_card": "https://github.com/google-research/google-research/blob/master/f_net/README.md",
         },
         "kaggle_handle": "kaggle://keras/f_net/keras/f_net_large_en/2",
     },

--- a/keras_hub/src/models/falcon/falcon_presets.py
+++ b/keras_hub/src/models/falcon/falcon_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "350B tokens of RefinedWeb dataset."
             ),
             "params": 1311625216,
-            "official_name": "Falcon",
             "path": "falcon",
-            "model_card": "https://huggingface.co/tiiuae/falcon-rw-1b",
         },
         "kaggle_handle": "kaggle://keras/falcon/keras/falcon_refinedweb_1b_en/1",
     },

--- a/keras_hub/src/models/flux/flux_presets.py
+++ b/keras_hub/src/models/flux/flux_presets.py
@@ -7,9 +7,7 @@ presets = {
                 "A 12 billion parameter rectified flow transformer capable of generating images from text descriptions."
             ),
             "params": 124439808,
-            "official_name": "FLUX.1-schnell",
             "path": "flux",
-            "model_card": "https://github.com/black-forest-labs/flux/blob/main/model_cards/FLUX.1-schnell.md",
         },
         "kaggle_handle": "TBA",
     },

--- a/keras_hub/src/models/gemma/gemma_presets.py
+++ b/keras_hub/src/models/gemma/gemma_presets.py
@@ -6,9 +6,7 @@ backbone_presets = {
         "metadata": {
             "description": "2 billion parameter, 18-layer, base Gemma model.",
             "params": 2506172416,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma/keras/gemma_2b_en/2",
     },
@@ -18,9 +16,7 @@ backbone_presets = {
                 "2 billion parameter, 18-layer, instruction tuned Gemma model."
             ),
             "params": 2506172416,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma/keras/gemma_instruct_2b_en/2",
     },
@@ -31,9 +27,7 @@ backbone_presets = {
                 "The 1.1 update improves model quality."
             ),
             "params": 2506172416,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma/keras/gemma_1.1_instruct_2b_en/3",
     },
@@ -45,9 +39,7 @@ backbone_presets = {
                 "completion. The 1.1 update improves model quality."
             ),
             "params": 2506172416,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/codegemma",
         },
         "kaggle_handle": "kaggle://keras/codegemma/keras/code_gemma_1.1_2b_en/1",
     },
@@ -59,9 +51,7 @@ backbone_presets = {
                 "completion."
             ),
             "params": 2506172416,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/codegemma",
         },
         "kaggle_handle": "kaggle://keras/codegemma/keras/code_gemma_2b_en/1",
     },
@@ -69,9 +59,7 @@ backbone_presets = {
         "metadata": {
             "description": "7 billion parameter, 28-layer, base Gemma model.",
             "params": 8537680896,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma/keras/gemma_7b_en/2",
     },
@@ -81,9 +69,7 @@ backbone_presets = {
                 "7 billion parameter, 28-layer, instruction tuned Gemma model."
             ),
             "params": 8537680896,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma/keras/gemma_instruct_7b_en/2",
     },
@@ -94,9 +80,7 @@ backbone_presets = {
                 "The 1.1 update improves model quality."
             ),
             "params": 8537680896,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma/keras/gemma_1.1_instruct_7b_en/3",
     },
@@ -108,9 +92,7 @@ backbone_presets = {
                 "completion."
             ),
             "params": 8537680896,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/codegemma",
         },
         "kaggle_handle": "kaggle://keras/codegemma/keras/code_gemma_7b_en/1",
     },
@@ -122,9 +104,7 @@ backbone_presets = {
                 "to code."
             ),
             "params": 8537680896,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/codegemma",
         },
         "kaggle_handle": "kaggle://keras/codegemma/keras/code_gemma_instruct_7b_en/1",
     },
@@ -136,9 +116,7 @@ backbone_presets = {
                 "to code. The 1.1 update improves model quality."
             ),
             "params": 8537680896,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/codegemma",
         },
         "kaggle_handle": "kaggle://keras/codegemma/keras/code_gemma_1.1_instruct_7b_en/1",
     },
@@ -146,9 +124,7 @@ backbone_presets = {
         "metadata": {
             "description": "2 billion parameter, 26-layer, base Gemma model.",
             "params": 2614341888,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma2/keras/gemma2_2b_en/1",
     },
@@ -156,9 +132,7 @@ backbone_presets = {
         "metadata": {
             "description": "2 billion parameter, 26-layer, instruction tuned Gemma model.",
             "params": 2614341888,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma2/keras/gemma2_instruct_2b_en/1",
     },
@@ -166,9 +140,7 @@ backbone_presets = {
         "metadata": {
             "description": "9 billion parameter, 42-layer, base Gemma model.",
             "params": 9241705984,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma2/keras/gemma2_9b_en/2",
     },
@@ -176,9 +148,7 @@ backbone_presets = {
         "metadata": {
             "description": "9 billion parameter, 42-layer, instruction tuned Gemma model.",
             "params": 9241705984,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma2/keras/gemma2_instruct_9b_en/2",
     },
@@ -186,9 +156,7 @@ backbone_presets = {
         "metadata": {
             "description": "27 billion parameter, 42-layer, base Gemma model.",
             "params": 27227128320,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma2/keras/gemma2_27b_en/1",
     },
@@ -196,9 +164,7 @@ backbone_presets = {
         "metadata": {
             "description": "27 billion parameter, 42-layer, instruction tuned Gemma model.",
             "params": 27227128320,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/gemma",
         },
         "kaggle_handle": "kaggle://keras/gemma2/keras/gemma2_instruct_27b_en/1",
     },
@@ -206,9 +172,7 @@ backbone_presets = {
         "metadata": {
             "description": "2 billion parameter, 26-layer, ShieldGemma model.",
             "params": 2614341888,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/shieldgemma",
         },
         "kaggle_handle": "kaggle://google/shieldgemma/keras/shieldgemma_2b_en/1",
     },
@@ -216,9 +180,7 @@ backbone_presets = {
         "metadata": {
             "description": "9 billion parameter, 42-layer, ShieldGemma model.",
             "params": 9241705984,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/shieldgemma",
         },
         "kaggle_handle": "kaggle://google/shieldgemma/keras/shieldgemma_9b_en/1",
     },
@@ -226,9 +188,7 @@ backbone_presets = {
         "metadata": {
             "description": "27 billion parameter, 42-layer, ShieldGemma model.",
             "params": 27227128320,
-            "official_name": "Gemma",
             "path": "gemma",
-            "model_card": "https://www.kaggle.com/models/google/shieldgemma",
         },
         "kaggle_handle": "kaggle://google/shieldgemma/keras/shieldgemma_27b_en/1",
     },

--- a/keras_hub/src/models/gpt2/gpt2_presets.py
+++ b/keras_hub/src/models/gpt2/gpt2_presets.py
@@ -9,9 +9,7 @@ backbone_presets = {
                 "Trained on WebText."
             ),
             "params": 124439808,
-            "official_name": "GPT-2",
             "path": "gpt2",
-            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/gpt2/keras/gpt2_base_en/2",
     },
@@ -22,9 +20,7 @@ backbone_presets = {
                 "Trained on WebText."
             ),
             "params": 354823168,
-            "official_name": "GPT-2",
             "path": "gpt2",
-            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/gpt2/keras/gpt2_medium_en/2",
     },
@@ -35,9 +31,7 @@ backbone_presets = {
                 "Trained on WebText."
             ),
             "params": 774030080,
-            "official_name": "GPT-2",
             "path": "gpt2",
-            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/gpt2/keras/gpt2_large_en/2",
     },
@@ -48,9 +42,7 @@ backbone_presets = {
                 "Trained on WebText."
             ),
             "params": 1557611200,
-            "official_name": "GPT-2",
             "path": "gpt2",
-            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/gpt2/keras/gpt2_extra_large_en/2",
     },
@@ -61,7 +53,6 @@ backbone_presets = {
                 "Finetuned on the CNN/DailyMail summarization dataset."
             ),
             "params": 124439808,
-            "official_name": "GPT-2",
             "path": "gpt2",
         },
         "kaggle_handle": "kaggle://keras/gpt2/keras/gpt2_base_en_cnn_dailymail/2",

--- a/keras_hub/src/models/llama/llama_presets.py
+++ b/keras_hub/src/models/llama/llama_presets.py
@@ -6,9 +6,7 @@ backbone_presets = {
         "metadata": {
             "description": "7 billion parameter, 32-layer, base LLaMA 2 model.",
             "params": 6738415616,
-            "official_name": "LLaMA 2",
             "path": "llama",
-            "model_card": "https://github.com/meta-llama/llama",
         },
         "kaggle_handle": "kaggle://keras/llama2/keras/llama2_7b_en/1",
     },
@@ -19,9 +17,7 @@ backbone_presets = {
                 "activation and weights quantized to int8."
             ),
             "params": 6739839488,
-            "official_name": "LLaMA 2",
             "path": "llama",
-            "model_card": "https://github.com/meta-llama/llama",
         },
         "kaggle_handle": "kaggle://keras/llama2/keras/llama2_7b_en_int8/1",
     },
@@ -32,9 +28,7 @@ backbone_presets = {
                 "model."
             ),
             "params": 6738415616,
-            "official_name": "LLaMA 2",
             "path": "llama",
-            "model_card": "https://github.com/meta-llama/llama",
         },
         "kaggle_handle": "kaggle://keras/llama2/keras/llama2_instruct_7b_en/1",
     },
@@ -45,9 +39,7 @@ backbone_presets = {
                 "model with activation and weights quantized to int8."
             ),
             "params": 6739839488,
-            "official_name": "LLaMA 2",
             "path": "llama",
-            "model_card": "https://github.com/meta-llama/llama",
         },
         "kaggle_handle": "kaggle://keras/llama2/keras/llama2_instruct_7b_en_int8/1",
     },
@@ -58,9 +50,7 @@ backbone_presets = {
                 "model."
             ),
             "params": 6738415616,
-            "official_name": "Vicuna",
             "path": "llama",
-            "model_card": "https://github.com/lm-sys/FastChat",
         },
         "kaggle_handle": "kaggle://keras/vicuna/keras/vicuna_1.5_7b_en/1",
     },

--- a/keras_hub/src/models/llama3/llama3_presets.py
+++ b/keras_hub/src/models/llama3/llama3_presets.py
@@ -6,9 +6,7 @@ backbone_presets = {
         "metadata": {
             "description": "8 billion parameter, 32-layer, base LLaMA 3 model.",
             "params": 8030261248,
-            "official_name": "LLaMA 3",
             "path": "llama3",
-            "model_card": "https://github.com/meta-llama/llama3",
         },
         "kaggle_handle": "kaggle://keras/llama3/keras/llama3_8b_en/3",
     },
@@ -19,9 +17,7 @@ backbone_presets = {
                 "activation and weights quantized to int8."
             ),
             "params": 8031894016,
-            "official_name": "LLaMA 3",
             "path": "llama3",
-            "model_card": "https://github.com/meta-llama/llama3",
         },
         "kaggle_handle": "kaggle://keras/llama3/keras/llama3_8b_en_int8/1",
     },
@@ -32,9 +28,7 @@ backbone_presets = {
                 "model."
             ),
             "params": 8030261248,
-            "official_name": "LLaMA 3",
             "path": "llama3",
-            "model_card": "https://github.com/meta-llama/llama3",
         },
         "kaggle_handle": "kaggle://keras/llama3/keras/llama3_instruct_8b_en/3",
     },
@@ -45,9 +39,7 @@ backbone_presets = {
                 "model with activation and weights quantized to int8."
             ),
             "params": 8031894016,
-            "official_name": "LLaMA 3",
             "path": "llama3",
-            "model_card": "https://github.com/meta-llama/llama3",
         },
         "kaggle_handle": (
             "kaggle://keras/llama3/keras/llama3_instruct_8b_en_int8/1"

--- a/keras_hub/src/models/mistral/mistral_presets.py
+++ b/keras_hub/src/models/mistral/mistral_presets.py
@@ -6,9 +6,7 @@ backbone_presets = {
         "metadata": {
             "description": "Mistral 7B base model",
             "params": 7241732096,
-            "official_name": "Mistral",
             "path": "mistral",
-            "model_card": "https://github.com/mistralai/mistral-src/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/mistral/keras/mistral_7b_en/6",
     },
@@ -16,9 +14,7 @@ backbone_presets = {
         "metadata": {
             "description": "Mistral 7B instruct model",
             "params": 7241732096,
-            "official_name": "Mistral",
             "path": "mistral",
-            "model_card": "https://github.com/mistralai/mistral-src/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/mistral/keras/mistral_instruct_7b_en/6",
     },
@@ -26,9 +22,7 @@ backbone_presets = {
         "metadata": {
             "description": "Mistral 7B instruct Version 0.2 model",
             "params": 7241732096,
-            "official_name": "Mistral",
             "path": "mistral",
-            "model_card": "https://github.com/mistralai/mistral-src/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/mistral/keras/mistral_0.2_instruct_7b_en/1",
     },

--- a/keras_hub/src/models/mit/mit_presets.py
+++ b/keras_hub/src/models/mit/mit_presets.py
@@ -18,7 +18,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 8 transformer blocks."
             ),
             "params": 3321962,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b0_ade20k_512/2",
@@ -29,7 +28,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 8 transformer blocks."
             ),
             "params": 13156554,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b1_ade20k_512/2",
@@ -40,7 +38,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 16 transformer blocks."
             ),
             "params": 24201418,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b2_ade20k_512/2",
@@ -51,7 +48,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 28 transformer blocks."
             ),
             "params": 44077258,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b3_ade20k_512/2",
@@ -62,7 +58,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 41 transformer blocks."
             ),
             "params": 60847818,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b4_ade20k_512/2",
@@ -73,7 +68,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 52 transformer blocks."
             ),
             "params": 81448138,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b5_ade20k_640/2",
@@ -84,7 +78,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 8 transformer blocks."
             ),
             "params": 3321962,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b0_cityscapes_1024/2",
@@ -95,7 +88,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 8 transformer blocks."
             ),
             "params": 13156554,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b1_cityscapes_1024/2",
@@ -106,7 +98,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 16 transformer blocks."
             ),
             "params": 24201418,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b2_cityscapes_1024/2",
@@ -117,7 +108,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 28 transformer blocks."
             ),
             "params": 44077258,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b3_cityscapes_1024/2",
@@ -128,7 +118,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 41 transformer blocks."
             ),
             "params": 60847818,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b4_cityscapes_1024/2",
@@ -139,7 +128,6 @@ backbone_presets_with_weights = {
                 "MiT (MixTransformer) model with 52 transformer blocks."
             ),
             "params": 81448138,
-            "official_name": "MiT",
             "path": "mit",
         },
         "kaggle_handle": "kaggle://keras/mit/keras/mit_b5_cityscapes_1024/2",

--- a/keras_hub/src/models/opt/opt_presets.py
+++ b/keras_hub/src/models/opt/opt_presets.py
@@ -9,9 +9,7 @@ backbone_presets = {
                 "BookCorpus, CommonCrawl, Pile, and PushShift.io corpora."
             ),
             "params": 125237760,
-            "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/opt/keras/opt_125m_en/2",
     },
@@ -24,9 +22,7 @@ backbone_presets = {
                 "BookCorpus, CommonCrawl, Pile, and PushShift.io corpora."
             ),
             "params": 1315753984,
-            "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/opt/keras/opt_1.3b_en/2",
     },
@@ -37,9 +33,7 @@ backbone_presets = {
                 "BookCorpus, CommonCrawl, Pile, and PushShift.io corpora."
             ),
             "params": 2700000000,
-            "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/opt/keras/opt_2.7b_en/2",
     },
@@ -50,9 +44,7 @@ backbone_presets = {
                 "BookCorpus, CommonCrawl, Pile, and PushShift.io corpora."
             ),
             "params": 6700000000,
-            "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "kaggle_handle": "kaggle://keras/opt/keras/opt_6.7b_en/2",
     },

--- a/keras_hub/src/models/pali_gemma/pali_gemma_presets.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "image size 224, mix fine tuned, text sequence " "length is 256"
             ),
             "params": 2923335408,
-            "official_name": "PaliGemma",
             "path": "pali_gemma",
-            "model_card": "https://www.kaggle.com/models/google/paligemma",
         },
         "kaggle_handle": "kaggle://keras/paligemma/keras/pali_gemma_3b_mix_224/3",
     },
@@ -20,9 +18,7 @@ backbone_presets = {
                 "image size 448, mix fine tuned, text sequence length is 512"
             ),
             "params": 2924220144,
-            "official_name": "PaliGemma",
             "path": "pali_gemma",
-            "model_card": "https://www.kaggle.com/models/google/paligemma",
         },
         "kaggle_handle": "kaggle://keras/paligemma/keras/pali_gemma_3b_mix_448/3",
     },
@@ -32,9 +28,7 @@ backbone_presets = {
                 "image size 224, pre trained, text sequence length is 128"
             ),
             "params": 2923335408,
-            "official_name": "PaliGemma",
             "path": "pali_gemma",
-            "model_card": "https://www.kaggle.com/models/google/paligemma",
         },
         "kaggle_handle": "kaggle://keras/paligemma/keras/pali_gemma_3b_224/3",
     },
@@ -44,9 +38,7 @@ backbone_presets = {
                 "image size 448, pre trained, text sequence length is 512"
             ),
             "params": 2924220144,
-            "official_name": "PaliGemma",
             "path": "pali_gemma",
-            "model_card": "https://www.kaggle.com/models/google/paligemma",
         },
         "kaggle_handle": "kaggle://keras/paligemma/keras/pali_gemma_3b_448/3",
     },
@@ -56,9 +48,7 @@ backbone_presets = {
                 "image size 896, pre trained, text sequence length " "is 512"
             ),
             "params": 2927759088,
-            "official_name": "PaliGemma",
             "path": "pali_gemma",
-            "model_card": "https://www.kaggle.com/models/google/paligemma",
         },
         "kaggle_handle": "kaggle://keras/paligemma/keras/pali_gemma_3b_896/3",
     },

--- a/keras_hub/src/models/phi3/phi3_presets.py
+++ b/keras_hub/src/models/phi3/phi3_presets.py
@@ -12,9 +12,7 @@ backbone_presets = {
                 "reasoning-dense properties."
             ),
             "params": 3821079552,
-            "official_name": "Phi-3",
             "path": "phi3",
-            "model_card": "https://huggingface.co/microsoft/Phi-3-mini-4k-instruct",
         },
         "kaggle_handle": "kaggle://keras/phi3/keras/phi3_mini_4k_instruct_en",
     },
@@ -28,9 +26,7 @@ backbone_presets = {
                 "reasoning-dense properties."
             ),
             "params": 3821079552,
-            "official_name": "Phi-3",
             "path": "phi3",
-            "model_card": "https://huggingface.co/microsoft/Phi-3-mini-128k-instruct",
         },
         "kaggle_handle": "kaggle://keras/phi3/keras/phi3_mini_128k_instruct_en",
     },

--- a/keras_hub/src/models/resnet/resnet_presets.py
+++ b/keras_hub/src/models/resnet/resnet_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 11186112,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/2110.00476",
         },
         "kaggle_handle": "kaggle://keras/resnetv1/keras/resnet_18_imagenet/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 23561152,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/2110.00476",
         },
         "kaggle_handle": "kaggle://keras/resnetv1/keras/resnet_50_imagenet/2",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 42605504,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/2110.00476",
         },
         "kaggle_handle": "kaggle://keras/resnetv1/keras/resnet_101_imagenet/2",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 58295232,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/2110.00476",
         },
         "kaggle_handle": "kaggle://keras/resnetv1/keras/resnet_152_imagenet/2",
     },
@@ -60,9 +52,7 @@ backbone_presets = {
                 "dataset at a 224x224 resolution."
             ),
             "params": 23561152,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/2110.00476",
         },
         "kaggle_handle": "kaggle://keras/resnetv2/keras/resnet_v2_50_imagenet/2",
     },
@@ -73,9 +63,7 @@ backbone_presets = {
                 "dataset at a 224x224 resolution."
             ),
             "params": 42605504,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/2110.00476",
         },
         "kaggle_handle": "kaggle://keras/resnetv2/keras/resnet_v2_101_imagenet/2",
     },
@@ -87,9 +75,7 @@ backbone_presets = {
                 "resolution."
             ),
             "params": 11722824,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_18_imagenet",
     },
@@ -101,9 +87,7 @@ backbone_presets = {
                 "resolution."
             ),
             "params": 21838408,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_34_imagenet",
     },
@@ -115,9 +99,7 @@ backbone_presets = {
                 "resolution."
             ),
             "params": 25629512,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_50_imagenet",
     },
@@ -129,9 +111,7 @@ backbone_presets = {
                 "resolution with knowledge distillation."
             ),
             "params": 25629512,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_50_ssld_imagenet",
     },
@@ -143,9 +123,7 @@ backbone_presets = {
                 "resolution with knowledge distillation and AutoAugment."
             ),
             "params": 25629512,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_50_ssld_v2_imagenet",
     },
@@ -158,9 +136,7 @@ backbone_presets = {
                 "additional fine-tuning of the classification head."
             ),
             "params": 25629512,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_50_ssld_v2_fix_imagenet",
     },
@@ -172,9 +148,7 @@ backbone_presets = {
                 "resolution."
             ),
             "params": 44673864,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_101_imagenet",
     },
@@ -186,9 +160,7 @@ backbone_presets = {
                 "resolution with knowledge distillation."
             ),
             "params": 44673864,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_101_ssld_imagenet",
     },
@@ -200,9 +172,7 @@ backbone_presets = {
                 "resolution."
             ),
             "params": 60363592,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_152_imagenet",
     },
@@ -214,9 +184,7 @@ backbone_presets = {
                 "resolution."
             ),
             "params": 74933064,
-            "official_name": "ResNet",
             "path": "resnet",
-            "model_card": "https://arxiv.org/abs/1812.01187",
         },
         "kaggle_handle": "kaggle://keras/resnet_vd/keras/resnet_vd_200_imagenet",
     },

--- a/keras_hub/src/models/retinanet/retinanet_presets.py
+++ b/keras_hub/src/models/retinanet/retinanet_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "RetinaNet model with ResNet50 backbone fine-tuned on COCO in 800x800 resolution."
             ),
             "params": 34121239,
-            "official_name": "RetinaNet",
             "path": "retinanet",
-            "model_card": "https://www.kaggle.com/models/keras/retinanet",
         },
         "kaggle_handle": "kaggle://keras/retinanet/keras/retinanet_resnet50_fpn_coco/1",
     }

--- a/keras_hub/src/models/roberta/roberta_presets.py
+++ b/keras_hub/src/models/roberta/roberta_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on English Wikipedia, BooksCorpus, CommonCraw, and OpenWebText."
             ),
             "params": 124052736,
-            "official_name": "RoBERTa",
             "path": "roberta",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/roberta/README.md",
         },
         "kaggle_handle": "kaggle://keras/roberta/keras/roberta_base_en/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on English Wikipedia, BooksCorpus, CommonCraw, and OpenWebText."
             ),
             "params": 354307072,
-            "official_name": "RoBERTa",
             "path": "roberta",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/roberta/README.md",
         },
         "kaggle_handle": "kaggle://keras/roberta/keras/roberta_large_en/2",
     },

--- a/keras_hub/src/models/sam/sam_presets.py
+++ b/keras_hub/src/models/sam/sam_presets.py
@@ -5,9 +5,7 @@ backbone_presets = {
         "metadata": {
             "description": ("The base SAM model trained on the SA1B dataset."),
             "params": 93735728,
-            "official_name": "SAMImageSegmenter",
             "path": "sam",
-            "model_card": "https://arxiv.org/abs/2304.02643",
         },
         "kaggle_handle": "kaggle://keras/sam/keras/sam_base_sa1b/4",
     },
@@ -15,9 +13,7 @@ backbone_presets = {
         "metadata": {
             "description": ("The large SAM model trained on the SA1B dataset."),
             "params": 641090864,
-            "official_name": "SAMImageSegmenter",
             "path": "sam",
-            "model_card": "https://arxiv.org/abs/2304.02643",
         },
         "kaggle_handle": "kaggle://keras/sam/keras/sam_large_sa1b/4",
     },
@@ -25,9 +21,7 @@ backbone_presets = {
         "metadata": {
             "description": ("The huge SAM model trained on the SA1B dataset."),
             "params": 312343088,
-            "official_name": "SAMImageSegmenter",
             "path": "sam",
-            "model_card": "https://arxiv.org/abs/2304.02643",
         },
         "kaggle_handle": "kaggle://keras/sam/keras/sam_huge_sa1b/4",
     },

--- a/keras_hub/src/models/segformer/segformer_presets.py
+++ b/keras_hub/src/models/segformer/segformer_presets.py
@@ -7,7 +7,6 @@ presets = {
                 "SegFormer model with MiTB0 backbone fine-tuned on ADE20k in 512x512 resolution."
             ),
             "params": 3719027,
-            "official_name": "SegFormerB0",
             "path": "segformer_b0",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b0_ade20k_512/2",
@@ -18,7 +17,6 @@ presets = {
                 "SegFormer model with MiTB1 backbone fine-tuned on ADE20k in 512x512 resolution."
             ),
             "params": 13682643,
-            "official_name": "SegFormerB1",
             "path": "segformer_b1",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b1_ade20k_512/2",
@@ -29,7 +27,6 @@ presets = {
                 "SegFormer model with MiTB2 backbone fine-tuned on ADE20k in 512x512 resolution."
             ),
             "params": 24727507,
-            "official_name": "SegFormerB2",
             "path": "segformer_b2",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b2_ade20k_512/2",
@@ -40,7 +37,6 @@ presets = {
                 "SegFormer model with MiTB3 backbone fine-tuned on ADE20k in 512x512 resolution."
             ),
             "params": 44603347,
-            "official_name": "SegFormerB3",
             "path": "segformer_b3",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b3_ade20k_512/2",
@@ -51,7 +47,6 @@ presets = {
                 "SegFormer model with MiTB4 backbone fine-tuned on ADE20k in 512x512 resolution."
             ),
             "params": 61373907,
-            "official_name": "SegFormerB4",
             "path": "segformer_b4",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b4_ade20k_512/2",
@@ -62,7 +57,6 @@ presets = {
                 "SegFormer model with MiTB5 backbone fine-tuned on ADE20k in 640x640 resolution."
             ),
             "params": 81974227,
-            "official_name": "SegFormerB5",
             "path": "segformer_b5",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b5_ade20k_640/2",
@@ -73,7 +67,6 @@ presets = {
                 "SegFormer model with MiTB0 backbone fine-tuned on Cityscapes in 1024x1024 resolution."
             ),
             "params": 3719027,
-            "official_name": "SegFormerB0",
             "path": "segformer_b0",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b0_cityscapes_1024/2",
@@ -84,7 +77,6 @@ presets = {
                 "SegFormer model with MiTB1 backbone fine-tuned on Cityscapes in 1024x1024 resolution."
             ),
             "params": 13682643,
-            "official_name": "SegFormerB1",
             "path": "segformer_b1",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b1_ade20k_512/2",
@@ -95,7 +87,6 @@ presets = {
                 "SegFormer model with MiTB2 backbone fine-tuned on Cityscapes in 1024x1024 resolution."
             ),
             "params": 24727507,
-            "official_name": "SegFormerB2",
             "path": "segformer_b2",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b2_cityscapes_1024/2",
@@ -106,7 +97,6 @@ presets = {
                 "SegFormer model with MiTB3 backbone fine-tuned on Cityscapes in 1024x1024 resolution."
             ),
             "params": 44603347,
-            "official_name": "SegFormerB3",
             "path": "segformer_b3",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b3_cityscapes_1024/2",
@@ -117,7 +107,6 @@ presets = {
                 "SegFormer model with MiTB4 backbone fine-tuned on Cityscapes in 1024x1024 resolution."
             ),
             "params": 61373907,
-            "official_name": "SegFormerB4",
             "path": "segformer_b4",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b4_cityscapes_1024/2",
@@ -128,7 +117,6 @@ presets = {
                 "SegFormer model with MiTB5 backbone fine-tuned on Cityscapes in 1024x1024 resolution."
             ),
             "params": 81974227,
-            "official_name": "SegFormerB5",
             "path": "segformer_b5",
         },
         "kaggle_handle": "kaggle://keras/segformer/keras/segformer_b5_cityscapes_1024/2",

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_presets.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_presets.py
@@ -9,9 +9,7 @@ backbone_presets = {
                 "Developed by Stability AI."
             ),
             "params": 2987080931,
-            "official_name": "StableDiffusion3",
             "path": "stable_diffusion_3",
-            "model_card": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
         },
         "kaggle_handle": "kaggle://keras/stablediffusion3/keras/stable_diffusion_3_medium/3",
     },
@@ -23,9 +21,7 @@ backbone_presets = {
                 "Developed by Stability AI."
             ),
             "params": 9048410595,
-            "official_name": "StableDiffusion3",
             "path": "stable_diffusion_3",
-            "model_card": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
         },
         "kaggle_handle": "kaggle://keras/stablediffusion-3.5/keras/stable_diffusion_3.5_large/1",
     },
@@ -39,9 +35,7 @@ backbone_presets = {
                 "Developed by Stability AI."
             ),
             "params": 9048410595,
-            "official_name": "StableDiffusion3",
             "path": "stable_diffusion_3",
-            "model_card": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large-turbo",
         },
         "kaggle_handle": "kaggle://keras/stablediffusion-3.5/keras/stable_diffusion_3.5_large_turbo/1",
     },

--- a/keras_hub/src/models/t5/t5_presets.py
+++ b/keras_hub/src/models/t5/t5_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Corpus (C4)."
             ),
             "params": 0,
-            "official_name": "T5",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_small_multi/2",
     },
@@ -18,9 +16,7 @@ backbone_presets = {
         "metadata": {
             "description": (""),
             "params": 60511616,
-            "official_name": "T5 1.1",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_1.1_small/1",
     },
@@ -31,9 +27,7 @@ backbone_presets = {
                 "Corpus (C4)."
             ),
             "params": 0,
-            "official_name": "T5",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_base_multi/2",
     },
@@ -41,9 +35,7 @@ backbone_presets = {
         "metadata": {
             "description": (""),
             "params": 247577856,
-            "official_name": "T5 1.1",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_1.1_base/1",
     },
@@ -54,9 +46,7 @@ backbone_presets = {
                 "Corpus (C4)."
             ),
             "params": 0,
-            "official_name": "T5",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_large_multi/2",
     },
@@ -64,9 +54,7 @@ backbone_presets = {
         "metadata": {
             "description": (""),
             "params": 750251008,
-            "official_name": "T5 1.1",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_1.1_large/1",
     },
@@ -74,9 +62,7 @@ backbone_presets = {
         "metadata": {
             "description": (""),
             "params": 2849757184,
-            "official_name": "T5 1.1",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_1.1_xl/1",
     },
@@ -84,9 +70,7 @@ backbone_presets = {
         "metadata": {
             "description": (""),
             "params": 11135332352,
-            "official_name": "T5 1.1",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/t5_1.1_xxl/1",
     },
@@ -97,9 +81,7 @@ backbone_presets = {
                 "Corpus (C4)."
             ),
             "params": 0,
-            "official_name": "T5",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/flan_small_multi/2",
     },
@@ -110,9 +92,7 @@ backbone_presets = {
                 "Corpus (C4)."
             ),
             "params": 0,
-            "official_name": "T5",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/flan_base_multi/2",
     },
@@ -123,9 +103,7 @@ backbone_presets = {
                 "Corpus (C4)."
             ),
             "params": 0,
-            "official_name": "T5",
             "path": "t5",
-            "model_card": "https://github.com/google-research/text-to-text-transfer-transformer/blob/main/README.md",
         },
         "kaggle_handle": "kaggle://keras/t5/keras/flan_large_multi/2",
     },

--- a/keras_hub/src/models/vgg/vgg_presets.py
+++ b/keras_hub/src/models/vgg/vgg_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 9220480,
-            "official_name": "vgg",
             "path": "vgg",
-            "model_card": "https://arxiv.org/abs/1409.1556",
         },
         "kaggle_handle": "kaggle://keras/vgg/keras/vgg_11_imagenet/1",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 9404992,
-            "official_name": "vgg",
             "path": "vgg",
-            "model_card": "https://arxiv.org/abs/1409.1556",
         },
         "kaggle_handle": "kaggle://keras/vgg/keras/vgg_13_imagenet/1",
     },
@@ -34,9 +30,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 14714688,
-            "official_name": "vgg",
             "path": "vgg",
-            "model_card": "https://arxiv.org/abs/1409.1556",
         },
         "kaggle_handle": "kaggle://keras/vgg/keras/vgg_16_imagenet/1",
     },
@@ -47,9 +41,7 @@ backbone_presets = {
                 "at a 224x224 resolution."
             ),
             "params": 20024384,
-            "official_name": "vgg",
             "path": "vgg",
-            "model_card": "https://arxiv.org/abs/1409.1556",
         },
         "kaggle_handle": "kaggle://keras/vgg/keras/vgg_19_imagenet/1",
     },

--- a/keras_hub/src/models/whisper/whisper_presets.py
+++ b/keras_hub/src/models/whisper/whisper_presets.py
@@ -7,9 +7,7 @@ backbone_presets = {
                 "English speech data."
             ),
             "params": 37184256,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_tiny_en/3",
     },
@@ -20,9 +18,7 @@ backbone_presets = {
                 "English speech data."
             ),
             "params": 124439808,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_base_en/3",
     },
@@ -33,9 +29,7 @@ backbone_presets = {
                 "English speech data."
             ),
             "params": 241734144,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_small_en/3",
     },
@@ -46,9 +40,7 @@ backbone_presets = {
                 "English speech data."
             ),
             "params": 763856896,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_medium_en/3",
     },
@@ -59,9 +51,7 @@ backbone_presets = {
                 "multilingual speech data."
             ),
             "params": 37760640,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_tiny_multi/3",
     },
@@ -72,9 +62,7 @@ backbone_presets = {
                 "multilingual speech data."
             ),
             "params": 72593920,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_base_multi/3",
     },
@@ -85,9 +73,7 @@ backbone_presets = {
                 "multilingual speech data."
             ),
             "params": 241734912,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_small_multi/3",
     },
@@ -98,9 +84,7 @@ backbone_presets = {
                 "multilingual speech data."
             ),
             "params": 763857920,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_medium_multi/3",
     },
@@ -111,9 +95,7 @@ backbone_presets = {
                 "multilingual speech data."
             ),
             "params": 1543304960,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_large_multi/3",
     },
@@ -125,9 +107,7 @@ backbone_presets = {
                 "of `whisper_large_multi`."
             ),
             "params": 1543304960,
-            "official_name": "Whisper",
             "path": "whisper",
-            "model_card": "https://github.com/openai/whisper/blob/main/model-card.md",
         },
         "kaggle_handle": "kaggle://keras/whisper/keras/whisper_large_multi_v2/3",
     },

--- a/keras_hub/src/models/xlm_roberta/xlm_roberta_presets.py
+++ b/keras_hub/src/models/xlm_roberta/xlm_roberta_presets.py
@@ -8,9 +8,7 @@ backbone_presets = {
                 "Trained on CommonCrawl in 100 languages."
             ),
             "params": 277450752,
-            "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/xlmr/README.md",
         },
         "kaggle_handle": "kaggle://keras/xlm_roberta/keras/xlm_roberta_base_multi/2",
     },
@@ -21,9 +19,7 @@ backbone_presets = {
                 "Trained on CommonCrawl in 100 languages."
             ),
             "params": 558837760,
-            "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
-            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/xlmr/README.md",
         },
         "kaggle_handle": "kaggle://keras/xlm_roberta/keras/xlm_roberta_large_multi/2",
     },


### PR DESCRIPTION
We can grab the class name from the keras.io, and we don't need to add a model card anymore, given that our kaggle pages are now linked and act as a much better model card.