### PR TITLE
Fix exception handling for file errors

### DIFF
--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -285,7 +285,7 @@ def tf_copy_gfile_to_cache(preset, path):
             # Work around this bug.
             os.remove(local_path)
             if isinstance(
-                e, tf.errors.PermissionDeniedError, tf.errors.NotFoundError
+                e, (tf.errors.PermissionDeniedError, tf.errors.NotFoundError)
             ):
                 raise FileNotFoundError(
                     f"`{path}` doesn't exist in preset directory `{preset}`.",


### PR DESCRIPTION
This pull request includes a small fix to the exception handling logic in the `tf_copy_gfile_to_cache` function. The change ensures that the code correctly checks if the exception is an instance of either `tf.errors.PermissionDeniedError` or `tf.errors.NotFoundError` by using a tuple, which is the correct syntax for `isinstance`.

* Fixed the `isinstance` call to use a tuple of exception types for proper error handling in `tf_copy_gfile_to_cache` in `preset_utils.py`.