### PR TITLE
Fix for wrong implementation of 'v' in 'compute_ciou' function

### DIFF
--- a/keras_hub/src/bounding_box/iou.py
+++ b/keras_hub/src/bounding_box/iou.py
@@ -237,9 +237,9 @@ def compute_ciou(boxes1, boxes2, bounding_box_format):
     )
 
     v = ops.squeeze(
-        ops.power(
-            (4 / math.pi**2)
-            * (ops.arctan(width_2 / height_2) - ops.arctan(width_1 / height_1)),
+        (4 / math.pi**2)
+        * ops.power(
+            (ops.arctan(width_2 / height_2) - ops.arctan(width_1 / height_1)),
             2,
         ),
         axis=-1,


### PR DESCRIPTION
This change will fix the following issue: https://github.com/keras-team/keras-hub/issues/2044