### PR TITLE
Update preset map for VGG model

### DIFF
--- a/tools/checkpoint_conversion/convert_vgg_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vgg_checkpoints.py
@@ -3,7 +3,7 @@
 Optionally uploads the model to Keras if the `--upload_uri` flag is passed.
 
 python tools/checkpoint_conversion/convert_vgg_checkpoints.py \
-    --preset vgg11 --upload_uri kaggle://kerashub/vgg/keras/vgg11
+    --preset vgg_11_imagenet --upload_uri kaggle://kerashub/vgg/keras/vgg_11_imagenet
 """
 
 import os


### PR DESCRIPTION
This PR updates the `VGG` model preset keys to align with the official naming convention used in Keras and Kaggle documentation.
