### PR TITLE
Use Flash Attention if available

### DIFF
--- a/keras_hub/src/models/falcon/falcon_attention.py
+++ b/keras_hub/src/models/falcon/falcon_attention.py
@@ -3,6 +3,8 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.utils.keras_utils import has_flash_attention_support
+
 
 class FalconAttention(keras.layers.Layer):
     def __init__(
@@ -108,18 +110,39 @@ class FalconAttention(keras.layers.Layer):
                     f"cache_update_index={cache_update_index}"
                 )
 
-        attention_scores = ops.einsum("bqnh,bknh->bnqk", query, key)
-        attention_scores = ops.add(attention_scores, alibi)
-        attention_scores = (
-            attention_scores * self.inv_norm_factor
-        )  # [batch_size, num_heads, query_length, kv_length]
-        attention_scores = self.softmax(
-            attention_scores, ops.expand_dims(attention_mask, 1)
-        )
-        attention_scores = self.attention_dropout(attention_scores)
-        attention_output = ops.einsum(
-            "bnqk,bknh->bqnh", attention_scores, value
-        )
+        if has_flash_attention_support() and self.attention_dropout_rate == 0:
+            # Use `dot_product_attention` with Flash Attention support if
+            # available.
+            if attention_mask is not None:
+                attention_mask = ops.expand_dims(attention_mask, axis=1)
+                attention_mask = ops.cast(attention_mask, dtype="bool")
+            attention_output = ops.dot_product_attention(
+                query,
+                key,
+                value,
+                bias=ops.multiply(
+                    alibi,
+                    ops.cast(self.inv_norm_factor, self.compute_dtype),
+                ),
+                mask=attention_mask,
+                scale=self.inv_norm_factor,
+            )
+        else:
+            attention_scores = ops.einsum("bqnh,bknh->bnqk", query, key)
+            attention_scores = ops.add(attention_scores, alibi)
+            # [batch_size, num_heads, query_length, kv_length]
+            attention_scores = ops.multiply(
+                attention_scores,
+                ops.cast(self.inv_norm_factor, self.compute_dtype),
+            )
+            attention_scores = self.softmax(
+                attention_scores, ops.expand_dims(attention_mask, 1)
+            )
+            attention_scores = self.attention_dropout(attention_scores)
+            attention_output = ops.einsum(
+                "bnqk,bknh->bqnh", attention_scores, value
+            )
+
         attention_output = ops.reshape(
             attention_output,
             [batch_size, seq_length, self.num_heads * self.head_dim],

--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -1,8 +1,11 @@
+import math
+
 import keras
 from keras import ops
 
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
+from keras_hub.src.utils.keras_utils import has_flash_attention_support
 
 
 # This is just a self-attention layer in Mistral. But it can be generalized
@@ -52,6 +55,7 @@ class CachedMistralAttention(keras.layers.Layer):
         # h = head dim
         self._hidden_dim = inputs_shape[-1]
         self._head_dim = self._hidden_dim // self._num_query_heads
+        self._inv_norm_factor = 1.0 / math.sqrt(self._head_dim)
 
         self._query_dense = keras.layers.EinsumDense(
             equation="bqm,muh->bquh",
@@ -192,11 +196,26 @@ class CachedMistralAttention(keras.layers.Layer):
         return self._softmax(attention_scores)
 
     def _compute_attention(self, query, key, value, attention_mask=None):
+        if has_flash_attention_support():
+            # Use `dot_product_attention` with Flash Attention support if
+            # available.
+            if attention_mask is not None:
+                attention_mask = ops.expand_dims(attention_mask, axis=1)
+                attention_mask = ops.cast(attention_mask, dtype="bool")
+            attention_output = ops.dot_product_attention(
+                query,
+                key,
+                value,
+                mask=attention_mask,
+                scale=self._inv_norm_factor,
+            )
+            return attention_output
+
         attention_scores = ops.einsum(self._dot_product_equation, query, key)
-
-        norm_factor = ops.sqrt(ops.cast(self._head_dim, self.compute_dtype))
-
-        attention_scores = attention_scores / norm_factor
+        attention_scores = ops.multiply(
+            attention_scores,
+            ops.cast(self._inv_norm_factor, self.compute_dtype),
+        )
         attention_scores = self._masked_softmax(
             attention_scores, attention_mask
         )

--- a/keras_hub/src/utils/keras_utils.py
+++ b/keras_hub/src/utils/keras_utils.py
@@ -53,3 +53,10 @@ def standardize_data_format(data_format):
             f"Received: data_format={data_format}"
         )
     return data_format
+
+
+def has_flash_attention_support():
+    if hasattr(keras.config, "is_flash_attention_enabled"):
+        return True
+    else:
+        return False


### PR DESCRIPTION
Related to #2046 

@divyashreepathihalli 

There are still some models can use newly introduced `ops.nn.dot_product_attention` but they might require some refactoring.
I can update them in a following PR.