### PR TITLE
Update dev version rule for nightly

### DIFF
--- a/pip_build.py
+++ b/pip_build.py
@@ -51,7 +51,11 @@ def update_version(build_path, package, version, is_nightly=False):
     with open(build_path / "setup.py", "w") as f:
         if is_nightly:
             date = datetime.datetime.now()
-            version += f".dev{date.strftime('%Y%m%d%H%M')}"
+            version = re.sub(
+                r"([0-9]+\.[0-9]+\.[0-9]+).*",
+                r"\1.dev" + date.strftime("%Y%m%d%H%M"),
+                version,
+            )
             package_name = f"{package_name}-nightly"
             if package == nlp_package:
                 # keras-nlp-nightly needs to depend on keras-hub-nightly


### PR DESCRIPTION
The `keras-hub-nightly` release workflow is [broken](https://github.com/keras-team/keras-hub/actions/runs/13712977424/job/38353921561) with the following error message:
```
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for sdist...
error in keras-nlp-nightly setup command: 'install_requires' must be a string or iterable of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
    keras-hub-nightly==0.20.0.dev0.dev2025030703[53](https://github.com/keras-team/keras-hub/actions/runs/13712977424/job/38353921561#step:7:54)
```
This PR updates the version naming rule to fix this.