### PR TITLE
Remove line break from print function call

### DIFF
--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -361,7 +361,7 @@ class Task(PipelineModel):
 
             # Output captured summary for non-interactive logging.
             if print_fn:
-                print_fn(console.end_capture())
+                print_fn(console.end_capture().rstrip("\n"))
 
         super().summary(
             line_length=line_length,


### PR DESCRIPTION
This pull request makes a minor change to the logging behavior in the `add_layer` method of `keras_hub/src/models/task.py`. The update ensures that the output from the summary is printed with the default line break behavior, rather than suppressing line breaks.

line_break parameter was causing error and we probably don't need it.