### PR TITLE
Add Qwen-2.5-Coder 0.5B preset

### DIFF
--- a/keras_hub/src/models/qwen/qwen_presets.py
+++ b/keras_hub/src/models/qwen/qwen_presets.py
@@ -25,7 +25,6 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/qwen/keras/qwen2.5_7b_en/3",
     },
-    
     "qwen2.5_coder_0.5b_en": {
         "metadata": {
             "description": (
@@ -37,7 +36,6 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/qwen/keras/qwen2.5_coder_0.5b_en/1",
     },
-    
     "qwen2.5_instruct_0.5b_en": {
         "metadata": {
             "description": (


### PR DESCRIPTION
## Description
Adds a Qwen-2.5-Coder 0.5B preset to Keras-Hub following existing Qwen-2.5 preset patterns.

## Reference
Fixes #2313
