### PR TITLE
Updates KerasHub Compatibility to Keras 3.12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
         version: [keras-stable]
         include:
           - backend: jax
-            version: keras-3.9
+            version: keras-3.12
           - backend: jax
             version: keras-nightly
           - backend: openvino
@@ -50,11 +50,11 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
-    - name: Pin Keras 3.9
-      if: ${{ matrix.version == 'keras-3.9'}}
+    - name: Pin Keras 3.12
+      if: ${{ matrix.version == 'keras-3.12'}}
       run: |
         pip uninstall -y keras jaxlib jax
-        pip install keras==3.9.0 --progress-bar off
+        pip install keras==3.12.0 --progress-bar off
         pip install jax==0.6.0 --progress-bar off
     - name: Pin Keras Nightly
       if: ${{ matrix.version == 'keras-nightly'}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "keras>=3.8",
+    "keras>=3.12",
     "absl-py",
     "numpy",
     "packaging",


### PR DESCRIPTION
## Description of the change
ReversibleEmbedding Layer is supported in Keras 3.12, and KerasHub should depend on that.


## Reference
https://github.com/keras-team/keras-hub/pull/2482

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
