### PR TITLE
update preset map for ViT model

### DIFF
--- a/tools/checkpoint_conversion/convert_vit_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vit_checkpoints.py
@@ -4,7 +4,7 @@ export KAGGLE_USERNAME=XXX
 export KAGGLE_KEY=XXX
 
 python tools/checkpoint_conversion/convert_vit_checkpoints.py \
-    --preset vit_base_patch16_224
+    --preset vit_base_patch16_224_imagenet
 """
 
 import os
@@ -30,17 +30,17 @@ from keras_hub.src.models.vit.vit_image_converter import ViTImageConverter
 FLAGS = flags.FLAGS
 
 PRESET_MAP = {
-    "vit_base_patch16_224": "google/vit-base-patch16-224",
-    "vit_base_patch16_384": "google/vit-base-patch16-384",
-    "vit_base_patch32_384": "google/vit-base-patch32-384",
-    "vit_large_patch16_224": "google/vit-large-patch16-224",
-    "vit_large_patch16_384": "google/vit-large-patch16-384",
-    "vit_large_patch32_384": "google/vit-large-patch32-384",
-    "vit_base_patch16_224_in21k": "google/vit-base-patch16-224-in21k",
-    "vit_base_patch32_224_in21k": "google/vit-base-patch32-224-in21k",
-    "vit_large_patch16_224_in21k": "google/vit-large-patch16-224-in21k",
-    "vit_large_patch32_224_in21k": "google/vit-large-patch32-224-in21k",
-    "vit_huge_patch14_224_in21k": "google/vit-huge-patch14-224-in21k",
+    "vit_base_patch16_224_imagenet": "google/vit-base-patch16-224",
+    "vit_base_patch16_384_imagenet": "google/vit-base-patch16-384",
+    "vit_base_patch32_384_imagenet": "google/vit-base-patch32-384",
+    "vit_large_patch16_224_imagenet": "google/vit-large-patch16-224",
+    "vit_large_patch16_384_imagenet": "google/vit-large-patch16-384",
+    "vit_large_patch32_384_imagenet": "google/vit-large-patch32-384",
+    "vit_base_patch16_224__imagenet21k": "google/vit-base-patch16-224-in21k",
+    "vit_base_patch32_224__imagenet21k": "google/vit-base-patch32-224-in21k",
+    "vit_large_patch16_224__imagenet21k": "google/vit-large-patch16-224-in21k",
+    "vit_large_patch32_224__imagenet21k": "google/vit-large-patch32-224-in21k",
+    "vit_huge_patch14_224__imagenet21k": "google/vit-huge-patch14-224-in21k",
 }
 
 flags.DEFINE_string(

--- a/tools/checkpoint_conversion/convert_vit_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vit_checkpoints.py
@@ -36,11 +36,11 @@ PRESET_MAP = {
     "vit_large_patch16_224_imagenet": "google/vit-large-patch16-224",
     "vit_large_patch16_384_imagenet": "google/vit-large-patch16-384",
     "vit_large_patch32_384_imagenet": "google/vit-large-patch32-384",
-    "vit_base_patch16_224__imagenet21k": "google/vit-base-patch16-224-in21k",
-    "vit_base_patch32_224__imagenet21k": "google/vit-base-patch32-224-in21k",
-    "vit_large_patch16_224__imagenet21k": "google/vit-large-patch16-224-in21k",
-    "vit_large_patch32_224__imagenet21k": "google/vit-large-patch32-224-in21k",
-    "vit_huge_patch14_224__imagenet21k": "google/vit-huge-patch14-224-in21k",
+    "vit_base_patch16_224_imagenet21k": "google/vit-base-patch16-224-in21k",
+    "vit_base_patch32_224_imagenet21k": "google/vit-base-patch32-224-in21k",
+    "vit_large_patch16_224_imagenet21k": "google/vit-large-patch16-224-in21k",
+    "vit_large_patch32_224_imagenet21k": "google/vit-large-patch32-224-in21k",
+    "vit_huge_patch14_224_imagenet21k": "google/vit-huge-patch14-224-in21k",
 }
 
 flags.DEFINE_string(


### PR DESCRIPTION
This PR updates `PRESET_MAP` for **ViT** model to align with the official naming convention used in Keras and Kaggle documentation.