### PR TITLE
fix: make dropout rate configurable in SegFormerImageSegmenter

### DIFF
--- a/keras_hub/src/models/segformer/segformer_image_segmenter.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter.py
@@ -40,7 +40,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
         projection_filters: int, number of filters in the
             convolution layer projecting the concatenated features into a
             segmentation map. Defaults to 256`.
-        dropout: float. The dropout rate to apply before the
+        dropout_rate: float. The dropout rate to apply before the
             segmentation head. Defaults to `0.1`.
 
 
@@ -123,7 +123,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
         backbone,
         num_classes,
         preprocessor=None,
-        dropout=0.1,
+        dropout_rate=0.1,
         **kwargs,
     ):
         if not isinstance(backbone, keras.layers.Layer) or not isinstance(
@@ -140,7 +140,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
 
         self.backbone = backbone
         self.preprocessor = preprocessor
-        self.dropout = keras.layers.Dropout(dropout)
+        self.dropout = keras.layers.Dropout(dropout_rate)
         self.output_segmentation_head = keras.layers.Conv2D(
             filters=num_classes, kernel_size=1, strides=1
         )
@@ -165,7 +165,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
         # === Config ===
         self.num_classes = num_classes
         self.backbone = backbone
-        self.dropout_rate = dropout
+        self.dropout_rate = dropout_rate
 
     def get_config(self):
         config = super().get_config()
@@ -173,7 +173,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
             {
                 "num_classes": self.num_classes,
                 "backbone": keras.saving.serialize_keras_object(self.backbone),
-                "dropout": self.dropout_rate,
+                "dropout_rate": self.dropout_rate,
             }
         )
         return config

--- a/keras_hub/src/models/segformer/segformer_image_segmenter.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter.py
@@ -40,6 +40,8 @@ class SegFormerImageSegmenter(ImageSegmenter):
         projection_filters: int, number of filters in the
             convolution layer projecting the concatenated features into a
             segmentation map. Defaults to 256`.
+        dropout: float. The dropout rate to apply before the
+            segmentation head. Defaults to `0.1`.
 
 
     Example:
@@ -121,6 +123,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
         backbone,
         num_classes,
         preprocessor=None,
+        dropout=0.1,
         **kwargs,
     ):
         if not isinstance(backbone, keras.layers.Layer) or not isinstance(
@@ -137,7 +140,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
 
         self.backbone = backbone
         self.preprocessor = preprocessor
-        self.dropout = keras.layers.Dropout(0.1)
+        self.dropout = keras.layers.Dropout(dropout)
         self.output_segmentation_head = keras.layers.Conv2D(
             filters=num_classes, kernel_size=1, strides=1
         )
@@ -162,6 +165,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
         # === Config ===
         self.num_classes = num_classes
         self.backbone = backbone
+        self.dropout_rate = dropout
 
     def get_config(self):
         config = super().get_config()
@@ -169,6 +173,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
             {
                 "num_classes": self.num_classes,
                 "backbone": keras.saving.serialize_keras_object(self.backbone),
+                "dropout": self.dropout_rate,
             }
         )
         return config


### PR DESCRIPTION
## Problem

The `SegFormerImageSegmenter` had its dropout rate stuck at `0.1`—no way to change it, no way to save or reload that value with `get_config()`. So, people couldn’t set the dropout rate they wanted, and whatever value was there just disappeared every time they saved or loaded the model.

## Fix

Now you can set the dropout rate yourself. Here’s what changed:
1. Added a `dropout=0.1` parameter to `__init__()`.
2. Used the new `dropout` argument instead of always using `0.1`.
3. Saved this value as `self.dropout_rate` under the config section.
4. Included `"dropout": self.dropout_rate` in `get_config()`.
5. Updated the docstring to reflect these changes.

The default is still `0.1`, so everything works just like before if you don’t set it.

cc: @mattdangerw @sachinprasadhs @divyashreepathihalli