### PR TITLE
Remove post layer normalization from MetaCLIP2VisionEncoder 

### DIFF
--- a/keras_hub/src/models/metaclip_2/metaclip_2_vision_encoder.py
+++ b/keras_hub/src/models/metaclip_2/metaclip_2_vision_encoder.py
@@ -107,9 +107,6 @@ class MetaCLIP2VisionEncoder(Backbone):
             )
             for i in range(num_layers)
         ]
-        self.post_layer_norm = layers.LayerNormalization(
-            epsilon=1e-5, dtype=dtype, name=f"{prefix}post_layer_norm"
-        )
 
         # === Functional Model ===
         image_input = layers.Input(shape=image_shape, name="images")


### PR DESCRIPTION
The layer already present in backbone itself as per the structure.


## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
