### PR TITLE
Add Devstral Small 1.1

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -401,6 +401,9 @@ from keras_hub.src.models.mistral.mistral_causal_lm_preprocessor import (
     MistralCausalLMPreprocessor as MistralCausalLMPreprocessor,
 )
 from keras_hub.src.models.mistral.mistral_tokenizer import (
+    MistralTiktokenTokenizer as MistralTiktokenTokenizer,
+)
+from keras_hub.src.models.mistral.mistral_tokenizer import (
     MistralTokenizer as MistralTokenizer,
 )
 from keras_hub.src.models.mit.mit_backbone import MiTBackbone as MiTBackbone

--- a/keras_hub/api/tokenizers/__init__.py
+++ b/keras_hub/api/tokenizers/__init__.py
@@ -54,6 +54,9 @@ from keras_hub.src.models.llama3.llama3_tokenizer import (
     Llama3Tokenizer as Llama3Tokenizer,
 )
 from keras_hub.src.models.mistral.mistral_tokenizer import (
+    MistralTiktokenTokenizer as MistralTiktokenTokenizer,
+)
+from keras_hub.src.models.mistral.mistral_tokenizer import (
     MistralTokenizer as MistralTokenizer,
 )
 from keras_hub.src.models.mixtral.mixtral_tokenizer import (
@@ -120,6 +123,9 @@ from keras_hub.src.tokenizers.sentence_piece_tokenizer import (
 )
 from keras_hub.src.tokenizers.sentence_piece_tokenizer_trainer import (
     compute_sentence_piece_proto as compute_sentence_piece_proto,
+)
+from keras_hub.src.tokenizers.tiktoken_tokenizer import (
+    TiktokenTokenizer as TiktokenTokenizer,
 )
 from keras_hub.src.tokenizers.tokenizer import Tokenizer as Tokenizer
 from keras_hub.src.tokenizers.unicode_codepoint_tokenizer import (

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -102,6 +102,7 @@ class MistralBackbone(Backbone):
         sliding_window=512,
         dropout=0,
         dtype=None,
+        head_dim=None,
         **kwargs,
     ):
         # === Layers ===

--- a/keras_hub/src/models/mistral/mistral_presets.py
+++ b/keras_hub/src/models/mistral/mistral_presets.py
@@ -44,7 +44,7 @@ backbone_presets = {
     },
     "devstral_small_1_1": {
         "metadata": {
-            "description": "Devstral Small 1.1 finetuned from Mistral-Small-3.1 24B base model",
+            "description": "Devstral Small 1.1 24B finetuned base model",
             "params": 23572403200,
             "path": "devstral_small_1_1",
         },

--- a/keras_hub/src/models/mistral/mistral_presets.py
+++ b/keras_hub/src/models/mistral/mistral_presets.py
@@ -48,6 +48,6 @@ backbone_presets = {
             "params": 23572403200,
             "path": "devstral_small_1_1",
         },
-        # "kaggle_handle": "kaggle://keras/mistral/keras/devstral_small_1_1/1",
+        "kaggle_handle": "kaggle://keras/mistral/keras/devstral_small_1_1/1",
     },
 }

--- a/keras_hub/src/models/mistral/mistral_presets.py
+++ b/keras_hub/src/models/mistral/mistral_presets.py
@@ -42,4 +42,12 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/mistral/keras/mistral_0.3_instruct_7b_en/1",
     },
+    "devstral_small_1_1": {
+        "metadata": {
+            "description": "Devstral Small 1.1 finetuned from Mistral-Small-3.1 24B base model",
+            "params": 23572403200,
+            "path": "devstral_small_1_1",
+        },
+        # "kaggle_handle": "kaggle://keras/mistral/keras/devstral_small_1_1/1",
+    },
 }

