### PR TITLE
GPT2 H5 to HF safe tesnor format

### DIFF
--- a/keras_hub/src/utils/transformers/export/gpt2.py
+++ b/keras_hub/src/utils/transformers/export/gpt2.py
@@ -1,0 +1,151 @@
+import keras.ops as ops
+
+
+def get_gpt2_config(backbone):
+    """Convert Keras GPT-2 config to Hugging Face GPT2Config."""
+    return {
+        # Core architectural dimensions
+        "vocab_size": backbone.vocabulary_size,
+        "n_positions": backbone.max_sequence_length,
+        "n_embd": backbone.hidden_dim,
+        "n_layer": backbone.num_layers,
+        "n_head": backbone.num_heads,
+        "n_inner": backbone.intermediate_dim,
+        # Activation and regularization
+        "activation_function": "gelu_new",
+        "resid_pdrop": backbone.dropout,
+        "embd_pdrop": backbone.dropout,
+        "attn_pdrop": backbone.dropout,
+        # Numerical stability and initialization
+        "layer_norm_epsilon": 1e-05,
+        "initializer_range": 0.02,
+        # Sequence summary settings
+        "summary_type": "cls_index",
+        "summary_use_proj": True,
+        "summary_activation": None,
+        "summary_proj_to_labels": True,
+        "summary_first_dropout": backbone.dropout,
+        # Model behavior and special tokens
+        "scale_attn_weights": True,
+        "use_cache": True,
+        "bos_token_id": 50256,
+        "eos_token_id": 50256,
+        "model_type": "gpt2",
+    }
+
+
+def get_gpt2_weights_map(keras_model, include_lm_head=False):
+    """Create a weights map for a given GPT-2 model."""
+    weights_map = {}
+
+    # Token and position embeddings
+    weights_map["transformer.wte.weight"] = keras_model.get_layer(
+        "token_embedding"
+    ).embeddings
+    weights_map["transformer.wpe.weight"] = keras_model.get_layer(
+        "position_embedding"
+    ).position_embeddings
+
+    for i in range(keras_model.num_layers):
+        # Attention weights
+        q_w = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._query_dense.kernel
+        k_w = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._key_dense.kernel
+        v_w = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._value_dense.kernel
+        q_b = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._query_dense.bias
+        k_b = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._key_dense.bias
+        v_b = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._value_dense.bias
+
+        q_w = ops.reshape(q_w, (keras_model.hidden_dim, keras_model.hidden_dim))
+        k_w = ops.reshape(k_w, (keras_model.hidden_dim, keras_model.hidden_dim))
+        v_w = ops.reshape(v_w, (keras_model.hidden_dim, keras_model.hidden_dim))
+
+        c_attn_w = ops.concatenate([q_w, k_w, v_w], axis=-1)
+        weights_map[f"transformer.h.{i}.attn.c_attn.weight"] = c_attn_w
+
+        q_b = ops.reshape(q_b, [-1])
+        k_b = ops.reshape(k_b, [-1])
+        v_b = ops.reshape(v_b, [-1])
+
+        c_attn_b = ops.concatenate([q_b, k_b, v_b], axis=-1)
+        weights_map[f"transformer.h.{i}.attn.c_attn.bias"] = c_attn_b
+
+        # Attention projection
+        c_proj_w = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer._output_dense.kernel
+        c_proj_w = ops.reshape(
+            c_proj_w, (keras_model.hidden_dim, keras_model.hidden_dim)
+        )
+        weights_map[f"transformer.h.{i}.attn.c_proj.weight"] = c_proj_w
+        weights_map[f"transformer.h.{i}.attn.c_proj.bias"] = (
+            keras_model.get_layer(
+                f"transformer_layer_{i}"
+            )._self_attention_layer._output_dense.bias
+        )
+
+        # Layer norms
+        weights_map[f"transformer.h.{i}.ln_1.weight"] = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer_norm.gamma
+        weights_map[f"transformer.h.{i}.ln_1.bias"] = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._self_attention_layer_norm.beta
+        weights_map[f"transformer.h.{i}.ln_2.weight"] = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._feedforward_layer_norm.gamma
+        weights_map[f"transformer.h.{i}.ln_2.bias"] = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._feedforward_layer_norm.beta
+
+        # MLP
+        c_fc_w = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._feedforward_intermediate_dense.kernel
+        weights_map[f"transformer.h.{i}.mlp.c_fc.weight"] = c_fc_w
+        weights_map[f"transformer.h.{i}.mlp.c_fc.bias"] = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._feedforward_intermediate_dense.bias
+        c_proj_w_mlp = keras_model.get_layer(
+            f"transformer_layer_{i}"
+        )._feedforward_output_dense.kernel
+        weights_map[f"transformer.h.{i}.mlp.c_proj.weight"] = c_proj_w_mlp
+        weights_map[f"transformer.h.{i}.mlp.c_proj.bias"] = (
+            keras_model.get_layer(
+                f"transformer_layer_{i}"
+            )._feedforward_output_dense.bias
+        )
+
+    # Final layer norm
+    weights_map["transformer.ln_f.weight"] = keras_model.get_layer(
+        "layer_norm"
+    ).gamma
+    weights_map["transformer.ln_f.bias"] = keras_model.get_layer(
+        "layer_norm"
+    ).beta
+
+    if include_lm_head:
+        # lm_head is tied to token embeddings
+        weights_map["lm_head.weight"] = weights_map["transformer.wte.weight"]
+
+    return weights_map
+
+
+def get_gpt2_tokenizer_config(tokenizer):
+    return {
+        "model_type": "gpt2",
+        "bos_token": "<|endoftext|>",
+        "eos_token": "<|endoftext|>",
+        "unk_token": "<|endoftext|>",
+    }

