### PR TITLE
Loosen class requirements in from_preset

### DIFF
--- a/keras_hub/src/layers/preprocessing/audio_converter.py
+++ b/keras_hub/src/layers/preprocessing/audio_converter.py
@@ -3,7 +3,6 @@ from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_hub.src.utils.preset_utils import builtin_presets
-from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_preset_loader
 from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
@@ -89,10 +88,7 @@ class AudioConverter(PreprocessingLayer):
         ```
         """
         loader = get_preset_loader(preset)
-        backbone_cls = loader.check_backbone_class()
-        if cls.backbone_cls != backbone_cls:
-            cls = find_subclass(preset, cls, backbone_cls)
-        return loader.load_audio_converter(cls, **kwargs)
+        return loader.load_audio_converter(cls=cls, kwargs=kwargs)
 
     def save_to_preset(self, preset_dir):
         """Save audio converter to a preset directory.

--- a/keras_hub/src/layers/preprocessing/audio_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/audio_converter_test.py
@@ -29,7 +29,7 @@ class AudioConverterTest(TestCase):
 
     @pytest.mark.large
     def test_from_preset_errors(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FileNotFoundError):
             AudioConverter.from_preset("bert_tiny_en_uncased")
         with self.assertRaises(ValueError):
             # No loading on a non-keras model.

--- a/keras_hub/src/layers/preprocessing/image_converter.py
+++ b/keras_hub/src/layers/preprocessing/image_converter.py
@@ -11,7 +11,6 @@ from keras_hub.src.layers.preprocessing.preprocessing_layer import (
 )
 from keras_hub.src.utils.keras_utils import standardize_data_format
 from keras_hub.src.utils.preset_utils import builtin_presets
-from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_preset_loader
 from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
@@ -380,10 +379,7 @@ class ImageConverter(PreprocessingLayer):
         ```
         """
         loader = get_preset_loader(preset)
-        backbone_cls = loader.check_backbone_class()
-        if cls.backbone_cls != backbone_cls:
-            cls = find_subclass(preset, cls, backbone_cls)
-        return loader.load_image_converter(cls, **kwargs)
+        return loader.load_image_converter(cls=cls, kwargs=kwargs)
 
     def save_to_preset(self, preset_dir):
         """Save image converter to a preset directory.

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -122,7 +122,7 @@ class ImageConverterTest(TestCase):
 
     @pytest.mark.large
     def test_from_preset_errors(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FileNotFoundError):
             ImageConverter.from_preset("bert_tiny_en_uncased")
         with self.assertRaises(ValueError):
             # No loading on a non-keras model.

--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -168,14 +168,9 @@ class Backbone(keras.Model):
         ```
         """
         loader = get_preset_loader(preset)
-        backbone_cls = loader.check_backbone_class()
-        if not issubclass(backbone_cls, cls):
-            raise ValueError(
-                f"Saved preset has type `{backbone_cls.__name__}` which is not "
-                f"a subclass of calling class `{cls.__name__}`. Call "
-                f"`from_preset` directly on `{backbone_cls.__name__}` instead."
-            )
-        return loader.load_backbone(backbone_cls, load_weights, **kwargs)
+        return loader.load_backbone(
+            cls=cls, load_weights=load_weights, kwargs=kwargs
+        )
 
     def save_to_preset(self, preset_dir, max_shard_size=10):
         """Save backbone to a preset directory.

--- a/keras_hub/src/tokenizers/tokenizer.py
+++ b/keras_hub/src/tokenizers/tokenizer.py
@@ -7,7 +7,6 @@ from keras_hub.src.layers.preprocessing.preprocessing_layer import (
 from keras_hub.src.utils.preset_utils import ASSET_DIR
 from keras_hub.src.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_hub.src.utils.preset_utils import builtin_presets
-from keras_hub.src.utils.preset_utils import find_subclass
 from keras_hub.src.utils.preset_utils import get_file
 from keras_hub.src.utils.preset_utils import get_preset_loader
 from keras_hub.src.utils.preset_utils import get_preset_saver
@@ -257,7 +256,6 @@ class Tokenizer(PreprocessingLayer):
         ```
         """
         loader = get_preset_loader(preset)
-        backbone_cls = loader.check_backbone_class()
-        if cls.backbone_cls != backbone_cls:
-            cls = find_subclass(preset, cls, backbone_cls)
-        return loader.load_tokenizer(cls, config_file, **kwargs)
+        return loader.load_tokenizer(
+            cls=cls, config_file=config_file, kwargs=kwargs
+        )


### PR DESCRIPTION
* Push all the preset loading logic to the preset loader class.
* Loosen restrictions on what tokenizers/image converts can be loaded with what backbones.
* Fix some bugs with converters.
* Pass user kwargs around explicitly as dicts instead of using **kwargs everywhere (which is less safe).