### PR TITLE
Fixing dtype issue causing issues in cobybara sync

### DIFF
--- a/keras_hub/src/models/clip/clip_layers.py
+++ b/keras_hub/src/models/clip/clip_layers.py
@@ -52,10 +52,7 @@ class CLIPVisionEmbedding(layers.Layer):
         self.position_ids = self.add_weight(
             shape=(1, self.num_positions),
             initializer="zeros",
-            # Let the backend determine the int dtype. For example, tf
-            # requires int64 for correct device placement, whereas jax and torch
-            # don't.
-            dtype=int,
+            dtype="int32",
             trainable=False,
             name="position_ids",
         )

--- a/keras_hub/src/models/deberta_v3/disentangled_self_attention.py
+++ b/keras_hub/src/models/deberta_v3/disentangled_self_attention.py
@@ -217,9 +217,9 @@ class DisentangledSelfAttention(keras.layers.Layer):
         )
 
         def _get_log_pos(abs_pos, mid):
-            numerator = ops.log(abs_pos / mid)
+            numerator = ops.log(ops.cast(abs_pos, "float32") / ops.cast(mid, "float32"))
             numerator = numerator * ops.cast(mid - 1, dtype=numerator.dtype)
-            denominator = ops.log((self.max_position_embeddings - 1) / mid)
+            denominator = ops.log(ops.cast(self.max_position_embeddings - 1, "float32") / ops.cast(mid, "float32"))
             val = ops.ceil(numerator / denominator)
             val = ops.cast(val, dtype=mid.dtype)
             val = val + mid

--- a/keras_hub/src/models/deberta_v3/disentangled_self_attention.py
+++ b/keras_hub/src/models/deberta_v3/disentangled_self_attention.py
@@ -217,9 +217,14 @@ class DisentangledSelfAttention(keras.layers.Layer):
         )
 
         def _get_log_pos(abs_pos, mid):
-            numerator = ops.log(ops.cast(abs_pos, "float32") / ops.cast(mid, "float32"))
+            numerator = ops.log(
+                ops.cast(abs_pos, "float32") / ops.cast(mid, "float32")
+            )
             numerator = numerator * ops.cast(mid - 1, dtype=numerator.dtype)
-            denominator = ops.log(ops.cast(self.max_position_embeddings - 1, "float32") / ops.cast(mid, "float32"))
+            denominator = ops.log(
+                ops.cast(self.max_position_embeddings - 1, "float32")
+                / ops.cast(mid, "float32")
+            )
             val = ops.ceil(numerator / denominator)
             val = ops.cast(val, dtype=mid.dtype)
             val = val + mid


### PR DESCRIPTION
This PR fixes the dtype error causing the failure if CLIPBackboneTest.test_backbone_basics. The test gave a value error saying:
ValueError: Incompatible type conversion requested to type int32 for `tf.Variable of type int64. Variable: <tf.Variable 'vision_encoder_embedding/position_ids:0' shape=(1, 197) dtype=int64