### PR TITLE
fix: serialize head_dtype in all ImageClassifier subclasses

### DIFF
--- a/keras_hub/src/models/deit/deit_image_classifier.py
+++ b/keras_hub/src/models/deit/deit_image_classifier.py
@@ -115,7 +115,6 @@ class DeiTImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
 
         # === Layers ===
         self.backbone = backbone
@@ -154,6 +153,7 @@ class DeiTImageClassifier(ImageClassifier):
 
         # === config ===
         self.num_classes = num_classes
+        self.head_dtype = head_dtype
         self.pooling = pooling
         self.activation = activation
         self.dropout = dropout

--- a/keras_hub/src/models/deit/deit_image_classifier.py
+++ b/keras_hub/src/models/deit/deit_image_classifier.py
@@ -115,6 +115,7 @@ class DeiTImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
 
         # === Layers ===
         self.backbone = backbone
@@ -166,6 +167,7 @@ class DeiTImageClassifier(ImageClassifier):
                 "pooling": self.pooling,
                 "activation": self.activation,
                 "dropout": self.dropout,
+                "head_dtype": self.head_dtype,
             }
         )
         return config

--- a/keras_hub/src/models/deit/deit_image_classifier.py
+++ b/keras_hub/src/models/deit/deit_image_classifier.py
@@ -167,7 +167,7 @@ class DeiTImageClassifier(ImageClassifier):
                 "pooling": self.pooling,
                 "activation": self.activation,
                 "dropout": self.dropout,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/hgnetv2/hgnetv2_image_classifier.py
+++ b/keras_hub/src/models/hgnetv2/hgnetv2_image_classifier.py
@@ -117,6 +117,7 @@ class HGNetV2ImageClassifier(ImageClassifier):
     ):
         name = kwargs.get("name", "hgnetv2_image_classifier")
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", "channels_last")
         channel_axis = -1 if data_format == "channels_last" else 1
         self.head_filters = (
@@ -211,6 +212,7 @@ class HGNetV2ImageClassifier(ImageClassifier):
                 "activation": self.activation,
                 "dropout": self.dropout,
                 "head_filters": self.head_filters,
+                "head_dtype": self.head_dtype,
             }
         )
         return config

--- a/keras_hub/src/models/hgnetv2/hgnetv2_image_classifier.py
+++ b/keras_hub/src/models/hgnetv2/hgnetv2_image_classifier.py
@@ -212,7 +212,7 @@ class HGNetV2ImageClassifier(ImageClassifier):
                 "activation": self.activation,
                 "dropout": self.dropout,
                 "head_filters": self.head_filters,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/hgnetv2/hgnetv2_image_classifier.py
+++ b/keras_hub/src/models/hgnetv2/hgnetv2_image_classifier.py
@@ -117,7 +117,6 @@ class HGNetV2ImageClassifier(ImageClassifier):
     ):
         name = kwargs.get("name", "hgnetv2_image_classifier")
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", "channels_last")
         channel_axis = -1 if data_format == "channels_last" else 1
         self.head_filters = (
@@ -202,6 +201,7 @@ class HGNetV2ImageClassifier(ImageClassifier):
         self.pooling = pooling
         self.dropout = dropout
         self.num_classes = num_classes
+        self.head_dtype = head_dtype
 
     def get_config(self):
         config = Task.get_config(self)

--- a/keras_hub/src/models/image_classifier.py
+++ b/keras_hub/src/models/image_classifier.py
@@ -100,7 +100,6 @@ class ImageClassifier(Task):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
@@ -152,6 +151,7 @@ class ImageClassifier(Task):
         self.activation = activation
         self.pooling = pooling
         self.dropout = dropout
+        self.head_dtype = head_dtype
 
     def get_config(self):
         # Backbone serialized in `super`

--- a/keras_hub/src/models/image_classifier.py
+++ b/keras_hub/src/models/image_classifier.py
@@ -100,6 +100,7 @@ class ImageClassifier(Task):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
@@ -161,6 +162,7 @@ class ImageClassifier(Task):
                 "pooling": self.pooling,
                 "activation": self.activation,
                 "dropout": self.dropout,
+                "head_dtype": self.head_dtype,
             }
         )
         return config

--- a/keras_hub/src/models/image_classifier.py
+++ b/keras_hub/src/models/image_classifier.py
@@ -162,7 +162,7 @@ class ImageClassifier(Task):
                 "pooling": self.pooling,
                 "activation": self.activation,
                 "dropout": self.dropout,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
