### PR TITLE
Add SigLIP2

### DIFF
--- a/keras_hub/src/models/siglip/siglip_backbone_test.py
+++ b/keras_hub/src/models/siglip/siglip_backbone_test.py
@@ -67,3 +67,53 @@ class SigLIPBackboneTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+
+class SigLIP2BackboneTest(TestCase):
+    def setUp(self):
+        vision_encoder = SigLIPVisionEncoder(
+            16, 128, 2, 2, 128, name="vision_encoder"
+        )
+        text_encoder = SigLIPTextEncoder(
+            64, 64, 64, 2, 2, 128, projection_dim=128, name="text_encoder"
+        )
+        self.init_kwargs = {
+            "vision_encoder": vision_encoder,
+            "text_encoder": text_encoder,
+        }
+        self.input_data = {
+            "images": ops.ones((2, 224, 224, 3)),
+            "token_ids": ops.ones((2, 64), dtype="int32"),
+        }
+
+    def test_backbone_basics(self):
+        self.run_backbone_test(
+            cls=SigLIPBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_output_shape={
+                "vision_logits": (2, 2),
+                "text_logits": (2, 2),
+            },
+        )
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=SigLIPBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.extra_large
+    def test_smallest_preset(self):
+        self.run_preset_test(
+            cls=SigLIPBackbone,
+            preset="siglip2_base_patch16_224",
+            input_data=self.input_data,
+            expected_output_shape={
+                "vision_logits": (2, 2),
+                "text_logits": (2, 2),
+            },
+        )

--- a/keras_hub/src/models/siglip/siglip_presets.py
+++ b/keras_hub/src/models/siglip/siglip_presets.py
@@ -10,7 +10,7 @@ backbone_presets = {
             "params": 203156230,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_base_patch16_224/2",
     },
@@ -22,7 +22,7 @@ backbone_presets = {
             "params": 203202370,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_base_patch16_256/1",
     },
@@ -34,7 +34,7 @@ backbone_presets = {
             "params": 203448450,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_base_patch16_384/1",
     },
@@ -46,7 +46,7 @@ backbone_presets = {
             "params": 203792962,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_base_patch16_512/1",
     },
@@ -58,7 +58,7 @@ backbone_presets = {
             "params": 652151106,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_large_patch16_256/1",
     },
@@ -70,7 +70,7 @@ backbone_presets = {
             "params": 652479106,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_large_patch16_384/1",
     },
@@ -83,7 +83,7 @@ backbone_presets = {
             "params": 877360578,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_so400m_patch14_224/2",
     },
@@ -96,7 +96,7 @@ backbone_presets = {
             "params": 877961291,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_so400m_patch14_384/1",
     },
@@ -109,7 +109,7 @@ backbone_presets = {
             "params": 1128759282,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_so400m_patch16_256_i18n/1",
     },
@@ -121,8 +121,204 @@ backbone_presets = {
             "params": 370626370,
             "official_name": "SigLIP",
             "path": "siglip",
-            "model_card": "https://www.kaggle.com/models/kerashub/siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip-659d5e62f0ae1a57ae0e83ba",
         },
         "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip_base_patch16_256_multilingual/1",
