### PR TITLE
Fix reversible embedding quantization

### DIFF
--- a/keras_hub/src/layers/modeling/reversible_embedding.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding.py
@@ -1,5 +1,3 @@
-import inspect
-
 import keras
 from keras import ops
 
@@ -187,18 +185,22 @@ class ReversibleEmbedding(keras.layers.Embedding):
             self._quantization_mode_error(self.quantization_mode)
 
     def _int8_build(self, embeddings_shape=None, config=None):
-        if (
-            "embeddings_shape"
-            in inspect.signature(super()._int8_build).parameters
-        ):
-            if embeddings_shape is None:
-                embeddings_shape = (self.input_dim, self.output_dim)
+        if embeddings_shape is None:
+            embeddings_shape = (self.input_dim, self.output_dim)
+
+        # Try to call with both parameters, fall back if not supported
+        try:
             super()._int8_build(
                 embeddings_shape=embeddings_shape, config=config
             )
-        else:
-            # Backward compatibility for older versions of Keras.
-            super()._int8_build(config=config)
+        except TypeError:
+            # Fall back to just embeddings_shape if config not supported
+            try:
+                super()._int8_build(embeddings_shape=embeddings_shape)
+            except TypeError:
+                # Final fallback for very old versions
+                super()._int8_build()
+
         self.inputs_quantizer = keras.quantizers.AbsMaxQuantizer(axis=-1)
         if not self.tie_weights:
             self.reverse_embeddings = self.add_weight(


### PR DESCRIPTION
This pull request improves compatibility of the `_int8_build` method in the `ReversibleEmbedding` layer with different Keras versions by replacing signature inspection with a safer, exception-based approach. It also cleans up unused imports.

**Compatibility improvements for `_int8_build`:**

* Updated `_int8_build` in `reversible_embedding.py` to use a try/except approach for calling `super()._int8_build` with different argument combinations, ensuring compatibility with various Keras versions without relying on `inspect.signature`.

**Code cleanup:**

* Removed the unused `inspect` import from `reversible_embedding.py`.## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
