### PR TITLE
Add back a format script for compat

### DIFF
--- a/shell/api_gen.sh
+++ b/shell/api_gen.sh
@@ -3,6 +3,12 @@ set -Eeuo pipefail
 
 base_dir=$(dirname $(dirname $0))
 
+if ! command -v pre-commit 2>&1 >/dev/null
+then
+    echo 'Please `pip install pre-commit` to run api_gen.sh.'
+    exit 1
+fi
+
 echo "Generating api directory with public APIs..."
 # Generate API Files
 python3 "${base_dir}"/api_gen.py

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if ! command -v pre-commit 2>&1 >/dev/null
+then
+    echo 'Please `pip install pre-commit` to run format.sh.'
+    exit 1
+fi
+
+base_dir=$(dirname $(dirname $0))
+
+echo "Formatting all files..."
+SKIP=api-gen pre-commit run --all-files


### PR DESCRIPTION
This will just call pre-commit (but skip api-gen). Will also prompt users to install if not installed, I've noticed a lot of unformatted PRs as of late.