### PR TITLE
LiteRT export tests temporarily disbled

### DIFF
--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -598,8 +598,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             self.skipTest("LiteRT export requires Keras >= 3.13")
 
         self.skipTest(
-            "#TODO: [issue #2572] Re-enable LiteRT tests after a new tf release."
-            " Can't test with tf 2.20 due to tf.lite module deprecation."
+            "#TODO: [#2572] Re-enable LiteRT tests after a new tf release. "
+            "Can't test with tf 2.20 due to tf.lite module deprecation."
         )
 
         # Extract comparison_mode from export_kwargs if provided


### PR DESCRIPTION
This pull request temporarily disables the LiteRT export tests in `test_case.py` due to incompatibility with TensorFlow 2.20, where the `tf.lite` module has been deprecated. The tests will be re-enabled after a new TensorFlow release resolves this issue.

Testing changes:

* Added a `self.skipTest` call in the `run_litert_export_test` method to skip LiteRT export tests, referencing issue #2572 and explaining the deprecation of `tf.lite` in TensorFlow 2.20.

https://github.com/keras-team/keras-hub/issues/2572