### PR TITLE
[OpenVINO backend] enable test_causal_lm_basics

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,7 +16,6 @@ OPENVINO_SUPPORTED_PATHS = [
 OPENVINO_SPECIFIC_SKIPPING_TESTS = {
     "test_backbone_basics": "bfloat16 dtype not supported",
     "test_score_loss": "Non-implemented roll operation",
-    "test_causal_lm_basics": "Missing ops and requires trainable backend",
 }
 
 


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
Enable `test_causal_lm_basics` for the `OpenVINO` backend.
The issue has been resolved in this PR: https://github.com/keras-team/keras/pull/21670, which allows the monkey patch to detect fit methods without explicitly defining them in `OPENVINO_SPECIFIC_SKIPPING_TESTS`.

Additionally, the OpenVINO mismatch issue from this PR: https://github.com/keras-team/keras-hub/pull/2389
 has also been fixed.

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
