### PR TITLE
Revert "Models should reference ReversibleEmbedding from Keras core (…

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
         version: [keras-stable]
         include:
           - backend: jax
-            version: keras-3.12
+            version: keras-3.9
           - backend: jax
             version: keras-nightly
           - backend: openvino
@@ -50,17 +50,17 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
-    - name: Pin Keras 3.12
-      if: ${{ matrix.version == 'keras-3.12'}}
+    - name: Pin Keras 3.9
+      if: ${{ matrix.version == 'keras-3.9'}}
       run: |
         pip uninstall -y keras jaxlib jax
-        pip install keras==3.12.0 --progress-bar off
+        pip install keras==3.9.0 --progress-bar off
         pip install jax==0.6.0 --progress-bar off
     - name: Pin Keras Nightly
       if: ${{ matrix.version == 'keras-nightly'}}
       run: |
         pip uninstall -y keras
-        pip install keras-nightly --no-cache-dir --progress-bar off
+        pip install keras-nightly --progress-bar off
     - name: Test with pytest
       run: |
         pytest keras_hub/

--- a/keras_hub/src/layers/modeling/reversible_embedding.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding.py
@@ -1,8 +1,283 @@
+import inspect
+
 import keras
+from keras import ops
 
 from keras_hub.src.api_export import keras_hub_export
 
 
 @keras_hub_export("keras_hub.layers.ReversibleEmbedding")