+    },
+    # SigLIP2.
+    "siglip2_base_patch16_224": {
+        "metadata": {
+            "description": (
+                "375 million parameter, patch size 16, image size 224, "
+                "pre-trained on WebLi."
+            ),
+            "params": 375188230,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_base_patch16_224/1",
+    },
+    "siglip2_base_patch16_256": {
+        "metadata": {
+            "description": (
+                "375 million parameter, patch size 16, image size 256, "
+                "pre-trained on WebLi."
+            ),
+            "params": 375234370,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_base_patch16_256/1",
+    },
+    "siglip2_base_patch32_256": {
+        "metadata": {
+            "description": (
+                "376 million parameter, patch size 32, image size 256, "
+                "pre-trained on WebLi."
+            ),
+            "params": 376856194,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_base_patch32_256/1",
+    },
+    "siglip2_base_patch16_384": {
+        "metadata": {
+            "description": (
+                "376 million parameter, patch size 16, image size 384, "
+                "pre-trained on WebLi."
+            ),
+            "params": 376856194,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_base_patch16_384/1",
+    },
+    "siglip2_base_patch16_512": {
+        "metadata": {
+            "description": (
+                "375 million parameter, patch size 16, image size 512, "
+                "pre-trained on WebLi."
+            ),
+            "params": 375824962,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_base_patch16_512/1",
+    },
+    "siglip2_large_patch16_256": {
+        "metadata": {
+            "description": (
+                "881 million parameter, patch size 16, image size 256, "
+                "pre-trained on WebLi."
+            ),
+            "params": 881527106,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_large_patch16_256/1",
+    },
+    "siglip2_large_patch16_384": {
+        "metadata": {
+            "description": (
+                "881 million parameter, patch size 16, image size 384, "
+                "pre-trained on WebLi."
+            ),
+            "params": 881855106,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_large_patch16_384/1",
+    },
+    "siglip2_large_patch16_512": {
+        "metadata": {
+            "description": (
+                "882 million parameter, patch size 16, image size 512, "
+                "pre-trained on WebLi."
+            ),
+            "params": 882314306,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_large_patch16_512/1",
+    },
+    "siglip2_giant_opt_patch16_256": {
+        "metadata": {
+            "description": (
+                "1.8 billion parameter, patch size 16, image size 256, "
+                "pre-trained on WebLi."
+            ),
+            "params": 1871394226,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_giant_opt_patch16_256/1",
+    },
+    "siglip2_giant_opt_patch16_384": {
+        "metadata": {
+            "description": (
+                "1.8 billion parameter, patch size 16, image size 384, "
+                "pre-trained on WebLi."
+            ),
+            "params": 1871886066,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_giant_opt_patch16_384/1",
+    },
+    "siglip2_so400m_patch14_224": {
+        "metadata": {
+            "description": (
+                "1.1 billion parameter, patch size 14, image size 224, "
+                "shape-optimized version, pre-trained on WebLi."
+            ),
+            "params": 1135463922,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_so400m_patch14_224/1",
+    },
+    "siglip2_so400m_patch14_384": {
+        "metadata": {
+            "description": (
+                "1.1 billion parameter, patch size 14, image size 224, "
+                "shape-optimized version, pre-trained on WebLi."
+            ),
+            "params": 1136009291,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_so400m_patch14_384/1",
+    },
+    "siglip2_so400m_patch16_256": {
+        "metadata": {
+            "description": (
+                "1.1 billion parameter, patch size 16, image size 256, "
+                "shape-optimized version, pre-trained on WebLi."
+            ),
+            "params": 1135671282,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_so400m_patch16_256/1",
+    },
+    "siglip2_so400m_patch16_384": {
+        "metadata": {
+            "description": (
+                "1.1 billion parameter, patch size 16, image size 384, "
+                "shape-optimized version, pre-trained on WebLi."
+            ),
+            "params": 1136040242,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_so400m_patch16_384/1",
+    },
+    "siglip2_so400m_patch16_512": {
+        "metadata": {
+            "description": (
+                "1.1 billion parameter, patch size 16, image size 512, "
+                "shape-optimized version, pre-trained on WebLi."
+            ),
+            "params": 1136555698,
+            "official_name": "SigLIP2",
+            "path": "siglip",
+            "model_card": "https://huggingface.co/collections/google/siglip2-67b5dcef38c175486e240107",
+        },
+        "kaggle_handle": "kaggle://kerashub/siglip/keras/siglip2_so400m_patch16_512/1",
     },
 }

--- a/keras_hub/src/models/siglip/siglip_text_encoder.py
+++ b/keras_hub/src/models/siglip/siglip_text_encoder.py
@@ -27,6 +27,8 @@ class SigLIPTextEncoder(Backbone):
             Defaults to `1e-6`.
         max_sequence_length: int. The maximum sequence length that this encoder
             can consume. Defaults to `64`.
+        projection_dim: int. The size of the projection in the head. If not
+            specified, set to `hidden_dim`. Defaults to `None`.
         dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
             for the models computations and weights. Note that some
             computations, such as softmax and layer normalization will always
@@ -44,10 +46,12 @@ class SigLIPTextEncoder(Backbone):
         intermediate_activation="gelu_approximate",
         layer_norm_epsilon=1e-6,
         max_sequence_length=64,
+        projection_dim=None,
         dtype=None,
         name=None,
         **kwargs,
     ):
+        projection_dim = projection_dim or hidden_dim
         # `prefix` is used to prevent duplicate name when utilizing multiple
         # SigLIP encoders within a single model.
         prefix = str(name) + "_" if name is not None else ""
@@ -78,7 +82,7 @@ class SigLIPTextEncoder(Backbone):
             name=f"{prefix}post_layer_norm",
         )
         self.head = layers.Dense(
-            hidden_dim,
+            projection_dim,
             kernel_initializer=initializers.LecunNormal(),
             dtype=dtype,
             name=f"{prefix}head",
@@ -115,6 +119,7 @@ class SigLIPTextEncoder(Backbone):
         self.intermediate_activation = intermediate_activation
         self.layer_norm_epsilon = layer_norm_epsilon
         self.max_sequence_length = max_sequence_length
+        self.projection_dim = projection_dim
 
     def get_config(self):
         config = super().get_config()
@@ -129,6 +134,7 @@ class SigLIPTextEncoder(Backbone):
                 "intermediate_activation": self.intermediate_activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "max_sequence_length": self.max_sequence_length,
+                "projection_dim": self.projection_dim,
             }
         )
         return config

--- a/tools/checkpoint_conversion/convert_siglip_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_siglip_checkpoints.py
@@ -23,6 +23,37 @@ python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
     --preset siglip_so400m_patch16_256_i18n --upload_uri kaggle://kerashub/siglip/keras/siglip_so400m_patch16_256_i18n
 python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
     --preset siglip_base_patch16_256_multilingual --upload_uri kaggle://kerashub/siglip/keras/siglip_base_patch16_256_multilingual
+
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_base_patch16_224 --upload_uri kaggle://kerashub/siglip/keras/siglip2_base_patch16_224
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_base_patch16_256 --upload_uri kaggle://kerashub/siglip/keras/siglip2_base_patch16_256
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_base_patch32_256 --upload_uri kaggle://kerashub/siglip/keras/siglip2_base_patch32_256
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_base_patch16_384 --upload_uri kaggle://kerashub/siglip/keras/siglip2_base_patch16_384
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_base_patch16_512 --upload_uri kaggle://kerashub/siglip/keras/siglip2_base_patch16_512
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_large_patch16_256 --upload_uri kaggle://kerashub/siglip/keras/siglip2_large_patch16_256
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_large_patch16_384 --upload_uri kaggle://kerashub/siglip/keras/siglip2_large_patch16_384
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_large_patch16_512 --upload_uri kaggle://kerashub/siglip/keras/siglip2_large_patch16_512
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_giant_opt_patch16_256 --upload_uri kaggle://kerashub/siglip/keras/siglip2_giant_opt_patch16_256
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_giant_opt_patch16_384 --upload_uri kaggle://kerashub/siglip/keras/siglip2_giant_opt_patch16_384
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_so400m_patch14_224 --upload_uri kaggle://kerashub/siglip/keras/siglip2_so400m_patch14_224
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_so400m_patch14_256 --upload_uri kaggle://kerashub/siglip/keras/siglip2_so400m_patch14_256
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_so400m_patch16_256 --upload_uri kaggle://kerashub/siglip/keras/siglip2_so400m_patch16_256
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_so400m_patch16_384 --upload_uri kaggle://kerashub/siglip/keras/siglip2_so400m_patch16_384
+python tools/checkpoint_conversion/convert_siglip_checkpoints.py \
+    --preset siglip2_so400m_patch16_512 --upload_uri kaggle://kerashub/siglip/keras/siglip2_so400m_patch16_512
 """
 
 import os
@@ -38,6 +69,7 @@ from transformers import SiglipModel
 from transformers import SiglipProcessor
 
 import keras_hub
+from keras_hub.src.models.gemma.gemma_tokenizer import GemmaTokenizer
 from keras_hub.src.models.siglip.siglip_backbone import SigLIPBackbone
 from keras_hub.src.models.siglip.siglip_image_converter import (
     SigLIPImageConverter,
@@ -62,6 +94,22 @@ PRESET_MAP = {
     "siglip_so400m_patch14_384": "google/siglip-so400m-patch14-384",
     "siglip_so400m_patch16_256_i18n": "google/siglip-so400m-patch16-256-i18n",
     "siglip_base_patch16_256_multilingual": "google/siglip-base-patch16-256-multilingual",  # noqa: E501
+    # SigLIP2 (NaFlex version is not supported yet)
+    "siglip2_base_patch16_224": "google/siglip2-base-patch16-224",
+    "siglip2_base_patch16_256": "google/siglip2-base-patch16-256",
+    "siglip2_base_patch32_256": "google/siglip2-base-patch32-256",
+    "siglip2_base_patch16_384": "google/siglip2-base-patch16-384",
+    "siglip2_base_patch16_512": "google/siglip2-base-patch16-512",
+    "siglip2_large_patch16_256": "google/siglip2-large-patch16-256",
+    "siglip2_large_patch16_384": "google/siglip2-large-patch16-384",
+    "siglip2_large_patch16_512": "google/siglip2-large-patch16-512",
+    "siglip2_giant_opt_patch16_256": "google/siglip2-giant-opt-patch16-256",
+    "siglip2_giant_opt_patch16_384": "google/siglip2-giant-opt-patch16-384",
+    "siglip2_so400m_patch14_224": "google/siglip2-so400m-patch14-224",
+    "siglip2_so400m_patch14_384": "google/siglip2-so400m-patch14-384",
+    "siglip2_so400m_patch16_256": "google/siglip2-so400m-patch16-256",
+    "siglip2_so400m_patch16_384": "google/siglip2-so400m-patch16-384",
+    "siglip2_so400m_patch16_512": "google/siglip2-so400m-patch16-512",
 }
 
 flags.DEFINE_string(
@@ -107,6 +155,7 @@ def convert_model(hf_model, dtype=None):
         intermediate_activation=text_encoder_config["hidden_act"],
         layer_norm_epsilon=text_encoder_config["layer_norm_eps"],
         max_sequence_length=text_encoder_config["max_position_embeddings"],
+        projection_dim=text_encoder_config.get("projection_size"),
         dtype=dtype,
     )
     return SigLIPBackbone(vision_encoder, text_encoder, dtype=dtype)
@@ -385,8 +434,11 @@ def convert_image_converter(hf_image_processor):
     )
 
 
-def convert_tokenizer(hf_tokenizer):
-    return SigLIPTokenizer(hf_tokenizer.vocab_file, add_eos=True)
+def convert_tokenizer(hf_tokenizer, is_siglip2=False):
+    if is_siglip2:
+        return GemmaTokenizer(hf_tokenizer.vocab_file)
+    else:
+        return SigLIPTokenizer(hf_tokenizer.vocab_file, add_eos=True)
 
 
 def validate_output(
@@ -395,6 +447,7 @@ def validate_output(
     keras_tokenizer,
     hf_model,
     hf_model_processor,
+    is_siglip2=False,
 ):
     file = keras.utils.get_file(
         origin=("http://images.cocodataset.org/val2017/000000039769.jpg")
@@ -408,6 +461,7 @@ def validate_output(
         images=[image, image],
         return_tensors="pt",
         padding="max_length",
+        max_length=64 if is_siglip2 else None,
     )
     hf_preprocessed = hf_inputs["pixel_values"].detach().cpu().numpy()
 
@@ -430,7 +484,9 @@ def validate_output(
     # Call with keras.
     keras_preprocessor = SigLIPPreprocessor(
         keras_tokenizer,
-        sequence_length=hf_model_processor.tokenizer.model_max_length,
+        sequence_length=(
+            64 if is_siglip2 else hf_model_processor.tokenizer.model_max_length
+        ),
     )
     token_ids = keras_preprocessor(
         {"images": keras.ops.convert_to_numpy(images), "prompts": text}
@@ -466,6 +522,9 @@ def main(_):
 
     print(f"🏃 Coverting {preset}")
 
+    # Whether the model is SigLIP2.
+    is_siglip2 = "siglip2" in preset
+
     # Load huggingface model.
     hf_model = SiglipModel.from_pretrained(hf_preset)
     hf_preprocessor = SiglipProcessor.from_pretrained(hf_preset)
@@ -476,7 +535,7 @@ def main(_):
     keras_image_converter = convert_image_converter(
         hf_preprocessor.image_processor
     )
-    keras_tokenizer = convert_tokenizer(hf_preprocessor.tokenizer)
+    keras_tokenizer = convert_tokenizer(hf_preprocessor.tokenizer, is_siglip2)
     print("✅ KerasHub model loaded.")
 
     convert_weights(keras_model, hf_model)
@@ -488,6 +547,7 @@ def main(_):
         keras_tokenizer,
         hf_model,
         hf_preprocessor,
+        is_siglip2,
     )
     print("✅ Output validated.")
 


### PR DESCRIPTION
I found that SigLIP2 (except for the NaFlex version) uses the same arch as SigLIP, so adding it is straightforward.
The main difference is that SigLIP2 uses Gemma tokenizer instead of the original one.

Here is the colab:
https://colab.research.google.com/drive/1fskiRDjis-ioUUORxYy8744_KPQ6lyIs?usp=sharing

|Lib|Model|Prob.|Loss|
|-|-|-|-|
|`transformers`|`google/siglip2-so400m-patch14-384`|63.1% (2 cats) vs. 0.0% (2 dogs)|5.57|
|`keras_hub`|`siglip2_so400m_patch14_384`|63.8% (2 cats) vs. 0.0% (2 dogs)|5.52|

New weights have been uploaded at:
https://www.kaggle.com/models/kerashub/siglip/