### PR TITLE
[internal] Reorder @pytest.mark.large decorator to fix CI

### DIFF
--- a/keras_hub/src/models/task_test.py
+++ b/keras_hub/src/models/task_test.py
@@ -108,7 +108,6 @@ class TestTask(TestCase):
         model.summary(print_fn=lambda x, line_break=False: summary.append(x))
         self.assertNotRegex("\n".join(summary), "Preprocessor:")
 
-    @pytest.mark.large
     @parameterized.named_parameters(
         {
             "testcase_name": "load_with_quantized_weights",
@@ -123,6 +122,7 @@ class TestTask(TestCase):
             "expected_dtype": "float32",
         },
     )
+    @pytest.mark.large
     def test_quantized_preset_loading_and_saving(
         self, load_weights, dtype_override, expected_dtype
     ):


### PR DESCRIPTION
## Description of the change
The order of the decorators matters in how internal tooling identifies tests

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
