### PR TITLE
Fix dtype bug in image converter

### DIFF
--- a/keras_hub/src/layers/preprocessing/image_converter.py
+++ b/keras_hub/src/layers/preprocessing/image_converter.py
@@ -280,6 +280,8 @@ class ImageConverter(PreprocessingLayer):
         return inputs
 
     def _expand_non_channel_dims(self, value, inputs):
+        input_dtype = keras.backend.standardize_dtype(inputs.dtype)
+
         unbatched = len(ops.shape(inputs)) == 3
         channels_first = self.data_format == "channels_first"
         if unbatched:
@@ -295,9 +297,9 @@ class ImageConverter(PreprocessingLayer):
             if keras.backend.backend() == "torch" and self.image_size is None:
                 return ops.expand_dims(value, broadcast_dims).cpu()
             expanded = ops.expand_dims(value, broadcast_dims)
-            return ops.cast(expanded, inputs.dtype)
+            return ops.cast(expanded, input_dtype)
         else:
-            return np.expand_dims(value, broadcast_dims).astype(inputs.dtype)
+            return np.expand_dims(value, broadcast_dims).astype(input_dtype)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/layers/preprocessing/image_converter.py
+++ b/keras_hub/src/layers/preprocessing/image_converter.py
@@ -294,9 +294,10 @@ class ImageConverter(PreprocessingLayer):
             # device (potentially GPU) after preprocessing.
             if keras.backend.backend() == "torch" and self.image_size is None:
                 return ops.expand_dims(value, broadcast_dims).cpu()
-            return ops.expand_dims(value, broadcast_dims)
+            expanded = ops.expand_dims(value, broadcast_dims)
+            return ops.cast(expanded, inputs.dtype)
         else:
-            return np.expand_dims(value, broadcast_dims)
+            return np.expand_dims(value, broadcast_dims).astype(inputs.dtype)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -46,9 +46,9 @@ class ImageConverterTest(TestCase):
         inputs = ops.cast(inputs, "bfloat16")
         outputs = converter(inputs)
         self.assertEqual(ops.shape(outputs), (4, 4, 3))
-        self.assertAllClose(outputs[:, :, 0], np.ones((4, 4)) * 0.701961)
-        self.assertAllClose(outputs[:, :, 1], np.ones((4, 4)) * 0.301569)
-        self.assertAllClose(outputs[:, :, 2], np.ones((4, 4)) * 0.852353)
+        self.assertAllClose(outputs[:, :, 0], np.ones((4, 4)) * 0.703125)
+        self.assertAllClose(outputs[:, :, 1], np.ones((4, 4)) * 0.302734)
+        self.assertAllClose(outputs[:, :, 2], np.ones((4, 4)) * 0.851562)
 
     @parameterized.parameters(
         (True, False),

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -35,6 +35,21 @@ class ImageConverterTest(TestCase):
         self.assertAllClose(outputs[:, :, 1], np.ones((4, 4)) * 0.301569)
         self.assertAllClose(outputs[:, :, 2], np.ones((4, 4)) * 0.852353)
 
+    def test_bfloat16_input(self):
+        converter = ImageConverter(
+            image_size=(4, 4),
+            scale=(1.0 / 255.0, 0.8 / 255.0, 1.2 / 255.0),
+            offset=(0.2, -0.1, 0.25),
+            dtype="bfloat16",
+        )
+        inputs = ops.ones((10, 10, 3)) * 128
+        inputs = ops.cast(inputs, "bfloat16")
+        outputs = converter(inputs)
+        self.assertEqual(ops.shape(outputs), (4, 4, 3))
+        self.assertAllClose(outputs[:, :, 0], np.ones((4, 4)) * 0.701961)
+        self.assertAllClose(outputs[:, :, 1], np.ones((4, 4)) * 0.301569)
+        self.assertAllClose(outputs[:, :, 2], np.ones((4, 4)) * 0.852353)
+
     @parameterized.parameters(
         (True, False),
         (False, True),


### PR DESCRIPTION
When we pass `bfloat16` as the dtype in image converter and call it, it fails. Here's a [Colab](https://colab.research.google.com/gist/abheesht17/c4eb5ecf392143ba8927c116954b8aa8/kerashub-image-converter-dtype-bug.ipynb) to demonstrate this.

Still curious why our preset tests for PaliGemma don't fail on GH Actions. Edit: Oh, it is because we don't run "large" tests:  https://github.com/keras-team/keras-hub/blob/master/.github/workflows/actions.yml#L63.

