### PR TITLE
Fixing dtype issue in siglip layer

### DIFF
--- a/keras_hub/src/models/siglip/siglip_layers.py
+++ b/keras_hub/src/models/siglip/siglip_layers.py
@@ -70,7 +70,7 @@ class SigLIPVisionEmbedding(layers.Layer):
         self.position_ids = self.add_weight(
             shape=(1, self.num_positions),
             initializer="zeros",
-            # Let the backend determine the int dtype. For example, tf
+            # Let the backend determine the int32 dtype. For example, tf
             # requires int64 for correct device placement, whereas jax and torch
             # don't.
             dtype="int32",
@@ -194,7 +194,7 @@ class SigLIPTextEmbedding(layers.Layer):
         self.position_ids = self.add_weight(
             shape=(1, self.sequence_length),
             initializer="zeros",
-            # Let the backend determine the int dtype. For example, tf
+            # Let the backend determine the int32 dtype. For example, tf
             # requires int64 for correct device placement, whereas jax and torch
             # don't.
             dtype="int32",


### PR DESCRIPTION
Fixing the ValueError: Incompatible type conversion requested to type int32 for `tf.Variable of type int64. which arose while running the SigLIPBackboneTest.test_backbone_basics test
Changed the dtype from int to int32