### PR TITLE
Add DeiT Model

### DIFF
--- a/keras_hub/api/layers/__init__.py
+++ b/keras_hub/api/layers/__init__.py
@@ -71,6 +71,9 @@ from keras_hub.src.models.retinanet.retinanet_image_converter import (
     RetinaNetImageConverter,
 )
 from keras_hub.src.models.sam.sam_image_converter import SAMImageConverter
+from keras_hub.src.models.deit.deit_image_converter import (
+    DeiTImageConverter,
+)
 from keras_hub.src.models.sam.sam_mask_decoder import SAMMaskDecoder
 from keras_hub.src.models.sam.sam_prompt_encoder import SAMPromptEncoder
 from keras_hub.src.models.segformer.segformer_image_converter import (

--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -111,6 +111,10 @@ from keras_hub.src.models.densenet.densenet_image_classifier_preprocessor import
 from keras_hub.src.models.deit.deit_backbone import(
     DeiTBackbone,
 )
+from keras_hub.src.models.deit.deit_image_classifier import DeiTImageClassifier
+from keras_hub.src.models.deit.deit_image_classifier_preprocessor import (
+    DeiTImageClassifierPreprocessor,
+)
 from keras_hub.src.models.distil_bert.distil_bert_backbone import (
     DistilBertBackbone,
 )

--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -108,6 +108,9 @@ from keras_hub.src.models.densenet.densenet_image_classifier import (
 from keras_hub.src.models.densenet.densenet_image_classifier_preprocessor import (
     DenseNetImageClassifierPreprocessor,
 )
+from keras_hub.src.models.deit.deit_backbone import(
+    DeiTBackbone,
+)
 from keras_hub.src.models.distil_bert.distil_bert_backbone import (
     DistilBertBackbone,
 )

--- a/keras_hub/src/models/deit/deit_backbone.py
+++ b/keras_hub/src/models/deit/deit_backbone.py
@@ -1,0 +1,136 @@
+import keras
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.utils.keras_utils import standardize_data_format
+from keras_hub.src.models.deit.deit_layers import DeiTEncoder
+from keras_hub.src.models.deit.deit_layers import DeiTEmbeddings
+
+@keras_hub_export("keras_hub.models.DeiTBackbone")
+class DeiTBackbone(Backbone):
+    """DeiT backbone.
+    
+    This backbone implements the Data-efficient Image Transformer (DeiT) architecture 
+    as described in [Training data-efficient image transformers & distillation through 
+    attention](https://arxiv.org/abs/2012.12877).
+    
+    Args:
+        image_shape: A tuple or list of 3 integers representing the shape of the
+            input image `(height, width, channels)`, `height` and `width` must
+            be equal.
+        patch_size: (int, int). The size of each image patch, the input image
+            will be divided into patches of shape `(patch_size_h, patch_size_w)`.
+        num_layers: int. The number of transformer encoder layers.
+        num_heads: int. The number of attention heads in each Transformer encoder layer.
+        hidden_dim: int. The dimensionality of the hidden representations.
+        mlp_dim: int. The dimensionality of the intermediate MLP layer in
+            each Transformer encoder layer.
+        dropout_rate: float. The dropout rate for the Transformer encoder layers.
+        attention_dropout: float. The dropout rate for the attention mechanism
+            in each Transformer encoder layer.
+        layer_norm_epsilon: float. Value used for numerical stability in layer normalization.
+        use_mha_bias: bool. Whether to use bias in the multi-head attention layers.
+        use_mlp_bias: bool. Whether to use bias in the MLP layers.
+        use_distillation_token: bool. Whether to include a distillation token for training.
+        data_format: str. `"channels_last"` or `"channels_first"`, specifying
+            the data format for the input image. If `None`, defaults to `"channels_last"`.
+        dtype: The dtype of the layer weights. Defaults to None.
+        output_hidden_states: Whether to return hidden states from all encoder layers. Defaults to False.  
+        return_attention_scores: Whether to return attention scores from all self-attention layers. Defaults to False.  
+        **kwargs: Additional keyword arguments to be passed to the parent `Backbone` class.
+    """
+
+    def __init__(
+        self,
+        image_shape,
+        patch_size,
+        num_layers,
+        num_heads,
+        hidden_dim,
+        intermediate_dim,
+        dropout_rate=0.0,
+        drop_path_rate=0.0,
+        attention_dropout=0.0,
+        layer_norm_epsilon=1e-6,
+        use_mha_bias=True,
+        use_distillation_token=False,
+        data_format=None,
+        dtype=None,
+        output_hidden_states=False,
+        return_attention_scores=False,
+        **kwargs,
+    ):
+        # === Set Data Format ===
+        data_format = standardize_data_format(data_format)
+        h_axis, w_axis, channels_axis = (
+            (-3, -2, -1) if data_format == "channels_last" else (-2, -1, -3)
+        )
+
+        # Validate input image shape
+        if image_shape[h_axis] is None or image_shape[w_axis] is None:
+            raise ValueError(
+                f"Image shape must have defined height and width. Found `None` "
+                f"at index {h_axis} (height) or {w_axis} (width). "
+                f"Image shape: {image_shape}"
+            )
+
+        if image_shape[h_axis] % patch_size[0] != 0:
+            raise ValueError(
+                f"Input height {image_shape[h_axis]} should be divisible by "
+                f"patch size {patch_size[0]}."
+            )
+
+        if image_shape[w_axis] % patch_size[1] != 0:
+            raise ValueError(
+                f"Input width {image_shape[w_axis]} should be divisible by "
+                f"patch size {patch_size[1]}."
+            )
+
+        num_channels = image_shape[channels_axis]
+
+        # === Functional Model ===
+        inputs = keras.layers.Input(shape=image_shape)
+
+        x = DeiTEmbeddings(
+            image_size=(image_shape[h_axis], image_shape[w_axis]),
+            patch_size=patch_size,
+            hidden_dim=hidden_dim,
+            num_channels=num_channels,
+            data_format=data_format,
+            dropout_rate=dropout_rate,
+            dtype=dtype,
+            name="deit_patching_and_embedding",
+        )(inputs)
+
+        output, all_hidden_states, all_attention_scores = DeiTEncoder(
+            num_layers=num_layers,
+            num_heads=num_heads,
+            hidden_dim=hidden_dim,
+            intermediate_dim=intermediate_dim,
+            use_mha_bias=use_mha_bias,
+            dropout_rate=dropout_rate,
+            attention_dropout=attention_dropout,
+            layer_norm_epsilon=layer_norm_epsilon,
+            dtype=dtype,
+            name="deit_encoder"
+          )(x, output_hidden_states=output_hidden_states, return_attention_scores=return_attention_scores)
+
+        super().__init__(
+            inputs=inputs,
+            outputs=output,
+            dtype=dtype,
+            **kwargs,
+        )
+
+        # === Config ===
+        self.image_shape = image_shape
+        self.patch_size = patch_size
+        self.num_layers = num_layers
+        self.num_heads = num_heads
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.dropout_rate = dropout_rate
+        self.attention_dropout = attention_dropout
+        self.layer_norm_epsilon = layer_norm_epsilon
+        self.use_mha_bias = use_mha_bias
+        self.data_format = data_format

--- a/keras_hub/src/models/deit/deit_backbone.py
+++ b/keras_hub/src/models/deit/deit_backbone.py
@@ -23,19 +23,16 @@ class DeiTBackbone(Backbone):
         num_layers: int. The number of transformer encoder layers.
         num_heads: int. The number of attention heads in each Transformer encoder layer.
         hidden_dim: int. The dimensionality of the hidden representations.
-        mlp_dim: int. The dimensionality of the intermediate MLP layer in
+        intermediate_dim: int. The dimensionality of the intermediate MLP layer in
             each Transformer encoder layer.
         dropout_rate: float. The dropout rate for the Transformer encoder layers.
         attention_dropout: float. The dropout rate for the attention mechanism
             in each Transformer encoder layer.
         layer_norm_epsilon: float. Value used for numerical stability in layer normalization.
         use_mha_bias: bool. Whether to use bias in the multi-head attention layers.
-        use_mlp_bias: bool. Whether to use bias in the MLP layers.
         data_format: str. `"channels_last"` or `"channels_first"`, specifying
             the data format for the input image. If `None`, defaults to `"channels_last"`.
         dtype: The dtype of the layer weights. Defaults to None.
-        output_hidden_states: Whether to return hidden states from all encoder layers. Defaults to False.  
-        return_attention_scores: Whether to return attention scores from all self-attention layers. Defaults to False.  
         **kwargs: Additional keyword arguments to be passed to the parent `Backbone` class.
     """
 
@@ -53,8 +50,6 @@ class DeiTBackbone(Backbone):
         use_mha_bias=True,
         data_format=None,
         dtype=None,
-        output_hidden_states=False,
-        return_attention_scores=False,
         **kwargs,
     ):
         # === Laters ===
@@ -103,7 +98,7 @@ class DeiTBackbone(Backbone):
             name="deit_patching_and_embedding",
         )(inputs)
 
-        output, all_hidden_states, all_attention_scores = DeiTEncoder(
+        output, _, _ = DeiTEncoder(
             num_layers=num_layers,
             num_heads=num_heads,
             hidden_dim=hidden_dim,
@@ -114,7 +109,7 @@ class DeiTBackbone(Backbone):
             layer_norm_epsilon=layer_norm_epsilon,
             dtype=dtype,
             name="deit_encoder"
-          )(x, output_hidden_states=output_hidden_states, return_attention_scores=return_attention_scores)
+          )(x)
 
         super().__init__(
             inputs=inputs,
@@ -135,3 +130,21 @@ class DeiTBackbone(Backbone):
         self.layer_norm_epsilon = layer_norm_epsilon
         self.use_mha_bias = use_mha_bias
         self.data_format = data_format
+    
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "image_shape": self.image_shape,
+                "patch_size": self.patch_size,
+                "num_layers": self.num_layers,
+                "num_heads": self.num_heads,
+                "hidden_dim": self.hidden_dim,
+                "intermediate_dim": self.intermediate_dim,
+                "dropout_rate": self.dropout_rate,
+                "attention_dropout": self.attention_dropout,
+                "layer_norm_epsilon": self.layer_norm_epsilon,
+                "use_mha_bias": self.use_mha_bias,
+            }
+        )
+        return config

--- a/keras_hub/src/models/deit/deit_backbone_test.py
+++ b/keras_hub/src/models/deit/deit_backbone_test.py
@@ -1,0 +1,37 @@
+import pytest
+from keras import ops
+
+from keras_hub.src.models.deit.deit_backbone import DeiTBackbone
+from keras_hub.src.tests.test_case import TestCase
+
+
+class DeiTBackboneTest(TestCase):
+    def setUp(self):
+        self.init_kwargs = {
+            "image_shape": (28, 28, 3),
+            "patch_size": 4,
+            "num_layers": 3,
+            "hidden_dim": 48,
+            "num_heads": 6,
+            "intermediate_dim": 48 * 4,
+            "use_mha_bias": True,
+        }
+        self.input_size = 28
+        self.input_data = ops.ones((2, self.input_size, self.input_size, 3))
+
+    def test_backbone_basics(self):
+        self.run_backbone_test(
+            cls=DeiTBackbone,
+            init_kwargs={**self.init_kwargs},
+            input_data=self.input_data,
+            expected_output_shape=(2, 50, 48),
+            run_quantization_check=False,
+        )
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=DeiTBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )

--- a/keras_hub/src/models/deit/deit_image_classifier.py
+++ b/keras_hub/src/models/deit/deit_image_classifier.py
@@ -1,0 +1,172 @@
+import keras
+from keras import ops
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.image_classifier import ImageClassifier
+from keras_hub.src.models.task import Task
+from keras_hub.src.models.deit.deit_backbone import DeiTBackbone
+from keras_hub.src.models.deit.deit_image_classifier_preprocessor import (
+    DeiTImageClassifierPreprocessor,
+)
+
+
+@keras_hub_export("keras_hub.models.DeiTImageClassifier")
+class DeiTImageClassifier(ImageClassifier):
+    """DeiT image classification task.
+
+    `DeiTImageClassifier` tasks wrap a `keras_hub.models.DeiTBackbone` and
+    a `keras_hub.models.Preprocessor` to create a model that can be used for
+    image classification. `DeiTImageClassifier` tasks take an additional
+    `num_classes` argument, controlling the number of predicted output classes.
+
+    To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
+    labels where `x` is a string and `y` is a integer from `[0, num_classes)`.
+
+    Not that unlike `keras_hub.model.ImageClassifier`, the `DeiTImageClassifier`
+    we pluck out `cls_token` which is first seqence from the backbone.
+
+    Args:
+        backbone: A `keras_hub.models.DeiTBackbone` instance or a `keras.Model`.
+        num_classes: int. The number of classes to predict.
+        preprocessor: `None`, a `keras_hub.models.Preprocessor` instance,
+            a `keras.Layer` instance, or a callable. If `None` no preprocessing
+            will be applied to the inputs.
+        pooling: String specifying the classification strategy. The choice
+            impacts the dimensionality and nature of the feature vector used for
+            classification.
+                `"token"`:  A single vector (class token) representing the
+                    overall image features.
+                `"gap"`: A single vector representing the average features
+                    across the spatial dimensions.
+        activation: `None`, str, or callable. The activation function to use on
+            the `Dense` layer. Set `activation=None` to return the output
+            logits. Defaults to `None`.
+        head_dtype: `None`, str, or `keras.mixed_precision.DTypePolicy`. The
+            dtype to use for the classification head's computations and weights.
+
+    Examples:
+
+    Call `predict()` to run inference.
+    ```python
+    # Load preset and train
+    images = np.random.randint(0, 256, size=(2, 384, 384, 3))
+    classifier = keras_hub.models.DeiTImageClassifier.from_preset(
+        "hf://facebook/deit-base-distilled-patch16-384"
+    )
+    classifier.predict(images)
+    ```
+
+    Call `fit()` on a single batch.
+    ```python
+    # Load preset and train
+    images = np.random.randint(0, 256, size=(2, 384, 384, 3))
+    labels = [0, 3]
+    classifier = keras_hub.models.DeiTImageClassifier.from_preset(
+        "hf://facebook/deit-base-distilled-patch16-384"
+    )
+    classifier.fit(x=images, y=labels, batch_size=2)
+    ```
+
+    Call `fit()` with custom loss, optimizer and backbone.
+    ```python
+    classifier = keras_hub.models.DeiTImageClassifier.from_preset(
+        "hf://facebook/deit-base-distilled-patch16-384"
+    )
+    classifier.compile(
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        optimizer=keras.optimizers.Adam(5e-5),
+    )
+    classifier.backbone.trainable = False
+    classifier.fit(x=images, y=labels, batch_size=2)
+    ```
+
+    Custom backbone.
+    ```python
+    images = np.random.randint(0, 256, size=(2, 384, 384, 3))
+    labels = [0, 3]
+    backbone = keras_hub.models.DeiTBackbone(
+        image_shape = (384, 384, 3),
+        patch_size=16,
+        num_layers=6,
+        num_heads=3,
+        hidden_dim=768,
+        intermediate_dim=2048
+    )
+    classifier = keras_hub.models.DeiTImageClassifier(
+        backbone=backbone,
+        num_classes=4,
+    )
+    classifier.fit(x=images, y=labels, batch_size=2)
+    ```
+    """
+
+    backbone_cls = DeiTBackbone
+    preprocessor_cls = DeiTImageClassifierPreprocessor
+
+    def __init__(
+        self,
+        backbone,
+        num_classes,
+        preprocessor=None,
+        pooling="token",
+        activation=None,
+        dropout=0.0,
+        head_dtype=None,
+        **kwargs,
+    ):
+        head_dtype = head_dtype or backbone.dtype_policy
+
+        # === Layers ===
+        self.backbone = backbone
+        self.preprocessor = preprocessor
+        self.dropout = keras.layers.Dropout(
+            rate=dropout,
+            dtype=head_dtype,
+            name="output_dropout",
+        )
+        print(preprocessor)
+
+        self.output_dense = keras.layers.Dense(
+            num_classes,
+            activation=activation,
+            dtype=head_dtype,
+            name="predictions",
+        )
+
+        # === Functional Model ===
+        inputs = self.backbone.input
+        x = self.backbone(inputs)
+        if pooling == "token":
+            x = x[:, 0]
+        elif pooling == "gap":
+            ndim = len(ops.shape(x))
+            x = ops.mean(x, axis=list(range(1, ndim - 1)))  # (1,) or (1,2)
+
+        outputs = self.output_dense(x)
+
+        # Skip the parent class functional model.
+        Task.__init__(
+            self,
+            inputs=inputs,
+            outputs=outputs,
+            **kwargs,
+        )
+
+        # === config ===
+        self.num_classes = num_classes
+        self.pooling = pooling
+        self.activation = activation
+        self.dropout = dropout
+
+    def get_config(self):
+        # Backbone serialized in `super`
+        config = super().get_config()
+        config.update(
+            {
+                "num_classes": self.num_classes,
+                "pooling": self.pooling,
+                "activation": self.activation,
+                "dropout": self.dropout,
+            }
+        )
+        return config

--- a/keras_hub/src/models/deit/deit_image_classifier_preprocessor.py
+++ b/keras_hub/src/models/deit/deit_image_classifier_preprocessor.py
@@ -1,0 +1,12 @@
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.image_classifier_preprocessor import (
+    ImageClassifierPreprocessor,
+)
+from keras_hub.src.models.deit.deit_backbone import DeiTBackbone
+from keras_hub.src.models.deit.deit_image_converter import DeiTImageConverter
+
+
+@keras_hub_export("keras_hub.models.ViTImageClassifierPreprocessor")
+class DeiTImageClassifierPreprocessor(ImageClassifierPreprocessor):
+    backbone_cls = DeiTBackbone
+    image_converter_cls = DeiTImageConverter

--- a/keras_hub/src/models/deit/deit_image_classifier_test.py
+++ b/keras_hub/src/models/deit/deit_image_classifier_test.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pytest
+
+from keras_hub.src.models.deit.deit_backbone import DeiTBackbone
+from keras_hub.src.models.deit.deit_image_classifier import DeiTImageClassifier
+from keras_hub.src.models.deit.deit_image_classifier_preprocessor import (
+    DeiTImageClassifierPreprocessor,
+)
+from keras_hub.src.models.deit.deit_image_converter import DeiTImageConverter
+from keras_hub.src.tests.test_case import TestCase
+
+
+class DeiTImageClassifierTest(TestCase):
+    def setUp(self):
+        self.images = np.ones((2, 28, 28, 3))
+        self.labels = [0, 1]
+        self.backbone = DeiTBackbone(
+            image_shape=(28, 28, 3),
+            patch_size=4,
+            num_layers=3,
+            num_heads=6,
+            hidden_dim=48,
+            intermediate_dim=48 * 4,
+        )
+        image_converter = DeiTImageConverter(
+            image_size=(28, 28),
+            scale=1 / 255.0,
+        )
+        preprocessor = DeiTImageClassifierPreprocessor(
+            image_converter=image_converter
+        )
+        self.init_kwargs = {
+            "backbone": self.backbone,
+            "num_classes": 2,
+            "preprocessor": preprocessor,
+        }
+        self.train_data = (self.images, self.labels)
+
+    def test_classifier_basics(self):
+        self.run_task_test(
+            cls=DeiTImageClassifier,
+            init_kwargs=self.init_kwargs,
+            train_data=self.train_data,
+            expected_output_shape=(2, 2),
+        )
+
+    def test_head_dtype(self):
+        model = DeiTImageClassifier(**self.init_kwargs, head_dtype="bfloat16")
+        self.assertEqual(model.output_dense.compute_dtype, "bfloat16")
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=DeiTImageClassifier,
+            init_kwargs=self.init_kwargs,
+            input_data=self.images,
+        )

--- a/keras_hub/src/models/deit/deit_image_converter.py
+++ b/keras_hub/src/models/deit/deit_image_converter.py
@@ -20,12 +20,12 @@ class DeiTImageConverter(ImageConverter):
     ```python
     import keras
     import numpy as np
-    from keras_hub.src.layers import DeiTImageConverter
+    from keras_hub.src.models.deit.deit_image_converter import DeiTImageConverter
     # Example image (replace with your actual image data)
-    image = np.random.rand(1, 224, 224, 3)  # Example: (B, H, W, C)
+    image = np.random.rand(1, 384, 384, 3)  # Example: (B, H, W, C)
     # Create a DeiTImageConverter instance
     converter = DeiTImageConverter(
-        image_size=(28,28),
+        image_size=(384, 384),
         scale=1/255.
     )
     # Preprocess the image
@@ -44,13 +44,15 @@ class DeiTImageConverter(ImageConverter):
 
     @preprocessing_function
     def call(self, inputs):
+        print(inputs.shape)
         x = super().call(inputs)
+        print(x.shape)
         # By default normalize using imagenet mean and std
         if self.norm_mean:
             x = x - self._expand_non_channel_dims(self.norm_mean, x)
         if self.norm_std:
             x = x / self._expand_non_channel_dims(self.norm_std, x)
-
+        print(x.shape)
         return x
 
     def get_config(self):

--- a/keras_hub/src/models/deit/deit_image_converter.py
+++ b/keras_hub/src/models/deit/deit_image_converter.py
@@ -1,0 +1,64 @@
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.utils.tensor_utils import preprocessing_function
+from keras_hub.src.layers.preprocessing.image_converter import ImageConverter
+from keras_hub.src.models.deit.deit_backbone import DeiTBackbone
+
+
+@keras_hub_export("keras_hub.layers.DeiTImageConverter")
+class DeiTImageConverter(ImageConverter):
+    """Converts images to the format expected by a DeiT model.
+    This layer performs image normalization using mean and standard deviation
+    values.
+    Args:
+        norm_mean: list or tuple of floats. Mean values for image normalization.
+            Defaults to `[0.5, 0.5, 0.5]`.
+        norm_std: list or tuple of floats. Standard deviation values for
+            image normalization. Defaults to `[0.5, 0.5, 0.5]`.
+        **kwargs: Additional keyword arguments passed to
+            `keras_hub.layers.preprocessing.ImageConverter`.
+    Examples:
+    ```python
+    import keras
+    import numpy as np
+    from keras_hub.src.layers import DeiTImageConverter
+    # Example image (replace with your actual image data)
+    image = np.random.rand(1, 224, 224, 3)  # Example: (B, H, W, C)
+    # Create a DeiTImageConverter instance
+    converter = DeiTImageConverter(
+        image_size=(28,28),
+        scale=1/255.
+    )
+    # Preprocess the image
+    preprocessed_image = converter(image)
+    ```
+    """
+
+    backbone_cls = DeiTBackbone
+
+    def __init__(
+        self, norm_mean=[0.5, 0.5, 0.5], norm_std=[0.5, 0.5, 0.5], **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.norm_mean = norm_mean
+        self.norm_std = norm_std
+
+    @preprocessing_function
+    def call(self, inputs):
+        x = super().call(inputs)
+        # By default normalize using imagenet mean and std
+        if self.norm_mean:
+            x = x - self._expand_non_channel_dims(self.norm_mean, x)
+        if self.norm_std:
+            x = x / self._expand_non_channel_dims(self.norm_std, x)
+
+        return x
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "norm_mean": self.norm_mean,
+                "norm_std": self.norm_std,
+            }
+        )
+        return config

--- a/keras_hub/src/models/deit/deit_layers.py
+++ b/keras_hub/src/models/deit/deit_layers.py
@@ -1,0 +1,416 @@
+import keras
+from keras import ops
+
+from keras_hub.src.utils.keras_utils import standardize_data_format
+class DeiTEmbeddings(keras.layers.Layer):
+    """Patches the image and embeds the patches.
+
+    Args:
+        image_size: int. Size of the input image (height or width).
+            Assumed to be square.
+        patch_size: int. Size of each image patch.
+        hidden_dim: int. Dimensionality of the patch embeddings.
+        num_channels: int. Number of channels in the input image. Defaults to
+            `3`.
+        data_format: str. `"channels_last"` or `"channels_first"`. Defaults to
+            `None` (which uses `"channels_last"`).
+        use_mask_token: bool. Whether to use a mask token. Defaults to `False`.
+        dropout_rate: float. Dropout rate. Between 0 and 1. Defaults to
+            `0.0`.
+        **kwargs: Additional keyword arguments passed to `keras.layers.Layer`
+    """
+
+    def __init__(
+        self,
+        image_size,
+        patch_size,
+        hidden_dim,
+        num_channels=3,
+        data_format=None,
+        use_mask_token=False,
+        dropout_rate=0.0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        grid_size = tuple([s // p for s, p in zip(image_size, patch_size)])
+        num_patches = grid_size[0] * grid_size[1]
+        num_positions = num_patches + 2
+
+        # === Config ===
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_dim = hidden_dim
+        self.num_channels = num_channels
+        self.num_patches = num_patches
+        self.num_positions = num_positions
+        self.data_format = standardize_data_format(data_format)
+        self.use_mask_token=use_mask_token
+        self.dropout_rate = dropout_rate
+
+    def build(self, input_shape):
+        if self.use_mask_token:
+            self.mask_token = self.add_weight(shape=(1, 1, self.hidden_dim),
+                                              initializer="zeros",
+                                              name="mask_token")
+        self.class_token = self.add_weight(
+            shape=(
+                1,
+                1,
+                self.hidden_dim,
+            ),
+            initializer="zeros",
+            name="class_token",
+        )
+        self.distillation_token = self.add_weight(
+            shape=(
+                1,
+                1,
+                self.hidden_dim,
+            ),
+            initializer="zeros",
+            name="distillation_token",
+        )
+        self.patch_embedding = keras.layers.Conv2D(
+            filters=self.hidden_dim,
+            kernel_size=self.patch_size,
+            strides=self.patch_size,
+            padding="valid",
+            activation=None,
+            dtype=self.dtype_policy,
+            data_format=self.data_format,
+            name="patch_embedding",
+        )
+        self.patch_embedding.build(input_shape)
+        self.position_embedding = self.add_weight(
+            shape=(1, self.num_positions, self.hidden_dim),  # Matches the shape in PyTorch
+            initializer=keras.initializers.RandomNormal(stddev=0.02),  # Equivalent to torch.randn()
+            trainable=True,
+            name="position_embedding"
+        )
+        self.dropout = keras.layers.Dropout(self.dropout_rate, name="dropout")
+
+        self.built = True
+
+    def call(self, inputs, bool_masked_pos = None):
+        print("called")
+        # TODO: adjust it based on data_format
+        batch_size, height, width, _ = inputs.shape
+        patch_embeddings = self.patch_embedding(inputs)
+        if self.data_format == "channels_first":
+            patch_embeddings = ops.transpose(
+                patch_embeddings, axes=(0, 2, 3, 1)
+            )
+        embeddings_shape = ops.shape(patch_embeddings)
+        patch_embeddings = ops.reshape(
+            patch_embeddings, [embeddings_shape[0], -1, embeddings_shape[-1]]
+        )
+
+        if bool_masked_pos is not None and self.use_mask_token:
+            # Expand dimensions to match the embeddings
+            bool_masked_pos_expanded = ops.expand_dims(bool_masked_pos, axis=-1)  # (batch_size, num_patches, 1)
+            mask_token_expanded = ops.expand_dims(self.mask_token, axis=0)  # (1, 1, hidden_size)
+            # Apply masking
+            embeddings = ops.where(bool_masked_pos_expanded, mask_token_expanded, embeddings)
+
+        class_token = ops.tile(self.class_token, (embeddings_shape[0], 1, 1))
+        distillation_token = ops.tile(self.distillation_token, (embeddings_shape[0], 1, 1))
+        embeddings = ops.concatenate([class_token, distillation_token, patch_embeddings], axis=1)
+        position_embedding = self.interpolate_pos_encoding(embeddings,height,width)
+        print("pos.shape",position_embedding.shape)
+        print("emb.shape",embeddings.shape)
+        embeddings = ops.add(embeddings, position_embedding)
+        embeddings = self.dropout(embeddings)
+        return embeddings
+
+    def interpolate_pos_encoding(self, embeddings, height: int, width: int):
+        """
+        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher resolution
+        images. This method is also adapted to support interpolation at float32 precision.
+        """
+
+        num_patches = embeddings.shape[1] - 1
+        num_positions = self.position_embedding.shape[1] - 1
+
+        # always interpolate when tracing to ensure the exported model works for dynamic input shapes
+        if num_patches == num_positions and height == width:
+            return self.position_embedding
+
+        class_distillation_pos_embed = self.position_embedding[:, :2]
+        patch_pos_embed = self.position_embedding[:, 2:]
+
+        dim = embeddings.shape[-1]
+        new_height = height // self.patch_size
+        new_width = width // self.patch_size
+
+        # Step 1: Compute sqrt_num_positions
+        sqrt_num_positions = keras.ops.cast(keras.ops.sqrt(num_positions), "float32")
+
+        # Step 2: Reshape
+        patch_pos_embed = keras.ops.reshape(patch_pos_embed, (1, sqrt_num_positions, sqrt_num_positions, dim))
+
+        # Step 3: Resize (Interpolation)
+        patch_pos_embed = keras.layers.Resizing(
+            new_height, new_width, interpolation="bicubic"
+        )(patch_pos_embed)
+
+        # Step 4: Flatten height & width dimensions
+        patch_pos_embed = keras.ops.reshape(patch_pos_embed, (1, -1, dim))
+
+        return ops.concatenate([class_distillation_pos_embed, patch_pos_embed], axis=1)
+    def compute_output_shape(self, input_shape):
+        return (
+            input_shape[0],
+            self.num_positions,
+            self.hidden_dim,
+        )
+
+class DeiTIntermediate(keras.layers.Layer):
+    """DeiTIntermediate block.
+    Args:
+        intermediate_dim: int. Dimensionality of the intermediate MLP layer.
+        **kwargs: Additional keyword arguments passed to `keras.layers.Layer`
+    """
+
+    def __init__(
+        self,
+        intermediate_dim,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # === Config ===
+        self.intermediate_dim = intermediate_dim
+
+    def build(self, input_shape):
+        self.intermediate = keras.layers.Dense(
+            units=self.intermediate_dim,
+            activation="gelu",
+            dtype=self.dtype_policy,
+            name="intermediate",
+        )
+        self.intermediate.build(input_shape)
+        self.built = True
+
+    def call(self, inputs):
+        out = self.intermediate(inputs)
+        return out
+
+
+class DeiTOutput(keras.layers.Layer):
+    """DeiT Output layer implementation."""
+
+    def __init__(self, hidden_dim, dropout_rate=0.1, **kwargs):
+        super().__init__(**kwargs)
+        self.hidden_dim = hidden_dim
+        self.dropout_rate = dropout_rate
+
+
+    def build(self, input_shape):
+        
+        self.dense = keras.layers.Dense(self.hidden_dim, name="output")
+        self.dense.build(input_shape)
+
+        self.dropout = keras.layers.Dropout(self.dropout_rate)
+        # Mark this layer as built
+        self.built = True
+
+    def call(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)  # Linear transformation
+        hidden_states = self.dropout(hidden_states)  # Apply dropout
+        hidden_states = hidden_states + input_tensor  # Residual connection
+        return hidden_states
+
+class DeiTEncoderBlock(keras.layers.Layer):
+    """DeiT encoder block.
+    Args:
+        num_heads: int. Number of attention heads.
+        hidden_dim: int. Dimensionality of the hidden representations.
+        mlp_dim: int. Dimensionality of the intermediate MLP layer.
+        use_mha_bias: bool. Whether to use bias in the multi-head attention
+            layer. Defaults to `True`.
+        drop_path_rate: float. Dropout rate. Between 0 and 1. Defaults to `0.0`.
+        attention_dropout: float. Dropout rate for the attention mechanism.
+            Between 0 and 1. Defaults to `0.0`.
+        layer_norm_epsilon: float. Small float value for layer normalization
+            stability. Defaults to `1e-6`.
+        **kwargs: Additional keyword arguments passed to `keras.layers.Layer`
+    """
+
+    def __init__(
+        self,
+        num_heads,
+        hidden_dim,
+        intermediate_dim,
+        use_mha_bias=True,
+        dropout_rate=0.0,
+        attention_dropout=0.0,
+        layer_norm_epsilon=1e-6,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        key_dim = hidden_dim // num_heads
+
+        # === Config ===
+        self.num_heads = num_heads
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.key_dim = key_dim
+        self.use_mha_bias = use_mha_bias
+        self.dropout_rate = dropout_rate
+        self.attention_dropout = attention_dropout
+        self.layer_norm_epsilon = layer_norm_epsilon
+
+    def build(self, input_shape):
+        # Attention block
+        self.layer_norm_1 = keras.layers.LayerNormalization(
+            epsilon=self.layer_norm_epsilon,
+            name="ln_1",
+            dtype=self.dtype_policy,
+        )
+        self.layer_norm_1.build(input_shape)
+        self.mha = keras.layers.MultiHeadAttention(
+            num_heads=self.num_heads,
+            key_dim=self.key_dim,
+            use_bias=self.use_mha_bias,
+            dropout=self.attention_dropout,
+            name="mha",
+            dtype=self.dtype_policy,
+        )
+        self.mha.build(input_shape, input_shape)
+
+        # MLP block
+        self.layer_norm_2 = keras.layers.LayerNormalization(
+            epsilon=self.layer_norm_epsilon,
+            name="ln_2",
+            dtype=self.dtype_policy,
+        )
+        self.layer_norm_2.build((None, None, self.hidden_dim))
+
+        # Intermediate Layer
+        self.intermediate = DeiTIntermediate(self.intermediate_dim)
+        self.intermediate.build((None, None, self.hidden_dim))
+
+        # Output Layer
+        self.output_layer = DeiTOutput(self.hidden_dim, self.dropout_rate)
+        self.output_layer.build((None, None, self.intermediate_dim))
+
+        self.built = True
+
+    def call(
+        self,
+        hidden_states,
+        attention_mask=None,
+        return_attention_scores=False,
+    ):
+        attention_scores = None
+        x = self.layer_norm_1(hidden_states)
+        if return_attention_scores:
+            x, attention_scores = self.mha(
+                x,
+                x,
+                attention_mask=attention_mask,
+                return_attention_scores=return_attention_scores,
+            )
+        else:
+            x = self.mha(
+                x,
+                x,
+                attention_mask=attention_mask,
+            )
+
+        x = x + hidden_states
+        y = self.layer_norm_2(x)
+        y = self.intermediate(y)
+        y = self.output_layer(y, x)
+
+        return y, attention_scores
+    
+class DeiTEncoder(keras.layers.Layer):
+    """DeiT Encoder class."""
+    
+    def __init__(
+        self,
+        num_layers,
+        num_heads,
+        hidden_dim,
+        intermediate_dim,
+        use_mha_bias=True,
+        dropout_rate=0.0,
+        attention_dropout=0.0,
+        layer_norm_epsilon=1e-6,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # === Config ===
+        self.num_layers = num_layers
+        self.num_heads = num_heads
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.use_mha_bias = use_mha_bias
+        self.dropout_rate = dropout_rate
+        self.attention_dropout = attention_dropout
+        self.layer_norm_epsilon = layer_norm_epsilon
+
+    def build(self, input_shape):
+        self.encoder_layers = []
+        for i in range(self.num_layers):
+            encoder_block = DeiTEncoderBlock(
+                num_heads=self.num_heads,
+                hidden_dim=self.hidden_dim,
+                intermediate_dim=self.intermediate_dim,
+                use_mha_bias=self.use_mha_bias,
+                dropout_rate=self.dropout_rate,
+                attention_dropout=self.attention_dropout,
+                layer_norm_epsilon=self.layer_norm_epsilon,
+                name=f"transformer_block_{i + 1}",
+            )
+            encoder_block.build((None, None, self.hidden_dim))
+            self.encoder_layers.append(encoder_block)
+        
+        self.built = True
+
+    def call(
+        self,
+        hidden_states,
+        attention_masks=None,
+        output_hidden_states=False,
+        return_attention_scores=False,
+    ):
+
+        batch_size = ops.shape(hidden_states)[0]  # Dynamic batch size
+        seq_len = ops.shape(hidden_states)[1]     # Sequence length
+        hidden_dim = ops.shape(hidden_states)[2]  # Hidden size
+
+        # Ensure valid tensor output even if disabled
+        all_hidden_states = (
+            ops.empty(shape=(0, seq_len, hidden_dim), dtype=hidden_states.dtype)
+            if not output_hidden_states else ()
+        )
+
+        all_self_attentions_scores = (
+            ops.empty(shape=(0, self.num_heads, seq_len, seq_len), dtype=hidden_states.dtype)
+            if not return_attention_scores else ()
+        )
+        
+
+        for i in range(self.num_layers):
+            attention_mask = (
+                attention_masks[i] if attention_masks is not None else None
+            )
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            hidden_states, scores = self.encoder_layers[i](
+                hidden_states,
+                attention_mask=attention_mask,
+                return_attention_scores=return_attention_scores,
+            )
+            if return_attention_scores:
+                all_self_attentions_scores = all_self_attentions_scores + (scores,)
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        return hidden_states, all_hidden_states, all_self_attentions_scores

--- a/keras_hub/src/utils/transformers/convert_deit.py
+++ b/keras_hub/src/utils/transformers/convert_deit.py
@@ -1,0 +1,158 @@
+import numpy as np
+
+from keras_hub.src.models.deit.deit_backbone import DeiTBackbone
+
+backbone_cls = DeiTBackbone
+
+
+def convert_backbone_config(transformers_config):
+    image_size = transformers_config["image_size"]
+    return {
+        "image_shape": (image_size, image_size, 3),
+        "patch_size": transformers_config["patch_size"],
+        "num_layers": transformers_config["num_hidden_layers"],
+        "num_heads": transformers_config["num_attention_heads"],
+        "hidden_dim": transformers_config["hidden_size"],
+        "intermediate_dim": transformers_config["intermediate_size"],
+        "dropout_rate": transformers_config["hidden_dropout_prob"],
+        "attention_dropout": transformers_config[
+            "attention_probs_dropout_prob"
+        ],
+        "layer_norm_epsilon": transformers_config["layer_norm_eps"],
+        # TODO
+        "use_mha_bias": True,
+        # "use_mha_bias": transformers_config["qkv_bias"],
+    }
+
+
+def convert_weights(backbone, loader, transformers_config):
+    def port_ln(keras_variable, weight_key):
+        loader.port_weight(keras_variable.gamma, f"{weight_key}.weight")
+        loader.port_weight(keras_variable.beta, f"{weight_key}.bias")
+
+    def port_dense(keras_variable, weight_key):
+        loader.port_weight(
+            keras_variable.kernel,
+            f"{weight_key}.weight",
+            hook_fn=lambda x, _: x.T,
+        )
+        if keras_variable.bias is not None:
+            loader.port_weight(keras_variable.bias, f"{weight_key}.bias")
+
+    def port_mha(keras_variable, weight_key, num_heads, hidden_dim):
+        # query
+        loader.port_weight(
+            keras_variable.query_dense.kernel,
+            f"{weight_key}.attention.query.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (hidden_dim, num_heads, hidden_dim // num_heads)
+            ),
+        )
+        loader.port_weight(
+            keras_variable.query_dense.bias,
+            f"{weight_key}.attention.query.bias",
+            hook_fn=lambda x, _: np.reshape(
+                x, (num_heads, hidden_dim // num_heads)
+            ),
+        )
+        # key
+        loader.port_weight(
+            keras_variable.key_dense.kernel,
+            f"{weight_key}.attention.key.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (hidden_dim, num_heads, hidden_dim // num_heads)
+            ),
+        )
+        loader.port_weight(
+            keras_variable.key_dense.bias,
+            f"{weight_key}.attention.key.bias",
+            hook_fn=lambda x, _: np.reshape(
+                x, (num_heads, hidden_dim // num_heads)
+            ),
+        )
+        # value
+        loader.port_weight(
+            keras_variable.value_dense.kernel,
+            f"{weight_key}.attention.value.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (hidden_dim, num_heads, hidden_dim // num_heads)
+            ),
+        )
+        loader.port_weight(
+            keras_variable.value_dense.bias,
+            f"{weight_key}.attention.value.bias",
+            hook_fn=lambda x, _: np.reshape(
+                x, (num_heads, hidden_dim // num_heads)
+            ),
+        )
+        # output
+        loader.port_weight(
+            keras_variable.output_dense.kernel,
+            f"{weight_key}.output.dense.weight",
+            hook_fn=lambda x, _: np.reshape(
+                x.T, (num_heads, hidden_dim // num_heads, hidden_dim)
+            ),
+        )
+        loader.port_weight(
+            keras_variable.output_dense.bias, f"{weight_key}.output.dense.bias"
+        )
+
+    loader.port_weight(
+        keras_variable=backbone.layers[1].patch_embedding.kernel,
+        hf_weight_key="deit.embeddings.patch_embeddings.projection.weight",
+        hook_fn=lambda x, _: np.transpose(x, (2, 3, 1, 0)),
+    )
+
+    loader.port_weight(
+        backbone.layers[1].patch_embedding.bias,
+        "deit.embeddings.patch_embeddings.projection.bias",
+    )
+
+    loader.port_weight(
+        backbone.layers[1].class_token,
+        "deit.embeddings.cls_token",
+    )
+
+    loader.port_weight(
+        backbone.layers[1].distillation_token,
+        "deit.embeddings.distillation_token",
+    )
+
+    loader.port_weight(
+        backbone.layers[1].position_embedding,
+        "deit.embeddings.position_embeddings",
+    )
+
+    encoder_layers = backbone.layers[2].encoder_layers
+    for i, encoder_block in enumerate(encoder_layers):
+        prefix = "deit.encoder.layer"
+        num_heads = encoder_block.num_heads
+        hidden_dim = encoder_block.hidden_dim
+
+        port_mha(
+            encoder_block.mha,
+            f"{prefix}.{i}.attention",
+            num_heads,
+            hidden_dim,
+        )
+        port_ln(encoder_block.layer_norm_1, f"{prefix}.{i}.layernorm_before")
+        port_ln(encoder_block.layer_norm_2, f"{prefix}.{i}.layernorm_after")
+
+        port_dense(
+            encoder_block.mlp.dense, f"{prefix}.{i}.intermediate.dense"
+        )
+        port_dense(encoder_block.output_layer.dense, f"{prefix}.{i}.output.dense")
+    port_ln(backbone.layers[2].layer_norm, "deit.layernorm")
+
+
+def convert_head(task, loader, transformers_config):
+    prefix = "classifier."
+    loader.port_weight(
+        task.output_dense.kernel,
+        hf_weight_key=prefix + "weight",
+        hook_fn=lambda x, _: x.T,
+    )
+    loader.port_weight(
+        task.output_dense.bias,
+        hf_weight_key=prefix + "bias",
+    )

--- a/keras_hub/src/utils/transformers/convert_deit.py
+++ b/keras_hub/src/utils/transformers/convert_deit.py
@@ -146,7 +146,9 @@ def convert_weights(backbone, loader, transformers_config):
 
 
 def convert_head(task, loader, transformers_config):
-    prefix = "classifier."
+    prefix = "cls_classifier."
+    print(task.output_dense.weights)
+
     loader.port_weight(
         task.output_dense.kernel,
         hf_weight_key=prefix + "weight",

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -6,6 +6,7 @@ from keras_hub.src.utils.preset_utils import jax_memory_cleanup
 from keras_hub.src.utils.transformers import convert_albert
 from keras_hub.src.utils.transformers import convert_bart
 from keras_hub.src.utils.transformers import convert_bert
+from keras_hub.src.utils.transformers import convert_deit
 from keras_hub.src.utils.transformers import convert_distilbert
 from keras_hub.src.utils.transformers import convert_gemma
 from keras_hub.src.utils.transformers import convert_gpt2
@@ -27,6 +28,8 @@ class TransformersPresetLoader(PresetLoader):
             self.converter = convert_bart
         elif model_type == "bert":
             self.converter = convert_bert
+        elif model_type == "deit":
+            self.converter = convert_deit
         elif model_type == "distilbert":
             self.converter = convert_distilbert
         elif model_type == "gemma" or model_type == "gemma2":

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -76,7 +76,7 @@ class TransformersPresetLoader(PresetLoader):
                 cls, load_weights, load_task_weights, **kwargs
             )
         # Support loading the classification head for classifier models.
-        if architecture == "ViTForImageClassification":
+        if architecture == "ViTForImageClassification" or architecture == "DeiTForImageClassificationWithTeacher":
             kwargs["num_classes"] = len(self.config["id2label"])
         task = super().load_task(cls, load_weights, load_task_weights, **kwargs)
         if load_task_weights:


### PR DESCRIPTION
Add VIT based DeiT (data-efficient image transformers) model to keras-hub along with its backbone, layers, tests. 
Paper: [https://arxiv.org/pdf/2012.12877](https://arxiv.org/pdf/2012.12877)
Model card: [https://huggingface.co/facebook/deit-small-distilled-patch16-224](https://huggingface.co/facebook/deit-small-distilled-patch16-224)