### PR TITLE
Set JAX and Tensorflow GPU timeouts to 2.5 hours

### DIFF
--- a/.kokoro/github/ubuntu/gpu/jax/continuous.cfg
+++ b/.kokoro/github/ubuntu/gpu/jax/continuous.cfg
@@ -31,4 +31,4 @@ before_action {
 }
 
 # Set timeout lower from default 180 mins
-timeout_mins: 120
+timeout_mins: 150

--- a/.kokoro/github/ubuntu/gpu/jax/presubmit.cfg
+++ b/.kokoro/github/ubuntu/gpu/jax/presubmit.cfg
@@ -31,4 +31,4 @@ before_action {
 }
 
 # Set timeout lower from default 180 mins
-timeout_mins: 120
+timeout_mins: 150

--- a/.kokoro/github/ubuntu/gpu/tensorflow/continuous.cfg
+++ b/.kokoro/github/ubuntu/gpu/tensorflow/continuous.cfg
@@ -31,4 +31,4 @@ before_action {
 }
 
 # Set timeout lower from default 180 mins
-timeout_mins: 120
+timeout_mins: 150

--- a/.kokoro/github/ubuntu/gpu/tensorflow/presubmit.cfg
+++ b/.kokoro/github/ubuntu/gpu/tensorflow/presubmit.cfg
@@ -31,4 +31,4 @@ before_action {
 }
 
 # Set timeout lower from default 180 mins
-timeout_mins: 120
+timeout_mins: 150


### PR DESCRIPTION
JAX and Tensorflow GPU tests failed with timeout issue, hence this PR increases the time limit for those to 150 minutes from 120 minutes earlier.