### PR TITLE
Fix masking in `TokenAndPositionEmbedding` and with JAX.

### DIFF
--- a/keras_hub/src/layers/modeling/token_and_position_embedding.py
+++ b/keras_hub/src/layers/modeling/token_and_position_embedding.py
@@ -1,5 +1,7 @@
 import keras
 from keras.layers import ReversibleEmbedding
+from keras.src.backend import get_keras_mask
+from keras.src.backend import set_keras_mask
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.modeling.position_embedding import PositionEmbedding
@@ -126,10 +128,10 @@ class TokenAndPositionEmbedding(keras.layers.Layer):
             positions=positions,
         )
         outputs = embedded_tokens + embedded_positions
+        mask = get_keras_mask(embedded_tokens)
+        if mask is not None:
+            set_keras_mask(outputs, mask)
         return outputs
-
-    def compute_mask(self, inputs, mask=None):
-        return self.token_embedding.compute_mask(inputs, mask=mask)
 
     def compute_output_shape(self, input_shape):
         return tuple(input_shape) + (self.embedding_dim,)

--- a/keras_hub/src/layers/modeling/token_and_position_embedding_test.py
+++ b/keras_hub/src/layers/modeling/token_and_position_embedding_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 from keras import ops
 from keras import random
+from keras.src.backend import get_keras_mask
 
 from keras_hub.src.layers.modeling.token_and_position_embedding import (
     TokenAndPositionEmbedding,
@@ -34,4 +35,4 @@ class TokenAndPositionEmbeddingTest(TestCase):
         input_data = np.array([[1, 0], [1, 0]])
         mask = input_data != 0
         outputs = test_layer(input_data)
-        self.assertAllEqual(outputs._keras_mask, mask)
+        self.assertAllEqual(get_keras_mask(outputs), mask)

--- a/keras_hub/src/layers/modeling/transformer_decoder_test.py
+++ b/keras_hub/src/layers/modeling/transformer_decoder_test.py
@@ -1,6 +1,8 @@
 from absl.testing import parameterized
 from keras import ops
 from keras import random
+from keras.src.backend import get_keras_mask
+from keras.src.backend import set_keras_mask
 
 from keras_hub.src.layers.modeling.transformer_decoder import TransformerDecoder
 from keras_hub.src.tests.test_case import TestCase
@@ -114,9 +116,9 @@ class TransformerDecoderTest(TestCase):
         decoder_sequence = random.uniform(shape=[1, 4, 6])
         encoder_sequence = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
-        decoder_sequence._keras_mask = mask
+        set_keras_mask(decoder_sequence, mask)
         outputs = decoder(decoder_sequence, encoder_sequence)
-        self.assertAllEqual(outputs._keras_mask, mask)
+        self.assertAllEqual(get_keras_mask(outputs), mask)
 
     def test_mask_propagation_without_cross_attention(self):
         decoder = TransformerDecoder(
@@ -125,9 +127,9 @@ class TransformerDecoderTest(TestCase):
         )
         decoder_sequence = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
-        decoder_sequence._keras_mask = mask
+        set_keras_mask(decoder_sequence, mask)
         outputs = decoder(decoder_sequence)
-        self.assertAllEqual(outputs._keras_mask, mask)
+        self.assertAllEqual(get_keras_mask(outputs), mask)
 
     def test_cache_call_is_correct(self):
         batch_size, seq_len, num_heads, key_dim = 2, 5, 2, 4

--- a/keras_hub/src/layers/modeling/transformer_encoder_test.py
+++ b/keras_hub/src/layers/modeling/transformer_encoder_test.py
@@ -2,6 +2,8 @@ import keras
 from absl.testing import parameterized
 from keras import ops
 from keras import random
+from keras.src.backend import get_keras_mask
+from keras.src.backend import set_keras_mask
 
 from keras_hub.src.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_hub.src.tests.test_case import TestCase
@@ -92,9 +94,9 @@ class TransformerEncoderTest(TestCase):
         )
         inputs = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
-        inputs._keras_mask = mask
+        set_keras_mask(inputs, mask)
         outputs = encoder(inputs)
-        self.assertAllEqual(outputs._keras_mask, mask)
+        self.assertAllEqual(get_keras_mask(outputs), mask)
 
     def test_attention_scores(self):
         encoder = TransformerEncoder(intermediate_dim=4, num_heads=2)


### PR DESCRIPTION
## Description of the change

**Problem 1**: https://github.com/keras-team/keras/pull/21961 broke `TokenAndPositionEmbedding`. `ReversibleEmbedding` applies the correct mask, however, no longer via `compute_mask`.

**Solution 1**: Instead of delegating `compute_mask` to the `ReversibleEmbedding`, `TokenAndPositionEmbedding` now directly uses the mask that is already returned in the output of the `ReversibleEmbedding`.

----

**Problem 2**: JAX doesn't always allow setting attributes on arrays, in particular setting a `_keras_mask` attribute on tracers will fail.

**Solution 2**: This problem was solved in core Keras back in 2024. We now use `keras.src.backend.get_keras_mask/set_keras_mask` everywhere.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
