### PR TITLE
Fix torch gpu requirements

### DIFF
--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -3,9 +3,9 @@ tensorflow-cpu~=2.18
 tensorflow-text~=2.18
 
 # Torch with cuda support.
---extra-index-url https://download.pytorch.org/whl/cu121
-torch==2.6.0+cpu
-torchvision==0.21.0+cpu
+--extra-index-url https://download.pytorch.org/whl/cu126
+torch==2.6.0+cu126
+torchvision==0.21.0+cu126
 
 # Jax cpu-only version.
 jax[cpu]


### PR DESCRIPTION
It should be `torch==2.6.0+cu*` with `--extra-index-url https://download.pytorch.org/whl/cu*`