-class ReversibleEmbedding(keras.layers.ReversibleEmbedding):
-    pass
+class ReversibleEmbedding(keras.layers.Embedding):
+    """An embedding layer which can project backwards to the input dim.
+
+    This layer is an extension of `keras.layers.Embedding` for language models.
+    This layer can be called "in reverse" with `reverse=True`, in which case the
+    layer will linearly project from `output_dim` back to `input_dim`.
+
+    By default, the reverse projection will use the transpose of the
+    `embeddings` weights to project to `input_dim` (weights are "tied"). If
+    `tie_weights=False`, the model will use a separate, trainable variable for
+    reverse projection.
+
+    This layer has no bias terms.
+
+    Args:
+        input_dim: Integer. Size of the vocabulary,
+            i.e. maximum integer index + 1.
+        output_dim: Integer. Dimension of the dense embedding.
+        tie_weights: Boolean, whether or not the matrix for embedding and
+            the matrix for the `reverse` projection should share the same
+            weights.
+        embeddings_initializer: Initializer for the `embeddings`
+            matrix (see `keras.initializers`).
+        embeddings_regularizer: Regularizer function applied to
+            the `embeddings` matrix (see `keras.regularizers`).
+        embeddings_constraint: Constraint function applied to
+            the `embeddings` matrix (see `keras.constraints`).
+        mask_zero: Boolean, whether or not the input value 0 is a special
+            "padding" value that should be masked out.
+        reverse_dtype: The dtype for the reverse projection computation.
+            Defaults to the `compute_dtype` of the layer.
+        logit_soft_cap: If `logit_soft_cap` is set and `reverse=True`, the
+            output logits will be scaled by
+            `tanh(logits / logit_soft_cap) * logit_soft_cap`. This narrows the
+            range of output logits and can improve training.
+        **kwargs: other keyword arguments passed to `keras.layers.Embedding`,
+            including `name`, `trainable`, `dtype` etc.
+
+    Call arguments:
+        inputs: The tensor inputs to the layer.
+        reverse: Boolean. If `True` the layer will perform a linear projection
+            from `output_dim` to `input_dim`, instead of a normal embedding
+            call. Default to `False`.
+
+    Example:
+    ```python
+    batch_size = 16
+    vocab_size = 100
+    hidden_dim = 32
+    seq_length = 50
+
+    # Generate random inputs.
+    token_ids = np.random.randint(vocab_size, size=(batch_size, seq_length))
+
+    embedding = keras_hub.layers.ReversibleEmbedding(vocab_size, hidden_dim)
+    # Embed tokens to shape `(batch_size, seq_length, hidden_dim)`.
+    hidden_states = embedding(token_ids)
+    # Project hidden states to shape `(batch_size, seq_length, vocab_size)`.
+    logits = embedding(hidden_states, reverse=True)
+    ```
+
+    References:
+    - [Vaswani et al., 2017](https://arxiv.org/abs/1706.03762)
+    - [Press and Wolf, 2016](https://arxiv.org/abs/1608.05859)
+    """
+
+    def __init__(
+        self,
+        input_dim,
+        output_dim,
+        tie_weights=True,
+        embeddings_initializer="uniform",
+        embeddings_regularizer=None,
+        embeddings_constraint=None,
+        mask_zero=False,
+        reverse_dtype=None,
+        logit_soft_cap=None,
+        **kwargs,
+    ):
+        super().__init__(
+            input_dim,
+            output_dim,
+            embeddings_initializer=embeddings_initializer,
+            embeddings_regularizer=embeddings_regularizer,
+            embeddings_constraint=embeddings_constraint,
+            mask_zero=mask_zero,
+            **kwargs,
+        )
+        self.tie_weights = tie_weights
+        self.reverse_dtype = reverse_dtype
+        self.logit_soft_cap = logit_soft_cap
+
+    def build(self, inputs_shape=None):
+        super().build(inputs_shape)
+        if (
+            not self.tie_weights
+            and getattr(self, "quantization_mode", None) != "int8"
+        ):
+            self.reverse_embeddings = self.add_weight(
+                name="reverse_embeddings",
+                shape=(self.output_dim, self.input_dim),
+                initializer=self.embeddings_initializer,
+                dtype=self.dtype,
+            )
+
+    def call(self, inputs, reverse=False):
+        if reverse:
+            if self.tie_weights:
+                kernel = ops.transpose(ops.convert_to_tensor(self.embeddings))
+            else:
+                kernel = self.reverse_embeddings
+            if self.reverse_dtype is not None:
+                inputs = ops.cast(inputs, self.reverse_dtype)
+                kernel = ops.cast(kernel, self.reverse_dtype)
+            logits = ops.matmul(inputs, kernel)
+            # Optionally soft-cap logits.
+            if self.logit_soft_cap is not None:
+                soft_cap = self.logit_soft_cap
+                logits = ops.tanh(logits / soft_cap) * soft_cap
+            return logits
+
+        return super().call(inputs)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "tie_weights": self.tie_weights,
+                "reverse_dtype": self.reverse_dtype,
+                "logit_soft_cap": self.logit_soft_cap,
+            }
+        )
+        return config
+
+    def save_own_variables(self, store):
+        if not self.built:
+            return
+        super().save_own_variables(store)
+        target_variables = []
+        if not self.tie_weights:
+            # Store the reverse embedding weights as the last weights.
+            target_variables.append(self.reverse_embeddings)
+            if getattr(self, "quantization_mode", None) == "int8":
+                target_variables.append(self.reverse_embeddings_scale)
+            for i, variable in enumerate(target_variables, start=len(store)):
+                store[str(i)] = variable
+
+    def load_own_variables(self, store):
+        if not self.built:
+            self.build()
+        super().load_own_variables(store)
+        if not self.tie_weights:
+            # Last weights in the stores are the reverse embedding weights.
+            target_variables = [self.reverse_embeddings]
+            if getattr(self, "quantization_mode", None) == "int8":
+                target_variables.append(self.reverse_embeddings_scale)
+            for i, variable in enumerate(
+                target_variables, start=len(store) - len(target_variables)
+            ):
+                variable.assign(store[str(i)])
+
+    def compute_output_spec(self, inputs, reverse=False):
+        output_shape = list(inputs.shape)
+        if reverse:
+            output_shape[-1] = self.input_dim
+        else:
+            output_shape += [self.output_dim]
+        return keras.KerasTensor(output_shape, dtype=self.compute_dtype)
+
+    # Quantization-related (int8) methods
+
+    def quantized_call(self, inputs, reverse=False):
+        # TODO (hongyu): This function could be removed once we add `*args` and
+        # `**kwargs` for `Embedding.quantized_call`
+        if self.quantization_mode == "int8":
+            return self._int8_call(inputs, reverse=reverse)
+        else:
+            self._quantization_mode_error(self.quantization_mode)
+
+    def _int8_build(self, embeddings_shape=None, config=None):
+        if (
+            "embeddings_shape"
+            in inspect.signature(super()._int8_build).parameters
+        ):
+            if embeddings_shape is None:
+                embeddings_shape = (self.input_dim, self.output_dim)
+            super()._int8_build(
+                embeddings_shape=embeddings_shape, config=config
+            )
+        else:
+            # Backward compatibility for older versions of Keras.
+            super()._int8_build(config=config)
+        self.inputs_quantizer = keras.quantizers.AbsMaxQuantizer(axis=-1)
+        if not self.tie_weights:
+            self.reverse_embeddings = self.add_weight(
+                name="reverse_embeddings",
+                shape=(self.output_dim, self.input_dim),
+                initializer="zeros",
+                dtype="int8",
+                trainable=False,
+            )
+            self.reverse_embeddings_scale = self.add_weight(
+                name="reverse_embeddings_scale",
+                shape=(self.input_dim,),
+                initializer="ones",
+                trainable=False,
+            )
+        self._is_quantized = True
+
+    def _int8_call(self, inputs, reverse=False):
+        if reverse:
+            if self.tie_weights:
+                kernel = ops.transpose(self._embeddings)
+                scale = ops.transpose(self.embeddings_scale)
+            else:
+                kernel = self.reverse_embeddings
+                scale = self.reverse_embeddings_scale
+            inputs, inputs_scale = self.inputs_quantizer(inputs)
+            logits = ops.matmul(inputs, kernel)
+            # De-scale outputs
+            logits = ops.cast(logits, self.compute_dtype)
+            logits = ops.divide(logits, ops.multiply(inputs_scale, scale))
+            # Optionally soft-cap logits.
+            if self.logit_soft_cap is not None:
+                soft_cap = self.logit_soft_cap
+                logits = ops.tanh(logits / soft_cap) * soft_cap
+            return logits
+
+        return super()._int8_call(inputs)
+
+    def quantize(self, mode, type_check=True, config=None):
+        del config
+        if type_check and type(self) is not ReversibleEmbedding:
+            raise self._not_implemented_error(self.quantize)
+
+        def abs_max_quantize(inputs, axis):
+            return keras.quantizers.abs_max_quantize(
+                inputs, axis=axis, to_numpy=True
+            )
+
+        if mode != "int8":
+            raise NotImplementedError(
+                "Invalid quantization mode. Expected 'int8'. "
+                f"Received: quantization_mode={mode}"
+            )
+
+        embeddings_shape = (self.input_dim, self.output_dim)
+        if mode == "int8":
+            embeddings, embeddings_scale = abs_max_quantize(
+                self._embeddings, axis=-1
+            )
+            embeddings_scale = ops.squeeze(embeddings_scale, axis=-1)
+            del self._embeddings
+            if not self.tie_weights:
+                reverse_embeddings, reverse_embeddings_scale = abs_max_quantize(
+                    self.reverse_embeddings, axis=0
+                )
+                reverse_embeddings_scale = ops.squeeze(
+                    reverse_embeddings_scale, axis=0
+                )
+                del self.reverse_embeddings
+        self.quantized_build(embeddings_shape, mode)
+        if mode == "int8":
+            self._embeddings.assign(embeddings)
+            self.embeddings_scale.assign(embeddings_scale)
+            if not self.tie_weights:
+                self.reverse_embeddings.assign(reverse_embeddings)
+                self.reverse_embeddings_scale.assign(reverse_embeddings_scale)
+
+        if self.dtype_policy.quantization_mode is None:
+            policy = keras.dtype_policies.get(
+                f"{mode}_from_{self.dtype_policy.name}"
+            )
+            self.dtype_policy = policy

