### PR TITLE
 Register T5Gemma2 Model Presets to Hub

### DIFF
--- a/keras_hub/src/models/t5gemma2/t5gemma2_presets.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_presets.py
@@ -1,4 +1,41 @@
 backbone_presets = {
-    # Placeholder presets — will be populated when checkpoints
-    # are made available.
+    "t5gemma2_270m_270m": {
+        "metadata": {
+            "description": (
+                "Encoder–decoder (T5-style) based out of Gemma3 model with "
+                "270M encoder + 270M decoder parameters, "
+                "supporting text generation, multilingual tasks "
+                "and long-context inputs."
+            ),
+            "params": 953800816,
+            "path": "t5gemma2",
+        },
+        "kaggle_handle": "kaggle://keras/t5gemma-2/keras/t5gemma2_270m_270m/1",
+    },
+    "t5gemma2_1b_1b": {
+        "metadata": {
+            "description": (
+                "Encoder–decoder (T5-style) based out of Gemma3 model with "
+                "1B encoder + 1B decoder parameters, "
+                "supporting text generation, multilingual tasks "
+                "and long-context inputs."
+            ),
+            "params": 2417966192,
+            "path": "t5gemma2",
+        },
+        "kaggle_handle": "kaggle://keras/t5gemma-2/keras/t5gemma2_1b_1b/1",
+    },
+    "t5gemma2_4b_4b": {
+        "metadata": {
+            "description": (
+                "Encoder–decoder (T5-style) based out of Gemma3 model with "
+                "4B encoder + 4B decoder parameters, "
+                "supporting text generation, multilingual tasks "
+                "and long-context inputs."
+            ),
+            "params": 8180020080,
+            "path": "t5gemma2",
+        },
+        "kaggle_handle": "kaggle://keras/t5gemma-2/keras/t5gemma2_4b_4b/1",
+    },
 }


### PR DESCRIPTION
## Description of the change

Registering T5Gemma presets to the hub for the recently merged T5Gemma2 models code. #2619 

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
