### PR TITLE
Fix `sequence_length` option in `CLIPTokenizer`

### DIFF
--- a/keras_hub/src/models/clip/clip_preprocessor.py
+++ b/keras_hub/src/models/clip/clip_preprocessor.py
@@ -83,7 +83,6 @@ class CLIPPreprocessor(Preprocessor):
             end_value=self.tokenizer.end_token_id,
             pad_value=self.tokenizer.pad_token_id,
             sequence_length=self.sequence_length,
-            return_padding_mask=True,
         )
         self.built = True
 
@@ -98,11 +97,16 @@ class CLIPPreprocessor(Preprocessor):
         sequence_length = sequence_length or self.sequence_length
         if self.to_lower:
             x = tf.strings.lower(x)
-        token_ids, padding_mask = self.packer(
+        token_ids = self.packer(
             self.tokenizer(x),
             sequence_length=sequence_length,
             add_start_value=self.add_start_token,
             add_end_value=self.add_end_token,
+        )
+        padding_mask = tf.where(
+            tf.not_equal(token_ids, self.tokenizer.pad_token_id),
+            tf.ones_like(token_ids, dtype="bool"),
+            tf.zeros_like(token_ids, dtype="bool"),
         )
         x = {
             "token_ids": token_ids,

--- a/keras_hub/src/models/clip/clip_preprocessor_test.py
+++ b/keras_hub/src/models/clip/clip_preprocessor_test.py
@@ -48,6 +48,16 @@ class CLIPPreprocessorTest(TestCase):
         x = preprocessor(input_data, sequence_length=5)
         self.assertAllEqual(x["token_ids"], [5, 1, 2, 1, 4])
 
+    def test_tokenizer_sequence_length(self):
+        init_kwargs = self.init_kwargs.copy()
+        init_kwargs["tokenizer"].sequence_length = 5
+        init_kwargs["add_end_token"] = False
+        input_data = "airplane"
+        preprocessor = CLIPPreprocessor(**init_kwargs)
+        x = preprocessor(input_data, sequence_length=5)
+        self.assertAllEqual(x["token_ids"], [5, 1, 2, 0, 0])
+        self.assertAllEqual(x["padding_mask"], [1, 1, 1, 0, 0])
+
     @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large
     def test_all_presets(self):

--- a/keras_hub/src/models/clip/clip_tokenizer.py
+++ b/keras_hub/src/models/clip/clip_tokenizer.py
@@ -161,7 +161,9 @@ class CLIPTokenizer(BytePairTokenizer):
         if self.sequence_length:
             output_shape = tokens.shape.as_list()
             output_shape[-1] = self.sequence_length
-            tokens = tokens.to_tensor(shape=output_shape)
+            tokens = tokens.to_tensor(
+                default_value=self.pad_token_id, shape=output_shape
+            )
 
         # Convert to a dense output if input in scalar
         if unbatched:

--- a/keras_hub/src/models/clip/clip_tokenizer_test.py
+++ b/keras_hub/src/models/clip/clip_tokenizer_test.py
@@ -31,6 +31,13 @@ class CLIPTokenizerTest(TestCase):
         tokenizer = CLIPTokenizer(**init_kwargs)
         self.assertEqual(tokenizer.pad_token_id, tokenizer.end_token_id)
 
+    def test_sequence_length(self):
+        init_kwargs = self.init_kwargs.copy()
+        init_kwargs["pad_with_end_token"] = True
+        init_kwargs["sequence_length"] = 4
+        tokenizer = CLIPTokenizer(**init_kwargs)
+        self.assertAllClose(tokenizer("airplane"), [0, 1, 3, 3])
+
     def test_errors_missing_special_tokens(self):
         with self.assertRaises(ValueError):
             CLIPTokenizer(vocabulary={"foo": 0, "bar": 1}, merges=["fo o"])


### PR DESCRIPTION
Fix #2018 

There is a bug in `CLIPTokenizer` where specifying `sequence_length` causes it to incorrectly use `tf.RaggedTensor.to_tensor` for padding, instead of `self.pad_token_id`.
Additionally, we need to compute `padding_mask` manually rather than relying on `tf.RaggedTensor.to_tensor` for the same reason.

This PR resolves the issue.