### PR TITLE
quantize(...) should accept a config object

### DIFF
--- a/keras_hub/src/layers/modeling/reversible_embedding.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding.py
@@ -235,7 +235,8 @@ class ReversibleEmbedding(keras.layers.Embedding):
 
         return super()._int8_call(inputs)
 
-    def quantize(self, mode, type_check=True):
+    def quantize(self, mode, type_check=True, config=None):
+        del config
         if type_check and type(self) is not ReversibleEmbedding:
             raise self._not_implemented_error(self.quantize)
 


### PR DESCRIPTION
## Description of the change
Modifies the quantize() API of ReversibleEmbedding (the only layer in KerasHub which supports quantization) to accept a config object. This is required to support config objects in the quantization API, which were introduced with GPTQ support in Keras.