### PR TITLE
 Enable newly released Med Gemma 1.5  4B  variant version to hub

### DIFF
--- a/keras_hub/src/models/gemma3/gemma3_presets.py
+++ b/keras_hub/src/models/gemma3/gemma3_presets.py
@@ -198,8 +198,8 @@ backbone_presets = {
         "metadata": {
             "description": (
                 "A 4 billion parameter model based on Gemma 3. "
-                "This model is instruction-tuned for performance on medical text "
-                "and image comprehension and is optimized for medical "
+                "This model is instruction-tuned for performance on medical "
+                "text and image comprehension and is optimized for medical "
                 "applications that involve a text generation component."
             ),
             "params": 4300079472,
@@ -211,8 +211,8 @@ backbone_presets = {
         "metadata": {
             "description": (
                 "A 27 billion parameter model based on Gemma 3. "
-                "This model is instruction-tuned for performance on medical text "
-                "and image comprehension and is optimized for medical "
+                "This model is instruction-tuned for performance on medical "
+                " text and image comprehension and is optimized for medical "
                 "applications that involve a text generation component."
             ),
             "params": 27432406640,


### PR DESCRIPTION
## Description of the change

Converted the newly released google [MedGemma-1.5 ](https://huggingface.co/google/medgemma-1.5-4b-it) HF checkpoint using the Gemma3 conversion script and uploaded to kaggle.


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
