### PR TITLE
Fix broken MiTBackbone example in SegFormerBackbone docs

### DIFF
--- a/keras_hub/src/models/segformer/segformer_backbone.py
+++ b/keras_hub/src/models/segformer/segformer_backbone.py
@@ -40,15 +40,15 @@ class SegFormerBackbone(Backbone):
     import keras_hub
 
     backbone = keras_hub.models.MiTBackbone(
-        depths=[2, 2, 2, 2],
         image_shape=(224, 224, 3),
-        hidden_dims=[32, 64, 160, 256],
         num_layers=4,
-        blockwise_num_heads=[1, 2, 5, 8],
-        blockwise_sr_ratios=[8, 4, 2, 1],
+        hidden_dims=[32, 64, 160, 256],
+        layerwise_depths=[2, 2, 2, 2],
+        layerwise_num_heads=[1, 2, 5, 8],
+        layerwise_sr_ratios=[8, 4, 2, 1],
+        layerwise_patch_sizes=[7, 3, 3, 3],
+        layerwise_strides=[4, 2, 2, 2],
         max_drop_path_rate=0.1,
-        patch_sizes=[7, 3, 3, 3],
-        strides=[4, 2, 2, 2],
     )
 
     segformer_backbone = keras_hub.models.SegFormerBackbone(


### PR DESCRIPTION
## Description of the change
Fixes a broken SegFormerBackbone example that used outdated MiTBackbone arguments and raised a runtime error.
The example now uses the correct MiTBackbone constructor arguments (layerwise_* and num_layers) so it can be copied and run successfully.
This is a documentation-only change.


## Reference
MiTBackbone API in Keras Hub

## Colab Notebook
Not applicable (documentation-only change).

<img width="1575" height="837" alt="image" src="https://github.com/user-attachments/assets/a670664b-956f-4806-b038-f450074e4815" />


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
