### PR TITLE
Support Loading Quantized Models with `from_preset()`

### DIFF
--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -91,22 +91,14 @@ class Backbone(keras.Model):
         }
 
         # Add quantization support by utilizing `DTypePolicyMap`
-        dtype = None
-        try:
-            if isinstance(
-                self.dtype_policy, keras.dtype_policies.DTypePolicyMap
-            ):
-                dtype = self.dtype_policy
-            else:
-                policy_map = keras.dtype_policies.DTypePolicyMap()
-                for layer in self._flatten_layers():
-                    if layer.quantization_mode is not None:
-                        policy_map[layer.path] = layer.dtype_policy
-                if len(policy_map) > 0:
-                    dtype = policy_map
-        # Before Keras 3.2, there is no `keras.dtype_policies.get`.
-        except AttributeError:
-            pass
+        dtype = self.dtype_policy
+        if not isinstance(dtype, keras.dtype_policies.DTypePolicyMap):
+            policy_map = keras.dtype_policies.DTypePolicyMap()
+            for layer in self._flatten_layers():
+                if layer.quantization_mode is not None:
+                    policy_map[layer.path] = layer.dtype_policy
+            if len(policy_map) > 0:
+                dtype = policy_map
 
         config.update({"dtype": dtype})
         return config

--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -100,7 +100,7 @@ class Backbone(keras.Model):
             if len(policy_map) > 0:
                 dtype = policy_map
 
-        config.update({"dtype": dtype})
+        config.update({"dtype": keras.dtype_policies.serialize(dtype)})
         return config
 
     @classmethod

--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -91,21 +91,24 @@ class Backbone(keras.Model):
         }
 
         # Add quantization support by utilizing `DTypePolicyMap`
+        dtype = None
         try:
             if isinstance(
                 self.dtype_policy, keras.dtype_policies.DTypePolicyMap
             ):
-                config.update({"dtype": self.dtype_policy})
+                dtype = self.dtype_policy
             else:
                 policy_map = keras.dtype_policies.DTypePolicyMap()
                 for layer in self._flatten_layers():
                     if layer.quantization_mode is not None:
                         policy_map[layer.path] = layer.dtype_policy
                 if len(policy_map) > 0:
-                    config.update({"dtype": policy_map})
+                    dtype = policy_map
         # Before Keras 3.2, there is no `keras.dtype_policies.get`.
         except AttributeError:
             pass
+
+        config.update({"dtype": dtype})
         return config
 
     @classmethod

--- a/keras_hub/src/models/task_test.py
+++ b/keras_hub/src/models/task_test.py
@@ -163,7 +163,7 @@ class TestTask(TestCase):
                     layer.kernel.dtype,
                     expected_dtype,
                     f"Layer '{layer.name}' kernel "
-                    "should have dtype '{expected_dtype}'",
+                    f"should have dtype '{expected_dtype}'",
                 )
 
         # Ensure inference runs without errors.

--- a/keras_hub/src/models/task_test.py
+++ b/keras_hub/src/models/task_test.py
@@ -107,7 +107,7 @@ class TestTask(TestCase):
         model.summary(print_fn=lambda x, line_break=False: summary.append(x))
         self.assertNotRegex("\n".join(summary), "Preprocessor:")
 
-    # @pytest.mark.large
+    @pytest.mark.large
     def test_save_to_preset_with_quantization(self):
         save_dir = self.get_temp_dir()
         task = TextClassifier.from_preset("bert_tiny_en_uncased", num_classes=2)

--- a/keras_hub/src/models/task_test.py
+++ b/keras_hub/src/models/task_test.py
@@ -4,6 +4,7 @@ import pathlib
 import keras
 import numpy as np
 import pytest
+from absl.testing import parameterized
 
 from keras_hub.src.models.bert.bert_text_classifier import BertTextClassifier
 from keras_hub.src.models.causal_lm import CausalLM
@@ -107,8 +108,70 @@ class TestTask(TestCase):
         model.summary(print_fn=lambda x, line_break=False: summary.append(x))
         self.assertNotRegex("\n".join(summary), "Preprocessor:")
 
