### PR TITLE
Try requiring a miniumum version of keras

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
         version: [keras-stable]
         include:
           - backend: jax
-            version: keras-3.1
+            version: keras-3.4
           - backend: jax
             version: keras-nightly
     runs-on: ubuntu-latest
@@ -48,11 +48,11 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
-    - name: Pin Keras 3.1
-      if: ${{ matrix.version == 'keras-3.1'}}
+    - name: Pin Keras 3.4
+      if: ${{ matrix.version == 'keras-3.4'}}
       run: |
         pip uninstall -y keras
-        pip install keras==3.1.0 --progress-bar off
+        pip install keras==3.4.1 --progress-bar off
     - name: Pin Keras Nightly
       if: ${{ matrix.version == 'keras-nightly'}}
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
         version: [keras-stable]
         include:
           - backend: jax
-            version: keras-3.4
+            version: keras-3.5
           - backend: jax
             version: keras-nightly
     runs-on: ubuntu-latest
@@ -48,11 +48,11 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
-    - name: Pin Keras 3.4
-      if: ${{ matrix.version == 'keras-3.4'}}
+    - name: Pin Keras 3.5
+      if: ${{ matrix.version == 'keras-3.5'}}
       run: |
         pip uninstall -y keras
-        pip install keras==3.4.1 --progress-bar off
+        pip install keras==3.5.0 --progress-bar off
     - name: Pin Keras Nightly
       if: ${{ matrix.version == 'keras-nightly'}}
       run: |

--- a/keras_hub/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding_test.py
@@ -10,7 +10,6 @@ from keras_hub.src.layers.modeling.reversible_embedding import (
     ReversibleEmbedding,
 )
 from keras_hub.src.tests.test_case import TestCase
-from keras_hub.src.utils.keras_utils import has_quantization_support
 
 
 class ReversibleEmbeddingTest(TestCase):
@@ -97,9 +96,6 @@ class ReversibleEmbeddingTest(TestCase):
         ("tie_weights", True), ("untie_weights", False)
     )
     def test_quantize_int8(self, tie_weights):
-        if not has_quantization_support():
-            self.skipTest("This version of Keras doesn't support quantization.")
-
         layer_config = dict(
             input_dim=100, output_dim=32, tie_weights=tie_weights
         )
@@ -148,9 +144,6 @@ class ReversibleEmbeddingTest(TestCase):
         ("untie_weights", False),
     )
     def test_quantize_dtype_argument(self, tie_weights):
-        if not has_quantization_support():
-            self.skipTest("This version of Keras doesn't support quantization.")
-
         self.run_layer_test(
             cls=ReversibleEmbedding,
             init_kwargs={

--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -1,7 +1,6 @@
 import keras
 
 from keras_hub.src.api_export import keras_hub_export
-from keras_hub.src.utils.keras_utils import assert_quantization_support
 from keras_hub.src.utils.preset_utils import builtin_presets
 from keras_hub.src.utils.preset_utils import get_preset_loader
 from keras_hub.src.utils.preset_utils import get_preset_saver
@@ -82,10 +81,6 @@ class Backbone(keras.Model):
     @token_embedding.setter
     def token_embedding(self, value):
         self._token_embedding = value
-
-    def quantize(self, mode, **kwargs):
-        assert_quantization_support()
-        return super().quantize(mode, **kwargs)
 
     def get_config(self):
         # Don't chain to super here. `get_config()` for functional models is

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -15,7 +15,6 @@ from keras_hub.src.layers.modeling.reversible_embedding import (
 )
 from keras_hub.src.models.retinanet.feature_pyramid import FeaturePyramid
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
-from keras_hub.src.utils.keras_utils import has_quantization_support
 from keras_hub.src.utils.tensor_utils import is_float_dtype
 
 
@@ -487,7 +486,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             self.run_precision_test(cls, init_kwargs, input_data)
 
         # Check quantization.
-        if run_quantization_check and has_quantization_support():
+        if run_quantization_check:
             self.run_quantization_test(backbone, cls, init_kwargs, input_data)
 
     def run_vision_backbone_test(

--- a/keras_hub/src/utils/keras_utils.py
+++ b/keras_hub/src/utils/keras_utils.py
@@ -2,7 +2,6 @@ import sys
 
 import keras
 from absl import logging
-from packaging.version import parse
 
 try:
     import tensorflow as tf
@@ -39,18 +38,6 @@ def print_msg(message, line_break=True):
 @keras.saving.register_keras_serializable(package="keras_hub")
 def gelu_approximate(x):
     return keras.activations.gelu(x, approximate=True)
-
-
-def has_quantization_support():
-    return False if parse(keras.version()) < parse("3.4.0") else True
-
-
-def assert_quantization_support():
-    if not has_quantization_support():
-        raise ValueError(
-            "Quantization API requires Keras >= 3.4.0 to function "
-            f"correctly. Received: '{keras.version()}'"
-        )
 
 
 def standardize_data_format(data_format):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     author_email="keras-hub@google.com",
     license="Apache License 2.0",
     install_requires=[
-        "keras>=3.4.1",
+        "keras>=3.5",
         "absl-py",
         "numpy",
         "packaging",

--- a/setup.py
+++ b/setup.py
@@ -38,17 +38,14 @@ setup(
     author_email="keras-hub@google.com",
     license="Apache License 2.0",
     install_requires=[
+        "keras>=3.4.1",
         "absl-py",
         "numpy",
         "packaging",
         "regex",
         "rich",
         "kagglehub",
-        # Don't require tensorflow-text on MacOS, there are no binaries for ARM.
-        # Also, we rely on tensorflow *transitively* through tensorflow-text.
-        # This avoid a slowdown during `pip install keras-hub` where pip would
-        # download many version of both libraries to find compatible versions.
-        "tensorflow-text; platform_system != 'Darwin'",
+        "tensorflow-text",
     ],
     extras_require={
         "extras": [


### PR DESCRIPTION
We now have a few reasons to need a min version of Keras:
1) Save model compat with with dtype changes (see https://github.com/keras-team/keras-hub/pull/2026#issuecomment-2560234273).
2) Quantization support.

This list will only grow, so I think the time has come to require a min version of Keras. All our current Keras workaround are solved by keras>3.5. Keras 3.5 has been out since august and is default in colab, let's try requiring it.