--- a/keras_hub/src/utils/transformers/export/gpt2_test.py
+++ b/keras_hub/src/utils/transformers/export/gpt2_test.py
@@ -1,0 +1,118 @@
+import json
+import os
+
+import keras.ops as ops
+import numpy as np
+import torch
+from transformers import GPT2LMHeadModel
+
+from keras_hub.src.models.gpt2.gpt2_backbone import GPT2Backbone
+from keras_hub.src.models.gpt2.gpt2_causal_lm import GPT2CausalLM
+from keras_hub.src.models.gpt2.gpt2_causal_lm_preprocessor import (
+    GPT2CausalLMPreprocessor,
+)
+from keras_hub.src.models.gpt2.gpt2_tokenizer import GPT2Tokenizer
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers.export.hf_exporter import (
+    export_to_safetensors,
+)
+
+
+class TestGPT2Export(TestCase):
+    def test_export_to_hf(self):
+        # 1. Setup Tokenizer Assets
+        vocab = {
+            "<|endoftext|>": 0,
+            "The": 1,
+            "Ġquick": 2,
+            "Ġbrown": 3,
+            "Ġfox": 4,
+            "Ġ": 5,
+            "q": 6,
+            "u": 7,
+            "i": 8,
+            "c": 9,
+            "k": 10,
+        }
+        merges = ["Ġ q", "u i", "c k"]
+
+        temp_dir = self.get_temp_dir()
+        vocab_path = os.path.join(temp_dir, "vocab.json")
+        merges_path = os.path.join(temp_dir, "merges.txt")
+
+        with open(vocab_path, "w") as f:
+            json.dump(vocab, f)
+        with open(merges_path, "w") as f:
+            f.write("\n".join(merges))
+
+        tokenizer = GPT2Tokenizer(vocabulary=vocab_path, merges=merges_path)
+
+        # 2. Create a small backbone
+        backbone = GPT2Backbone(
+            vocabulary_size=len(vocab),
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=64,
+            intermediate_dim=128,
+            max_sequence_length=128,
+            layer_norm_epsilon=1e-5,
+            dropout=0,
+        )
+
+        # 3. Create preprocessor & model
+        preprocessor = GPT2CausalLMPreprocessor(
+            tokenizer=tokenizer, sequence_length=32
+        )
+        keras_model = GPT2CausalLM(backbone=backbone, preprocessor=preprocessor)
+
+        # 4. Set Random Weights
+        rng = np.random.default_rng(42)
+        weights = keras_model.get_weights()
+        for i in range(len(weights)):
+            weights[i] = rng.random(weights[i].shape).astype(weights[i].dtype)
+        keras_model.set_weights(weights)
+
+        # 5. Export to Hugging Face format
+        export_path = os.path.join(temp_dir, "export_task")
+        export_to_safetensors(keras_model, export_path)
+
+        # Patch config for EOS to match our tiny vocab
+        config_path = os.path.join(export_path, "config.json")
+        with open(config_path, "r") as f:
+            cfg = json.load(f)
+        cfg["bos_token_id"] = 0
+        cfg["eos_token_id"] = 0
+        with open(config_path, "w") as f:
+            json.dump(cfg, f, indent=2)
+
+        # 6. Load with Hugging Face Transformers
+        hf_model = GPT2LMHeadModel.from_pretrained(export_path)
+        # hf_tokenizer = HFGPT2Tokenizer.from_pretrained(export_path)
+
+        # 7. Verify Configuration
+        hf_config = hf_model.config
+        self.assertEqual(hf_config.vocab_size, backbone.vocabulary_size)
+        self.assertEqual(hf_config.n_layer, backbone.num_layers)
+        self.assertEqual(hf_config.n_head, backbone.num_heads)
+        self.assertEqual(hf_config.n_embd, backbone.hidden_dim)
+        self.assertEqual(hf_config.n_inner, backbone.intermediate_dim)
+
+        # 8. Compare Outputs (Logits)
+        input_ids = np.array([[1, 2, 5, 6]])
+
+        # Keras Inference
+        keras_inputs = {
+            "token_ids": input_ids,
+            "padding_mask": np.ones_like(input_ids),
+        }
+        keras_logits = keras_model(keras_inputs)
+
+        # HF Inference
+        hf_inputs = {"input_ids": torch.tensor(input_ids)}
+        hf_logits = hf_model(**hf_inputs).logits
+
+        # Verify numerical equivalence
+        keras_logits_np = ops.convert_to_numpy(keras_logits)
+        hf_logits_np = hf_logits.detach().cpu().numpy()
+
+        self.assertAllClose(keras_logits_np, hf_logits_np, atol=1e-5, rtol=1e-5)

