### PR TITLE
Add return_attention_scores support to CachedMultiHeadAttention

### DIFF
--- a/keras_hub/src/layers/modeling/cached_multi_head_attention.py
+++ b/keras_hub/src/layers/modeling/cached_multi_head_attention.py
@@ -64,6 +64,12 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
         updated cache.
     """
 
+    def __init__(self, num_heads, key_dim, return_attention_scores=False, **kwargs):
+        # Call the parent class constructor
+        super().__init__(num_heads, key_dim, **kwargs)
+        # New flag to optionally return attention scores
+        self._return_attention_scores = return_attention_scores
+
     def call(
         self,
         query,
@@ -118,6 +124,12 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
 
         attention_output = self._output_dense(attention_output)
 
-        if cache is not None:
-            return attention_output, cache
-        return attention_output
+         # Returning updated logic to support attention_scores if requested
+        if self._return_attention_scores:
+            if cache is not None:
+                return attention_output, attention_scores, cache
+            return attention_output, attention_scores
+        else:
+            if cache is not None:
+                return attention_output, cache
+            return attention_output


### PR DESCRIPTION
This PR addresses [#2055](https://github.com/keras-team/keras-hub/issues/2055), where attention_scores was always None due to the _return_attention_scores flag not being set in the CachedMultiHeadAttention subclass.

In recent Keras versions, the base MultiHeadAttention layer uses a private flag self._return_attention_scores to decide whether or not to return attention scores from _compute_attention.

However, CachedMultiHeadAttention was not passing or setting this flag at all, which meant attention_scores were silently dropped — making them inaccessible for debugging or analysis.

In this PR we did the following-
1.Adds return_attention_scores as an optional argument to the constructor (default False, just like in base MHA).
2.Sets self._return_attention_scores appropriately.
3.Updates the call() method to return attention_scores alongside attention_output and cache when requested — fully preserving existing behavior otherwise.