### PR TITLE
Add Roberta converter

### DIFF
--- a/keras_hub/src/utils/transformers/convert_roberta.py
+++ b/keras_hub/src/utils/transformers/convert_roberta.py
@@ -1,0 +1,136 @@
+import numpy as np
+
+from keras_hub.src.models.roberta.roberta_backbone import RobertaBackbone
+from keras_hub.src.utils.preset_utils import HF_TOKENIZER_CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
+from keras_hub.src.utils.preset_utils import load_json
+
+backbone_cls = RobertaBackbone
+
+
+def convert_backbone_config(transformers_config):
+    return {
+        "vocabulary_size": transformers_config["vocab_size"],
+        "num_layers": transformers_config["num_hidden_layers"],
+        "num_heads": transformers_config["num_attention_heads"],
+        "hidden_dim": transformers_config["hidden_size"],
+        "intermediate_dim": transformers_config["intermediate_size"],
+    }
+
+
+def convert_weights(backbone, loader, transformers_config):
+    # Embedding layer
+    loader.port_weight(
+        keras_variable=backbone.get_layer("token_embedding").embeddings,
+        hf_weight_key="roberta.embeddings.word_embeddings.weight",
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer("position_embedding").position_embeddings,
+        hf_weight_key="roberta.embeddings.position_embeddings.weight",
+    )
+    # Roberta does not use segment embeddings
+    loader.port_weight(
+        keras_variable=backbone.get_layer("embeddings_layer_norm").beta,
+        hf_weight_key="roberta.embeddings.LayerNorm.beta",
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer("embeddings_layer_norm").gamma,
+        hf_weight_key="roberta.embeddings.LayerNorm.gamma",
+    )
+
+    def transpose_and_reshape(x, shape):
+        return np.reshape(np.transpose(x), shape)
+
+    # Attention blocks
+    for i in range(backbone.num_layers):
+        block = backbone.get_layer(f"transformer_layer_{i}")
+        attn = block._self_attention_layer
+        hf_prefix = "roberta.encoder.layer."
+        # Attention layers
+        loader.port_weight(
+            keras_variable=attn.query_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.query.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.query_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.query.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=attn.key_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.key.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.key_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.key.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=attn.value_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.value.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.value_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.value.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=attn.output_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.dense.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.output_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.dense.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        # Attention layer norm.
+        loader.port_weight(
+            keras_variable=block._self_attention_layer_norm.beta,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.LayerNorm.beta",
+        )
+        loader.port_weight(
+            keras_variable=block._self_attention_layer_norm.gamma,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.LayerNorm.gamma",
+        )
+        # MLP layers
+        loader.port_weight(
+            keras_variable=block._feedforward_intermediate_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.intermediate.dense.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_intermediate_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.intermediate.dense.bias",
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_output_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.output.dense.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_output_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.output.dense.bias",
+        )
+        # Output layer norm.
+        loader.port_weight(
+            keras_variable=block._feedforward_layer_norm.beta,
+            hf_weight_key=f"{hf_prefix}{i}.output.LayerNorm.beta",
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_layer_norm.gamma,
+            hf_weight_key=f"{hf_prefix}{i}.output.LayerNorm.gamma",
+        )
+    # Roberta does not use a pooler layer
+
+
+def convert_tokenizer(cls, preset, **kwargs):
+    transformers_config = load_json(preset, HF_TOKENIZER_CONFIG_FILE)
+    return cls(
+        get_file(preset, "vocab.txt"),
+        lowercase=transformers_config["do_lower_case"],
+        **kwargs,
+    )

--- a/keras_hub/src/utils/transformers/convert_roberta_test.py
+++ b/keras_hub/src/utils/transformers/convert_roberta_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.roberta.roberta_backbone import RobertaBackbone
+from keras_hub.src.models.roberta.roberta_text_classifier import RobertaTextClassifier
+from keras_hub.src.models.text_classifier import TextClassifier
+from keras_hub.src.tests.test_case import TestCase
+
+
+class TestTask(TestCase):
+    @pytest.mark.large
+    def test_convert_tiny_preset(self):
+        model = RobertaTextClassifier.from_preset("hf://FacebookAI/roberta-base", num_classes=2)
+        prompt = "That movies was terrible."
+        model.predict([prompt])
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = TextClassifier.from_preset(
+            "hf://FacebookAI/roberta-base",
+            num_classes=2,
+            load_weights=False,
+        )
+        self.assertIsInstance(model, RobertaTextClassifier)
+        model = Backbone.from_preset(
+            "hf://FacebookAI/roberta-base",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, RobertaBackbone)
+
+    # TODO: compare numerics with huggingface model

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -12,6 +12,7 @@ from keras_hub.src.utils.transformers import convert_gpt2
 from keras_hub.src.utils.transformers import convert_llama3
 from keras_hub.src.utils.transformers import convert_mistral
 from keras_hub.src.utils.transformers import convert_pali_gemma
+from keras_hub.src.utils.transformers import convert_roberta
 from keras_hub.src.utils.transformers import convert_vit
 from keras_hub.src.utils.transformers.safetensor_utils import SafetensorLoader
 
@@ -39,6 +40,8 @@ class TransformersPresetLoader(PresetLoader):
             self.converter = convert_mistral
         elif model_type == "paligemma":
             self.converter = convert_pali_gemma
+        elif model_type == "roberta":
+            self.converter = convert_roberta
         elif model_type == "vit":
             self.converter = convert_vit
         else:


### PR DESCRIPTION
A few doubts - 
1. the model outputs from keras and huggingface are not similar at all. 
```
from transformers import RobertaTokenizer
from transformers import TFRobertaModel

hf_model = TFRobertaModel.from_pretrained("roberta-base", output_hidden_states=True)
tokenizer = RobertaTokenizer.from_pretrained("roberta-base")

text = "Hello, how are you?"
inputs = tokenizer(text, return_tensors="tf", padding=True, truncation=True)
hf_output = hf_model(**inputs).last_hidden_state
keras_inputs = {
    "token_ids": inputs["input_ids"].numpy(),  # Token IDs
    "padding_mask": inputs["attention_mask"].numpy(),  # Padding Mask
}
keras_output = model(keras_inputs)
```
![Output comparison](https://github.com/user-attachments/assets/ef07212d-8690-4ed1-97bc-9fb213f06362)

3. Hugging Face’s RoBERTa uses 514 position embeddings (512 positions + 2 extra tokens), whereas Keras only expects 512.

4. Tokenizer comparison
![image](https://github.com/user-attachments/assets/139b00ab-6ce2-466a-9559-d4d41d268267)
