### PR TITLE
Removes unnecessary call to `torch.no_grad()`

### DIFF
--- a/keras_hub/src/utils/transformers/export/gemma_test.py
+++ b/keras_hub/src/utils/transformers/export/gemma_test.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import torch
 from sentencepiece import SentencePieceTrainer
 from transformers import GemmaForCausalLM
 from transformers import GemmaTokenizer as HFGemmaTokenizer
@@ -133,10 +132,9 @@ class TestGemmaExport(TestCase):
         prompt = "the quick"
         keras_output = keras_model.generate(prompt, max_length=20)
         input_ids = hf_tokenizer.encode(prompt, return_tensors="pt")
-        with torch.no_grad():
-            output_ids = hf_model.generate(
-                input_ids, max_length=20, do_sample=False
-            )
+        output_ids = hf_model.generate(
+            input_ids, max_length=20, do_sample=False
+        )
         hf_output = hf_tokenizer.decode(output_ids[0], skip_special_tokens=True)
         self.assertEqual(
             keras_output, hf_output, "Generated outputs do not match"


### PR DESCRIPTION
HF transformers already decorates the call to `generate()` with `torch.no_grad`, therefore, the call to the context manager in test code  was not required.

Reference: https://github.com/huggingface/transformers/blob/4d57c39007d98ab5ffb90df6f1695db8738c9410/src/transformers/generation/utils.py#L2228