--- a/keras_hub/src/models/mistral/mistral_tokenizer.py
+++ b/keras_hub/src/models/mistral/mistral_tokenizer.py
@@ -6,10 +6,12 @@ from keras_hub.src.tokenizers.sentence_piece_tokenizer import (
 from keras_hub.src.tokenizers.tiktoken_tokenizer import TiktokenTokenizer
 
 
-@keras_hub_export([
-    "keras_hub.tokenizers.MistralTokenizer",
-    "keras_hub.models.MistralTokenizer",
-])
+@keras_hub_export(
+    [
+        "keras_hub.tokenizers.MistralTokenizer",
+        "keras_hub.models.MistralTokenizer",
+    ]
+)
 class MistralTokenizer(SentencePieceTokenizer):
     """Mistral tokenizer layer based on SentencePiece.
 
@@ -56,18 +58,15 @@ class MistralTokenizer(SentencePieceTokenizer):
         super().__init__(proto=proto, **kwargs)
 
 
-@keras_hub_export([
-    "keras_hub.tokenizers.NewMistralTokenizer",
-    "keras_hub.models.NewMistralTokenizer",
-])
-class NewMistralTokenizer(TiktokenTokenizer):
+@keras_hub_export(
+    [
+        "keras_hub.tokenizers.MistralTiktokenTokenizer",
+        "keras_hub.models.MistralTiktokenTokenizer",
+    ]
+)
+class MistralTiktokenTokenizer(TiktokenTokenizer):
     """
-    Tekken-based tokenizer for Mistral models.
-
-    Responsibilities:
-      • Add required Mistral special tokens (<s>, </s>, pad)
-      • Delegate tekken.json parsing to TiktokenTokenizer
-      • Use Tiktoken backend via TiktokenTokenizer normalisation
+    Tiktoken-based tokenizer for Mistral models.
     """
 
     backbone_cls = MistralBackbone

--- a/keras_hub/src/models/mistral/mistral_tokenizer.py
+++ b/keras_hub/src/models/mistral/mistral_tokenizer.py
@@ -3,14 +3,13 @@ from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.tokenizers.sentence_piece_tokenizer import (
     SentencePieceTokenizer,
 )
+from keras_hub.src.tokenizers.tiktoken_tokenizer import TiktokenTokenizer
 
 
-@keras_hub_export(
-    [
-        "keras_hub.tokenizers.MistralTokenizer",
-        "keras_hub.models.MistralTokenizer",
-    ]
-)
+@keras_hub_export([
+    "keras_hub.tokenizers.MistralTokenizer",
+    "keras_hub.models.MistralTokenizer",
+])
 class MistralTokenizer(SentencePieceTokenizer):
     """Mistral tokenizer layer based on SentencePiece.
 
@@ -55,3 +54,32 @@ class MistralTokenizer(SentencePieceTokenizer):
         self._add_special_token("</s>", "end_token")
         self.pad_token_id = 0
         super().__init__(proto=proto, **kwargs)
+
+
+@keras_hub_export([
+    "keras_hub.tokenizers.NewMistralTokenizer",
+    "keras_hub.models.NewMistralTokenizer",
+])
+class NewMistralTokenizer(TiktokenTokenizer):
+    """
+    Tekken-based tokenizer for Mistral models.
+
+    Responsibilities:
+      • Add required Mistral special tokens (<s>, </s>, pad)
+      • Delegate tekken.json parsing to TiktokenTokenizer
+      • Use Tiktoken backend via TiktokenTokenizer normalisation
+    """
+
+    backbone_cls = MistralBackbone
+
+    def __init__(self, proto, sequence_length=None, dtype="int32", **kwargs):
+        self._add_special_token("<s>", "start_token")
+        self._add_special_token("</s>", "end_token")
+        self.pad_token_id = 0
+
+        super().__init__(
+            proto=proto,
+            sequence_length=sequence_length,
+            dtype=dtype,
+            **kwargs,
+        )

--- a/keras_hub/src/tokenizers/tiktoken_tokenizer.py
+++ b/keras_hub/src/tokenizers/tiktoken_tokenizer.py
@@ -1,0 +1,414 @@
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any
+from typing import Dict
+
+import keras
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.tokenizers import tokenizer
+from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import is_int_dtype
+from keras_hub.src.utils.tensor_utils import is_string_dtype
+from keras_hub.src.utils.tensor_utils import preprocessing_function
+from keras_hub.src.utils.tensor_utils import tensor_to_list
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
+
+try:
+    import tiktoken
+except ImportError:
+    tiktoken = None
+
+
+TIKTOKEN_CONFIG_FILENAME = "tiktoken_config.json"
+
+
+def _load_json_like(proto):
+    """Resolve proto into a Python object (path/bytes/dict)."""
+    if isinstance(proto, (str, Path)):
+        with open(proto, "r", encoding="utf-8") as f:
+            return json.load(f)
+    if isinstance(proto, (bytes, bytearray)):
+        return json.loads(proto.decode("utf-8"))
+    if isinstance(proto, dict):
+        return proto
+    raise ValueError(f"Unsupported proto type: {type(proto)}")
+
+
+def _is_normalized_proto(model_data: Dict[str, Any]) -> bool:
+    """Check whether the proto already has the normalized shape."""
+    return "pattern" in model_data and "mergeable_ranks" in model_data
+
+
+def _normalize_tekken_proto(model_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert tekken.json structure into normalized proto for tiktoken."""
+    if "config" not in model_data or "vocab" not in model_data:
+        raise ValueError(
+            "Tekken JSON missing required 'config' or 'vocab' fields."
+        )
+
+    cfg = model_data["config"]
+    pattern = cfg["pattern"]
+    vocab_size = cfg["default_vocab_size"]
+    num_special_tokens = cfg["default_num_special_tokens"]
+
+    special_tokens = model_data.get("special_tokens") or []
+    special_lookup = {t["token_str"]: t["rank"] for t in special_tokens}
+
+    inner_vocab_size = vocab_size - num_special_tokens
+    vocab_slice = model_data["vocab"][:inner_vocab_size]
+    mergeable_ranks = {
+        entry["token_bytes"]: entry["rank"] for entry in vocab_slice
+    }
+
+    normalized = {
+        "pattern": pattern,
+        "mergeable_ranks": mergeable_ranks,
+        "special_tokens": special_tokens,
+        "special_lookup": special_lookup,
+        "num_special_tokens": num_special_tokens,
+        "vocab_size": vocab_size,
+        "raw_json": model_data,
+    }
+
+    return normalized
+
+
+def _encode_strings(strings, model):
+    """Encode a single string or list of strings using tiktoken."""
+    if isinstance(strings, (list, tuple)):
+        return model.encode_batch(strings)
+    return model.encode(strings)
+
+
+def _decode_token_ids(token_ids_list, model):
+    """Decode token IDs → string(s). Supports nested lists."""
+    if not isinstance(token_ids_list, list):
+        return model.decode([token_ids_list])
+
+    if len(token_ids_list) == 0:
+        return ""
+
+    if isinstance(token_ids_list[0], list):
+        return model.decode_batch(token_ids_list)
+
+    return model.decode(token_ids_list)
+
+
+def _normalize_mergeable_ranks(mr: Dict[Any, Any]) -> Dict[bytes, int]:
+    """Ensure mergeable_ranks has bytes keys and integer ranks.
+
+    JSON cannot store byte keys, so Tekken-format or similar loaders
+    store base64 strings. This function converts those keys → bytes.
+    """
+    normalized = {}
+
+    for k, v in mr.items():
+        rank = int(v)
+
+        # Convert key to bytes
+        if isinstance(k, str):
+            # Likely base64 encoded bytes
+            try:
+                key_bytes = base64.b64decode(k)
+            except Exception:
+                # fallback to utf-8
+                key_bytes = k.encode("utf-8", errors="surrogatepass")
+        elif isinstance(k, (bytes, bytearray)):
+            key_bytes = bytes(k)
+        else:
+            key_bytes = str(k).encode("utf-8", errors="surrogatepass")
+
+        normalized[key_bytes] = rank
+
+    return normalized
+
+
+@keras_hub_export("keras_hub.tokenizers.TiktokenTokenizer")
+class TiktokenTokenizer(tokenizer.Tokenizer):
+    """
+    Format-agnostic tiktoken tokenizer with Tekken support.
+
+    The tokenizer can consume:
+      • A normalized proto dict with keys:
+        {
+            "pattern": str,
+            "mergeable_ranks": Dict[base64|bytes → rank],
+            "special_tokens": list[{token_str, rank}] (optional),
+            "special_lookup": Dict[token_str → rank] (optional),
+            "num_special_tokens": int,
+            "vocab_size": int,
+            "raw_json": original JSON (optional)
+        }
+      • A Tekken JSON (path/bytes/dict). It will be normalized internally.
+    """
+
+    def __init__(
+        self,
+        proto,
+        sequence_length=None,
+        name="tiktoken",
+        dtype="int32",
+        add_bos=False,
+        add_eos=False,
+        **kwargs,
+    ):
+        if tf is None:
+            raise ImportError("TensorFlow is required for TiktokenTokenizer.")
+        if tiktoken is None:
+            raise ImportError("tiktoken must be installed.")
+
+        if not (is_int_dtype(dtype) or is_string_dtype(dtype)):
+            raise ValueError(
+                f"Output dtype must be int or string. Received {dtype}."
+            )
+
+        super().__init__(dtype=dtype, **kwargs)
+
+        self.name = name
+        self.sequence_length = sequence_length
+        self.add_bos = add_bos
+        self.add_eos = add_eos
+
+        self.proto = None
+        self._model = None
+        self._num_special_tokens = 0
+        self._vocab_size = None
+        self._all_special_tokens = []
+        self._special_tokens_reverse_vocab = {}
+
+        self.set_proto(proto)
+
+    def _refresh_special_token_ids(self):
+        """Update cached special token ids from the current reverse vocab."""
+        if not hasattr(self, "_special_token_attrs"):
+            return
+        for attr in self._special_token_attrs:
+            token = getattr(self, attr, None)
+            if token is None:
+                setattr(self, f"{attr}_id", None)
+                continue
+            if token in self._special_tokens_reverse_vocab:
+                setattr(
+                    self,
+                    f"{attr}_id",
+                    int(self._special_tokens_reverse_vocab[token]),
+                )
+            else:
+                setattr(self, f"{attr}_id", None)
+
+    def _get_special_id(self, attr_name, default_token=None):
+        """Return id for a special token attribute if known."""
+        token = getattr(self, attr_name, None)
+        if token is None:
+            token = default_token
+        if token and token in self._special_tokens_reverse_vocab:
+            return int(self._special_tokens_reverse_vocab[token])
+        return getattr(self, f"{attr_name}_id", None)
+
+    def save_assets(self, dir_path):
+        """Save the raw normalized proto JSON."""
+        if self.proto is None:
+            return
+
+        raw_json = self.proto.get("raw_json", self.proto)
+
+        path = os.path.join(dir_path, TIKTOKEN_CONFIG_FILENAME)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(raw_json, f, ensure_ascii=False)
+
+    def load_assets(self, dir_path):
+        """Load saved proto JSON and reinitialize tokenizer."""
+        path = os.path.join(dir_path, TIKTOKEN_CONFIG_FILENAME)
+        self.set_proto(path)
+
+    def set_proto(self, proto):
+        """Load normalized proto (dict OR tekken JSON path/bytes/dict)."""
+        if proto is None:
+            self.proto = None
+            self._model = None
+            return
+
+        model_data = _load_json_like(proto)
+        if _is_normalized_proto(model_data):
+            normalized_proto = model_data
+        else:
+            normalized_proto = _normalize_tekken_proto(model_data)
+
+        # Validate minimum requirements
+        if (
+            "pattern" not in normalized_proto
+            or "mergeable_ranks" not in normalized_proto
+        ):
+            raise ValueError(
+                "Normalized proto missing required fields "
+                "('pattern', 'mergeable_ranks')."
+            )
+
+        pattern = normalized_proto["pattern"]
+        mergeable_ranks = _normalize_mergeable_ranks(
+            normalized_proto["mergeable_ranks"]
+        )
+
+        self._num_special_tokens = int(
+            normalized_proto.get("num_special_tokens", 0)
+        )
+        self._vocab_size = normalized_proto.get("vocab_size")
+        self._all_special_tokens = normalized_proto.get("special_tokens", [])
+        self._special_tokens_reverse_vocab = normalized_proto.get(
+            "special_lookup", {}
+        )
+
+        self.proto = normalized_proto
+
+        self._model = tiktoken.Encoding(
+            name=self.name,
+            pat_str=pattern,
+            mergeable_ranks=mergeable_ranks,
+            special_tokens={},
+        )
+
+        self._refresh_special_token_ids()
+
+    def vocabulary_size(self):
+        self._check_vocabulary()
+        return int(self._model.n_vocab)
+
+    def get_vocabulary(self):
+        self._check_vocabulary()
+        vocab = []
+        for i in range(self._model.n_vocab):
+            token_bytes = self._model.decode_single_token_bytes(i)
+            text = token_bytes.decode("utf-8", errors="backslashreplace")
+            vocab.append(text.replace("Ġ", "▁"))
+        return vocab
+
+    def id_to_token(self, tid):
+        self._check_vocabulary()
+
+        # Special tokens:
+        if tid < self._num_special_tokens:
+            if self._all_special_tokens:
+                return self._all_special_tokens[tid]["token_str"]
+
+        # Regular token (offset)
+        tid = tid - self._num_special_tokens
+        token_bytes = self._model.decode_single_token_bytes(tid)
+        return token_bytes.decode("utf-8", errors="replace")
+
+    def token_to_id(self, token):
+        self._check_vocabulary()
+
+        if token in self._special_tokens_reverse_vocab:
+            return int(self._special_tokens_reverse_vocab[token])
+
+        encoded = self._model.encode(token)
+        if len(encoded) != 1:
+            raise ValueError(
+                f"Token '{token}' splits into multiple tokens: {encoded}. "
+                "Use tokenize() for multi-token sequences."
+            )
+
+        return int(encoded[0]) + self._num_special_tokens
+
+    @preprocessing_function
+    def tokenize(self, inputs):
+        self._check_vocabulary()
+
+        inputs = tf.convert_to_tensor(inputs)
+        unbatched = inputs.shape.rank == 0
+        if unbatched:
+            inputs = tf.expand_dims(inputs, 0)
+
+        strings = tensor_to_list(inputs)
+        encoded = _encode_strings(strings, self._model)
+
+        if self._num_special_tokens > 0:
+            encoded = [
+                [int(t) + self._num_special_tokens for t in seq]
+                for seq in encoded
+            ]
+
+        if self.add_bos:
+            bos_id = self._get_special_id("start_token", "<s>")
+            encoded = [[bos_id] + seq for seq in encoded]
+
+        if self.add_eos:
+            eos_id = self._get_special_id("end_token", "</s>")
+            encoded = [seq + [eos_id] for seq in encoded]
+
+        if self.compute_dtype == tf.string:
+            encoded = [[str(t) for t in seq] for seq in encoded]
+            rt = tf.ragged.constant(encoded, dtype=tf.string)
+        else:
+            rt = tf.ragged.constant(encoded, dtype=self.compute_dtype)
+
+        if self.sequence_length:
+            out_shape = rt.shape.as_list()
+            out_shape[-1] = self.sequence_length
+            rt = rt.to_tensor(shape=out_shape, default_value=0)
+
+        if unbatched:
+            rt = tf.squeeze(rt, 0)
+            if self.sequence_length:
+                tf.ensure_shape(rt, [self.sequence_length])
+
+        return rt
+
+    @preprocessing_function
+    def detokenize(self, inputs):
+        self._check_vocabulary()
+
+        inputs, unbatched, _ = convert_to_ragged_batch(inputs)
+        inputs = tf.cast(inputs, "int32")
+
+        input_list = tensor_to_list(inputs)
+
+        def strip_special(seq):
+            return [
+                int(t) - self._num_special_tokens
+                for t in seq
+                if int(t) >= self._num_special_tokens
+            ]
+
+        if isinstance(input_list, list):
+            regular_lists = []
+            for seq in input_list:
+                if isinstance(seq, list):
+                    regular_lists.append(strip_special(seq))
+                else:
+                    regular_lists.append(strip_special([seq]))
+            decoded = _decode_token_ids(regular_lists, self._model)
+        else:
+            decoded = [
+                _decode_token_ids(strip_special(input_list), self._model)
+            ]
+
+        out = tf.constant(decoded)
+        if unbatched:
+            out = tf.squeeze(out, 0)
+
+        return out
+
+    def _check_vocabulary(self):
+        if self.proto is None:
+            raise ValueError("Tokenizer proto not set.")
+        if self._model is None:
+            raise ValueError("Tokenizer model not initialized.")
+
+    def compute_output_spec(self, input_spec):
+        if self.sequence_length:
+            return keras.KerasTensor(
+                input_spec.shape + (self.sequence_length,),
+                dtype=self.compute_dtype,
+            )
+        return keras.KerasTensor(
+            input_spec.shape + (None,),
+            dtype=self.compute_dtype,
+        )

--- a/keras_hub/src/tokenizers/tiktoken_tokenizer.py
+++ b/keras_hub/src/tokenizers/tiktoken_tokenizer.py
@@ -2,8 +2,6 @@ import base64
 import json
 import os
 from pathlib import Path
-from typing import Any
-from typing import Dict
 
 import keras
 
@@ -41,12 +39,12 @@ def _load_json_like(proto):
     raise ValueError(f"Unsupported proto type: {type(proto)}")
 
 
-def _is_normalized_proto(model_data: Dict[str, Any]) -> bool:
+def _is_normalized_proto(model_data) -> bool:
     """Check whether the proto already has the normalized shape."""
     return "pattern" in model_data and "mergeable_ranks" in model_data
 
 
-def _normalize_tekken_proto(model_data: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_tekken_proto(model_data) -> dict:
     """Convert tekken.json structure into normalized proto for tiktoken."""
     if "config" not in model_data or "vocab" not in model_data:
         raise ValueError(
@@ -101,7 +99,7 @@ def _decode_token_ids(token_ids_list, model):
     return model.decode(token_ids_list)
 
 
-def _normalize_mergeable_ranks(mr: Dict[Any, Any]) -> Dict[bytes, int]:
+def _normalize_mergeable_ranks(mr) -> dict:
     """Ensure mergeable_ranks has bytes keys and integer ranks.
 
     JSON cannot store byte keys, so Tekken-format or similar loaders

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -274,7 +274,8 @@ def strip_to_ragged(token_ids, mask, ids_to_strip):
 
 
 def assert_tf_libs_installed(symbol_name):
-    if tf_text is None or tf is None:
+    # undo this in final commit
+    if tf is None:
         raise ImportError(
             f"{symbol_name} requires `tensorflow` and `tensorflow-text` for "
             "text processing. Run `pip install tensorflow-text` to install "

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
+from keras_hub.src.models.mistral.mistral_tokenizer import MistralTokenizer
+from keras_hub.src.models.mistral.mistral_tokenizer import NewMistralTokenizer
 from keras_hub.src.utils.preset_utils import check_file_exists
 from keras_hub.src.utils.preset_utils import get_file
 
@@ -114,7 +116,6 @@ def convert_weights(backbone, loader, transformers_config):
 
 
 def convert_tokenizer(cls, preset, **kwargs):
-
     if check_file_exists(preset, "tekken.json"):
-        return cls(get_file(preset, "tekken.json"), **kwargs)
-    return cls(get_file(preset, "tokenizer.model"), **kwargs)
+        return NewMistralTokenizer(get_file(preset, "tekken.json"), **kwargs)
+    return MistralTokenizer(get_file(preset, "tokenizer.model"), **kwargs)

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -113,6 +113,6 @@ def convert_weights(backbone, loader, transformers_config):
 
 
 def convert_tokenizer(cls, preset, **kwargs):
-    if "devstral" in preset.lower():
+    if preset == "devstral_small_1_1":
         preset = "mistralai/Mistral-Small-24B-Base-2501"
     return cls(get_file(preset, "tokenizer.model"), **kwargs)

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
+from keras_hub.src.utils.preset_utils import check_file_exists
 from keras_hub.src.utils.preset_utils import get_file
 
 backbone_cls = MistralBackbone
@@ -113,6 +114,7 @@ def convert_weights(backbone, loader, transformers_config):
 
 
 def convert_tokenizer(cls, preset, **kwargs):
-    if preset == "devstral_small_1_1":
-        preset = "mistralai/Mistral-Small-24B-Base-2501"
+
+    if check_file_exists(preset, "tekken.json"):
+        return cls(get_file(preset, "tekken.json"), **kwargs)
     return cls(get_file(preset, "tokenizer.model"), **kwargs)

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -113,4 +113,6 @@ def convert_weights(backbone, loader, transformers_config):
 
 
 def convert_tokenizer(cls, preset, **kwargs):
+    if "devstral" in preset.lower():
+        preset = "mistralai/Mistral-Small-24B-Base-2501"
     return cls(get_file(preset, "tokenizer.model"), **kwargs)

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -1,8 +1,10 @@
 import numpy as np
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
+from keras_hub.src.models.mistral.mistral_tokenizer import (
+    MistralTiktokenTokenizer,
+)
 from keras_hub.src.models.mistral.mistral_tokenizer import MistralTokenizer
-from keras_hub.src.models.mistral.mistral_tokenizer import NewMistralTokenizer
 from keras_hub.src.utils.preset_utils import check_file_exists
 from keras_hub.src.utils.preset_utils import get_file
 
@@ -117,5 +119,7 @@ def convert_weights(backbone, loader, transformers_config):
 
 def convert_tokenizer(cls, preset, **kwargs):
     if check_file_exists(preset, "tekken.json"):
-        return NewMistralTokenizer(get_file(preset, "tekken.json"), **kwargs)
+        return MistralTiktokenTokenizer(
+            get_file(preset, "tekken.json"), **kwargs
+        )
     return MistralTokenizer(get_file(preset, "tokenizer.model"), **kwargs)

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -22,6 +22,7 @@ def convert_backbone_config(transformers_config):
         "rope_max_wavelength": transformers_config["rope_theta"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
         "sliding_window": transformers_config["sliding_window"],
+        "head_dim": transformers_config.get("head_dim", None),
     }
 
 

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -59,6 +59,8 @@ class TransformersPresetLoader(PresetLoader):
             self.converter = convert_llama3
         elif model_type == "mistral":
             self.converter = convert_mistral
+        elif model_type == "mistral3":
+            self.converter = convert_mistral
         elif model_type == "paligemma":
             self.converter = convert_pali_gemma
         elif model_type == "vit":

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -222,12 +222,7 @@ def main(_):
         # === Load the Huggingface model ===
         hf_model = MistralForCausalLM.from_pretrained(hf_preset)
 
-        if preset == "devstral_small_1_1":
-            hf_tokenizer = AutoTokenizer.from_pretrained(
-                "mistralai/Mistral-Small-24B-Base-2501"
-            )
-        else:
-            hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
+        hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
         hf_model.eval()
         print("\n-> Huggingface model and tokenizer loaded")
 
@@ -246,14 +241,7 @@ def main(_):
         )
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)
 
-        if "devstral" in hf_preset.lower():
-            keras_hub_tokenizer = MistralTokenizer.from_preset(
-                "hf://mistralai/Mistral-Small-24B-Base-2501"
-            )
-        else:
-            keras_hub_tokenizer = MistralTokenizer.from_preset(
-                f"hf://{hf_preset}"
-            )
+        keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://{hf_preset}")
         print("\n-> Keras 3 model and tokenizer loaded.")
 
         # === Port the weights ===

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -223,8 +223,8 @@ def main(_):
         hf_model = MistralForCausalLM.from_pretrained(hf_preset)
         if "devstral" in hf_preset.lower():
             hf_tokenizer = AutoTokenizer.from_pretrained(
-                "mistralai/Mistral-Small-24B-Base-2501"
-            )
+        if preset == "devstral_small_1_1":
+            hf_tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-Small-24B-Base-2501")
         else:
             hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
         hf_model.eval()

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -5,6 +5,7 @@ import tempfile
 import traceback
 
 import numpy as np
+import torch
 from absl import app
 from absl import flags
 from keras import ops
@@ -223,7 +224,9 @@ def main(_):
 
     try:
         # === Load the Huggingface model ===
-        hf_model = MistralForCausalLM.from_pretrained(hf_preset)
+        hf_model = MistralForCausalLM.from_pretrained(
+            hf_preset, torch_dtype=torch.float16
+        )
 
         hf_tokenizer = MistralCommonBackend.from_pretrained(hf_preset)
         hf_model.eval()

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -221,7 +221,10 @@ def main(_):
     try:
         # === Load the Huggingface model ===
         hf_model = MistralForCausalLM.from_pretrained(hf_preset)
-        hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
+        if "devstral" in hf_preset.lower():
+            hf_tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-Small-24B-Base-2501")
+        else:   
+            hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
         hf_model.eval()
         print("\n-> Huggingface model and tokenizer loaded")
 
@@ -241,7 +244,7 @@ def main(_):
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)
 
         if "devstral" in hf_preset.lower():
