### PR TITLE
[MLX backend] Support for MLX backend across `layers` tests

### DIFF
--- a/keras_hub/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding_test.py
@@ -2,6 +2,7 @@ import os
 
 import keras
 import numpy as np
+import pytest
 from absl.testing import parameterized
 from keras import ops
 from keras import random
@@ -95,6 +96,7 @@ class ReversibleEmbeddingTest(TestCase):
     @parameterized.named_parameters(
         ("tie_weights", True), ("untie_weights", False)
     )
+    @pytest.mark.skipif(keras.config.backend() == "mlx", reason="quantization not yet implemented for mlx backend")
     def test_quantize_int8(self, tie_weights):
         layer_config = dict(
             input_dim=100, output_dim=32, tie_weights=tie_weights

--- a/keras_hub/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding_test.py
@@ -96,7 +96,10 @@ class ReversibleEmbeddingTest(TestCase):
     @parameterized.named_parameters(
         ("tie_weights", True), ("untie_weights", False)
     )
-    @pytest.mark.skipif(keras.config.backend() == "mlx", reason="quantization not yet implemented for mlx backend")
+    @pytest.mark.skipif(
+        keras.config.backend() == "mlx",
+        reason="quantization not yet implemented for mlx backend",
+    )
     def test_quantize_int8(self, tie_weights):
         layer_config = dict(
             input_dim=100, output_dim=32, tie_weights=tie_weights

--- a/keras_hub/src/layers/modeling/token_and_position_embedding_test.py
+++ b/keras_hub/src/layers/modeling/token_and_position_embedding_test.py
@@ -1,6 +1,8 @@
+import keras
 import numpy as np
 from keras import ops
 from keras import random
+from keras.src import backend
 
 from keras_hub.src.layers.modeling.token_and_position_embedding import (
     TokenAndPositionEmbedding,
@@ -34,4 +36,7 @@ class TokenAndPositionEmbeddingTest(TestCase):
         input_data = np.array([[1, 0], [1, 0]])
         mask = input_data != 0
         outputs = test_layer(input_data)
-        self.assertAllEqual(outputs._keras_mask, mask)
+        if keras.config.backend() == "mlx":
+            self.assertAllEqual(backend.get_keras_mask(outputs), mask)
+        else:
+            self.assertAllEqual(outputs._keras_mask, mask)

--- a/keras_hub/src/layers/modeling/transformer_decoder_test.py
+++ b/keras_hub/src/layers/modeling/transformer_decoder_test.py
@@ -1,6 +1,8 @@
+import keras
 from absl.testing import parameterized
 from keras import ops
 from keras import random
+from keras.src import backend
 
 from keras_hub.src.layers.modeling.transformer_decoder import TransformerDecoder
 from keras_hub.src.tests.test_case import TestCase
@@ -114,9 +116,14 @@ class TransformerDecoderTest(TestCase):
         decoder_sequence = random.uniform(shape=[1, 4, 6])
         encoder_sequence = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
-        decoder_sequence._keras_mask = mask
-        outputs = decoder(decoder_sequence, encoder_sequence)
-        self.assertAllEqual(outputs._keras_mask, mask)
+        if keras.config.backend() == "mlx":
+            backend.set_keras_mask(decoder_sequence, mask)
+            outputs = decoder(decoder_sequence, encoder_sequence)
+            self.assertAllEqual(backend.get_keras_mask(outputs), mask)
+        else:
+            decoder_sequence._keras_mask = mask
+            outputs = decoder(decoder_sequence, encoder_sequence)
+            self.assertAllEqual(outputs._keras_mask, mask)
 
     def test_mask_propagation_without_cross_attention(self):
         decoder = TransformerDecoder(
@@ -125,9 +132,15 @@ class TransformerDecoderTest(TestCase):
         )
         decoder_sequence = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
-        decoder_sequence._keras_mask = mask
-        outputs = decoder(decoder_sequence)
-        self.assertAllEqual(outputs._keras_mask, mask)
+
+        if keras.config.backend() == "mlx":
+            backend.set_keras_mask(decoder_sequence, mask)
+            outputs = decoder(decoder_sequence)
+            self.assertAllEqual(backend.get_keras_mask(outputs), mask)
+        else:
+            decoder_sequence._keras_mask = mask
+            outputs = decoder(decoder_sequence)
+            self.assertAllEqual(outputs._keras_mask, mask)
 
     def test_cache_call_is_correct(self):
         batch_size, seq_len, num_heads, key_dim = 2, 5, 2, 4

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -58,7 +58,7 @@ class ImageConverterTest(TestCase):
             # mlx only suports float64 on the cpu
             # can force all operations onto cpu stream with float64
             float_image = ops.ones((10, 10, 3), dtype="float32") * 255
-        else:  
+        else:
             int_image = ops.ones((10, 10, 3), dtype="uint8") * 255
             float_image = ops.ones((10, 10, 3), dtype="float64") * 255
 

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -52,8 +52,16 @@ class ImageConverterTest(TestCase):
 
     def test_dtypes(self):
         converter = ImageConverter(image_size=(4, 4), scale=1.0 / 255.0)
-        int_image = ops.ones((10, 10, 3), dtype="uint8") * 255
-        float_image = ops.ones((10, 10, 3), dtype="float64") * 255
+        if keras.config.backend() == "mlx":
+            # mlx backend does not support int matmul
+            int_image = ops.ones((10, 10, 3), dtype="float16") * 255
+            # mlx only suports float64 on the cpu
+            # can force all operations onto cpu stream with float64
+            float_image = ops.ones((10, 10, 3), dtype="float32") * 255
+        else:  
+            int_image = ops.ones((10, 10, 3), dtype="uint8") * 255
+            float_image = ops.ones((10, 10, 3), dtype="float64") * 255
+
         self.assertDTypeEqual(converter(int_image), "float32")
         self.assertDTypeEqual(converter(float_image), "float32")
         self.assertAllClose(converter(int_image), np.ones((4, 4, 3)))

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -9,6 +9,7 @@ import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 from keras import tree
+# from keras.src.trainers.data_adapters import is_mlx_array
 
 from keras_hub.src.layers.modeling.reversible_embedding import (
     ReversibleEmbedding,
@@ -16,6 +17,7 @@ from keras_hub.src.layers.modeling.reversible_embedding import (
 from keras_hub.src.models.retinanet.feature_pyramid import FeaturePyramid
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
 from keras_hub.src.utils.tensor_utils import is_float_dtype
+from keras_hub.src.utils.tensor_utils import is_mlx_array
 
 
 def convert_to_comparible_type(x):
@@ -33,6 +35,10 @@ def convert_to_comparible_type(x):
     if isinstance(x, (tf.Tensor, tf.RaggedTensor)):
         return x
     if hasattr(x, "__array__"):
+        return ops.convert_to_numpy(x)
+    if keras.config.backend() == "mlx" and is_mlx_array(x):
+        # this is to handle bfloat16
+        # mlx arrays don't have an __array__ attribute
         return ops.convert_to_numpy(x)
     return x
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -9,8 +9,8 @@ import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 from keras import tree
-# from keras.src.trainers.data_adapters import is_mlx_array
 
+# from keras.src.trainers.data_adapters import is_mlx_array
 from keras_hub.src.layers.modeling.reversible_embedding import (
     ReversibleEmbedding,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,9 @@ torchvision>=0.16.0
 # Jax.
 jax[cpu]
 
+# MLX.
+pybind11[global]
+cmake
+mlx
+
 -r requirements-common.txt


### PR DESCRIPTION
## Description of the change
This PR is the first (of more to come) to add support for the MLX backend of Keras to work with Keras Hub.
The focus of this PR is tests in `keras_hub/src/layers`, with the following notes:
- Quantization is not yet implemented for the MLX backend
- MLX does not currently support float8
- MLX does not support matmul with integer data types
- masking is handled separately from a `_keras_mask` attribute, as it cannot be added to MLX `array` objects

Any feedback on changes and implementations here would be appreciated. Will modify as needed! 

Note that I have not included MLX in the GitHub CI yet. There are still a few issues failing tests on the Linux environment, so might need to wait until MLX is available via Keras nightly, also open to any other suggestions.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).