### PR TITLE
Vit bug

### DIFF
--- a/keras_hub/src/models/vit/vit_layers.py
+++ b/keras_hub/src/models/vit/vit_layers.py
@@ -257,6 +257,7 @@ class ViTEncoderBlock(keras.layers.Layer):
             hidden_dim=self.hidden_dim,
             mlp_dim=self.mlp_dim,
             use_bias=self.use_mlp_bias,
+            dropout_rate=self.dropout_rate,
             name="mlp",
             dtype=self.dtype_policy,
         )

--- a/keras_hub/src/models/vit/vit_layers.py
+++ b/keras_hub/src/models/vit/vit_layers.py
@@ -65,6 +65,7 @@ class MLP(keras.layers.Layer):
 
     def call(self, inputs):
         x = self.dense_1(inputs)
+        x = self.dropout(x)
         x = self.dense_2(x)
         out = self.dropout(x)
         return out


### PR DESCRIPTION
* Add missing dropout arg
* As per [official implementation](https://github.com/google-research/vision_transformer/blob/main/vit_jax/models_vit.py#L91) a dropout layer was missing in MLP, which was not existing huggingface implementation, so just added a dropout layer

@abheesht17 thanks for pointing it out.