### PR TITLE
fix: apply pytorch torchfix `weights_only = True`

### DIFF
--- a/tools/checkpoint_conversion/convert_roberta_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_roberta_checkpoints.py
@@ -60,7 +60,7 @@ def convert_checkpoints(size):
     checkpoint_path = os.path.join(extract_dir, "model.pt")
 
     # Load PyTorch RoBERTa checkpoint.
-    pt_ckpt = torch.load(checkpoint_path, map_location=torch.device("cpu"))
+    pt_ckpt = torch.load(checkpoint_path, map_location=torch.device("cpu"), weights_only=True)
     pt_cfg = pt_ckpt["args"]
     pt_model = pt_ckpt["model"]
 

--- a/tools/checkpoint_conversion/convert_xlm_roberta_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_xlm_roberta_checkpoints.py
@@ -45,7 +45,7 @@ def convert_checkpoints(size):
     checkpoint_path = os.path.join(extract_dir, "model.pt")
 
     # Load PyTorch XLM-R checkpoint.
-    pt_ckpt = torch.load(checkpoint_path, map_location=torch.device("cpu"))
+    pt_ckpt = torch.load(checkpoint_path, map_location=torch.device("cpu"), weights_only=True)
     pt_cfg = pt_ckpt["args"]
     pt_model = pt_ckpt["model"]
 


### PR DESCRIPTION
Apply a suggestion from https://github.com/pytorch-labs/torchfix, as `torch.load` without `weights_only` parameter is unsafe

This was introduced in torch >= 2.0.x, which based on the requirements file, is compatible 👍 