-            keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://mistralai/Mistral-Small-24B-Base-2501")
+            keras_hub_tokenizer = MistralTokenizer.from_preset("hf://mistralai/Mistral-Small-24B-Base-2501")
         else:
             keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://{hf_preset}")
         print("\n-> Keras 3 model and tokenizer loaded.")

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -222,8 +222,10 @@ def main(_):
         # === Load the Huggingface model ===
         hf_model = MistralForCausalLM.from_pretrained(hf_preset)
         if "devstral" in hf_preset.lower():
-            hf_tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-Small-24B-Base-2501")
-        else:   
+            hf_tokenizer = AutoTokenizer.from_pretrained(
+                "mistralai/Mistral-Small-24B-Base-2501"
+            )
+        else:
             hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
         hf_model.eval()
         print("\n-> Huggingface model and tokenizer loaded")
@@ -244,9 +246,13 @@ def main(_):
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)
 
         if "devstral" in hf_preset.lower():
-            keras_hub_tokenizer = MistralTokenizer.from_preset("hf://mistralai/Mistral-Small-24B-Base-2501")
+            keras_hub_tokenizer = MistralTokenizer.from_preset(
+                "hf://mistralai/Mistral-Small-24B-Base-2501"
+            )
         else:
-            keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://{hf_preset}")
+            keras_hub_tokenizer = MistralTokenizer.from_preset(
+                f"hf://{hf_preset}"
+            )
         print("\n-> Keras 3 model and tokenizer loaded.")
 
         # === Port the weights ===

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -240,7 +240,10 @@ def main(_):
         )
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)
 
