### PR TITLE
Handles incompatible quantization mode for ReversibleEmbedding

### DIFF
--- a/keras_hub/src/layers/modeling/reversible_embedding.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding.py
@@ -247,7 +247,7 @@ class ReversibleEmbedding(keras.layers.Embedding):
 
         if mode != "int8":
             raise NotImplementedError(
-                "Invalid quantization mode. Expected one 'int8'. "
+                "Invalid quantization mode. Expected 'int8'. "
                 f"Received: quantization_mode={mode}"
             )
 


### PR DESCRIPTION
## Description of the change
`ReversibleEmbedding` does not yet support `"int4"` quantization mode. However, it presently does not raise an exception at the right place, leading to silent misconfiguration of the layer's variables. This misconfiguration only becomes apparent when trying to use the `call` API.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
