### PR TITLE
Allow flexible positions in Gemma

### DIFF
--- a/keras_hub/src/layers/modeling/transformer_layer_utils.py
+++ b/keras_hub/src/layers/modeling/transformer_layer_utils.py
@@ -90,3 +90,19 @@ def merge_padding_and_attention_mask(
         else:
             return ops.minimum(mask, attention_mask)
     return mask
+
+
+def compute_positions_from_mask(mask):
+    """Computes positions from provided padding mask.
+
+    Args:
+        mask: Tensor of shape `(batch_size, sequence_length)`. Padding mask,
+            1 for non-padding tokens, 0 for padding tokens.
+
+    Returns:
+        positions: Tensor of the same shape as `mask`, which contains indices
+            corresponding to positions of tokens in the sequence.
+    """
+    positions = ops.cumsum(mask, axis=-1)
+    positions = ops.subtract(positions, ops.greater_equal(positions, 1))
+    return positions

--- a/keras_hub/src/layers/modeling/transformer_layer_utils.py
+++ b/keras_hub/src/layers/modeling/transformer_layer_utils.py
@@ -104,5 +104,4 @@ def compute_positions_from_mask(mask):
             corresponding to positions of tokens in the sequence.
     """
     positions = ops.cumsum(mask, axis=-1)
-    positions = ops.subtract(positions, ops.greater_equal(positions, 1))
-    return positions
+    return ops.subtract(positions, ops.greater_equal(positions, 1))

--- a/keras_hub/src/layers/modeling/transformer_layer_utils_test.py
+++ b/keras_hub/src/layers/modeling/transformer_layer_utils_test.py
@@ -51,5 +51,5 @@ class TransformerLayerUtilsTest(TestCase):
         )
         output = utils.compute_positions_from_mask(mask)
 
-        expected_output = ops.array([[0, 0, 0, 1, 0], [0, 0, 1, 1, 2]])
+        expected_output = ops.array([[0, 0, 0, 1, 1], [0, 0, 1, 1, 2]])
         self.assertAllEqual(output, expected_output)

--- a/keras_hub/src/layers/modeling/transformer_layer_utils_test.py
+++ b/keras_hub/src/layers/modeling/transformer_layer_utils_test.py
@@ -41,3 +41,15 @@ class TransformerLayerUtilsTest(TestCase):
                 padding_mask,
                 attention_mask,
             )
+
+    def test_compute_positions_from_mask(self):
+        mask = ops.array(
+            [
+                [False, False, True, True, False],
+                [True, False, True, False, True],
+            ]
+        )
+        output = utils.compute_positions_from_mask(mask)
+
+        expected_output = ops.array([[0, 0, 0, 1, 0], [0, 0, 1, 1, 2]])
+        self.assertAllEqual(output, expected_output)

--- a/keras_hub/src/models/gemma/gemma_attention.py
+++ b/keras_hub/src/models/gemma/gemma_attention.py
@@ -97,7 +97,7 @@ class CachedGemmaAttention(keras.layers.Layer):
 
         self.built = True
 
-    def _apply_rope(self, x, start_index, positions):
+    def _apply_rope(self, x, start_index, positions=None):
         """Rope rotate q or k."""
         x = self.rope_layer(x, start_index=start_index, positions=positions)
         # Gemma uses a different layout for positional embeddings.

--- a/keras_hub/src/models/gemma/gemma_backbone_test.py
+++ b/keras_hub/src/models/gemma/gemma_backbone_test.py
@@ -31,6 +31,13 @@ class GemmaBackboneTest(TestCase):
             expected_output_shape=(2, 5, 16),
         )
 
+    def test_flexible_positions(self):
+        self.run_positions_test(
+            cls=GemmaBackbone,
+            init_kwargs=self.init_kwargs,
+            vocabulary_size=self.init_kwargs["vocabulary_size"],
+        )
+
     @pytest.mark.large
     def test_saved_model(self):
         self.run_model_saving_test(
@@ -186,6 +193,13 @@ class Gemma2BackboneTest(TestCase):
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output_shape=(2, 10, 16),
+        )
+
+    def test_flexible_positions(self):
+        self.run_positions_test(
+            cls=GemmaBackbone,
+            init_kwargs=self.init_kwargs,
+            vocabulary_size=self.init_kwargs["vocabulary_size"],
         )
 
     def test_sliding_window(self):

--- a/keras_hub/src/models/gemma/gemma_decoder_block.py
+++ b/keras_hub/src/models/gemma/gemma_decoder_block.py
@@ -169,10 +169,6 @@ class GemmaDecoderBlock(keras.layers.Layer):
         cache=None,
         cache_update_index=0,
     ):
-        positions = None
-        if padding_mask is not None:
-            positions = compute_positions_from_mask(padding_mask)
-
         normalized_x = self.pre_attention_norm(x)
         attention_mask = self._compute_attention_mask(
             normalized_x, padding_mask, cache, cache_update_index
@@ -185,6 +181,10 @@ class GemmaDecoderBlock(keras.layers.Layer):
                 cache_update_index=cache_update_index,
             )
         else:
+            positions = None
+            if padding_mask is not None:
+                positions = compute_positions_from_mask(padding_mask)
+
             attention = self.attention(
                 normalized_x,
                 attention_mask=attention_mask,

--- a/keras_hub/src/models/gemma/gemma_decoder_block.py
+++ b/keras_hub/src/models/gemma/gemma_decoder_block.py
@@ -5,6 +5,9 @@ from keras_hub.src.layers.modeling.transformer_layer_utils import (
     compute_causal_mask,
 )
 from keras_hub.src.layers.modeling.transformer_layer_utils import (
+    compute_positions_from_mask,
+)
+from keras_hub.src.layers.modeling.transformer_layer_utils import (
     merge_padding_and_attention_mask,
 )
 from keras_hub.src.models.gemma.gemma_attention import CachedGemmaAttention
@@ -166,6 +169,10 @@ class GemmaDecoderBlock(keras.layers.Layer):
         cache=None,
         cache_update_index=0,
     ):
+        positions = None
+        if padding_mask is not None:
+            positions = compute_positions_from_mask(padding_mask)
+
         normalized_x = self.pre_attention_norm(x)
         attention_mask = self._compute_attention_mask(
             normalized_x, padding_mask, cache, cache_update_index
@@ -181,6 +188,7 @@ class GemmaDecoderBlock(keras.layers.Layer):
             attention = self.attention(
                 normalized_x,
                 attention_mask=attention_mask,
+                positions=positions,
             )
 
         if self.use_post_attention_norm:

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -729,10 +729,9 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         """Tests that conventional and flexible positions give same output."""
         model = cls(**init_kwargs)
 
+        rng = np.random.default_rng(seed=42)
         x1 = {
-            "token_ids": np.random.randint(
-                shape=(2, 5), minval=1, maxval=vocabulary_size, seed=42
-            ),
+            "token_ids": rng.integers(low=1, high=vocabulary_size, size=(2, 5)),
             "padding_mask": np.array(
                 [
                     [True] * 3 + [False] * 2,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -740,10 +740,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 ]
             ),
         }
-
         # Convert token_ids to list for easier manipulation.
-        token_ids_lst = x1.tolist()
-
+        token_ids_lst = x1["token_ids"].tolist()
         x2 = {
             "token_ids": ops.array(
                 [
@@ -759,8 +757,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             ),
         }
 
-        output_1 = model(**x1)
-        output_2 = model(**x2)
+        output_1 = model.predict(x1)
+        output_2 = model.predict(x2)
         self.assertAllClose(output_1[0][:3], output_2[0][1:4])
         self.assertAllClose(output_1[1][:2], output_2[1][2:4])
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -730,10 +730,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         model = cls(**init_kwargs)
 
         x1 = {
-            "token_ids": keras.random.randint(
+            "token_ids": np.random.randint(
                 shape=(2, 5), minval=1, maxval=vocabulary_size, seed=42
             ),
-            "padding_mask": ops.array(
+            "padding_mask": np.array(
                 [
                     [True] * 3 + [False] * 2,
                     [True] * 2 + [False] * 3,
@@ -743,13 +743,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         # Convert token_ids to list for easier manipulation.
         token_ids_lst = x1["token_ids"].tolist()
         x2 = {
-            "token_ids": ops.array(
+            "token_ids": np.array(
                 [
                     [0] + token_ids_lst[0][:3] + [0],
                     [0] * 2 + token_ids_lst[1][:2] + [0],
                 ]
             ),
-            "padding_mask": ops.array(
+            "padding_mask": np.array(
                 [
                     [False] + [True] * 3 + [False],
                     [False] * 2 + [True] * 2 + [False],

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -720,6 +720,50 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             output = ops.argmax(output, axis=-1)
             self.assertAllEqual(output, expected_labels)
 
+    def run_positions_test(
+        self,
+        cls,
+        init_kwargs,
+        vocabulary_size,
+    ):
+        """Tests that conventional and flexible positions give same output."""
+        model = cls(**init_kwargs)
+
+        x1 = {
+            "token_ids": keras.random.randint(
+                shape=(2, 5), minval=1, maxval=vocabulary_size, seed=42
+            ),
+            "padding_mask": ops.array(
+                [
+                    [True] * 3 + [False] * 2,
+                    [True] * 2 + [False] * 3,
+                ]
+            ),
+        }
+
+        # Convert token_ids to list for easier manipulation.
+        token_ids_lst = x1.tolist()
+
+        x2 = {
+            "token_ids": ops.array(
+                [
+                    [0] + token_ids_lst[0][:3] + [0],
+                    [0] * 2 + token_ids_lst[1][:2] + [0],
+                ]
+            ),
+            "padding_mask": ops.array(
+                [
+                    [False] + [True] * 3 + [False],
+                    [False] * 2 + [True] * 2 + [False],
+                ]
+            ),
+        }
+
+        output_1 = model(**x1)
+        output_2 = model(**x2)
+        self.assertAllClose(output_1[0][:3], output_2[0][1:4])
+        self.assertAllClose(output_1[1][:2], output_2[1][2:4])
+
     def get_test_data_dir(self):
         return str(pathlib.Path(__file__).parent / "test_data")
 


### PR DESCRIPTION
Follows https://github.com/keras-team/keras-hub/pull/2369

We left-pad prompts for DPO (and GRPO/PPO), in which case, we need to compute flexible positions. This PR does it for Gemma, but we can extend it to other models soon.

**Delta**
- A function to compute positions from padding mask;
- Modify `GemmaDecoderBlock`, `CachedGemmaAttention` in order to pass these flexible positions.

This PR does **not**, however, modify the `generate()` code to account for left-padded prompts. This will be a more involved changes, with modifications required to `generate_preprocess()`; it makes sense to do this later when we start work on GRPO/PPO.