-        keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://{hf_preset}")
+        if "devstral" in hf_preset.lower():
+            keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://mistralai/Mistral-Small-24B-Base-2501")
+        else:
+            keras_hub_tokenizer = MistralTokenizer.from_preset(f"hf://{hf_preset}")
         print("\n-> Keras 3 model and tokenizer loaded.")
 
         # === Port the weights ===

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -22,6 +22,7 @@ PRESET_MAP = {
     "mistral_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.1",
     "mistral_0.2_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.2",
     "mistral_0.3_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.3",
+    "devstral_small_1_1": "mistralai/Devstral-Small-2507",
 }
 
 FLAGS = flags.FLAGS

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -221,10 +221,11 @@ def main(_):
     try:
         # === Load the Huggingface model ===
         hf_model = MistralForCausalLM.from_pretrained(hf_preset)
-        if "devstral" in hf_preset.lower():
-            hf_tokenizer = AutoTokenizer.from_pretrained(
+
         if preset == "devstral_small_1_1":
-            hf_tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-Small-24B-Base-2501")
+            hf_tokenizer = AutoTokenizer.from_pretrained(
+                "mistralai/Mistral-Small-24B-Base-2501"
+            )
         else:
             hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
         hf_model.eval()

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -8,7 +8,10 @@ import numpy as np
 from absl import app
 from absl import flags
 from keras import ops
-from transformers import AutoTokenizer
+
+# !pip install git+https://github.com/huggingface/transformers.git
+# !pip install mistral-common
+from transformers import MistralCommonBackend
 from transformers import MistralForCausalLM
 
 from keras_hub.models import MistralBackbone
@@ -222,7 +225,7 @@ def main(_):
         # === Load the Huggingface model ===
         hf_model = MistralForCausalLM.from_pretrained(hf_preset)
 
-        hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
+        hf_tokenizer = MistralCommonBackend.from_pretrained(hf_preset)
         hf_model.eval()
         print("\n-> Huggingface model and tokenizer loaded")
 

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -228,18 +228,24 @@ def main(_):
         hf_tokenizer = MistralCommonBackend.from_pretrained(hf_preset)
         hf_model.eval()
         print("\n-> Huggingface model and tokenizer loaded")
+        hf_config = hf_model.config
+        rope_theta = getattr(
+            hf_config,
+            "rope_theta",
+            getattr(hf_config.rope_parameters, "theta", None),
+        )
 
         # === Load the KerasHub model ===
         backbone_kwargs = dict(
-            vocabulary_size=hf_model.config.vocab_size,
-            hidden_dim=hf_model.config.hidden_size,
-            num_layers=hf_model.config.num_hidden_layers,
-            num_query_heads=hf_model.config.num_attention_heads,
-            num_key_value_heads=hf_model.config.num_key_value_heads,
-            intermediate_dim=hf_model.config.intermediate_size,
-            sliding_window=hf_model.config.sliding_window,
-            layer_norm_epsilon=hf_model.config.rms_norm_eps,
-            rope_max_wavelength=hf_model.config.rope_theta,
+            vocabulary_size=hf_config.vocab_size,
+            hidden_dim=hf_config.hidden_size,
+            num_layers=hf_config.num_hidden_layers,
+            num_query_heads=hf_config.num_attention_heads,
+            num_key_value_heads=hf_config.num_key_value_heads,
+            intermediate_dim=hf_config.intermediate_size,
+            sliding_window=hf_config.sliding_window,
+            layer_norm_epsilon=hf_config.rms_norm_eps,
+            rope_max_wavelength=rope_theta,
             dtype="float32",
         )
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)