--- a/keras_hub/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_hub/src/layers/modeling/reversible_embedding_test.py
@@ -1,0 +1,161 @@
+import os
+
+import keras
+import numpy as np
+from absl.testing import parameterized
+from keras import ops
+from keras import random
+
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
+from keras_hub.src.tests.test_case import TestCase
+
+
+class ReversibleEmbeddingTest(TestCase):
+    @parameterized.named_parameters(
+        ("tie_weights", True),
+        ("untie_weights", False),
+    )
+    def test_layer_behaviors_tied(self, tie_weights):
+        self.run_layer_test(
+            cls=ReversibleEmbedding,
+            init_kwargs={
+                "input_dim": 100,
+                "output_dim": 32,
+                "tie_weights": tie_weights,
+                "embeddings_initializer": "HeNormal",
+                "logit_soft_cap": 50,
+            },
+            input_data=random.randint(minval=0, maxval=100, shape=(4, 10)),
+            expected_output_shape=(4, 10, 32),
+            expected_num_trainable_weights=1 if tie_weights else 2,
+        )
+
+    @parameterized.named_parameters(
+        ("tie_weights", True),
+        ("untie_weights", False),
+    )
+    def test_saving(self, tie_weights):
+        input_data = random.randint(minval=0, maxval=100, shape=(4, 10))
+        model = keras.Sequential(
+            [
+                ReversibleEmbedding(
+                    input_dim=100,
+                    output_dim=32,
+                    tie_weights=tie_weights,
+                )
+            ]
+        )
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        model_output = model(input_data)
+        model.save(path, save_format="keras_v3")
+        restored_model = keras.models.load_model(path)
+        restored_output = restored_model(input_data)
+        self.assertAllClose(model_output, restored_output)
+
+    def test_correctness(self):
+        layer = ReversibleEmbedding(input_dim=3, output_dim=2)
+        layer.build()
+        layer.embeddings.assign(np.array([[0.0, 0.0], [2.0, 2.0], [3.0, 3.0]]))
+        out = layer(np.array(([2, 1, 0])))
+        self.assertAllClose(out, np.array([[3.0, 3.0], [2.0, 2.0], [0.0, 0.0]]))
+
+        layer = ReversibleEmbedding(input_dim=3, output_dim=2)
+        layer.build()
+        layer.embeddings.assign(np.array([[0.0, 0.0], [2.0, 2.0], [3.0, 3.0]]))
+        out = layer(np.array(([[1.0, 1.0]])), reverse=True)
+        self.assertAllClose(out, np.array([[0.0, 4.0, 6.0]]))
+
+        layer = ReversibleEmbedding(input_dim=3, output_dim=2, logit_soft_cap=5)
+        layer.build()
+        layer.embeddings.assign(np.array([[0.0, 0.0], [2.0, 2.0], [3.0, 3.0]]))
+        out = layer(np.array(([[1.0, 1.0]])), reverse=True)
+        self.assertAllClose(out, np.array([[0.0, 3.320184, 4.168273]]))
+
+    def test_reverse_dtype(self):
+        embedding = ReversibleEmbedding(100, 16, reverse_dtype="float32")
+        input_data = ops.ones(shape=(4, 10, 16))
+        output_data = embedding(input_data, reverse=True)
+        self.assertEqual(output_data.shape, (4, 10, 100))
+        self.assertDTypeEqual(output_data, "float32")
+
+        if keras.config.backend() == "torch":
+            import torch
+
+            if not torch.cuda.is_available():
+                self.skipTest("Torch CPU does not support float16")
+
+        embedding = ReversibleEmbedding(100, 16, reverse_dtype="float16")
+        input_data = ops.ones(shape=(4, 10, 16))
+        output_data = embedding(input_data, reverse=True)
+        self.assertEqual(output_data.shape, (4, 10, 100))
+        self.assertDTypeEqual(output_data, "float16")
+
+    @parameterized.named_parameters(
+        ("tie_weights", True), ("untie_weights", False)
+    )
+    def test_quantize_int8(self, tie_weights):
+        layer_config = dict(
+            input_dim=100, output_dim=32, tie_weights=tie_weights
+        )
+        layer = ReversibleEmbedding(**layer_config)
+        layer.build()
+        x = random.randint(shape=(64, 100), minval=0, maxval=9)
+        x_reverse = random.uniform(shape=(64, 32))
+        y_float = layer(x)
+        y_reverse_float = layer(x_reverse, reverse=True)
+        layer.quantize("int8")
+
+        # Verify weights dtype
+        if not tie_weights:
+            self.assertEqual(
+                keras.backend.standardize_dtype(layer.reverse_embeddings.dtype),
+                "int8",
+            )
+            self.assertEqual(
+                keras.backend.standardize_dtype(
+                    layer.reverse_embeddings_scale.dtype
+                ),
+                layer.variable_dtype,
+            )
+
+        # Try eager call and verify output correctness
+        y_quantized = layer(x)
+        y_reverse_quantized = layer(x_reverse, reverse=True)
+        mse = ops.mean(ops.square(y_float - y_quantized))
+        mse_reverse = ops.mean(
+            ops.square(y_reverse_float - y_reverse_quantized)
+        )
+        self.assertLess(mse, 1e-3)  # A weak correctness test
+        self.assertLess(mse_reverse, 1e-3)  # A weak correctness test
+
+        # Try saving and reloading the model
+        model = keras.models.Sequential([layer])
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "quantized_model.keras"
+        )
+        model.save(temp_filepath)
+        new_model = keras.models.load_model(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    @parameterized.named_parameters(
+        ("tie_weights", True),
+        ("untie_weights", False),
+    )
+    def test_quantize_dtype_argument(self, tie_weights):
+        self.run_layer_test(
+            cls=ReversibleEmbedding,
+            init_kwargs={
+                "input_dim": 100,
+                "output_dim": 32,
+                "tie_weights": tie_weights,
+                "embeddings_initializer": "HeNormal",
+                "dtype": "int8_from_float32",
+            },
+            input_data=random.randint(minval=0, maxval=100, shape=(4, 10)),
+            expected_output_shape=(4, 10, 32),
+            expected_num_trainable_weights=0,
+            expected_num_non_trainable_weights=2 if tie_weights else 4,
+            expected_num_non_trainable_variables=2 if tie_weights else 4,
+        )

--- a/keras_hub/src/layers/modeling/token_and_position_embedding.py
+++ b/keras_hub/src/layers/modeling/token_and_position_embedding.py
@@ -1,8 +1,10 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.utils.keras_utils import clone_initializer
 
 

--- a/keras_hub/src/models/albert/albert_backbone.py
+++ b/keras_hub/src/models/albert/albert_backbone.py
@@ -1,8 +1,10 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.utils.keras_utils import gelu_approximate

--- a/keras_hub/src/models/bart/bart_backbone.py
+++ b/keras_hub/src/models/bart/bart_backbone.py
@@ -1,8 +1,10 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.layers.modeling.transformer_decoder import TransformerDecoder
 from keras_hub.src.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_hub.src.models.backbone import Backbone

--- a/keras_hub/src/models/bert/bert_backbone.py
+++ b/keras_hub/src/models/bert/bert_backbone.py
@@ -1,8 +1,10 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.utils.keras_utils import gelu_approximate

--- a/keras_hub/src/models/bloom/bloom_backbone.py
+++ b/keras_hub/src/models/bloom/bloom_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.bloom.bloom_decoder import BloomDecoder
 

--- a/keras_hub/src/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_hub/src/models/deberta_v3/deberta_v3_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.deberta_v3.disentangled_attention_encoder import (
     DisentangledAttentionEncoder,

--- a/keras_hub/src/models/electra/electra_backbone.py
+++ b/keras_hub/src/models/electra/electra_backbone.py
@@ -1,8 +1,10 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.utils.keras_utils import gelu_approximate

--- a/keras_hub/src/models/f_net/f_net_backbone.py
+++ b/keras_hub/src/models/f_net/f_net_backbone.py
@@ -1,9 +1,11 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.f_net_encoder import FNetEncoder
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.utils.keras_utils import gelu_approximate
 

--- a/keras_hub/src/models/falcon/falcon_backbone.py
+++ b/keras_hub/src/models/falcon/falcon_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.falcon.falcon_transformer_decoder import (
     FalconTransformerDecoder,

--- a/keras_hub/src/models/gemma/gemma_backbone.py
+++ b/keras_hub/src/models/gemma/gemma_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.gemma.gemma_decoder_block import GemmaDecoderBlock
 from keras_hub.src.models.gemma.rms_normalization import RMSNormalization

--- a/keras_hub/src/models/gemma3/gemma3_backbone.py
+++ b/keras_hub/src/models/gemma3/gemma3_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.gemma.rms_normalization import RMSNormalization
 from keras_hub.src.models.gemma3.gemma3_decoder_block import Gemma3DecoderBlock

--- a/keras_hub/src/models/gpt2/gpt2_backbone.py
+++ b/keras_hub/src/models/gpt2/gpt2_backbone.py
@@ -1,8 +1,10 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.layers.modeling.transformer_decoder import TransformerDecoder
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.utils.keras_utils import gelu_approximate

--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_backbone.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.gpt_neo_x.gpt_neo_x_decoder import GPTNeoXDecoder
 from keras_hub.src.utils.keras_utils import gelu_approximate

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.gpt_oss.gpt_oss_decoder import (
     GptOssTransformerDecoder,

--- a/keras_hub/src/models/llama/llama_backbone.py
+++ b/keras_hub/src/models/llama/llama_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.llama.llama_decoder import LlamaTransformerDecoder
 from keras_hub.src.models.llama.llama_layernorm import LlamaLayerNorm

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.mistral.mistral_layer_norm import (
     MistralLayerNormalization,

--- a/keras_hub/src/models/mixtral/mixtral_backbone.py
+++ b/keras_hub/src/models/mixtral/mixtral_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.mixtral.mixtral_decoder import (
     MixtralTransformerDecoder,

--- a/keras_hub/src/models/moonshine/moonshine_backbone.py
+++ b/keras_hub/src/models/moonshine/moonshine_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.moonshine.moonshine_decoder import (
     MoonshineDecoderBlock,

--- a/keras_hub/src/models/pali_gemma/pali_gemma_backbone.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.gemma.rms_normalization import RMSNormalization
 from keras_hub.src.models.pali_gemma.pali_gemma_decoder_block import (

--- a/keras_hub/src/models/phi3/phi3_backbone.py
+++ b/keras_hub/src/models/phi3/phi3_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.phi3.phi3_decoder import Phi3Decoder
 from keras_hub.src.models.phi3.phi3_layernorm import Phi3LayerNorm

--- a/keras_hub/src/models/qwen/qwen_backbone.py
+++ b/keras_hub/src/models/qwen/qwen_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.qwen.qwen_decoder import QwenTransformerDecoder
 from keras_hub.src.models.qwen.qwen_layernorm import QwenLayerNorm

--- a/keras_hub/src/models/qwen3/qwen3_backbone.py
+++ b/keras_hub/src/models/qwen3/qwen3_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.qwen3.qwen3_decoder import Qwen3TransformerDecoder
 from keras_hub.src.models.qwen3.qwen3_layernorm import Qwen3LayerNorm

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.qwen3_moe.qwen3_moe_decoder import (
     Qwen3MoeTransformerDecoder,

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.qwen.qwen_layernorm import QwenLayerNorm
 from keras_hub.src.models.qwen_moe.qwen_moe_decoder import (

--- a/keras_hub/src/models/roformer_v2/roformer_v2_backbone.py
+++ b/keras_hub/src/models/roformer_v2/roformer_v2_backbone.py
@@ -1,8 +1,10 @@
 import keras
 from keras import activations
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.roformer_v2.roformer_v2_attention import RoformerNorm
 from keras_hub.src.models.roformer_v2.roformer_v2_encoder import (

--- a/keras_hub/src/models/siglip/siglip_layers.py
+++ b/keras_hub/src/models/siglip/siglip_layers.py
@@ -3,8 +3,10 @@ import math
 from keras import initializers
 from keras import layers
 from keras import ops
-from keras.layers import ReversibleEmbedding
 
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import gelu_approximate
 from keras_hub.src.utils.keras_utils import standardize_data_format

--- a/keras_hub/src/models/smollm3/smollm3_backbone.py
+++ b/keras_hub/src/models/smollm3/smollm3_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.smollm3.smollm3_layers import SmolLM3DecoderLayer
 

--- a/keras_hub/src/models/stable_diffusion_3/t5_encoder.py
+++ b/keras_hub/src/models/stable_diffusion_3/t5_encoder.py
@@ -1,6 +1,8 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.t5.t5_layer_norm import T5LayerNorm
 from keras_hub.src.models.t5.t5_transformer_layer import T5TransformerLayer
 

--- a/keras_hub/src/models/t5/t5_backbone.py
+++ b/keras_hub/src/models/t5/t5_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.t5.t5_layer_norm import T5LayerNorm
 from keras_hub.src.models.t5.t5_transformer_layer import T5TransformerLayer

--- a/keras_hub/src/models/t5gemma/t5gemma_backbone.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_backbone.py
@@ -1,7 +1,9 @@
 import keras
-from keras.layers import ReversibleEmbedding
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.gemma.rms_normalization import RMSNormalization
 from keras_hub.src.models.t5gemma.t5gemma_decoder import T5GemmaDecoderLayer

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -9,8 +9,10 @@ import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 from keras import tree
-from keras.layers import ReversibleEmbedding
 
+from keras_hub.src.layers.modeling.reversible_embedding import (
+    ReversibleEmbedding,
+)
 from keras_hub.src.models.retinanet.feature_pyramid import FeaturePyramid
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
 from keras_hub.src.utils.tensor_utils import is_float_dtype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "keras>=3.12",
+    "keras>=3.8",
     "absl-py",
     "numpy",
     "packaging",


### PR DESCRIPTION
…#2482)"

This reverts commit ed5c542c2c6f8c9288687ae1eaf9ac918f39dda8.

## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
