### PR TITLE
Fix tensorflow-text import to not break core tensorflow functionality

### DIFF
--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -10,16 +10,14 @@ import numpy as np
 from keras import ops
 from packaging import version
 
-tf = None
-tf_text = None
 try:
     import tensorflow as tf
-    try:
-        import tensorflow_text as tf_text
-    except ImportError:
-        pass
 except ImportError:
-    pass
+    tf = None
+try:
+    import tensorflow_text as tf_text
+except ImportError:
+    tf_text = None
 
 
 NO_CONVERT_COUNTER = threading.local()


### PR DESCRIPTION
## Description
Separates the try-except blocks for `tensorflow` and `tensorflow-text` imports to allow the library to function when tensorflow-text is unavailable (e.g., Python 3.13 where tensorflow-text support is not yet available).

## Problem
Currently, if `tensorflow-text` fails to import, both `tf` and `tf_text` are set to `None`, even if `tensorflow` imports successfully. This causes `AttributeError: 'NoneType' object has no attribute 'RaggedTensor'` errors in downstream libraries.

## Related Issues
- Fixes google/metrax#115