### PR TITLE
Update with tf.function to speed up BytePairTokenizer class

### DIFF
--- a/keras_hub/src/tokenizers/byte_pair_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer.py
@@ -412,6 +412,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         self._check_vocabulary()
         return self.vocabulary[token]
 
+    @tf.function(reduce_retracing=True)
     def _bpe_merge_one_step(self, words, mask):
         """Perform one step of byte-pair merge."""
         # Get all word pairs.
@@ -493,6 +494,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         words = remove_strings_from_inputs(words, "")
         return [words, mask]
 
+    @tf.function(reduce_retracing=True)
     def _bpe_merge(self, inputs):
         """Perform byte-pair merge for each word in the inputs."""
         num_words = tf.shape(inputs)[0]
@@ -617,6 +619,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         split_unicode = self.byte2unicode.lookup(split_bytes)
         return split_unicode
 
+    @tf.function(reduce_retracing=True)
     def _bpe_merge_and_update_cache(self, tokens):
         """Process unseen tokens and add to cache."""
         words = self._transform_bytes(tokens)


### PR DESCRIPTION
BytePairTokenizer class giving me warning like this when tokenize text on GPU and taking more time to tokenize the text.

WARNING:tensorflow:5 out of the last 11 calls to <bound method BytePairTokenizer._bpe_merge_one_step of <GPT2Tokenizer name=gpt2_tokenizer, built=False>> triggered tf.function retracing. Tracing is expensive and the excessive number of tracings could be due to (1) creating @tf.function repeatedly in a loop, (2) passing tensors with different shapes, (3) passing Python objects instead of tensors. For (1), please define your @tf.function outside of the loop. For (2), @tf.function has reduce_retracing=True option that can avoid unnecessary retracing. For (3), please refer to https://www.tensorflow.org/guide/function#controlling_retracing and https://www.tensorflow.org/api_docs/python/tf/function for  more details.

Fixes the issue [#2056](https://github.com/keras-team/keras-hub/issues/2056)
