### PR TITLE
Fix batch preprocessing bug in Moonshine generation

### DIFF
--- a/keras_hub/src/models/moonshine/moonshine_audio_to_text_preprocessor.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_to_text_preprocessor.py
@@ -266,11 +266,7 @@ class MoonshineAudioToTextPreprocessor(AudioToTextPreprocessor):
                 and 0 <= token < vocab_size
             ]
             processed_sequences.append(filtered_tokens)
-        if tf is not None:
-            try:
-                processed_sequences = tf.ragged.constant(
-                    processed_sequences, dtype=tf.int32
-                )
-            except Exception:
-                pass
+        processed_sequences = tf.ragged.constant(
+            processed_sequences, dtype=tf.int32
+        )
         return self.tokenizer.detokenize(processed_sequences)

--- a/keras_hub/src/models/moonshine/moonshine_audio_to_text_preprocessor.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_to_text_preprocessor.py
@@ -266,4 +266,11 @@ class MoonshineAudioToTextPreprocessor(AudioToTextPreprocessor):
                 and 0 <= token < vocab_size
             ]
             processed_sequences.append(filtered_tokens)
+        if tf is not None:
+            try:
+                processed_sequences = tf.ragged.constant(
+                    processed_sequences, dtype=tf.int32
+                )
+            except Exception:
+                pass
         return self.tokenizer.detokenize(processed_sequences)


### PR DESCRIPTION
## Description of the change
To ragged in batched generation if available. Essentially, the relevant part of `strip_to_ragged()` from `tensor_utils.py`, but only what's needed for the `generate_postprocess()` functionality.

## Colab Notebook
[Before And After The Fix](https://colab.research.google.com/drive/1ARA3yO7AsNNj2A8i3uCMRjr37EqK63eF)

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).