### PR TITLE
Enable Flash Attention for SD3 MMDiT

### DIFF
--- a/keras_hub/src/models/stable_diffusion_3/mmdit.py
+++ b/keras_hub/src/models/stable_diffusion_3/mmdit.py
@@ -599,10 +599,8 @@ class MMDiTBlock(layers.Layer):
 
         # Use the fast path when `ops.dot_product_attention` and flash attention
         # are available.
-        if (
-            hasattr(ops, "dot_product_attention")
-            and hasattr(keras.config, "is_flash_attention_enabled")
-            and keras.backend.backend() != "tensorflow"
+        if hasattr(ops, "dot_product_attention") and hasattr(
+            keras.config, "is_flash_attention_enabled"
         ):
             # `ops.dot_product_attention` is slower than the vanilla
             # implementation in the tensorflow backend.

--- a/keras_hub/src/models/stable_diffusion_3/mmdit.py
+++ b/keras_hub/src/models/stable_diffusion_3/mmdit.py
@@ -595,9 +595,30 @@ class MMDiTBlock(layers.Layer):
         self.context_block.build(context_shape, timestep_embedding_shape)
 
     def _compute_attention(self, query, key, value):
+        batch_size = ops.shape(query)[0]
+
+        # Use the fast path when `ops.dot_product_attention` and flash attention
+        # are available.
+        if (
+            hasattr(ops, "dot_product_attention")
+            and hasattr(keras.config, "is_flash_attention_enabled")
+            and keras.backend.backend() != "tensorflow"
+        ):
+            # `ops.dot_product_attention` is slower than the vanilla
+            # implementation in the tensorflow backend.
+            encoded = ops.dot_product_attention(
+                query,
+                key,
+                value,
+                scale=self._inverse_sqrt_key_dim,
+                flash_attention=keras.config.is_flash_attention_enabled(),
+            )
+            return ops.reshape(
+                encoded, (batch_size, -1, self.num_heads * self.head_dim)
+            )
+
         # Ref: jax.nn.dot_product_attention
         # https://github.com/jax-ml/jax/blob/db89c245ac66911c98f265a05956fdfa4bc79d83/jax/_src/nn/functions.py#L846
-        batch_size = ops.shape(query)[0]
         logits = ops.einsum("BTNH,BSNH->BNTS", query, key)
         logits = ops.multiply(logits, self._inverse_sqrt_key_dim)
         probs = self.softmax(logits)


### PR DESCRIPTION
This PR utilizes `ops.dot_product_attention` to accelerate inference in SD3

- 800x800
- SD3 medium
- float16

|Backend|Flash Attention|Cost Time|Improvement|
|-|-|-|-|
|jax|❌|10.61s||
|jax|✅|5.45s|-48.7%|
|torch|❌|24.10s||
|torch|✅|18.43s|-23.6%|

I noticed that `ops.dot_product_attention` performed slower than the vanilla impl in the tensorflow backend. Therefore, this optimization path is skipped for it.
(vanilla: 10.55s vs. `ops.dot_product_attention`: 14.33s)

EDITED:
jax now runs faster than `diffusers` in an out-of-box manner:
`diffusers.StableDiffusion3Pipeline`: 6.15s

The benchmark script (KerasHub):

```python
import time

from keras_hub.src.models.stable_diffusion_3.stable_diffusion_3_text_to_image import (
    StableDiffusion3TextToImage,
)

height, width = 800, 800
preset = "stable_diffusion_3_medium"
num_steps = 28
guidance_scale = 7.0
dtype = "float16"
prompt = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
prompt = [prompt]
text_to_image = StableDiffusion3TextToImage.from_preset(
    preset,
    image_shape=(height, width, 3),
    dtype=dtype,
)

for _ in range(1):
    _ = text_to_image.generate(
        prompt, num_steps=num_steps, guidance_scale=guidance_scale
    )
print("Finish warmup.")

st = time.time()
images = text_to_image.generate(
    prompt, num_steps=num_steps, guidance_scale=guidance_scale
)
ed = time.time()
print(f"Cost time: {ed-st:.2f}s")

```

The benchmark script (`diffusers`):

```python
import time

import torch
from diffusers import StableDiffusion3Pipeline

pipe = StableDiffusion3Pipeline.from_pretrained(
    "stabilityai/stable-diffusion-3-medium-diffusers",
    text_encoder_3=None,
    tokenizer_3=None,
    torch_dtype=torch.float16,
)
pipe = pipe.to("cuda")
height, width = 800, 800
prompt = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"

image = pipe(
    prompt,
    negative_prompt="",
    num_inference_steps=28,
    guidance_scale=7.0,
    height=height,
    width=width,
).images[0]
print("Finish warmup.")

st = time.time()
image = pipe(
    prompt,
    negative_prompt="",
    num_inference_steps=28,
    guidance_scale=7.0,
    height=height,
    width=width,
).images[0]
print(time.time() - st)

```