### PR DESCRIPTION
## Description of the change
Added presets for Devstral Small 1.1


## Reference
Github Issue - #2333
Model HF - https://huggingface.co/mistralai/Devstral-Small-2507
The Devstral HF contains only `tekken.json` but we need `tokenizers.json` format. There are 2 solutions for this - 
1. Use the [conversion script](https://github.com/huggingface/transformers/blob/main/src/transformers/models/mistral/convert_mistral_weights_to_hf.py#L223) from `huggingface/transformers` - This converts the `tekken.json` and loads `Autotokenizer`
2. Use tokenizer from `mistralai/Mistral-Small-24B-Base-2501` -  referencing this [issue from unsloth](https://github.com/unslothai/unsloth/issues/2652), Since Devstral is just finetuned, we can use the earlier model to obtain tokenizer (yes, this model has a `tokenizers.json` format)

I've gone ahead with the **Option 2** and implemented it in the code.   
I've updated presets in `mistral_presets.py`, `convert_mistral.py`, and `convert_mistral_checkpoints.py`.   

## Colab Notebook
I could not load it in colab since the model is 24B and runtime is crashing, but i will try it in Modal/Lambda and attach the results here.

## Doubts
1. This is the kaggle link for the model - https://www.kaggle.com/models/mistral-ai/devstral-small-2507, but I'm unsure on the kaggle_handle format
2. cc @sachinprasadhs let me know if there any changes to make