### PR TITLE
Fix `generate` for OpenVino backend.

### DIFF
--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -137,7 +137,7 @@ class CausalLM(Task):
 
             def wrapped_generate_function(inputs, stop_token_ids=None):
                 # Convert to numpy for OpenVINO backend
-                inputs = tree.map_structure(ops.array, inputs)
+                inputs = tree.map_structure(ops.convert_to_numpy, inputs)
                 return ov_infer(
                     self, inputs, stop_token_ids, self.generate_step
                 )


### PR DESCRIPTION
## Description of the change

The `generate` function was using `ops.array` to convert to NumPy. However, that is not what `ops.array` does, and the OpenVino behavior of `ops.array` was fixed to return an `OpenVINOKerasTensor`.

Use `ops.convert_to_numpy` instead.

## Reference

https://github.com/keras-team/keras/commit/5e8a4a1a9656f5bc4b05145bd41f5b46bb12c2f8#diff-2636022d3080ecc6561123fb4eea436990b67d350276decf78a35d61bc063c2b
