### PR TITLE
[FIX] Prevent TypeError in text-only Gemma3CausalLM and improve gener…

### DIFF
--- a/keras_hub/src/models/gemma3/gemma3_causal_lm.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm.py
@@ -227,7 +227,7 @@ class Gemma3CausalLM(CausalLM):
         )
         return hidden_states, cache
 
-    def generate_step(self, inputs, stop_token_ids=[106]):
+    def generate_step(self, inputs, stop_token_ids=None):
         """A compilable generation function for a single batch of inputs.
 
         This function represents the inner, XLA-compilable, generation function
@@ -326,11 +326,14 @@ class Gemma3CausalLM(CausalLM):
         else:
             # Without early stopping, all locations will have been updated.
             padding_mask = ops.ones_like(token_ids, dtype="bool")
-        return {
+        output_dict = {
             "token_ids": token_ids,
             "padding_mask": padding_mask,
-            "images": images,
         }
+        if images is not None:
+            output_dict["images"] = images
+    
+        return output_dict
 
     def generate(
         self,


### PR DESCRIPTION
…ate_step defaults

1. Bug Fix: TypeError during generation for text-only models

The Problem:
When using a Gemma3CausalLM model configured for text-only processing (i.e., with vision_encoder=None and preprocessor=None), a call to causal_lm.generate() fails with a TypeError.

The root cause is that the internal generate_step method returns a dictionary containing an 'images': None key-value pair. This None value is eventually passed to ops.concatenate during the output normalization step, which does not accept None as a valid input. This workflow is common when pretraining a model from scratch.

The Fix:
The generate_step method has been modified to only include the 'images' key in its returned dictionary if an image tensor is actually present. This ensures that a None value is never passed to downstream functions, resolving the TypeError.

Proof of Bug and Fix:
The following Colab notebook demonstrates the bug with the original code and shows the successful execution after applying this fix: https://colab.research.google.com/drive/1QVk2idB6fcdYYJb1cBQGaKHe5QSGjCti?usp=sharing


2. Refactoring: Remove Hardcoded Stop Token

The Problem:
The internal generate_step method has a hardcoded default stop_token_ids=[106], which corresponds to the <end_of_turn> token. This is conceptually incorrect for a base architectural model, as the model itself should not have opinions about instruction-following or conversational tokens. This hardcoded value can interfere with pretraining or sampling raw text.

The Fix:
The method signature has been changed from stop_token_ids=[106] to stop_token_ids=None.

This is a safe, non-breaking change because the public-facing Gemma3CausalLM.generate() method is already responsible for setting the appropriate stop tokens when a user specifies stop_token_ids="auto".

## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
