### PR TITLE
 Made y optional when we use for inference

### DIFF
--- a/keras_hub/src/models/segformer/segformer_image_segmenter_preprocessor.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter_preprocessor.py
@@ -23,7 +23,8 @@ class SegFormerImageSegmenterPreprocessor(ImageSegmenterPreprocessor):
     def call(self, x, y=None, sample_weight=None):
         if self.image_converter:
             x = self.image_converter(x)
-            y = self.image_converter(y)
+            if y is not None:
+                y = self.image_converter(y)
 
         x = x / 255
         x = (x - IMAGENET_DEFAULT_MEAN) / IMAGENET_DEFAULT_STD


### PR DESCRIPTION
`SegFormerImageSegmenterPreprocessor` currently requires label data (y) or it will crash. For inference, we don't want to provide y, so we make it optional.