+++ b/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
@@ -24,6 +24,7 @@ class MobileNetImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
@@ -79,6 +80,7 @@ class MobileNetImageClassifier(ImageClassifier):
             {
                 "num_classes": self.num_classes,
                 "num_features": self.num_features,
+                "head_dtype": self.head_dtype,
             }
         )
         return config

--- a/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
+++ b/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
@@ -80,7 +80,7 @@ class MobileNetImageClassifier(ImageClassifier):
             {
                 "num_classes": self.num_classes,
                 "num_features": self.num_features,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
+++ b/keras_hub/src/models/mobilenet/mobilenet_image_classifier.py
@@ -24,7 +24,6 @@ class MobileNetImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
@@ -71,6 +70,7 @@ class MobileNetImageClassifier(ImageClassifier):
 
         # === Config ===
         self.num_classes = num_classes
+        self.head_dtype = head_dtype
         self.num_features = num_features
 
     def get_config(self):

--- a/keras_hub/src/models/mobilenetv5/mobilenetv5_image_classifier.py
+++ b/keras_hub/src/models/mobilenetv5/mobilenetv5_image_classifier.py
@@ -88,6 +88,7 @@ class MobileNetV5ImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", "channels_last")
 
         # === Layers ===
@@ -152,6 +153,7 @@ class MobileNetV5ImageClassifier(ImageClassifier):
                 "head_hidden_size": self.head_hidden_size,
                 "global_pool": self.global_pool_type,
                 "drop_rate": self.drop_rate,
+                "head_dtype": self.head_dtype,
             }
         )
         return config

--- a/keras_hub/src/models/mobilenetv5/mobilenetv5_image_classifier.py
+++ b/keras_hub/src/models/mobilenetv5/mobilenetv5_image_classifier.py
@@ -88,7 +88,6 @@ class MobileNetV5ImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", "channels_last")
 
         # === Layers ===
@@ -141,6 +140,7 @@ class MobileNetV5ImageClassifier(ImageClassifier):
 
         # === Config ===
         self.num_classes = num_classes
+        self.head_dtype = head_dtype
         self.head_hidden_size = head_hidden_size
         self.global_pool_type = global_pool
         self.drop_rate = drop_rate

--- a/keras_hub/src/models/mobilenetv5/mobilenetv5_image_classifier.py
+++ b/keras_hub/src/models/mobilenetv5/mobilenetv5_image_classifier.py
@@ -153,7 +153,7 @@ class MobileNetV5ImageClassifier(ImageClassifier):
                 "head_hidden_size": self.head_hidden_size,
                 "global_pool": self.global_pool_type,
                 "drop_rate": self.drop_rate,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -119,6 +119,10 @@ class Task(PipelineModel):
             config["preprocessor"] = keras.layers.deserialize(
                 config["preprocessor"]
             )
+        if "head_dtype" in config and isinstance(config["head_dtype"], dict):
+            config["head_dtype"] = keras.dtype_policies.deserialize(
+                config["head_dtype"]
+            )
         return cls(**config)
 
     @classproperty

--- a/keras_hub/src/models/task_test.py
+++ b/keras_hub/src/models/task_test.py
@@ -273,6 +273,26 @@ class TestTask(TestCase):
         actual = restored_task.predict(batch)
         self.assertAllClose(expected, actual)
 
+    def test_image_classifier_head_dtype_serialization(self):
+        inputs = keras.Input(shape=(None, None, 3))
+        outputs = keras.layers.Dense(8)(inputs)
+        backbone = keras.Model(inputs, outputs)
+        model = ImageClassifier(
+            backbone=backbone,
+            num_classes=10,
+            head_dtype="float32",
+        )
+        # Verify head_dtype is in config
+        config = model.get_config()
+        self.assertIn("head_dtype", config)
+
+        # Verify round-trip via from_config
+        restored = ImageClassifier.from_config(config)
+        self.assertEqual(
+            str(model.head_dtype),
+            str(restored.head_dtype),
+        )
+
     def _create_gemma_for_export_tests(self):
         proto = os.path.join(self.get_test_data_dir(), "gemma_export_vocab.spm")
         tokenizer = GemmaTokenizer(proto=proto)

--- a/keras_hub/src/models/vgg/vgg_image_classifier.py
+++ b/keras_hub/src/models/vgg/vgg_image_classifier.py
@@ -212,7 +212,7 @@ class VGGImageClassifier(ImageClassifier):
                 "activation": self.activation,
                 "pooling_hidden_dim": self.pooling_hidden_dim,
                 "dropout": self.dropout,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/vgg/vgg_image_classifier.py
