### PR TITLE
Add import test for Qwen3-TTS hub registration

### DIFF
--- a/integration_tests/import_test.py
+++ b/integration_tests/import_test.py
@@ -6,3 +6,10 @@ import keras_hub
 class ImportTest(unittest.TestCase):
     def test_version(self):
         self.assertIsNotNone(keras_hub.__version__)
+        
+    def test_qwen3_tts_is_registered(self):
+        self.assertTrue(
+            hasattr(keras_hub.models, "Qwen3TTS"),
+            "Qwen3TTS model should be registered in keras_hub.models",
+        )
+        


### PR DESCRIPTION
This PR adds a minimal import test to ensure that the
Qwen3-TTS model is properly registered in keras-hub.

This is a small follow-up to #2546.
No API changes.
