### PR TITLE
Use large size images in `DepthAnything` unit tests.

### DIFF
--- a/keras_hub/src/models/depth_anything/depth_anything_backbone_test.py
+++ b/keras_hub/src/models/depth_anything/depth_anything_backbone_test.py
@@ -18,7 +18,7 @@ class DepthAnythingBackboneTest(TestCase):
             16 * 4,
             1.0,
             0,
-            image_shape=(70, 70, 3),
+            image_shape=(126, 126, 3),
             apply_layernorm=True,
             name="image_encoder",
         )
@@ -31,14 +31,14 @@ class DepthAnythingBackboneTest(TestCase):
             "head_in_index": -1,
             "feature_keys": ["stage1", "stage2", "stage3", "stage4"],
         }
-        self.input_data = np.ones((2, 70, 70, 3), dtype="float32")
+        self.input_data = np.ones((2, 126, 126, 3), dtype="float32")
 
     def test_backbone_basics(self):
         self.run_backbone_test(
             cls=DepthAnythingBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
-            expected_output_shape=(2, 70, 70, 1),
+            expected_output_shape=(2, 126, 126, 1),
         )
 
     @pytest.mark.large

--- a/keras_hub/src/models/depth_anything/depth_anything_depth_estimator_test.py
+++ b/keras_hub/src/models/depth_anything/depth_anything_depth_estimator_test.py
@@ -27,12 +27,14 @@ class DepthAnythingDepthEstimatorTest(TestCase):
             16 * 4,
             1.0,
             0,
-            image_shape=(70, 70, 3),
+            image_shape=(126, 126, 3),
             apply_layernorm=True,
         )
-        self.images = np.ones((2, 70, 70, 3), dtype="float32")
-        self.depths = np.zeros((2, 70, 70, 1), dtype="float32")
-        self.image_converter = DepthAnythingImageConverter(image_size=(70, 70))
+        self.images = np.ones((2, 126, 126, 3), dtype="float32")
+        self.depths = np.zeros((2, 126, 126, 1), dtype="float32")
+        self.image_converter = DepthAnythingImageConverter(
+            image_size=(126, 126)
+        )
         self.preprocessor = DepthAnythingDepthEstimatorPreprocessor(
             self.image_converter
         )
@@ -58,7 +60,7 @@ class DepthAnythingDepthEstimatorTest(TestCase):
             cls=DepthAnythingDepthEstimator,
             init_kwargs=self.init_kwargs,
             train_data=self.train_data,
-            expected_output_shape={"depths": (2, 70, 70, 1)},
+            expected_output_shape={"depths": (2, 126, 126, 1)},
         )
 
     @pytest.mark.extra_large


### PR DESCRIPTION
Otherwise some of the intermediary convolutions have an output of size zero, which is no longer supported.

This fixes the tests against keras-nightly.