### PR TITLE
Added LayoutLMv3 

### DIFF
--- a/keras_hub/src/models/layoutlmv3/layoutlmv3_backbone.py
+++ b/keras_hub/src/models/layoutlmv3/layoutlmv3_backbone.py
@@ -1,0 +1,478 @@
+import keras
+import tensorflow as tf
+import numpy as np
+from keras import layers
+from keras import ops
+from keras.src.saving import register_keras_serializable
+
+@register_keras_serializable()
+class LayoutLMv3Backbone(keras.Model):
+    """LayoutLMv3 backbone model.
+    
+    This class implements the LayoutLMv3 model architecture as described in
+    "LayoutLMv3: Pre-training for Document AI with Unified Text and Image Masking"
+    (https://arxiv.org/abs/2204.08387).
+    
+    Args:
+        vocab_size: The size of the vocabulary.
+        hidden_size: The size of the hidden layers.
+        num_hidden_layers: The number of hidden layers.
+        num_attention_heads: The number of attention heads.
+        intermediate_size: The size of the intermediate layer in the transformer encoder.
+        hidden_act: The activation function for the intermediate layer.
+        hidden_dropout_prob: The dropout probability for the hidden layers.
+        attention_probs_dropout_prob: The dropout probability for the attention probabilities.
+        max_position_embeddings: The maximum sequence length for position embeddings.
+        type_vocab_size: The size of the token type vocabulary.
+        initializer_range: The standard deviation of the truncated normal initializer.
+        layer_norm_eps: The epsilon value for layer normalization.
+        image_size: The size of the input image (height, width).
+        patch_size: The size of the image patches.
+        num_channels: The number of input image channels.
+        qkv_bias: Whether to use bias in the query, key, value projections.
+        use_abs_pos: Whether to use absolute position embeddings.
+        use_rel_pos: Whether to use relative position embeddings.
+        rel_pos_bins: The number of relative position bins.
+        max_rel_pos: The maximum relative position distance.
+        spatial_embedding_dim: The size of the spatial embedding dimension.
+        **kwargs: Additional keyword arguments.
+    """
+    
+    def __init__(
+        self,
+        vocab_size=30522,
+        hidden_size=768,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        intermediate_size=3072,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        max_position_embeddings=512,
+        type_vocab_size=2,
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        image_size=(112, 112),
+        patch_size=16,
+        num_channels=3,
+        qkv_bias=True,
+        use_abs_pos=True,
+        use_rel_pos=False,
+        rel_pos_bins=32,
+        max_rel_pos=128,
+        spatial_embedding_dim=128,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.max_position_embeddings = max_position_embeddings
+        self.type_vocab_size = type_vocab_size
+        self.initializer_range = initializer_range
+        self.layer_norm_eps = layer_norm_eps
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.num_channels = num_channels
+        self.qkv_bias = qkv_bias
+        self.use_abs_pos = use_abs_pos
+        self.use_rel_pos = use_rel_pos
+        self.rel_pos_bins = rel_pos_bins
+        self.max_rel_pos = max_rel_pos
+        self.spatial_embedding_dim = spatial_embedding_dim
+        
+        # Input layers
+        self.input_ids = layers.Input(shape=(None,), dtype=tf.int32, name="input_ids")
+        self.bbox = layers.Input(shape=(None, 4), dtype=tf.int32, name="bbox")
+        self.attention_mask = layers.Input(shape=(None,), dtype=tf.int32, name="attention_mask")
+        self.image = layers.Input(shape=(*image_size, num_channels), dtype=tf.float32, name="image")
+        
+        # Embeddings
+        self.word_embeddings = layers.Embedding(
+            vocab_size, hidden_size, name="embeddings.word_embeddings"
+        )
+        self.position_embeddings = layers.Embedding(
+            max_position_embeddings, hidden_size, name="embeddings.position_embeddings"
+        )
+        self.x_position_embeddings = layers.Embedding(1024, spatial_embedding_dim, name="embeddings.x_position_embeddings")
+        self.y_position_embeddings = layers.Embedding(1024, spatial_embedding_dim, name="embeddings.y_position_embeddings")
+        self.h_position_embeddings = layers.Embedding(1024, spatial_embedding_dim, name="embeddings.h_position_embeddings")
+        self.w_position_embeddings = layers.Embedding(1024, spatial_embedding_dim, name="embeddings.w_position_embeddings")
+        self.token_type_embeddings = layers.Embedding(
+            type_vocab_size, hidden_size, name="embeddings.token_type_embeddings"
+        )
+        
+        # Layer normalization
+        self.embeddings_LayerNorm = layers.LayerNormalization(
+            epsilon=layer_norm_eps, name="embeddings.LayerNorm"
+        )
+        self.norm = layers.LayerNormalization(epsilon=layer_norm_eps, name="norm")
+        
+        # Spatial embedding projections
+        self.x_proj = layers.Dense(hidden_size, name="x_proj")
+        self.y_proj = layers.Dense(hidden_size, name="y_proj")
+        self.h_proj = layers.Dense(hidden_size, name="h_proj")
+        self.w_proj = layers.Dense(hidden_size, name="w_proj")
+        
+        # Transformer encoder layers
+        self.encoder_layers = [
+            LayoutLMv3TransformerLayer(
+                hidden_size=hidden_size,
+                num_attention_heads=num_attention_heads,
+                intermediate_size=intermediate_size,
+                hidden_act=hidden_act,
+                hidden_dropout_prob=hidden_dropout_prob,
+                attention_probs_dropout_prob=attention_probs_dropout_prob,
+                initializer_range=initializer_range,
+                layer_norm_eps=layer_norm_eps,
+                qkv_bias=qkv_bias,
+                use_rel_pos=use_rel_pos,
+                rel_pos_bins=rel_pos_bins,
+                max_rel_pos=max_rel_pos,
+                name=f"encoder.layer.{i}",
+            )
+            for i in range(num_hidden_layers)
+        ]
+        
+        # Image processing
+        self.patch_embed = layers.Conv2D(
+            hidden_size,
+            kernel_size=(patch_size, patch_size),
+            strides=(patch_size, patch_size),
+            name="patch_embed.proj",
+        )
+        self.patch_embed_layer_norm = layers.LayerNormalization(
+            epsilon=layer_norm_eps, name="LayerNorm"
+        )
+        
+        # CLS token
+        self.cls_token = self.add_weight(
+            shape=(1, 1, hidden_size),
+            initializer="random_normal",
+            trainable=True,
+            name="cls_token",
+        )
+        
+        # Pooler
+        self.pooler = layers.Dense(hidden_size, activation="tanh", name="pooler")
+        
+    def call(self, inputs):
+        input_ids = inputs["input_ids"]
+        bbox = inputs["bbox"]
+        attention_mask = inputs["attention_mask"]
+        image = inputs["image"]
+        
+        # Get sequence length
+        seq_length = tf.shape(input_ids)[1]
+        
+        # Create position IDs
+        position_ids = tf.range(seq_length, dtype=tf.int32)
+        position_embeddings = self.position_embeddings(position_ids)
+        
+        # Get spatial embeddings
+        x_position_embeddings = self.x_position_embeddings(bbox[:, :, 0])
+        y_position_embeddings = self.y_position_embeddings(bbox[:, :, 1])
+        h_position_embeddings = self.h_position_embeddings(bbox[:, :, 2])
+        w_position_embeddings = self.w_position_embeddings(bbox[:, :, 3])
+        
+        # Project spatial embeddings to hidden size
+        x_position_embeddings = self.x_proj(x_position_embeddings)
+        y_position_embeddings = self.y_proj(y_position_embeddings)
+        h_position_embeddings = self.h_proj(h_position_embeddings)
+        w_position_embeddings = self.w_proj(w_position_embeddings)
+        
+        # Get word embeddings and token type embeddings
+        word_embeddings = self.word_embeddings(input_ids)
+        token_type_ids = tf.zeros_like(input_ids[:, 0:1])
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+        token_type_embeddings = tf.broadcast_to(
+            token_type_embeddings,
+            [tf.shape(input_ids)[0], tf.shape(input_ids)[1], self.hidden_size],
+        )
+        
+        # Combine all embeddings
+        text_embeddings = (
+            word_embeddings
+            + position_embeddings
+            + x_position_embeddings
+            + y_position_embeddings
+            + h_position_embeddings
+            + w_position_embeddings
+            + token_type_embeddings
+        )
+        
+        # Process image
+        patch_embeddings = self.patch_embed(image)
+        batch_size = tf.shape(patch_embeddings)[0]
+        patch_embeddings_shape = tf.shape(patch_embeddings)
+        num_patches = patch_embeddings_shape[1] * patch_embeddings_shape[2]
+        patch_embeddings = tf.reshape(
+            patch_embeddings, [batch_size, num_patches, self.hidden_size]
+        )
+        patch_embeddings = self.patch_embed_layer_norm(patch_embeddings)
+        
+        # Combine text and image embeddings
+        x = tf.concat([text_embeddings, patch_embeddings], axis=1)
+        
+        # Add CLS token
+        cls_tokens = tf.broadcast_to(
+            self.cls_token, [tf.shape(x)[0], 1, self.hidden_size]
+        )
+        x = tf.concat([cls_tokens, x], axis=1)
+        
+        # Apply layer normalization
+        x = self.embeddings_LayerNorm(x)
+        
+        # Create attention mask
+        new_seq_length = tf.shape(x)[1]
+        extended_attention_mask = tf.ones(
+            (tf.shape(input_ids)[0], new_seq_length), dtype=tf.int32
+        )
+        extended_attention_mask = tf.cast(
+            extended_attention_mask[:, tf.newaxis, tf.newaxis, :],
+            dtype=tf.float32,
+        )
+        extended_attention_mask = tf.broadcast_to(
+            extended_attention_mask,
+            (tf.shape(input_ids)[0], self.num_attention_heads, new_seq_length, new_seq_length),
+        )
+        
+        # Pass through transformer layers
+        for layer in self.encoder_layers:
+            x = layer(x, extended_attention_mask)
+        
+        # Apply final layer normalization
+        x = self.norm(x)
+        
+        # Apply pooler
+        pooled_output = self.pooler(x[:, 0])
+        
+        return {
+            "sequence_output": x,
+            "pooled_output": pooled_output,
+        }
+
+@register_keras_serializable()
+class LayoutLMv3TransformerLayer(layers.Layer):
+    """Transformer layer for LayoutLMv3.
+    
+    Args:
+        hidden_size: The size of the hidden layers.
+        num_attention_heads: The number of attention heads.
+        intermediate_size: The size of the intermediate layer.
+        hidden_act: The activation function for the intermediate layer.
+        hidden_dropout_prob: The dropout probability for the hidden layers.
+        attention_probs_dropout_prob: The dropout probability for the attention probabilities.
+        initializer_range: The standard deviation of the truncated normal initializer.
+        layer_norm_eps: The epsilon value for layer normalization.
+        qkv_bias: Whether to use bias in the query, key, value projections.
+        use_rel_pos: Whether to use relative position embeddings.
+        rel_pos_bins: The number of relative position bins.
+        max_rel_pos: The maximum relative position distance.
+        **kwargs: Additional keyword arguments.
+    """
+    
+    def __init__(
+        self,
+        hidden_size=768,
+        num_attention_heads=12,
+        intermediate_size=3072,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        qkv_bias=True,
+        use_rel_pos=False,
+        rel_pos_bins=32,
+        max_rel_pos=128,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.initializer_range = initializer_range
+        self.layer_norm_eps = layer_norm_eps
+        self.qkv_bias = qkv_bias
+        self.use_rel_pos = use_rel_pos
+        self.rel_pos_bins = rel_pos_bins
+        self.max_rel_pos = max_rel_pos
+        
+        # Attention layer
+        self.attention = LayoutLMv3Attention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            dropout=attention_probs_dropout_prob,
+            qkv_bias=qkv_bias,
+            use_rel_pos=use_rel_pos,
+            rel_pos_bins=rel_pos_bins,
+            max_rel_pos=max_rel_pos,
+            name="attention",
+        )
+        
+        # Layer normalization
+        self.attention_output_dense = layers.Dense(hidden_size, name="attention.output.dense")
+        self.attention_output_layernorm = layers.LayerNormalization(
+            epsilon=layer_norm_eps, name="attention.output.LayerNorm"
+        )
+        
+        # Intermediate layer
+        self.intermediate_dense = layers.Dense(
+            intermediate_size, activation=hidden_act, name="intermediate.dense"
+        )
+        
+        # Output layer
+        self.output_dense = layers.Dense(hidden_size, name="output.dense")
+        self.output_layernorm = layers.LayerNormalization(
+            epsilon=layer_norm_eps, name="output.LayerNorm"
+        )
+        
+        # Dropout
+        self.dropout = layers.Dropout(hidden_dropout_prob)
+        
+    def call(self, hidden_states, attention_mask=None):
+        # Self-attention
+        attention_output = self.attention(hidden_states, attention_mask)
+        attention_output = self.attention_output_dense(attention_output)
+        attention_output = self.dropout(attention_output)
+        attention_output = self.attention_output_layernorm(attention_output + hidden_states)
+        
+        # Feed-forward
+        intermediate_output = self.intermediate_dense(attention_output)
+        intermediate_output = self.output_dense(intermediate_output)
+        intermediate_output = self.dropout(intermediate_output)
+        output = self.output_layernorm(intermediate_output + attention_output)
+        
+        return output
+
+@register_keras_serializable()
+class LayoutLMv3Attention(layers.Layer):
+    """Attention layer for LayoutLMv3.
+    
+    Args:
+        hidden_size: The size of the hidden layers.
+        num_attention_heads: The number of attention heads.
+        dropout: The dropout probability.
+        qkv_bias: Whether to use bias in the query, key, value projections.
+        use_rel_pos: Whether to use relative position embeddings.
+        rel_pos_bins: The number of relative position bins.
+        max_rel_pos: The maximum relative position distance.
+        **kwargs: Additional keyword arguments.
+    """
+    
+    def __init__(
+        self,
+        hidden_size=768,
+        num_attention_heads=12,
+        dropout=0.1,
+        qkv_bias=True,
+        use_rel_pos=False,
+        rel_pos_bins=32,
+        max_rel_pos=128,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.dropout = dropout
+        self.qkv_bias = qkv_bias
+        self.use_rel_pos = use_rel_pos
+        self.rel_pos_bins = rel_pos_bins
+        self.max_rel_pos = max_rel_pos
+        
+        # Query, key, value projections
+        self.q_proj = layers.Dense(hidden_size, use_bias=qkv_bias, name="query")
+        self.k_proj = layers.Dense(hidden_size, use_bias=qkv_bias, name="key")
+        self.v_proj = layers.Dense(hidden_size, use_bias=qkv_bias, name="value")
+        
+        # Output projection
+        self.out_proj = layers.Dense(hidden_size, name="output")
+        
+        # Dropout
+        self.dropout_layer = layers.Dropout(dropout)
+        
+        # Relative position embeddings (if enabled)
+        if use_rel_pos:
+            self.rel_pos_bias = self.add_weight(
+                shape=(2 * rel_pos_bins - 1, num_attention_heads),
+                initializer="zeros",
+                trainable=True,
+                name="rel_pos_bias",
+            )
+    
+    def call(self, hidden_states, attention_mask=None):
+        batch_size = tf.shape(hidden_states)[0]
+        seq_length = tf.shape(hidden_states)[1]
+        
+        # Project to query, key, value
+        q = self.q_proj(hidden_states)
+        k = self.k_proj(hidden_states)
+        v = self.v_proj(hidden_states)
+        
+        # Reshape for attention
+        q = tf.reshape(q, (batch_size, seq_length, self.num_attention_heads, -1))
+        k = tf.reshape(k, (batch_size, seq_length, self.num_attention_heads, -1))
+        v = tf.reshape(v, (batch_size, seq_length, self.num_attention_heads, -1))
+        
+        # Transpose for attention
+        q = tf.transpose(q, perm=[0, 2, 1, 3])
+        k = tf.transpose(k, perm=[0, 2, 1, 3])
+        v = tf.transpose(v, perm=[0, 2, 1, 3])
+        
+        # Compute attention scores
+        attention_scores = tf.matmul(q, k, transpose_b=True)
+        attention_scores = attention_scores / tf.math.sqrt(tf.cast(tf.shape(k)[-1], tf.float32))
+        
+        # Apply attention mask
+        if attention_mask is not None:
+            attention_scores = attention_scores + (1.0 - attention_mask) * -10000.0
+        
+        # Apply relative position bias if enabled
+        if self.use_rel_pos:
+            rel_pos_bias = self._get_rel_pos_bias(seq_length)
+            attention_scores = attention_scores + rel_pos_bias
+        
+        # Apply softmax
+        attention_probs = tf.nn.softmax(attention_scores, axis=-1)
+        attention_probs = self.dropout_layer(attention_probs)
+        
+        # Apply attention to values
+        context = tf.matmul(attention_probs, v)
+        
+        # Reshape and project output
+        context = tf.transpose(context, perm=[0, 2, 1, 3])
+        context = tf.reshape(context, (batch_size, seq_length, self.hidden_size))
+        output = self.out_proj(context)
+        
+        return output
+    
+    def _get_rel_pos_bias(self, seq_length):
+        """Get relative position bias."""
+        # Create relative position indices
+        pos = tf.range(seq_length)
+        rel_pos = pos[:, None] - pos[None, :]
+        rel_pos = rel_pos + self.rel_pos_bins - 1
+        
+        # Clip to valid range
+        rel_pos = tf.clip_by_value(rel_pos, 0, 2 * self.rel_pos_bins - 2)
+        
+        # Get bias values
+        bias = tf.gather(self.rel_pos_bias, rel_pos)
+        
+        # Reshape for attention
+        bias = tf.transpose(bias, perm=[2, 0, 1])
+        bias = tf.expand_dims(bias, 0)
+        
+        return bias 

--- a/keras_hub/src/models/layoutlmv3/layoutlmv3_backbone_test.py
+++ b/keras_hub/src/models/layoutlmv3/layoutlmv3_backbone_test.py
@@ -1,0 +1,172 @@
+import os
+import pytest
+import tensorflow as tf
+import numpy as np
+from keras import backend
+from tensorflow.python.keras.testing_utils import test_combinations
+from tensorflow.python.keras.testing_utils import test_utils
+from keras_hub.src.models.layoutlmv3.layoutlmv3_backbone import LayoutLMv3Backbone
+
+@test_combinations.run_all_keras_modes
+class LayoutLMv3BackboneTest(test_combinations.TestCase):
+    def setUp(self):
+        super(LayoutLMv3BackboneTest, self).setUp()
+        self.backbone = LayoutLMv3Backbone(
+            vocab_size=30522,
+            hidden_size=768,
+            num_hidden_layers=12,
+            num_attention_heads=12,
+            intermediate_size=3072,
+            hidden_act="gelu",
+            hidden_dropout_prob=0.1,
+            attention_probs_dropout_prob=0.1,
+            max_position_embeddings=512,
+            type_vocab_size=2,
+            initializer_range=0.02,
+            layer_norm_eps=1e-12,
+            image_size=(112, 112),
+            patch_size=16,
+            num_channels=3,
+            qkv_bias=True,
+            use_abs_pos=True,
+            use_rel_pos=False,
+            rel_pos_bins=32,
+            max_rel_pos=128,
+        )
+        
+        # Create dummy inputs
+        self.batch_size = 2
+        self.seq_length = 64
+        self.input_ids = tf.random.uniform(
+            (self.batch_size, self.seq_length), minval=0, maxval=30522, dtype=tf.int32
+        )
+        self.bbox = tf.random.uniform(
+            (self.batch_size, self.seq_length, 4), minval=0, maxval=512, dtype=tf.int32
+        )
+        self.attention_mask = tf.ones((self.batch_size, self.seq_length), dtype=tf.int32)
+        self.image = tf.random.uniform(
+            (self.batch_size, 112, 112, 3), minval=0, maxval=1, dtype=tf.float32
+        )
+        
+        self.inputs = {
+            "input_ids": self.input_ids,
+            "bbox": self.bbox,
+            "attention_mask": self.attention_mask,
+            "image": self.image,
+        }
+    
+    def test_backbone_basics(self):
+        """Test the basic functionality of the backbone."""
+        # Test model creation
+        self.assertIsInstance(self.backbone, LayoutLMv3Backbone)
+        
+        # Test model call
+        outputs = self.backbone(self.inputs)
+        self.assertIsInstance(outputs, dict)
+        self.assertIn("sequence_output", outputs)
+        self.assertIn("pooled_output", outputs)
+        
+        # Test output shapes
+        sequence_output = outputs["sequence_output"]
+        pooled_output = outputs["pooled_output"]
+        
+        expected_seq_length = self.seq_length + (112 // 16) * (112 // 16) + 1  # text + image patches + cls token
+        self.assertEqual(sequence_output.shape, (self.batch_size, expected_seq_length, 768))
+        self.assertEqual(pooled_output.shape, (self.batch_size, 768))
+    
+    def test_backbone_save_and_load(self):
+        """Test saving and loading the backbone."""
+        # Save the model
+        save_path = os.path.join(self.get_temp_dir(), "layoutlmv3_backbone")
+        self.backbone.save(save_path)
+        
+        # Load the model
+        loaded_backbone = tf.keras.models.load_model(save_path)
+        
+        # Test loaded model
+        outputs = loaded_backbone(self.inputs)
+        self.assertIsInstance(outputs, dict)
+        self.assertIn("sequence_output", outputs)
+        self.assertIn("pooled_output", outputs)
+        
+        # Compare outputs
+        original_outputs = self.backbone(self.inputs)
+        tf.debugging.assert_near(
+            outputs["sequence_output"], original_outputs["sequence_output"], rtol=1e-5
+        )
+        tf.debugging.assert_near(
+            outputs["pooled_output"], original_outputs["pooled_output"], rtol=1e-5
+        )
+    
+    def test_backbone_with_different_input_shapes(self):
+        """Test the backbone with different input shapes."""
+        # Test with different sequence lengths
+        seq_lengths = [32, 128]
+        for seq_len in seq_lengths:
+            inputs = {
+                "input_ids": tf.random.uniform(
+                    (self.batch_size, seq_len), minval=0, maxval=30522, dtype=tf.int32
+                ),
+                "bbox": tf.random.uniform(
+                    (self.batch_size, seq_len, 4), minval=0, maxval=512, dtype=tf.int32
+                ),
+                "attention_mask": tf.ones((self.batch_size, seq_len), dtype=tf.int32),
+                "image": self.image,
+            }
+            outputs = self.backbone(inputs)
+            expected_seq_length = seq_len + (112 // 16) * (112 // 16) + 1
+            self.assertEqual(outputs["sequence_output"].shape, (self.batch_size, expected_seq_length, 768))
+        
+        # Test with different batch sizes
+        batch_sizes = [1, 4]
+        for batch_size in batch_sizes:
+            inputs = {
+                "input_ids": tf.random.uniform(
+                    (batch_size, self.seq_length), minval=0, maxval=30522, dtype=tf.int32
+                ),
+                "bbox": tf.random.uniform(
+                    (batch_size, self.seq_length, 4), minval=0, maxval=512, dtype=tf.int32
+                ),
+                "attention_mask": tf.ones((batch_size, self.seq_length), dtype=tf.int32),
+                "image": tf.random.uniform(
+                    (batch_size, 112, 112, 3), minval=0, maxval=1, dtype=tf.float32
+                ),
+            }
+            outputs = self.backbone(inputs)
+            expected_seq_length = self.seq_length + (112 // 16) * (112 // 16) + 1
+            self.assertEqual(outputs["sequence_output"].shape, (batch_size, expected_seq_length, 768))
+    
+    def test_backbone_with_attention_mask(self):
+        """Test the backbone with different attention masks."""
+        # Create a mask with some padding
+        attention_mask = tf.ones((self.batch_size, self.seq_length), dtype=tf.int32)
+        attention_mask = tf.tensor_scatter_nd_update(
+            attention_mask,
+            tf.constant([[0, 32], [1, 48]]),  # Set some positions to 0
+            tf.constant([0, 0], dtype=tf.int32),
+        )
+        
+        inputs = {
+            "input_ids": self.input_ids,
+            "bbox": self.bbox,
+            "attention_mask": attention_mask,
+            "image": self.image,
+        }
+        
+        outputs = self.backbone(inputs)
+        self.assertIsInstance(outputs, dict)
+        self.assertIn("sequence_output", outputs)
+        self.assertIn("pooled_output", outputs)
+    
+    def test_backbone_gradient(self):
+        """Test that the backbone produces gradients."""
+        with tf.GradientTape() as tape:
+            outputs = self.backbone(self.inputs)
+            loss = tf.reduce_mean(outputs["pooled_output"])
+        
+        # Check if gradients exist for all trainable variables
+        gradients = tape.gradient(loss, self.backbone.trainable_variables)
+        for grad in gradients:
+            self.assertIsNotNone(grad)
+            self.assertFalse(tf.reduce_all(tf.math.is_nan(grad)))
+            self.assertFalse(tf.reduce_all(tf.math.is_inf(grad))) 

--- a/keras_hub/src/models/layoutlmv3/layoutlmv3_presets.py
+++ b/keras_hub/src/models/layoutlmv3/layoutlmv3_presets.py
@@ -1,0 +1,110 @@
+"""LayoutLMv3 presets."""
+
+from keras_hub.src.models.layoutlmv3.layoutlmv3_backbone import LayoutLMv3Backbone
+from keras_hub.src.models.layoutlmv3.layoutlmv3_tokenizer import LayoutLMv3Tokenizer
+
+def layoutlmv3_base(
+    *,
+    load_weights=True,
+    **kwargs,
+):
+    """Create a LayoutLMv3 base model.
+    
+    Args:
+        load_weights: Whether to load pretrained weights.
+        **kwargs: Additional keyword arguments.
+        
+    Returns:
+        A tuple of (backbone, tokenizer).
+    """
+    backbone = LayoutLMv3Backbone(
+        vocab_size=30522,
+        hidden_size=768,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        intermediate_size=3072,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        max_position_embeddings=512,
+        type_vocab_size=2,
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        image_size=(112, 112),
+        patch_size=16,
+        num_channels=3,
+        qkv_bias=True,
+        use_abs_pos=True,
+        use_rel_pos=False,
+        rel_pos_bins=32,
+        max_rel_pos=128,
+        **kwargs,
+    )
+    
+    tokenizer = LayoutLMv3Tokenizer(
+        vocabulary=None,  # Will be loaded from pretrained weights
+        lowercase=True,
+        strip_accents=True,
+    )
+    
+    if load_weights:
+        # TODO: Load pretrained weights from GCP bucket
+        pass
+    
+    return backbone, tokenizer
+
+def layoutlmv3_large(
+    *,
+    load_weights=True,
+    **kwargs,
+):
+    """Create a LayoutLMv3 large model.
+    
+    Args:
+        load_weights: Whether to load pretrained weights.
+        **kwargs: Additional keyword arguments.
+        
+    Returns:
+        A tuple of (backbone, tokenizer).
+    """
+    backbone = LayoutLMv3Backbone(
+        vocab_size=30522,
+        hidden_size=1024,
+        num_hidden_layers=24,
+        num_attention_heads=16,
+        intermediate_size=4096,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        max_position_embeddings=512,
+        type_vocab_size=2,
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        image_size=(112, 112),
+        patch_size=16,
+        num_channels=3,
+        qkv_bias=True,
+        use_abs_pos=True,
+        use_rel_pos=False,
+        rel_pos_bins=32,
+        max_rel_pos=128,
+        **kwargs,
+    )
+    
+    tokenizer = LayoutLMv3Tokenizer(
+        vocabulary=None,  # Will be loaded from pretrained weights
+        lowercase=True,
+        strip_accents=True,
+    )
+    
+    if load_weights:
+        # TODO: Load pretrained weights from GCP bucket
+        pass
+    
+    return backbone, tokenizer
+
+# Dictionary mapping preset names to their corresponding functions
+LAYOUTLMV3_PRESETS = {
+    "layoutlmv3_base": layoutlmv3_base,
+    "layoutlmv3_large": layoutlmv3_large,
+} 

--- a/keras_hub/src/models/layoutlmv3/layoutlmv3_tokenizer.py
+++ b/keras_hub/src/models/layoutlmv3/layoutlmv3_tokenizer.py
@@ -1,0 +1,138 @@
+import tensorflow as tf
+from keras import layers
+from keras.src.saving import register_keras_serializable
+from ...tokenizers.word_piece_tokenizer import WordPieceTokenizer
+
+@register_keras_serializable()
+class LayoutLMv3Tokenizer(WordPieceTokenizer):
+    """LayoutLMv3 tokenizer.
+    
+    This tokenizer inherits from WordPieceTokenizer and adds LayoutLMv3-specific
+    special tokens and functionality.
+    
+    Args:
+        vocabulary: A list of strings containing the vocabulary.
+        lowercase: Whether to lowercase the input text.
+        strip_accents: Whether to strip accents from the input text.
+        **kwargs: Additional keyword arguments.
+    """
+    
+    def __init__(
+        self,
+        vocabulary=None,
+        lowercase=True,
+        strip_accents=True,
+        **kwargs,
+    ):
+        super().__init__(
+            vocabulary=vocabulary,
+            lowercase=lowercase,
+            strip_accents=strip_accents,
+            **kwargs,
+        )
+        
+        # Special tokens
+        self.cls_token = "[CLS]"
+        self.sep_token = "[SEP]"
+        self.pad_token = "[PAD]"
+        self.mask_token = "[MASK]"
+        self.unk_token = "[UNK]"
+        
+        # Special token IDs
+        self.cls_token_id = self.token_to_id(self.cls_token)
+        self.sep_token_id = self.token_to_id(self.sep_token)
+        self.pad_token_id = self.token_to_id(self.pad_token)
+        self.mask_token_id = self.token_to_id(self.mask_token)
+        self.unk_token_id = self.token_to_id(self.unk_token)
+        
+        # Special token masks
+        self.cls_token_mask = tf.constant(1, dtype=tf.int32)
+        self.sep_token_mask = tf.constant(1, dtype=tf.int32)
+        self.pad_token_mask = tf.constant(0, dtype=tf.int32)
+        self.mask_token_mask = tf.constant(1, dtype=tf.int32)
+        self.unk_token_mask = tf.constant(1, dtype=tf.int32)
+    
+    def call(self, inputs):
+        """Tokenize the input text.
+        
+        Args:
+            inputs: A string or list of strings to tokenize.
+            
+        Returns:
+            A dictionary containing:
+                - token_ids: The token IDs.
+                - padding_mask: The padding mask.
+                - attention_mask: The attention mask.
+        """
+        # Tokenize the input text
+        tokenized = super().call(inputs)
+        
+        # Add special tokens
+        token_ids = tokenized["token_ids"]
+        padding_mask = tokenized["padding_mask"]
+        
+        # Add [CLS] token at the beginning
+        cls_token_ids = tf.fill([tf.shape(token_ids)[0], 1], self.cls_token_id)
+        cls_token_mask = tf.fill([tf.shape(padding_mask)[0], 1], self.cls_token_mask)
+        
+        token_ids = tf.concat([cls_token_ids, token_ids], axis=1)
+        padding_mask = tf.concat([cls_token_mask, padding_mask], axis=1)
+        
+        # Add [SEP] token at the end
+        sep_token_ids = tf.fill([tf.shape(token_ids)[0], 1], self.sep_token_id)
+        sep_token_mask = tf.fill([tf.shape(padding_mask)[0], 1], self.sep_token_mask)
+        
+        token_ids = tf.concat([token_ids, sep_token_ids], axis=1)
+        padding_mask = tf.concat([padding_mask, sep_token_mask], axis=1)
+        
+        # Create attention mask
+        attention_mask = tf.cast(padding_mask, dtype=tf.int32)
+        
+        return {
+            "token_ids": token_ids,
+            "padding_mask": padding_mask,
+            "attention_mask": attention_mask,
+        }
+    
+    def detokenize(self, token_ids):
+        """Convert token IDs back to text.
+        
+        Args:
+            token_ids: A tensor of token IDs.
+            
+        Returns:
+            A list of strings containing the detokenized text.
+        """
+        # Remove special tokens
+        token_ids = token_ids[:, 1:-1]  # Remove [CLS] and [SEP]
+        
+        # Convert to text
+        return super().detokenize(token_ids)
+    
+    def get_config(self):
+        """Get the tokenizer configuration.
+        
+        Returns:
+            A dictionary containing the tokenizer configuration.
+        """
+        config = super().get_config()
+        config.update({
+            "cls_token": self.cls_token,
+            "sep_token": self.sep_token,
+            "pad_token": self.pad_token,
+            "mask_token": self.mask_token,
+            "unk_token": self.unk_token,
+        })
+        return config
+    
+    @classmethod
+    def from_config(cls, config):
+        """Create a tokenizer from a configuration dictionary.
+        
+        Args:
+            config: A dictionary containing the tokenizer configuration.
+            
+        Returns:
+            A LayoutLMv3Tokenizer instance.
+        """
+        return cls(**config) 

--- a/keras_hub/src/models/layoutlmv3/layoutlmv3_tokenizer_test.py
+++ b/keras_hub/src/models/layoutlmv3/layoutlmv3_tokenizer_test.py
@@ -1,0 +1,162 @@
+import os
+import pytest
+import tensorflow as tf
+import numpy as np
+from keras import backend
+from keras.testing_infra import test_combinations
+from keras.testing_infra import test_utils
+from keras_hub.src.models.layoutlmv3.layoutlmv3_tokenizer import LayoutLMv3Tokenizer
+
+@test_combinations.run_all_keras_modes
+class LayoutLMv3TokenizerTest(test_combinations.TestCase):
+    def setUp(self):
+        super(LayoutLMv3TokenizerTest, self).setUp()
+        
+        # Create a dummy vocabulary
+        self.vocab = [
+            "[PAD]",
+            "[UNK]",
+            "[CLS]",
+            "[SEP]",
+            "[MASK]",
+            "the",
+            "quick",
+            "brown",
+            "fox",
+            "jumps",
+            "over",
+            "lazy",
+            "dog",
+            "##s",
+            "##ing",
+            "##ed",
+        ]
+        
+        self.tokenizer = LayoutLMv3Tokenizer(
+            vocabulary=self.vocab,
+            lowercase=True,
+            strip_accents=True,
+        )
+    
+    def test_tokenizer_basics(self):
+        """Test the basic functionality of the tokenizer."""
+        # Test tokenizer creation
+        self.assertIsInstance(self.tokenizer, LayoutLMv3Tokenizer)
+        
+        # Test special tokens
+        self.assertEqual(self.tokenizer.cls_token, "[CLS]")
+        self.assertEqual(self.tokenizer.sep_token, "[SEP]")
+        self.assertEqual(self.tokenizer.pad_token, "[PAD]")
+        self.assertEqual(self.tokenizer.mask_token, "[MASK]")
+        self.assertEqual(self.tokenizer.unk_token, "[UNK]")
+        
+        # Test tokenization
+        text = "The quick brown fox jumps over the lazy dog"
+        outputs = self.tokenizer(text)
+        
+        self.assertIsInstance(outputs, dict)
+        self.assertIn("token_ids", outputs)
+        self.assertIn("padding_mask", outputs)
+        self.assertIn("attention_mask", outputs)
+        
+        # Check output shapes
+        token_ids = outputs["token_ids"]
+        padding_mask = outputs["padding_mask"]
+        attention_mask = outputs["attention_mask"]
+        
+        self.assertEqual(token_ids.shape[0], 1)  # batch size
+        self.assertEqual(padding_mask.shape[0], 1)  # batch size
+        self.assertEqual(attention_mask.shape[0], 1)  # batch size
+        self.assertEqual(token_ids.shape[1], padding_mask.shape[1])  # sequence length
+        self.assertEqual(token_ids.shape[1], attention_mask.shape[1])  # sequence length
+    
+    def test_tokenizer_special_tokens(self):
+        """Test that special tokens are correctly added."""
+        text = "The quick brown fox"
+        outputs = self.tokenizer(text)
+        token_ids = outputs["token_ids"][0]  # Get first sequence
+        
+        # Check that [CLS] is at the beginning
+        self.assertEqual(token_ids[0], self.tokenizer.cls_token_id)
+        
+        # Check that [SEP] is at the end
+        self.assertEqual(token_ids[-1], self.tokenizer.sep_token_id)
+        
+        # Check that padding mask is correct
+        padding_mask = outputs["padding_mask"][0]
+        self.assertEqual(padding_mask[0], 1)  # [CLS] token
+        self.assertEqual(padding_mask[-1], 1)  # [SEP] token
+        self.assertTrue(tf.reduce_all(padding_mask[1:-1] == 1))  # All other tokens
+    
+    def test_tokenizer_batch(self):
+        """Test tokenization with batch inputs."""
+        texts = [
+            "The quick brown fox",
+            "The lazy dog jumps",
+        ]
+        outputs = self.tokenizer(texts)
+        
+        # Check batch dimension
+        self.assertEqual(outputs["token_ids"].shape[0], 2)
+        self.assertEqual(outputs["padding_mask"].shape[0], 2)
+        self.assertEqual(outputs["attention_mask"].shape[0], 2)
+        
+        # Check that each sequence has [CLS] and [SEP]
+        for i in range(2):
+            token_ids = outputs["token_ids"][i]
+            self.assertEqual(token_ids[0], self.tokenizer.cls_token_id)
+            self.assertEqual(token_ids[-1], self.tokenizer.sep_token_id)
+    
+    def test_tokenizer_detokenize(self):
+        """Test detokenization."""
+        text = "The quick brown fox"
+        outputs = self.tokenizer(text)
+        token_ids = outputs["token_ids"]
+        
+        # Detokenize
+        detokenized = self.tokenizer.detokenize(token_ids)
+        
+        # Check that special tokens are removed
+        self.assertNotIn("[CLS]", detokenized[0])
+        self.assertNotIn("[SEP]", detokenized[0])
+        
+        # Check that the text is preserved (up to tokenization)
+        self.assertIn("quick", detokenized[0].lower())
+        self.assertIn("brown", detokenized[0].lower())
+        self.assertIn("fox", detokenized[0].lower())
+    
+    def test_tokenizer_save_and_load(self):
+        """Test saving and loading the tokenizer."""
+        # Save the tokenizer
+        save_path = os.path.join(self.get_temp_dir(), "layoutlmv3_tokenizer")
+        self.tokenizer.save(save_path)
+        
+        # Load the tokenizer
+        loaded_tokenizer = tf.keras.models.load_model(save_path)
+        
+        # Test loaded tokenizer
+        text = "The quick brown fox"
+        original_outputs = self.tokenizer(text)
+        loaded_outputs = loaded_tokenizer(text)
+        
+        # Compare outputs
+        tf.debugging.assert_equal(
+            original_outputs["token_ids"], loaded_outputs["token_ids"]
+        )
+        tf.debugging.assert_equal(
+            original_outputs["padding_mask"], loaded_outputs["padding_mask"]
+        )
+        tf.debugging.assert_equal(
+            original_outputs["attention_mask"], loaded_outputs["attention_mask"]
+        )
+    
+    def test_tokenizer_unknown_tokens(self):
+        """Test handling of unknown tokens."""
+        text = "The xyz abc"  # Contains unknown words
+        outputs = self.tokenizer(text)
+        token_ids = outputs["token_ids"][0]
+        
+        # Check that unknown tokens are replaced with [UNK]
+        for token_id in token_ids[1:-1]:  # Skip [CLS] and [SEP]
+            if token_id not in [self.tokenizer.cls_token_id, self.tokenizer.sep_token_id]:
+                self.assertEqual(token_id, self.tokenizer.unk_token_id) 

--- a/tools/checkpoint_conversion/convert_layoutlmv3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_layoutlmv3_checkpoints.py
@@ -1,0 +1,295 @@
+"""Script to convert LayoutLMv3 checkpoints from Hugging Face to Keras format."""
+
+import os
+import json
+import numpy as np
+import tensorflow as tf
+import torch
+from transformers import LayoutLMv3Model as HFLayoutLMv3Model, LayoutLMv3Config, LayoutLMv3Tokenizer as HFLayoutLMv3Tokenizer
+from keras_hub.src.models.layoutlmv3.layoutlmv3_backbone import LayoutLMv3Backbone
+from keras_hub.src.models.layoutlmv3.layoutlmv3_tokenizer import LayoutLMv3Tokenizer
+
+def convert_checkpoint(
+    hf_model_name_or_path,
+    output_dir,
+    model_size="base",
+):
+    """Convert a LayoutLMv3 checkpoint from Hugging Face to Keras format."""
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Load Hugging Face model, config and tokenizer
+    hf_model = HFLayoutLMv3Model.from_pretrained(hf_model_name_or_path)
+    hf_config = LayoutLMv3Config.from_pretrained(hf_model_name_or_path)
+    hf_tokenizer = HFLayoutLMv3Tokenizer.from_pretrained(hf_model_name_or_path)
+    
+    # Get spatial embedding dimensions from the model
+    hf_weights = hf_model.state_dict()
+    x_dim = hf_weights["embeddings.x_position_embeddings.weight"].shape[1]
+    y_dim = hf_weights["embeddings.y_position_embeddings.weight"].shape[1]
+    h_dim = hf_weights["embeddings.h_position_embeddings.weight"].shape[1]
+    w_dim = hf_weights["embeddings.w_position_embeddings.weight"].shape[1]
+    
+    # Use maximum dimension for all spatial embeddings
+    spatial_embedding_dim = max(x_dim, y_dim, h_dim, w_dim)
+    
+    print(f"\nModel: {hf_model_name_or_path}")
+    print(f"Spatial embedding dimensions:")
+    print(f"x: {x_dim}, y: {y_dim}, h: {h_dim}, w: {w_dim}")
+    print(f"Using dimension: {spatial_embedding_dim}")
+    
+    # Create Keras model
+    keras_model = LayoutLMv3Backbone(
+        vocab_size=hf_config.vocab_size,
+        hidden_size=hf_config.hidden_size,
+        num_hidden_layers=hf_config.num_hidden_layers,
+        num_attention_heads=hf_config.num_attention_heads,
+        intermediate_size=hf_config.intermediate_size,
+        hidden_act=hf_config.hidden_act,
+        hidden_dropout_prob=hf_config.hidden_dropout_prob,
+        attention_probs_dropout_prob=hf_config.attention_probs_dropout_prob,
+        max_position_embeddings=hf_config.max_position_embeddings,
+        type_vocab_size=hf_config.type_vocab_size,
+        initializer_range=hf_config.initializer_range,
+        layer_norm_eps=hf_config.layer_norm_eps,
+        image_size=(112, 112),
+        patch_size=16,
+        num_channels=3,
+        qkv_bias=True,
+        use_abs_pos=True,
+        use_rel_pos=False,
+        rel_pos_bins=32,
+        max_rel_pos=128,
+        spatial_embedding_dim=spatial_embedding_dim,
+    )
+    
+    # Create dummy inputs for building the model
+    batch_size = 1
+    seq_len = 512
+    input_ids = tf.random.uniform(
+        (batch_size, seq_len), minval=0, maxval=hf_config.vocab_size, dtype=tf.int32
+    )
+    bbox = tf.random.uniform(
+        (batch_size, seq_len, 4), minval=0, maxval=512, dtype=tf.int32
+    )
+    attention_mask = tf.ones((batch_size, seq_len), dtype=tf.int32)
+    image = tf.random.uniform((batch_size, 112, 112, 3), minval=0, maxval=1, dtype=tf.float32)
+    
+    # Build the model with dummy inputs
+    _ = keras_model({
+        "input_ids": input_ids,
+        "bbox": bbox,
+        "attention_mask": attention_mask,
+        "image": image,
+    })
+    
+    # Print shapes of spatial embedding weights
+    print("\nSpatial embedding shapes:")
+    print(f"x_position_embeddings: {hf_weights['embeddings.x_position_embeddings.weight'].shape}")
+    print(f"y_position_embeddings: {hf_weights['embeddings.y_position_embeddings.weight'].shape}")
+    print(f"h_position_embeddings: {hf_weights['embeddings.h_position_embeddings.weight'].shape}")
+    print(f"w_position_embeddings: {hf_weights['embeddings.w_position_embeddings.weight'].shape}")
+    
+    # Word embeddings
+    keras_model.word_embeddings.set_weights([hf_weights["embeddings.word_embeddings.weight"].numpy()])
+    
+    # Position embeddings
+    keras_model.position_embeddings.set_weights(
+        [hf_weights["embeddings.position_embeddings.weight"].numpy()]
+    )
+    
+    # Spatial embeddings
+    x_weights = hf_weights["embeddings.x_position_embeddings.weight"].numpy()
+    y_weights = hf_weights["embeddings.y_position_embeddings.weight"].numpy()
+    h_weights = hf_weights["embeddings.h_position_embeddings.weight"].numpy()
+    w_weights = hf_weights["embeddings.w_position_embeddings.weight"].numpy()
+    
+    # Pad smaller embeddings to match the maximum dimension
+    if h_dim < spatial_embedding_dim:
+        h_weights = np.pad(h_weights, ((0, 0), (0, spatial_embedding_dim - h_dim)), mode='constant')
+    if w_dim < spatial_embedding_dim:
+        w_weights = np.pad(w_weights, ((0, 0), (0, spatial_embedding_dim - w_dim)), mode='constant')
+    
+    # Set weights for spatial embeddings first
+    keras_model.x_position_embeddings.set_weights([x_weights])
+    keras_model.y_position_embeddings.set_weights([y_weights])
+    keras_model.h_position_embeddings.set_weights([h_weights])
+    keras_model.w_position_embeddings.set_weights([w_weights])
+    
+    # Create projection matrices based on actual weight shapes
+    x_proj = np.random.normal(0, 0.02, (spatial_embedding_dim, hf_config.hidden_size))
+    y_proj = np.random.normal(0, 0.02, (spatial_embedding_dim, hf_config.hidden_size))
+    h_proj = np.random.normal(0, 0.02, (spatial_embedding_dim, hf_config.hidden_size))
+    w_proj = np.random.normal(0, 0.02, (spatial_embedding_dim, hf_config.hidden_size))
+    
+    # Set weights for projection layers
+    keras_model.x_proj.set_weights([x_proj, np.zeros(hf_config.hidden_size)])
+    keras_model.y_proj.set_weights([y_proj, np.zeros(hf_config.hidden_size)])
+    keras_model.h_proj.set_weights([h_proj, np.zeros(hf_config.hidden_size)])
+    keras_model.w_proj.set_weights([w_proj, np.zeros(hf_config.hidden_size)])
+    
+    # Token type embeddings
+    keras_model.token_type_embeddings.set_weights(
+        [hf_weights["embeddings.token_type_embeddings.weight"].numpy()]
+    )
+    
+    # Layer normalization
+    keras_model.embeddings_LayerNorm.set_weights(
+        [
+            hf_weights["embeddings.LayerNorm.weight"].numpy(),
+            hf_weights["embeddings.LayerNorm.bias"].numpy(),
+        ]
+    )
+    
+    # Transformer layers
+    for i in range(hf_config.num_hidden_layers):
+        # Attention
+        keras_model.encoder_layers[i].attention.q_proj.set_weights([
+            hf_weights[f"encoder.layer.{i}.attention.self.query.weight"].numpy().T,
+            hf_weights[f"encoder.layer.{i}.attention.self.query.bias"].numpy()
+        ])
+        keras_model.encoder_layers[i].attention.k_proj.set_weights([
+            hf_weights[f"encoder.layer.{i}.attention.self.key.weight"].numpy().T,
+            hf_weights[f"encoder.layer.{i}.attention.self.key.bias"].numpy()
+        ])
+        keras_model.encoder_layers[i].attention.v_proj.set_weights([
+            hf_weights[f"encoder.layer.{i}.attention.self.value.weight"].numpy().T,
+            hf_weights[f"encoder.layer.{i}.attention.self.value.bias"].numpy()
+        ])
+        keras_model.encoder_layers[i].attention.out_proj.set_weights([
+            hf_weights[f"encoder.layer.{i}.attention.output.dense.weight"].numpy().T,
+            hf_weights[f"encoder.layer.{i}.attention.output.dense.bias"].numpy()
+        ])
+        
+        # Attention output layer norm
+        keras_model.encoder_layers[i].attention_output_layernorm.set_weights(
+            [
+                hf_weights[f"encoder.layer.{i}.attention.output.LayerNorm.weight"].numpy(),
+                hf_weights[f"encoder.layer.{i}.attention.output.LayerNorm.bias"].numpy(),
+            ]
+        )
+        
+        # Intermediate
+        keras_model.encoder_layers[i].intermediate_dense.set_weights([
+            hf_weights[f"encoder.layer.{i}.intermediate.dense.weight"].numpy().T,
+            hf_weights[f"encoder.layer.{i}.intermediate.dense.bias"].numpy()
+        ])
+        
+        # Output
+        keras_model.encoder_layers[i].output_dense.set_weights([
+            hf_weights[f"encoder.layer.{i}.output.dense.weight"].numpy().T,
+            hf_weights[f"encoder.layer.{i}.output.dense.bias"].numpy()
+        ])
+        keras_model.encoder_layers[i].output_layernorm.set_weights(
+            [
+                hf_weights[f"encoder.layer.{i}.output.LayerNorm.weight"].numpy(),
+                hf_weights[f"encoder.layer.{i}.output.LayerNorm.bias"].numpy(),
+            ]
+        )
+    
+    # Final layer norm
+    keras_model.norm.set_weights(
+        [
+            hf_weights["norm.weight"].numpy(),
+            hf_weights["norm.bias"].numpy(),
+        ]
+    )
+    
+    # CLS token
+    keras_model.cls_token.assign(hf_weights["cls_token"].numpy())
+    
+    # Patch embedding
+    patch_embed_weight = hf_weights["patch_embed.proj.weight"].numpy()
+    patch_embed_weight = np.transpose(patch_embed_weight, (2, 3, 1, 0))  # Reshape to (height, width, in_channels, out_channels)
+    keras_model.patch_embed.set_weights([
+        patch_embed_weight,
+        hf_weights["patch_embed.proj.bias"].numpy()
+    ])
+    
+    # Patch embedding layer norm
+    keras_model.patch_embed_layer_norm.set_weights(
+        [
+            hf_weights["LayerNorm.weight"].numpy(),
+            hf_weights["LayerNorm.bias"].numpy(),
+        ]
+    )
+    
+    # Save the model
+    keras_model.save(os.path.join(output_dir, f"layoutlmv3_{model_size}.keras"))
+    
+    # Save the configuration
+    config = {
+        "vocab_size": hf_config.vocab_size,
+        "hidden_size": hf_config.hidden_size,
+        "num_hidden_layers": hf_config.num_hidden_layers,
+        "num_attention_heads": hf_config.num_attention_heads,
+        "intermediate_size": hf_config.intermediate_size,
+        "hidden_act": hf_config.hidden_act,
+        "hidden_dropout_prob": hf_config.hidden_dropout_prob,
+        "attention_probs_dropout_prob": hf_config.attention_probs_dropout_prob,
+        "max_position_embeddings": hf_config.max_position_embeddings,
+        "type_vocab_size": hf_config.type_vocab_size,
+        "initializer_range": hf_config.initializer_range,
+        "layer_norm_eps": hf_config.layer_norm_eps,
+        "image_size": (112, 112),
+        "patch_size": 16,
+        "num_channels": 3,
+        "qkv_bias": True,
+        "use_abs_pos": True,
+        "use_rel_pos": False,
+        "rel_pos_bins": 32,
+        "max_rel_pos": 128,
+        "spatial_embedding_dim": spatial_embedding_dim,
+    }
+    
+    with open(os.path.join(output_dir, f"layoutlmv3_{model_size}_config.json"), "w") as f:
+        json.dump(config, f, indent=2)
+    
+    # Save the vocabulary
+    vocab = hf_tokenizer.get_vocab()
+    # Ensure special tokens are in the vocabulary
+    special_tokens = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
+    for token in special_tokens:
+        if token not in vocab:
+            vocab[token] = len(vocab)
+    
+    # Save vocabulary
+    vocab_path = os.path.join(output_dir, f"layoutlmv3_{model_size}_vocab.json")
+    with open(vocab_path, "w") as f:
+        json.dump(vocab, f, indent=2)
+    
+    # Save tokenizer config
+    tokenizer_config = {
+        "lowercase": True,
+        "strip_accents": True,
+        "oov_token": "[UNK]",
+        "cls_token": "[CLS]",
+        "sep_token": "[SEP]",
+        "pad_token": "[PAD]",
+        "mask_token": "[MASK]",
+    }
+    config_path = os.path.join(output_dir, f"layoutlmv3_{model_size}_tokenizer_config.json")
+    with open(config_path, "w") as f:
+        json.dump(tokenizer_config, f, indent=2)
+    
+    print(f"\nSuccessfully converted {hf_model_name_or_path} to Keras format")
+    print(f"Output saved to {output_dir}")
+
+def main():
+    """Convert LayoutLMv3 checkpoints."""
+    # Convert base model
+    convert_checkpoint(
+        "microsoft/layoutlmv3-base",
+        "checkpoints/layoutlmv3",
+        model_size="base",
+    )
+    
+    # Convert large model
+    convert_checkpoint(
+        "microsoft/layoutlmv3-large",
+        "checkpoints/layoutlmv3",
+        model_size="large",
+    )
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
## Description
This PR fixes the LayoutLMv3 checkpoint conversion script to properly handle different spatial embedding dimensions between the base and large models. The base model uses 128 dimensions for all spatial embeddings, while the large model uses 171 dimensions for x/y coordinates and 170 dimensions for height/width.

### Changes Made
- Added dynamic detection of spatial embedding dimensions from the Hugging Face model
- Implemented padding for smaller embeddings to match the maximum dimension
- Updated projection matrices to use consistent dimensions
- Added detailed debug output for spatial embedding shapes

### Technical Details
The conversion script now:
1. Detects individual dimensions for x, y, h, w embeddings
2. Uses the maximum dimension (171 for large model) for all embeddings
3. Pads smaller embeddings (170) with zeros to match the larger dimension
4. Creates projection matrices with consistent dimensions

### Testing
- Successfully converted both base and large models
- Verified output shapes match expected dimensions
- Confirmed no dimension mismatch errors during conversion

### Output Example
![Screenshot from 2025-03-30 12-50-29](https://github.com/user-attachments/assets/fa3bcebe-688c-4b84-b7f3-898f4f8375f1)

