### PR TITLE
Fix float16 issue in SD3 when using JAX CPU.

### DIFF
--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone.py
@@ -1,4 +1,6 @@
 import keras
+from keras import backend
+from keras import distribution
 from keras import layers
 from keras import ops
 
@@ -621,11 +623,17 @@ class StableDiffusion3Backbone(Backbone):
                 config["vae"]["config"]["dtype"] = dtype_config
 
         # Text encoders default to float16 dtype if not specified.
+        # TODO: JAX CPU doesn't support float16 in `nn.dot_product_attention`.
+        is_jax_cpu = (
+            backend.backend() == "jax"
+            and "cpu" in distribution.list_devices()[0].lower()
+        )
         for text_encoder in ("clip_l", "clip_g", "t5"):
             if (
                 text_encoder in config
                 and config[text_encoder] is not None
                 and "dtype" not in config[text_encoder]["config"]
+                and not is_jax_cpu
             ):
                 config[text_encoder]["config"]["dtype"] = "float16"
 

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_backbone_test.py
@@ -1,4 +1,6 @@
 import pytest
+from keras import backend
+from keras import distribution
 from keras import ops
 
 from keras_hub.src.models.clip.clip_text_encoder import CLIPTextEncoder
@@ -11,6 +13,12 @@ from keras_hub.src.tests.test_case import TestCase
 
 class StableDiffusion3BackboneTest(TestCase):
     def setUp(self):
+        # TODO: JAX CPU doesn't support float16 in `nn.dot_product_attention`.
+        is_jax_cpu = (
+            backend.backend() == "jax"
+            and "cpu" in distribution.list_devices()[0].lower()
+        )
+
         image_shape = (64, 64, 3)
         height, width = image_shape[0], image_shape[1]
         vae = VAEBackbone(
@@ -31,11 +39,20 @@ class StableDiffusion3BackboneTest(TestCase):
             64,
             "quick_gelu",
             -2,
-            dtype="float16",
+            dtype="float16" if not is_jax_cpu else None,
             name="clip_l",
         )
         clip_g = CLIPTextEncoder(
-            20, 64, 64, 2, 2, 128, "gelu", -2, dtype="float16", name="clip_g"
+            20,
+            64,
+            64,
+            2,
+            2,
+            128,
+            "gelu",
+            -2,
+            dtype="float16" if not is_jax_cpu else None,
+            name="clip_g",
         )
         self.init_kwargs = {
             "mmdit_patch_size": 2,

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_image_to_image_test.py
@@ -1,5 +1,7 @@
 import keras
 import pytest
+from keras import backend
+from keras import distribution
 from keras import ops
 
 from keras_hub.src.models.clip.clip_preprocessor import CLIPPreprocessor
@@ -34,6 +36,11 @@ class StableDiffusion3ImageToImageTest(TestCase):
             clip_l_preprocessor, clip_g_preprocessor
         )
 
+        # TODO: JAX CPU doesn't support float16 in `nn.dot_product_attention`.
+        is_jax_cpu = (
+            backend.backend() == "jax"
+            and "cpu" in distribution.list_devices()[0].lower()
+        )
         self.backbone = StableDiffusion3Backbone(
             mmdit_patch_size=2,
             mmdit_hidden_dim=16 * 2,
@@ -60,7 +67,7 @@ class StableDiffusion3ImageToImageTest(TestCase):
                 128,
                 "quick_gelu",
                 -2,
-                dtype="float16",
+                dtype="float16" if not is_jax_cpu else None,
                 name="clip_l",
             ),
             clip_g=CLIPTextEncoder(
@@ -72,7 +79,7 @@ class StableDiffusion3ImageToImageTest(TestCase):
                 256,
                 "gelu",
                 -2,
-                dtype="float16",
+                dtype="float16" if not is_jax_cpu else None,
                 name="clip_g",
             ),
             image_shape=(64, 64, 3),

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_inpaint_test.py
@@ -1,5 +1,7 @@
 import keras
 import pytest
+from keras import backend
+from keras import distribution
 from keras import ops
 
 from keras_hub.src.models.clip.clip_preprocessor import CLIPPreprocessor
@@ -34,6 +36,11 @@ class StableDiffusion3InpaintTest(TestCase):
             clip_l_preprocessor, clip_g_preprocessor
         )
 
+        # TODO: JAX CPU doesn't support float16 in `nn.dot_product_attention`.
+        is_jax_cpu = (
+            backend.backend() == "jax"
+            and "cpu" in distribution.list_devices()[0].lower()
+        )
         self.backbone = StableDiffusion3Backbone(
             mmdit_patch_size=2,
             mmdit_hidden_dim=16 * 2,
@@ -60,7 +67,7 @@ class StableDiffusion3InpaintTest(TestCase):
                 128,
                 "quick_gelu",
                 -2,
-                dtype="float16",
+                dtype="float16" if not is_jax_cpu else None,
                 name="clip_l",
             ),
             clip_g=CLIPTextEncoder(
@@ -72,7 +79,7 @@ class StableDiffusion3InpaintTest(TestCase):
                 256,
                 "gelu",
                 -2,
-                dtype="float16",
+                dtype="float16" if not is_jax_cpu else None,
                 name="clip_g",
             ),
             image_shape=(64, 64, 3),

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_test.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_test.py
@@ -1,5 +1,7 @@
 import keras
 import pytest
+from keras import backend
+from keras import distribution
 from keras import ops
 
 from keras_hub.src.models.clip.clip_preprocessor import CLIPPreprocessor
@@ -34,6 +36,11 @@ class StableDiffusion3TextToImageTest(TestCase):
             clip_l_preprocessor, clip_g_preprocessor
         )
 
+        # TODO: JAX CPU doesn't support float16 in `nn.dot_product_attention`.
+        is_jax_cpu = (
+            backend.backend() == "jax"
+            and "cpu" in distribution.list_devices()[0].lower()
+        )
         self.backbone = StableDiffusion3Backbone(
             mmdit_patch_size=2,
             mmdit_hidden_dim=16 * 2,
@@ -60,7 +67,7 @@ class StableDiffusion3TextToImageTest(TestCase):
                 128,
                 "quick_gelu",
                 -2,
-                dtype="float16",
+                dtype="float16" if not is_jax_cpu else None,
                 name="clip_l",
             ),
             clip_g=CLIPTextEncoder(
@@ -72,7 +79,7 @@ class StableDiffusion3TextToImageTest(TestCase):
                 256,
                 "gelu",
                 -2,
-                dtype="float16",
+                dtype="float16" if not is_jax_cpu else None,
                 name="clip_g",
             ),
             image_shape=(64, 64, 3),


### PR DESCRIPTION
## Description of the change

This should fix the issue reported in https://github.com/keras-team/keras-hub/pull/2292

The root cause is that JAX's `nn.dot_product_attention` does not support float16 on the CPU. The solution is to use float32 when running on the JAX CPU.

cc @sachinprasadhs 

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
