### PR TITLE
Fix for llama3.1 instruct models

### DIFF
--- a/keras_hub/src/utils/transformers/convert_llama3.py
+++ b/keras_hub/src/utils/transformers/convert_llama3.py
@@ -126,10 +126,11 @@ def convert_tokenizer(cls, preset, **kwargs):
     tokenizer_config = load_json(preset, "tokenizer.json")
     vocab = tokenizer_config["model"]["vocab"]
     merges = tokenizer_config["model"]["merges"]
-    
+
     # Handle different merge formats
     if merges and isinstance(merges[0], list) and len(merges[0]) == 2:
-        # Convert list of lists format [["Ġ", "a"], ["Ġ", "b"]] to space-separated strings
+        # Convert list of lists format [["Ġ", "a"], ["Ġ", "b"]]
+        # to space-separated strings
         merges = [" ".join(merge) for merge in merges]
 
     # Load all special tokens with the exception of "reserved" ones.


### PR DESCRIPTION
This pull request improves the robustness of the `convert_tokenizer` method in `convert_llama3.py` by adding support for different formats of the `merges` data structure. Now, the code can handle both lists of strings and lists of lists for merge rules.

Tokenizer conversion improvements:
* Updated the `convert_tokenizer` method to detect and convert `merges` entries from a list-of-lists format (e.g., `[["Ġ", "a"], ["Ġ", "b"]]`) into the expected space-separated string format, ensuring compatibility with various tokenizer configurations.

[Colab Noebook for proof](https://colab.research.google.com/gist/pctablet505/14b3a1dcc6a51fcf03d1a06e57e07c42/llama3-1x-instruct-model-fix.ipynb)