### PR TITLE
Fix dtype issues on JAX CPU in SD3 tests.

### DIFF
--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
@@ -31,11 +31,26 @@ class StableDiffusion3BackboneTest(TestCase):
             64,
             "quick_gelu",
             -2,
-            dtype="float16",
+            # TODO: JAX CPU doesn't support float16 for
+            # `nn.dot_product_attention`. We set dtype to float32 despite the
+            # model defaulting to float16.
+            dtype="float32",
             name="clip_l",
         )
         clip_g = CLIPTextEncoder(
-            20, 64, 64, 2, 2, 128, "gelu", -2, dtype="float16", name="clip_g"
+            20,
+            64,
+            64,
+            2,
+            2,
+            128,
+            "gelu",
+            -2,
+            # TODO: JAX CPU doesn't support float16 for
+            # `nn.dot_product_attention`. We set dtype to float32 despite the
+            # model defaulting to float16.
+            dtype="float32",
+            name="clip_g",
         )
         self.init_kwargs = {
             "mmdit_patch_size": 2,


### PR DESCRIPTION
## Description of the change

It looks like the new version of JAX doesn't support `float16 x float16 -> float32` in `nn.dot_product_attention`.
As a workaround, we can set the dtype to float32 in the tests.

cc @sachinprasadhs 

## Reference

https://github.com/keras-team/keras-hub/pull/2292

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
