### PR TITLE
  Update Kaggle Models link to Keras organization page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # KerasHub: Multi-framework Pretrained Models
 [![](https://github.com/keras-team/keras-hub/workflows/Tests/badge.svg?branch=master)](https://github.com/keras-team/keras-hub/actions?query=workflow%3ATests+branch%3Amaster)
 ![Python](https://img.shields.io/badge/python-v3.11.0+-success.svg)
+[![Kaggle Models](https://img.shields.io/badge/Kaggle-Models-brightgreen?colorA=0099ff)](https://www.kaggle.com/organizations/keras/models)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/keras-team/keras-hub/issues)
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Description of the change

Previously landing on general [kaggle models page](https://kaggle.com/models/). Now it will land on the [Keras organization page](https://www.kaggle.com/organizations/keras/models)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
