### PR TITLE
Doc: Fix parameter name typo in BertBackbone docstring

### DIFF
--- a/keras_hub/src/models/bert/bert_backbone.py
+++ b/keras_hub/src/models/bert/bert_backbone.py
@@ -145,8 +145,12 @@ class BertBackbone(Backbone):
         )
 
         # === Functional Model ===
-        token_id_input = keras.Input(shape=(None,), dtype="int32", name="token_ids")
-        segment_id_input = keras.Input(shape=(None,), dtype="int32", name="segment_ids")
+        token_id_input = keras.Input(
+            shape=(None,), dtype="int32", name="token_ids"
+        )
+        segment_id_input = keras.Input(
+            shape=(None,), dtype="int32", name="segment_ids"
+        )
         padding_mask_input = keras.Input(
             shape=(None,), dtype="int32", name="padding_mask"
         )


### PR DESCRIPTION
Fixed a typo in the `BertBackbone` docstring where the argument `hidden_dim` was incorrectly referred to as `hidden size`.