### PR TITLE
Revert "Doc: Fix parameter name typo in BertBackbone docstring (#2529)"

### DIFF
--- a/keras_hub/src/models/bert/bert_backbone.py
+++ b/keras_hub/src/models/bert/bert_backbone.py
@@ -33,7 +33,7 @@ class BertBackbone(Backbone):
         vocabulary_size: int. The size of the token vocabulary.
         num_layers: int. The number of transformer layers.
         num_heads: int. The number of attention heads for each transformer.
-            The hidden_dim must be divisible by the number of attention heads.
+            The hidden size must be divisible by the number of attention heads.
         hidden_dim: int. The size of the transformer encoding and pooler layers.
         intermediate_dim: int. The output dimension of the first Dense layer in
             a two-layer feedforward network for each transformer.


### PR DESCRIPTION
This reverts commit 3a795a07e79555fd5813ace724e1b496897ec397.