-    # @pytest.mark.large
-    def test_save_to_preset_with_quantization(self):
+    @pytest.mark.large
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "load_with_quantized_weights",
+            "load_weights": True,
+            "dtype_override": None,
+            "expected_dtype": "int8",
+        },
+        {
+            "testcase_name": "override_dtype_without_loading_weights",
+            "load_weights": False,
+            "dtype_override": "float32",
+            "expected_dtype": "float32",
+        },
+    )
+    def test_quantized_preset_loading_and_saving(
+        self, load_weights, dtype_override, expected_dtype
+    ):
+        # Create, quantize, and save the model preset.
+        save_dir = self.get_temp_dir()
+        task = TextClassifier.from_preset("bert_tiny_en_uncased", num_classes=2)
+        task.quantize(mode="int8")
+        task.save_to_preset(save_dir)
+
+        # Verify that all necessary files were created.
+        path = pathlib.Path(save_dir)
+        self.assertTrue(os.path.exists(path / CONFIG_FILE))
+        self.assertTrue(os.path.exists(path / MODEL_WEIGHTS_FILE))
+        self.assertTrue(os.path.exists(path / METADATA_FILE))
+        self.assertTrue(os.path.exists(path / TASK_CONFIG_FILE))
+        self.assertTrue(os.path.exists(path / TASK_WEIGHTS_FILE))
+
+        # Verify the contents of the task config file.
+        task_config = load_json(save_dir, TASK_CONFIG_FILE)
+        self.assertNotIn("build_config", task_config)
+        self.assertNotIn("compile_config", task_config)
+        self.assertIn("backbone", task_config["config"])
+        self.assertIn("preprocessor", task_config["config"])
+        self.assertEqual(BertTextClassifier, check_config_class(task_config))
+
+        # Restore the task from the preset using parameterized arguments.
+        restored_task = TextClassifier.from_preset(
+            save_dir,
+            num_classes=2,
+            load_weights=load_weights,
+            dtype=dtype_override,
+        )
+
+        # Check that the layers have the expected data type.
+        for layer in restored_task._flatten_layers():
+            if isinstance(layer, keras.layers.Dense) and layer.name != "logits":
+                self.assertEqual(
+                    layer.kernel.dtype,
+                    expected_dtype,
+                    f"Layer '{layer.name}' kernel "
+                    "should have dtype '{expected_dtype}'",
+                )
+
+        # Ensure inference runs without errors.
+        data = ["the quick brown fox.", "the slow brown fox."]
+        _ = restored_task.predict(data)
+
+    @pytest.mark.large
+    def test_load_quantized_preset_with_dtype_override(self):
         save_dir = self.get_temp_dir()
         task = TextClassifier.from_preset("bert_tiny_en_uncased", num_classes=2)
         task.quantize(mode="int8")
@@ -132,22 +195,12 @@ class TestTask(TestCase):
         # Check the preset directory task class.
         self.assertEqual(BertTextClassifier, check_config_class(task_config))
 
-        # Try loading the model from preset directory.
-        restored_task = TextClassifier.from_preset(save_dir, num_classes=2)
-
-        # Validate dtypes for quantized layers are in lower precision.
-        for layer in restored_task._flatten_layers():
-            if isinstance(layer, keras.layers.Dense) and layer.name != "logits":
-                self.assertEqual(
-                    layer.kernel.dtype,
-                    "int8",
-                    f"{layer.name=} should be in lower precision (int8)",
-                )
-
-        # Test whether inference works.
-        data = ["the quick brown fox.", "the slow brown fox."]
-
-        _ = restored_task.predict(data)
+        # Loading the model in full-precision should cause an error during
+        # initialization. The serialized quantized layers include additional
+        # quantization specific weights (kernel_scale, etc.) which the
+        # full-precision layer is not aware about and can't handle.
+        with self.assertRaises(ValueError):
+            TextClassifier.from_preset(save_dir, num_classes=2, dtype="float32")
 
     @pytest.mark.large
     def test_save_to_preset(self):

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -687,6 +687,8 @@ class KerasPresetLoader(PresetLoader):
             )
         # We found a `task.json` with a complete config for our class.
         # Forward backbone args.
+        if "config" in self.config and "dtype" in self.config["config"]:
+            kwargs["dtype"] = self.config["config"]["dtype"]
         backbone_kwargs, kwargs = self.get_backbone_kwargs(**kwargs)
         if "backbone" in task_config["config"]:
             backbone_config = task_config["config"]["backbone"]["config"]

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -723,11 +723,12 @@ class KerasPresetLoader(PresetLoader):
           saved types verbatim.
 
         Args:
-            config: The model configuration.
-            kwargs: Additional keyword arguments, potentially including `dtype`.
+            config: dict. The model configuration.
+            kwargs: dict. Additional keyword arguments, potentially including
+             `dtype`.
 
         Returns:
