### PR TITLE
Fix: Correct coverage tracking for keras_hub

### DIFF
--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -57,8 +57,8 @@ pip install huggingface_hub
 if [ "${RUN_XLARGE:-0}" == "1" ]
 then
    pytest keras_hub --check_gpu --run_large --run_extra_large \
-      --cov=keras-hub
+      --cov=keras_hub
 else
    pytest keras_hub --check_gpu --run_large \
-      --cov=keras-hub
+      --cov=keras_hub
 fi


### PR DESCRIPTION
The pytest-cov configuration in the Kokoro build script was instructing coverage to be collected for `keras-hub` (with a hyphen). However, the actual Python package name is `keras_hub` (with an underscore), as defined in `pyproject.toml` and Python's import system.

This mismatch caused a `CoverageWarning: Module keras-hub was never imported`, which was treated as an error in the presubmit checks.

This commit updates the `.kokoro/github/ubuntu/gpu/build.sh` script to use `--cov=keras_hub` so that coverage is correctly tracked for the `keras_hub` package.

## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
