### PR TITLE
Fixes compute_output_shape for PaliGemmaVitEncoder and Gemma3VisionEncoderBlock

### DIFF
--- a/keras_hub/src/models/gemma3/gemma3_vision_encoder.py
+++ b/keras_hub/src/models/gemma3/gemma3_vision_encoder.py
@@ -488,7 +488,7 @@ class Gemma3VisionEncoderBlock(keras.layers.Layer):
             # Fix the compatibility issue with Keras 3.1 where
             # `compute_output_spec` fails to propagate `inputs_shape`
             # correctly, causing it to be `None`.
-            inputs_shape = [None, None, None]
+            return [None, None, self.hidden_dim]
         return [
             None,
             (inputs_shape[2] // self.patch_size) ** 2,

--- a/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
@@ -329,7 +329,7 @@ class PaliGemmaVitEncoder(keras.layers.Layer):
             # Fix the compatibility issue with Keras 3.1 where
             # `compute_output_spec` fails to propagate `inputs_shape`
             # correctly, causing it to be `None`.
-            inputs_shape = [None, None, None]
+            return [None, None, self.hidden_dim]
         return [
             inputs_shape[0],
             (inputs_shape[1] // self.patch_size) ** 2,


### PR DESCRIPTION
The logic for handling a Keras 3.1 edge case was missing a return statement, causing this code to run into the following error when running `keras_hub/src/models/pali_gemma/pali_gemma_backbone_test.py`:
```
self = <PaliGemmaVitEncoder name=image_encoder, built=True>
inputs_shape = [None, None, None]

    def compute_output_shape(self, inputs_shape):
        if inputs_shape is None:
            # Fix the compatibility issue with Keras 3.1 where
            # `compute_output_spec` fails to propagate `inputs_shape`
            # correctly, causing it to be `None`.
            inputs_shape = [None, None, None]
        return [
            inputs_shape[0],
>           (inputs_shape[1] // self.patch_size) ** 2,
            self.hidden_dim,
        ]
E       TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'
```
<img width="500" alt="Screenshot 2025-04-09 at 12 50 20 PM" src="https://github.com/user-attachments/assets/b85ed525-e24e-4aab-86ef-3eafefb3154f" />


Additionally, we replace the last dimension of the output shape with `self.hidden_dim`, since we know for sure that we will be projecting `hidden_dim` outputs to the next layer.

The failing test now passes with these changes:
<img width="500" alt="Screenshot 2025-04-09 at 12 53 41 PM" src="https://github.com/user-attachments/assets/329007e8-ba91-4031-94d0-4a93f03d2f4f" />
