### PR TITLE
Add download support for modelscople.

### DIFF
--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -27,11 +27,12 @@ except ImportError:
 KAGGLE_PREFIX = "kaggle://"
 GS_PREFIX = "gs://"
 HF_PREFIX = "hf://"
+MODELSCOPE_PREFIX = "modelscope://"
 
 KAGGLE_SCHEME = "kaggle"
 GS_SCHEME = "gs"
 HF_SCHEME = "hf"
-
+MODELSCOPE_SCHEME = "modelscope"
 ASSET_DIR = "assets"
 TOKENIZER_ASSET_DIR = f"{ASSET_DIR}/tokenizer"
 
@@ -165,6 +166,39 @@ def get_file(preset, path):
                 raise ValueError(message)
     elif scheme in tf_registered_schemes():
         return tf_copy_gfile_to_cache(preset, path)
+    elif scheme == MODELSCOPE_SCHEME:
+        try:
+            from modelscope.hub.snapshot_download import snapshot_download
+        except:
+            raise ImportError(
+                "`from_preset()` requires the `modelscope` package to "
+                "load from '{preset}'. "
+                "Please install with `pip install modelscope`."
+            )
+        modelscope_handle = preset.removeprefix(MODELSCOPE_SCHEME + "://")
+        try:
+            return_path =  snapshot_download(
+                modelscope_handle
+            )+'/'+path
+            if os.path.exists(return_path):
+                return return_path
+            raise FileNotFoundError(
+                    f"`{return_path}` doesn't exist in preset directory `{preset}`."
+                )
+        except HFValidationError as e:
+            raise ValueError(
+                "Unexpected ModelScope preset. Hugging Face model handles "
+                "should have the form 'modelscope://{org}/{model}'. For example, "
+                f"'modelscope://username/bert_base_en'. Received: preset={preset}."
+            ) from e
+        except EntryNotFoundError as e:
+            message = str(e)
+            if message.find("403 Client Error"):
+                raise FileNotFoundError(
+                    f"`{path}` doesn't exist in preset directory `{preset}`."
+                )
+            else:
+                raise ValueError(message)
     elif scheme == HF_SCHEME:
         if huggingface_hub is None:
             raise ImportError(

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -185,7 +185,7 @@ def get_file(preset, path):
             raise FileNotFoundError(
                     f"`{return_path}` doesn't exist in preset directory `{preset}`."
                 )
-        except HFValidationError as e:
+        except ValueError as e:
             raise ValueError(
                 "Unexpected ModelScope preset. Hugging Face model handles "
                 "should have the form 'modelscope://{org}/{model}'. For example, "

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -169,32 +169,31 @@ def get_file(preset, path):
     elif scheme == MODELSCOPE_SCHEME:
         try:
             from modelscope.hub.snapshot_download import snapshot_download
-        except:
+        except ImportError:
             raise ImportError(
-                "To load a preset from ModelScope {preset} using from_preset, install the "
-                "modelscope package with: pip install modelscope."
+                "To load a preset from ModelScope {preset} using from_preset,"
+                "install the modelscope package with: pip install modelscope."
             )
         modelscope_handle = preset.removeprefix(MODELSCOPE_SCHEME + "://")
         try:
-            return_path =  snapshot_download(
-                modelscope_handle
-            )+'/'+path
+            return_path = snapshot_download(modelscope_handle) + "/" + path
             if os.path.exists(return_path):
                 return return_path
             raise FileNotFoundError(
-                    f"`{return_path}` doesn't exist in preset directory `{preset}`."
-                )                
+                f"`{return_path}` doesn't exist in preset directory `{preset}`."
+            )
         except ValueError as e:
             raise ValueError(
                 "ModelScope handles should follow the format "
-                f"'modelscope://{{org}}/{{model}}' (e.g., 'modelscope://username/bert_base_en'). "
+                f"'modelscope://{{org}}/{{model}}'  "
+                "(e.g., 'modelscope://username/bert_base_en')."
                 f"Received: preset='{preset}.'"
             ) from e
         except EntryNotFoundError as e:
             message = str(e)
             if message.find("403 Client Error"):
                 raise FileNotFoundError(
-                    f"`{path}` doesn't exist in preset directory `{preset}`."
+                    f"`{path}` not exist in preset directory `{preset}`."
                 )
             else:
                 raise ValueError(message)

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -171,9 +171,8 @@ def get_file(preset, path):
             from modelscope.hub.snapshot_download import snapshot_download
         except:
             raise ImportError(
-                "`from_preset()` requires the `modelscope` package to "
-                "load from '{preset}'. "
-                "Please install with `pip install modelscope`."
+                "To load a preset from ModelScope {preset} using from_preset, install the "
+                "modelscope package with: pip install modelscope."
             )
         modelscope_handle = preset.removeprefix(MODELSCOPE_SCHEME + "://")
         try:
@@ -184,12 +183,12 @@ def get_file(preset, path):
                 return return_path
             raise FileNotFoundError(
                     f"`{return_path}` doesn't exist in preset directory `{preset}`."
-                )
+                )                
         except ValueError as e:
             raise ValueError(
-                "Unexpected ModelScope preset. Hugging Face model handles "
-                "should have the form 'modelscope://{org}/{model}'. For example, "
-                f"'modelscope://username/bert_base_en'. Received: preset={preset}."
+                "ModelScope handles should follow the format "
+                f"'modelscope://{{org}}/{{model}}' (e.g., 'modelscope://username/bert_base_en'). "
+                f"Received: preset='{preset}.'"
             ) from e
         except EntryNotFoundError as e:
             message = str(e)


### PR DESCRIPTION
Due to relevant legal restrictions of the Chinese government, Chinese users find it quite inconvenient to use HF. 
Therefore, Chinese users often use the Chinese version of HF, which is [ModelScope](https://www.modelscope.cn/models/LLM-Research/Llama-3.3-70B-Instruct/files). 
Considering this aspect, I think we should add download support for ModelScope.
Generally, Chinese users use it as a cloud disk for storing hf data. Therefore, we only need to make slight changes in the download section, and the other parts are exactly the same as hf.
The usage is similar to hf.
```
modelscope://username/bert_base_en
```