### PR TITLE
Make gemma inputs int32 same as other models

### DIFF
--- a/keras_hub/src/models/gemma/gemma_backbone.py
+++ b/keras_hub/src/models/gemma/gemma_backbone.py
@@ -148,10 +148,10 @@ class GemmaBackbone(Backbone):
 
         # === Functional Model ===
         token_id_input = keras.Input(
-            shape=(None,), dtype="float32", name="token_ids"
+            shape=(None,), dtype="int32", name="token_ids"
         )
         padding_mask_input = keras.Input(
-            shape=(None,), dtype="float32", name="padding_mask"
+            shape=(None,), dtype="int32", name="padding_mask"
         )
         x = self.token_embedding(token_id_input)
         x = x * ops.cast(ops.sqrt(hidden_dim), x.dtype)


### PR DESCRIPTION
I don't think anything was broken because of this, but we should not have float32 inputs in this case.