### PR TITLE
Remove einops dep

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,6 +19,3 @@ sentencepiece
 tensorflow-datasets
 safetensors
 pillow
-# Will be replaced once https://github.com/keras-team/keras/issues/20332
-# is resolved
-einops 


### PR DESCRIPTION
We shouldn't add a new dependency for just two reshape calls. We can do this the less readable way for now.