--- a/keras_hub/src/utils/transformers/export/hf_exporter.py
+++ b/keras_hub/src/utils/transformers/export/hf_exporter.py
@@ -21,6 +21,13 @@ from keras_hub.src.utils.transformers.export.gemma3 import (
     get_gemma3_weights_map,
 )
 
+# --- GPT2 Utils ---
+from keras_hub.src.utils.transformers.export.gpt2 import get_gpt2_config
+from keras_hub.src.utils.transformers.export.gpt2 import (
+    get_gpt2_tokenizer_config,
+)
+from keras_hub.src.utils.transformers.export.gpt2 import get_gpt2_weights_map
+
 # --- Qwen Utils ---
 from keras_hub.src.utils.transformers.export.qwen import get_qwen_config
 from keras_hub.src.utils.transformers.export.qwen import (
@@ -32,29 +39,26 @@ MODEL_CONFIGS = {
     "GemmaBackbone": get_gemma_config,
     "Gemma3Backbone": get_gemma3_config,
     "QwenBackbone": get_qwen_config,
+    "GPT2Backbone": get_gpt2_config,
 }
 
 MODEL_EXPORTERS = {
     "GemmaBackbone": get_gemma_weights_map,
     "Gemma3Backbone": get_gemma3_weights_map,
     "QwenBackbone": get_qwen_weights_map,
+    "GPT2Backbone": get_gpt2_weights_map,
 }
 
 MODEL_TOKENIZER_CONFIGS = {
     "GemmaTokenizer": get_gemma_tokenizer_config,
     "Gemma3Tokenizer": get_gemma3_tokenizer_config,
     "QwenTokenizer": get_qwen_tokenizer_config,
+    "GPT2Tokenizer": get_gpt2_tokenizer_config,
 }
 
 
 def export_backbone(backbone, path, include_lm_head=False):
-    """Export the backbone model to HuggingFace format.
-
-    Args:
-        backbone: The Keras backbone model to convert.
-        path: str. Path to save the exported model.
-        include_lm_head: bool. If True, include lm_head weights if applicable.
-    """
+    """Export the backbone model to HuggingFace format."""
     backend = keras.config.backend()
     model_type = backbone.__class__.__name__
     if model_type not in MODEL_CONFIGS:
@@ -65,9 +69,11 @@ def export_backbone(backbone, path, include_lm_head=False):
         raise ValueError(
             f"Export to Transformers format not implemented for {model_type}"
         )
+
     # Get config
     get_config_fn = MODEL_CONFIGS[model_type]
     hf_config = get_config_fn(backbone)
+
     # Get weights
     get_weights_fn = MODEL_EXPORTERS[model_type]
     weights_dict = get_weights_fn(backbone, include_lm_head=include_lm_head)
@@ -88,7 +94,6 @@ def export_backbone(backbone, path, include_lm_head=False):
     # Save weights based on backend
     weights_path = os.path.join(path, "model.safetensors")
     if backend == "torch":
-        # Lazy import to prevent crash on TF-only environments
         import torch
         from safetensors.torch import save_file
 
@@ -110,8 +115,17 @@ def export_backbone(backbone, path, include_lm_head=False):
 
             weights_dict_torch[k] = t
 
-        # Handle Tied Weights
+        # --- Handle Tied Weights ---
         if (
+            "lm_head.weight" in weights_dict_torch
+            and "transformer.wte.weight" in weights_dict_torch
+        ):
+            wte = weights_dict_torch["transformer.wte.weight"]
+            lm = weights_dict_torch["lm_head.weight"]
+            if wte.data_ptr() == lm.data_ptr():
+                weights_dict_torch["lm_head.weight"] = lm.clone().contiguous()
+
+        elif (
             "lm_head.weight" in weights_dict_torch
             and "model.embed_tokens.weight" in weights_dict_torch
         ):
@@ -135,23 +149,16 @@ def export_backbone(backbone, path, include_lm_head=False):
 
 
 def export_tokenizer(tokenizer, path):
-    """Export only the tokenizer to HuggingFace Transformers format.
-
-    Args:
-        tokenizer: The Keras tokenizer to convert.
-        path: str. Path to save the exported tokenizer.
-    """
+    """Export only the tokenizer to HuggingFace Transformers format."""
     os.makedirs(path, exist_ok=True)
-
-    # Save tokenizer assets
     tokenizer.save_assets(path)
 
-    # Export tokenizer config
     tokenizer_type = tokenizer.__class__.__name__
     if tokenizer_type not in MODEL_TOKENIZER_CONFIGS:
         raise ValueError(
             f"Export to Transformer format not implemented for {tokenizer_type}"
         )
+
     get_tokenizer_config_fn = MODEL_TOKENIZER_CONFIGS[tokenizer_type]
     tokenizer_config = get_tokenizer_config_fn(tokenizer)
     tokenizer_config_path = os.path.join(path, "tokenizer_config.json")
@@ -169,14 +176,16 @@ def export_tokenizer(tokenizer, path):
         else:
             warnings.warn(f"{vocab_spm_path} not found.")
 
-    # 2. BPE Models (Qwen)
-    elif tokenizer_type == "QwenTokenizer":
+    # 2. BPE Models (Qwen / GPT-2)
+    elif tokenizer_type in ["QwenTokenizer", "GPT2Tokenizer"]:
         vocab_json_path = os.path.join(path, "vocabulary.json")
         vocab_hf_path = os.path.join(path, "vocab.json")
         if os.path.exists(vocab_json_path):
             shutil.move(vocab_json_path, vocab_hf_path)
         else:
-            warnings.warn(f"{vocab_json_path} not found.")
+            warnings.warn(
+                f"{vocab_json_path} not found.Tokenizer may not load correctly."
+            )
 
 
 def export_to_safetensors(keras_model, path):
@@ -197,9 +206,6 @@ def export_to_safetensors(keras_model, path):
         keras_model.preprocessor is not None
         and keras_model.preprocessor.tokenizer is None
     ):
-        raise ValueError(
-            "CausalLM preprocessor must have a tokenizer for export "
-            "if attached."
-        )
+        raise ValueError("CausalLM preprocessor must have a tokenizer.")
     if keras_model.preprocessor is not None:
         export_tokenizer(keras_model.preprocessor.tokenizer, path)


### PR DESCRIPTION
GPT2 model conversion from keras to hf safetensors format. colab [gist](https://colab.research.google.com/gist/LakshmiKalaKadali/366108c36895fe75a0f73c62583a4fd4/gpt2.ipynb#scrollTo=BcuFoSEgV_x6)

Updated export_backbone to support transformers Config objects by checking for .to_dict(). This improves robustness
for models using official Config classes.
Updated export_tokenizer to manually save vocab.json and merges.txt for GPT2Tokenizer, handling the specific naming
conventions required by Hugging Face.
Added logic to handle tied weights (specifically lm_head and wte). The exporter now detects if weights share memory
and clones them to prevent SafeTensors serialization errors.
