### PR TITLE
Resolve preset comparison bug in glue load model method

### DIFF
--- a/benchmarks/glue.py
+++ b/benchmarks/glue.py
@@ -66,7 +66,7 @@ def load_data():
     feature_names = ("sentence1", "sentence2")
 
     def split_features(x):
-        # GLUE comes with dictonary data, we convert it to a uniform format
+        # GLUE comes with dictionary data, we convert it to a uniform format
         # (features, label), where features is a tuple consisting of all
         # features.
         features = tuple([x[name] for name in feature_names])
@@ -93,11 +93,11 @@ def load_model(model, preset, num_classes):
                 continue
             if not hasattr(symbol, "from_preset"):
                 continue
-            for preset in symbol.presets:
-                if preset and preset != preset:
+            for current_preset in symbol.presets:
+                if current_preset and current_preset != preset:
                     continue
-                model = symbol.from_preset(preset, num_classes=num_classes)
-                logging.info(f"\nUsing model {name} with preset {preset}\n")
+                model = symbol.from_preset(current_preset, num_classes=num_classes)
+                logging.info(f"\nUsing model {name} with preset {current_preset}\n")
                 return model
 
     raise ValueError(f"Model {model} or preset {preset} not found.")

--- a/benchmarks/glue.py
+++ b/benchmarks/glue.py
@@ -94,7 +94,7 @@ def load_model(model, preset, num_classes):
             if not hasattr(symbol, "from_preset"):
                 continue
             for current_preset in symbol.presets:
-                if current_preset and current_preset != preset:
+                if preset and current_preset != preset:
                     continue
                 model = symbol.from_preset(current_preset, num_classes=num_classes)
                 logging.info(f"\nUsing model {name} with preset {current_preset}\n")

--- a/benchmarks/glue.py
+++ b/benchmarks/glue.py
@@ -93,11 +93,11 @@ def load_model(model, preset, num_classes):
                 continue
             if not hasattr(symbol, "from_preset"):
                 continue
-            for current_preset in symbol.presets:
-                if preset and current_preset != preset:
+            for cur_preset in symbol.presets:
+                if preset and cur_preset != preset:
                     continue
-                model = symbol.from_preset(current_preset, num_classes=num_classes)
-                logging.info(f"\nUsing model {name} with preset {current_preset}\n")
+                model = symbol.from_preset(cur_preset, num_classes=num_classes)
+                logging.info(f"\nUsing model {name} with preset {cur_preset}\n")
                 return model
 
     raise ValueError(f"Model {model} or preset {preset} not found.")


### PR DESCRIPTION
## Description of the change
This small PR fixes a bug in glue's `load_model()` method where the `preset` comparison failed due to variable shadowing.

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