-            The resolved dtype.
+            str, dict, or DTypePolicy. The resolved dtype.
         """
         # 1. If a user specified dtype is passed, use that.
         if "dtype" in kwargs and kwargs["dtype"] is not None:

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -688,6 +688,8 @@ class KerasPresetLoader(PresetLoader):
         # We found a `task.json` with a complete config for our class.
         # Forward backbone args.
         if "config" in self.config and "dtype" in self.config["config"]:
+            # Forward the serialized dtype from the config. This is critical for
+            # restoring quantized models, which rely on a `DTypePolicyMap`.
             kwargs["dtype"] = self.config["config"]["dtype"]
         backbone_kwargs, kwargs = self.get_backbone_kwargs(**kwargs)
         if "backbone" in task_config["config"]:

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -310,7 +310,29 @@ def is_tensor_type(x):
 
 
 def is_float_dtype(dtype):
-    return "float" in keras.backend.standardize_dtype(dtype)
+    """
+    Checks if a dtype is a float type by using a regex.
+
+    This function standardizes the input dtype and then uses a regular
+    expression to perform an exact match. It identifies standard floats,
+    bfloats, and mixed-precision float types.
+
+    For example:
+    - `is_float_dtype("float32")` returns `True`.
+    - `is_float_dtype("bfloat16")` returns `True`.
+    - `is_float_dtype("mixed_float16")` returns `True`.
+    - `is_float_dtype("int8")` returns `False`.
+    - `is_float_dtype("int8_from_float32")` returns `False`.
+
+    Args:
+        dtype: str, DTypePolicy. The data type to check.
+
+    Returns:
+        bool: `True` if the dtype is a floating-point type, `False` otherwise.
+    """
+    pattern = re.compile(r"^(mixed_)?(b)?float[0-9]*$")
+    standardized_dtype = keras.backend.standardize_dtype(dtype)
+    return pattern.match(standardized_dtype) is not None
 
 
 def is_int_dtype(dtype):

--- a/keras_hub/src/utils/tensor_utils_test.py
+++ b/keras_hub/src/utils/tensor_utils_test.py
@@ -325,8 +325,6 @@ class IsFloatDtypeTest(TestCase):
             "uint8",
             "bool",
             "string",
-            "int8_from_float32",
-            "int4_from_bfloat16",
         ]
         for dtype in non_float_dtypes:
             self.assertFalse(is_float_dtype(dtype))

--- a/keras_hub/src/utils/tensor_utils_test.py
+++ b/keras_hub/src/utils/tensor_utils_test.py
@@ -8,6 +8,7 @@ from keras_hub.src.utils.tensor_utils import any_equal
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_inputs
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_outputs
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import is_float_dtype
 from keras_hub.src.utils.tensor_utils import is_tensor_type
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import target_gather
@@ -304,3 +305,28 @@ class TargetGatherTest(TestCase):
         indices = np.array([0, 1], dtype="int32")
         with self.assertRaisesRegex(ValueError, "larger than 3"):
             _ = target_gather(targets, indices)
+
+
+class IsFloatDtypeTest(TestCase):
+    def test_float_dtypes_return_true(self):
+        float_dtypes = [
+            "float16",
+            "float32",
+            "float64",
+            "bfloat16",
+        ]
+        for dtype in float_dtypes:
+            self.assertTrue(is_float_dtype(dtype))
+
+    def test_non_float_dtypes_return_false(self):
+        non_float_dtypes = [
+            "int8",
+            "int32",
+            "uint8",
+            "bool",
+            "string",
+            "int8_from_float32",
+            "int4_from_bfloat16",
+        ]
+        for dtype in non_float_dtypes:
+            self.assertFalse(is_float_dtype(dtype))


### PR DESCRIPTION
## Description of the change
This change resolves an issue with loading quantized models from presets. Previously, the model's serialized `DTypePolicyMap` was not correctly passed to the backbone during loading, which caused failures during initialization of quantized layers.

The fix introduces a new `_resolve_dtype` utility function that determines the correct `dtype` for the model based on the following rules:

1. User-specified `dtype`: If a user explicitly provides a `dtype` in the from_preset call (e.g., `from_preset("bert_tiny_en_uncased", num_classes=2, dtype="float32")`), that value is used.

2. Float type casting: If no user `dtype` is provided and the saved `dtype` is a floating-point type (e.g., "float32"), the model will be loaded using the current Keras default `dtype` policy. This allows for safe casting between different floating-point precisions.

3. `DTypePolicyMap`: If no user `dtype` is provided and the saved `dtype` is a complex object (like a `DTypePolicyMap` for quantization), the saved type is used as is. This ensures that quantization configurations are preserved during loading.

## Colab Notebook
1. **Failing Case**: This [notebook](https://colab.research.google.com/gist/JyotinderSingh/ee2ac4a68713430a15f7eac44c8a4c97/kerashub-models-can-t-be-loaded-from-quantized-presets.ipynb) demonstrates the original bug where loading the preset fails.
3. **Successful Case**: This [notebook](https://colab.research.google.com/gist/JyotinderSingh/0a77400a46f105aeb6ec60757c3a9670/kerashub-models-loaded-from-quantized-presets.ipynb) shows the corrected behavior where the quantized preset loads successfully with this change.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
