### PR TITLE
fix: Update Moonshine to support the JAX backend in the `keras-nightly` version

### DIFF
--- a/keras_hub/src/models/moonshine/moonshine_backbone.py
+++ b/keras_hub/src/models/moonshine/moonshine_backbone.py
@@ -54,6 +54,9 @@ class Arange(keras.layers.Layer):
         sequence_length = keras.ops.shape(inputs)[1]
         return keras.ops.arange(sequence_length, dtype="int32")
 
+    def compute_output_shape(self, input_shape):
+        return (input_shape[1],)
+
 
 @keras_hub_export("keras_hub.models.MoonshineBackbone")
 class MoonshineBackbone(Backbone):


### PR DESCRIPTION
## Description of the change
Update Moonshine to support the JAX backend in the `keras-nightly` version.
The T5 fix is more involved; adding the `compute_output_shape()` method cascades into quantized model build issues. I currently don’t have the bandwidth to address this involved fix.
Feel free to merge this and handle T5 later though!

cc: @divyashreepathihalli @mattdangerw

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).