+++ b/keras_hub/src/models/vgg/vgg_image_classifier.py
@@ -114,7 +114,6 @@ class VGGImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
@@ -196,6 +195,7 @@ class VGGImageClassifier(ImageClassifier):
 
         # === Config ===
         self.num_classes = num_classes
+        self.head_dtype = head_dtype
         self.activation = activation
         self.pooling = pooling
         self.pooling_hidden_dim = pooling_hidden_dim

--- a/keras_hub/src/models/vgg/vgg_image_classifier.py
+++ b/keras_hub/src/models/vgg/vgg_image_classifier.py
@@ -114,6 +114,7 @@ class VGGImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
         data_format = getattr(backbone, "data_format", None)
 
         # === Layers ===
@@ -211,6 +212,7 @@ class VGGImageClassifier(ImageClassifier):
                 "activation": self.activation,
                 "pooling_hidden_dim": self.pooling_hidden_dim,
                 "dropout": self.dropout,
+                "head_dtype": self.head_dtype,
             }
         )
         return config

--- a/keras_hub/src/models/vit/vit_image_classifier.py
+++ b/keras_hub/src/models/vit/vit_image_classifier.py
@@ -183,7 +183,7 @@ class ViTImageClassifier(ImageClassifier):
                 "intermediate_dim": self.intermediate_dim,
                 "activation": self.activation,
                 "dropout": self.dropout,
-                "head_dtype": self.head_dtype,
+                "head_dtype": keras.dtype_policies.serialize(self.head_dtype),
             }
         )
         return config

--- a/keras_hub/src/models/vit/vit_image_classifier.py
+++ b/keras_hub/src/models/vit/vit_image_classifier.py
@@ -120,7 +120,6 @@ class ViTImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
-        self.head_dtype = head_dtype
 
         # === Layers ===
         self.backbone = backbone
@@ -168,6 +167,7 @@ class ViTImageClassifier(ImageClassifier):
 
         # === config ===
         self.num_classes = num_classes
+        self.head_dtype = head_dtype
         self.pooling = pooling
         self.intermediate_dim = intermediate_dim
         self.activation = activation

--- a/keras_hub/src/models/vit/vit_image_classifier.py
+++ b/keras_hub/src/models/vit/vit_image_classifier.py
@@ -120,6 +120,7 @@ class ViTImageClassifier(ImageClassifier):
         **kwargs,
     ):
         head_dtype = head_dtype or backbone.dtype_policy
+        self.head_dtype = head_dtype
 
         # === Layers ===
         self.backbone = backbone
@@ -182,6 +183,7 @@ class ViTImageClassifier(ImageClassifier):
                 "intermediate_dim": self.intermediate_dim,
                 "activation": self.activation,
                 "dropout": self.dropout,
+                "head_dtype": self.head_dtype,
             }
         )
         return config


### PR DESCRIPTION
Problem

Turns out, the `head_dtype` serialization bug from #2614 pops up in six other `ImageClassifier` subclasses too.

Here’s what happened: `head_dtype` gets passed into `__init__()` and helps set the dtype policy for classifier head layers. But nobody actually saved it on `self` or included it in `get_config()`. So, every time you saved or loaded the model, that value just disappeared without warning.

Affected Models

- VitImageClassifier → vit/vit_image_classifier.py
- DeiTImageClassifier → deit/deit_image_classifier.py
- VGGImageClassifier → vgg/vgg_image_classifier.py
- MobileNetImageClassifier → mobilenet/mobilenet_image_classifier.py
- MobileNetV5ImageClassifier → mobilenetv5/mobilenetv5_image_classifier.py
- HGNetV2ImageClassifier → hgnetv2/hgnetv2_image_classifier.py

Fix

Just like in #2614, I fixed all six subclasses with two quick changes:

1. Saved `head_dtype` in `__init__()`:
   self.head_dtype = head_dtype

2. Added `head_dtype` to `get_config()`:
   "head_dtype": self.head_dtype,

Result

- Now `head_dtype` sticks around when saving and loading models.
- Serialization matches the base `ImageClassifier`.
- No breaking changes.

Related

This builds on #2614, which patched the same problem in the base `ImageClassifier`. 

cc: @mattdangerw @sachinprasadhs @divyashreepathihalli