### PR TITLE
Add logits support to whisper backbone

### DIFF
--- a/keras_hub/src/models/whisper/whisper_backbone.py
+++ b/keras_hub/src/models/whisper/whisper_backbone.py
@@ -286,3 +286,13 @@ class WhisperBackbone(Backbone):
             }
         )
         return config
+
+    def logits(self, *args, **kwargs):
+        result = self(*args, **kwargs)
+        token_embedding = None
+        for embedding_type in self.decoder_embeddings:
+            if "token_embedding" in embedding_type.path:
+                token_embedding = embedding_type
+        return keras.ops.matmul(
+            result["decoder_sequence_output"], keras.ops.transpose(token_embedding)
+        )

--- a/keras_hub/src/models/whisper/whisper_backbone.py
+++ b/keras_hub/src/models/whisper/whisper_backbone.py
@@ -290,7 +290,7 @@ class WhisperBackbone(Backbone):
     def logits(self, *args, **kwargs):
         result = self(*args, **kwargs)
         token_embedding = None
-        for embedding_type in self.decoder_embeddings:
+        for embedding_type in self.decoder_embeddings.weights:
             if "token_embedding" in embedding_type.path:
                 token_embedding = embedding_type
         return keras.ops.matmul(

--- a/keras_hub/src/models/whisper/whisper_backbone_test.py
+++ b/keras_hub/src/models/whisper/whisper_backbone_test.py
@@ -70,9 +70,7 @@ class WhisperBackboneTest(TestCase):
                 "decoder_token_ids": ops.array(
                     [[50257, 50362, 464, 2068, 7586, 21831, 13, 50256, 50256]]
                 ),
-                "decoder_padding_mask": ops.array(
-                    [[1, 1, 1, 1, 1, 1, 1, 1, 0]]
-                ),
+                "decoder_padding_mask": ops.array([[1, 1, 1, 1, 1, 1, 1, 1, 0]]),
             },
             expected_output_shape={
                 "encoder_sequence_output": (1, 1500, 384),
@@ -87,6 +85,23 @@ class WhisperBackboneTest(TestCase):
                     [13.238, 1.051, 8.348, -20.012, -5.022]
                 ),
             },
+        )
+
+    @pytest.mark.large
+    def test_logits(self):
+        backbone_cls = WhisperBackbone.from_preset("whisper_tiny_en")
+        input_data = {
+            "encoder_features": ops.ones((1, 3000, 80)),
+            "decoder_token_ids": ops.array(
+                [[50257, 50362, 464, 2068, 7586, 21831, 13, 50256, 50256]]
+            ),
+            "decoder_padding_mask": ops.array([[1, 1, 1, 1, 1, 1, 1, 1, 1]]),
+        }
+        logits = backbone_cls.logits(input_data)
+        self.assertEqual(logits.shape, (1, 9, 51864))
+        self.assertAllEqual(
+            ops.argmax(ops.squeeze(logits, axis=0), axis=-1),
+            [50361, 357, 50256, 395, 263, 50256, 50256, 50256, 50256],
         )
 
     @pytest.mark.extra_large


### PR DESCRIPTION
Currently the WhisperBacbone does not support logits output as we can see [here](https://github.com/openai/whisper/blob/517a43ecd132a2089d85f4ebc044728a71d49f6e/whisper/model.py#L245). 

This would be a building block for other tasks under Whisper Casual LLM.

Test output has been validated with whisper's output: [Colab](https://colab.research.google.com/drive/149TMr04SvELRg-Tl6iN4VedI72evydbs#scrollTo=du0dbnpvuyXp)