### PR TITLE
Remove `pad_with_end_token` argument in `CLIPTokenizer`.

### DIFF
--- a/keras_hub/src/models/clip/clip_preprocessor_test.py
+++ b/keras_hub/src/models/clip/clip_preprocessor_test.py
@@ -25,7 +25,7 @@ class CLIPPreprocessorTest(TestCase):
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output={
-                "token_ids": [[5, 1, 2, 1, 3, 4, 0, 0]],
+                "token_ids": [[5, 1, 2, 1, 3, 4, 4, 4]],
                 "padding_mask": [[1, 1, 1, 1, 1, 1, 0, 0]],
             },
         )
@@ -39,7 +39,7 @@ class CLIPPreprocessorTest(TestCase):
             add_end_token=False,
         )
         x = preprocessor(input_data)
-        self.assertAllEqual(x["token_ids"], [[1, 2, 1, 3, 0, 0, 0, 0]] * 4)
+        self.assertAllEqual(x["token_ids"], [[1, 2, 1, 3, 4, 4, 4, 4]] * 4)
         self.assertAllEqual(x["padding_mask"], [[1, 1, 1, 1, 0, 0, 0, 0]] * 4)
 
     def test_sequence_length_override(self):

--- a/keras_hub/src/models/clip/clip_tokenizer_test.py
+++ b/keras_hub/src/models/clip/clip_tokenizer_test.py
@@ -25,12 +25,6 @@ class CLIPTokenizerTest(TestCase):
             expected_detokenize_output=["airplane", "airport"],
         )
 
-    def test_pad_with_end_token(self):
-        init_kwargs = self.init_kwargs.copy()
-        init_kwargs["pad_with_end_token"] = True
-        tokenizer = CLIPTokenizer(**init_kwargs)
-        self.assertEqual(tokenizer.pad_token_id, tokenizer.end_token_id)
-
     def test_errors_missing_special_tokens(self):
         with self.assertRaises(ValueError):
             CLIPTokenizer(vocabulary={"foo": 0, "bar": 1}, merges=["fo o"])

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_preprocessor_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_preprocessor_test.py
@@ -57,4 +57,4 @@ class StableDiffusion3TextToImagePreprocessorTest(TestCase):
         self.assertIn("clip_l", x)
         self.assertIn("clip_g", x)
         self.assertAllEqual(x["clip_l"][0], [4, 0, 1, 3, 3, 3, 3, 3])
-        self.assertAllEqual(x["clip_g"][0], [4, 0, 1, 3, 0, 0, 0, 0])
+        self.assertAllEqual(x["clip_g"][0], [4, 0, 1, 3, 3, 3, 3, 3])


### PR DESCRIPTION
Related to #2018

I have verified that `CLIPTokenizer` should always use `end_token_id` as `pad_token_id` in both CLIP and SD3.
I’m not sure why I initially implemented `pad_with_end_token` arg. It might be related to how the internal SD3 code was implemented.

`CLIPPreprocessor` is still needed for both CLIP and SD3. When I implemented it, I didn’t have a clear idea about adding a task class for CLIP.
@mattdangerw @divyashreepathihalli WDYT?

The script to verify the outputs:
```python
import keras
import numpy as np
import transformers

import keras_hub

text = "a cat sitting on the table"

tokenizer = keras_hub.models.Tokenizer.from_preset("clip_vit_base_patch32")
preprocessor = keras_hub.models.CLIPPreprocessor(tokenizer, sequence_length=16)
keras_results = preprocessor(text)
print(keras_results)

tokenizer = transformers.CLIPTokenizerFast.from_pretrained(
    "openai/clip-vit-base-patch32"
)
transformers_results = tokenizer(text, padding="max_length", max_length=16)
print(transformers_results)

np.testing.assert_allclose(
    keras.ops.convert_to_numpy(keras_results["token_ids"]),
    transformers_results["input_ids"],
)
np.testing.assert_allclose(
    keras.ops.convert_to_numpy(keras_results["padding_mask"]),
    transformers_results["attention_mask"],
)

```