### PR TITLE
Adds support for AWQ to use `get_quantization_layer_structure` hooks

### DIFF
--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -431,7 +431,7 @@ class CausalLM(Task):
         self.generate_function = None
 
     def get_quantization_layer_structure(self, mode):
-        if mode != "gptq":
+        if mode not in ["gptq", "awq"]:
             return None
 
         backbone = self.backbone

--- a/keras_hub/src/models/gemma/gemma_causal_lm.py
+++ b/keras_hub/src/models/gemma/gemma_causal_lm.py
@@ -433,7 +433,7 @@ class GemmaCausalLM(CausalLM):
         return per_token_loss
 
     def get_quantization_layer_structure(self, mode):
-        if mode != "gptq":
+        if mode not in ["gptq", "awq"]:
             return None
 
         # Wrap embedding + scaling

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm.py
@@ -422,7 +422,7 @@ class GPT2CausalLM(CausalLM):
         return per_token_loss
 
     def get_quantization_layer_structure(self, mode):
-        if mode != "gptq":
+        if mode not in ["gptq", "awq"]:
             return None
 
         backbone = self.backbone

--- a/keras_hub/src/models/masked_lm.py
+++ b/keras_hub/src/models/masked_lm.py
@@ -86,7 +86,7 @@ class MaskedLM(Task):
         )
 
     def get_quantization_layer_structure(self, mode):
-        if mode != "gptq":
+        if mode not in ["gptq", "awq"]:
             return None
 
         backbone = self.backbone


### PR DESCRIPTION
## Description of the change
This change is required to allow the AWQ quantization mode in keras to use the `get_quantization_layer_structure` hooks in KerasHub models to understand the model topology.
