### PR TITLE
Fix Moonshine LiteRT export: Handle boolean masks in test runner

### DIFF
--- a/keras_hub/src/models/moonshine/moonshine_audio_to_text_test.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_to_text_test.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 import keras
+from keras import ops
 import numpy as np
 import pytest
 
@@ -145,16 +146,32 @@ class MoonshineAudioToTextTest(TestCase):
             input_data=self.input_data,
         )
 
-    @pytest.mark.skip(
-        reason="TODO: Bug with MoonshineAudioToText liteRT export"
-    )
     def test_litert_export(self):
+        # LiteRT inputs are strict about types.
+        # The model expects boolean masks, but the test data provides int32.
+        
+        # 1. Convert ALL inputs to numpy first to avoid "mixing tensors" error.
+        input_data = {}
+        for k, v in self.input_data.items():
+            input_data[k] = ops.convert_to_numpy(v)
+
+        # 2. Force masks to boolean
+        if "encoder_padding_mask" in input_data:
+            input_data["encoder_padding_mask"] = np.array(
+                input_data["encoder_padding_mask"], dtype=bool
+            )
+        
+        if "decoder_padding_mask" in input_data:
+            input_data["decoder_padding_mask"] = np.array(
+                input_data["decoder_padding_mask"], dtype=bool
+            )
+
         self.run_litert_export_test(
             cls=MoonshineAudioToText,
             init_kwargs=self.init_kwargs,
-            input_data=self.input_data,
+            input_data=input_data,
         )
-
+        
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in MoonshineAudioToText.presets:

--- a/keras_hub/src/models/moonshine/moonshine_audio_to_text_test.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_to_text_test.py
@@ -2,9 +2,9 @@ import os
 from unittest.mock import patch
 
 import keras
-from keras import ops
 import numpy as np
 import pytest
+from keras import ops
 
 from keras_hub.src.models.moonshine.moonshine_audio_converter import (
     MoonshineAudioConverter,
@@ -149,7 +149,7 @@ class MoonshineAudioToTextTest(TestCase):
     def test_litert_export(self):
         # LiteRT inputs are strict about types.
         # The model expects boolean masks, but the test data provides int32.
-        
+
         # 1. Convert ALL inputs to numpy first to avoid "mixing tensors" error.
         input_data = {}
         for k, v in self.input_data.items():
@@ -160,7 +160,7 @@ class MoonshineAudioToTextTest(TestCase):
             input_data["encoder_padding_mask"] = np.array(
                 input_data["encoder_padding_mask"], dtype=bool
             )
-        
+
         if "decoder_padding_mask" in input_data:
             input_data["decoder_padding_mask"] = np.array(
                 input_data["decoder_padding_mask"], dtype=bool
@@ -170,8 +170,9 @@ class MoonshineAudioToTextTest(TestCase):
             cls=MoonshineAudioToText,
             init_kwargs=self.init_kwargs,
             input_data=input_data,
+            strict_input_types=True,
         )
-        
+
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in MoonshineAudioToText.presets:

--- a/keras_hub/src/models/moonshine/moonshine_audio_to_text_test.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_to_text_test.py
@@ -151,20 +151,12 @@ class MoonshineAudioToTextTest(TestCase):
         # The model expects boolean masks, but the test data provides int32.
 
         # 1. Convert ALL inputs to numpy first to avoid "mixing tensors" error.
-        input_data = {}
-        for k, v in self.input_data.items():
-            input_data[k] = ops.convert_to_numpy(v)
+        input_data = {k: ops.convert_to_numpy(v) for k, v in self.input_data.items()}
 
         # 2. Force masks to boolean
-        if "encoder_padding_mask" in input_data:
-            input_data["encoder_padding_mask"] = np.array(
-                input_data["encoder_padding_mask"], dtype=bool
-            )
-
-        if "decoder_padding_mask" in input_data:
-            input_data["decoder_padding_mask"] = np.array(
-                input_data["decoder_padding_mask"], dtype=bool
-            )
+        for mask_key in ("encoder_padding_mask", "decoder_padding_mask"):
+            if mask_key in input_data:
+                input_data[mask_key] = input_data[mask_key].astype(bool)
 
         self.run_litert_export_test(
             cls=MoonshineAudioToText,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -705,14 +705,14 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     if hasattr(x, "dtype"):
                         if isinstance(x, np.ndarray):
                             if x.dtype == bool:
-                                return x.astype(np.int32)
+                                return x  # Keep as boolean!
                             elif x.dtype == np.float64:
                                 return x.astype(np.float32)
                             elif x.dtype == np.int64:
                                 return x.astype(np.int32)
                         else:  # TensorFlow tensor
                             if x.dtype == tf.bool:
-                                return ops.cast(x, "int32").numpy()
+                                return x.numpy()
                             elif x.dtype == tf.float64:
                                 return ops.cast(x, "float32").numpy()
                             elif x.dtype == tf.int64:


### PR DESCRIPTION
## Description of the change
This PR fixes a bug in the LiteRT export testing infrastructure that prevented models with boolean inputs (like Moonshine) from being tested correctly.

**The Issue:**
The `run_litert_export_test` utility in `test_case.py` was incorrectly casting all boolean inputs to `int32` before passing them to the TFLite interpreter. This caused a type mismatch error (`ValueError: Cannot set tensor: Got value of type INT32 but expected type BOOL`) for models that strictly require boolean masks.

**The Fix:**
1.  **Updated `test_case.py`:** Modified `convert_for_tflite` to preserve `bool` data types for both NumPy arrays and TensorFlow tensors, instead of forcing a cast to `int32`.
2.  **Enabled Moonshine Test:** Removed the `@pytest.mark.skip` from `test_litert_export` in `moonshine_audio_to_text_test.py`.
3.  **Updated Test Inputs:** Refactored the test to use `keras.ops.convert_to_numpy` and explicitly ensure masks are cast to `bool`, resolving the "mixing tensors and non-tensors" validation error.

## Reference
Fixes #2493

## Colab Notebook
N/A (Bug fix for existing test infrastructure)

## Checklist
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).