### PR TITLE
Remove exact matching of outputs from Gemma 3 conversion notebook

### DIFF
--- a/tools/checkpoint_conversion/convert_gemma3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_gemma3_checkpoints.py
@@ -498,11 +498,6 @@ def validate_output(
     flax_output = flax_sampler.chat(input_str, images=image)
     print("🔶 Flax output:", flax_output)
 
-    if flax_output.startswith(keras_output):
-        print("✅ Output validated!")
-    else:
-        print("❌ Output does not match!")
-
 
 def main(_):
     preset = FLAGS.preset


### PR DESCRIPTION
The `generate()` output matches for the first ~30-50 tokens (for most presets), but diverges after that. Moreover, if you compare HF, Flax, KerasHub outputs, they are different. This is mostly due to `bfloat16` resulting in error accumulation. For `float32`, the outputs match for 200+ tokens