### PR TITLE
Fix/sentencepiece import pattern

### DIFF
--- a/keras_hub/src/models/t5gemma/t5gemma_tokenizer.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_tokenizer.py
@@ -37,7 +37,7 @@ class T5GemmaTokenizer(SentencePieceTokenizer):
     ```python
     import io
     import tensorflow as tf
-    import sentencepiece
+    from sentencepiece import SentencePieceTrainer
 
     # Unbatched input.
     tokenizer = keras_hub.models.T5GemmaTokenizer.from_preset(
@@ -54,7 +54,7 @@ class T5GemmaTokenizer(SentencePieceTokenizer):
     # Custom vocabulary.
     bytes_io = io.BytesIO()
     ds = tf.data.Dataset.from_tensor_slices(["The quick brown fox jumped."])
-    sentencepiece.SentencePieceTrainer.train(
+    SentencePieceTrainer.train(
         sentence_iterator=ds.as_numpy_iterator(),
         model_writer=bytes_io,
         vocab_size=8,

--- a/keras_hub/src/tests/doc_tests/docstring_test.py
+++ b/keras_hub/src/tests/doc_tests/docstring_test.py
@@ -7,7 +7,8 @@ import unittest
 import keras
 import numpy as np
 import pytest
-import sentencepiece
+from sentencepiece import SentencePieceProcessor
+from sentencepiece import SentencePieceTrainer
 import tensorflow as tf
 
 import keras_hub
@@ -121,7 +122,8 @@ def test_fenced_docstrings(docstring_module):
                     "keras": keras,
                     "keras_hub": keras_hub,
                     "io": io,
-                    "sentencepiece": sentencepiece,
+                    "SentencePieceTrainer": SentencePieceTrainer,
+                    "SentencePieceProcessor": SentencePieceProcessor,
                 },
                 checker=docstring_lib.DoctestOutputChecker(),
                 optionflags=(

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
@@ -61,8 +61,9 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
     From bytes.
     ```python
     def train_sentence_piece_bytes(ds, size):
+        from sentencepiece import SentencePieceTrainer
         bytes_io = io.BytesIO()
-        sentencepiece.SentencePieceTrainer.train(
+        SentencePieceTrainer.train(
             sentence_iterator=ds.as_numpy_iterator(),
             model_writer=bytes_io,
             vocab_size=size,
@@ -80,8 +81,9 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
     From a file.
     ```python
     def train_sentence_piece_file(ds, path, size):
+        from sentencepiece import SentencePieceTrainer
         with open(path, "wb") as model_file:
-            sentencepiece.SentencePieceTrainer.train(
+            SentencePieceTrainer.train(
                 sentence_iterator=ds.as_numpy_iterator(),
                 model_writer=model_file,
                 vocab_size=size,

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer_trainer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer_trainer.py
@@ -3,10 +3,13 @@ import io
 from keras_hub.src.utils.tensor_utils import assert_tf_libs_installed
 
 try:
-    import sentencepiece as spm
+    from sentencepiece import SentencePieceTrainer
+except ImportError:
+    SentencePieceTrainer = None
+
+try:
     import tensorflow as tf
 except ImportError:
-    spm = None
     tf = None
 
 from keras_hub.src.api_export import keras_hub_export
@@ -81,7 +84,7 @@ def compute_sentence_piece_proto(
     """
     assert_tf_libs_installed("compute_sentence_piece_proto")
 
-    if spm is None:
+    if SentencePieceTrainer is None:
         raise ImportError(
             f"{compute_sentence_piece_proto.__name__} requires the "
             "`sentencepiece` package. Please install it with "
@@ -105,7 +108,7 @@ def compute_sentence_piece_proto(
         open(proto_output_file, "wb") if proto_output_file else io.BytesIO()
     )
     if tf is not None and isinstance(data, tf.data.Dataset):
-        spm.SentencePieceTrainer.train(
+        SentencePieceTrainer.train(
             sentence_iterator=data.as_numpy_iterator(),
             model_writer=model_writer,
             vocab_size=vocabulary_size,
@@ -117,7 +120,7 @@ def compute_sentence_piece_proto(
             eos_id=3,
         )
     else:
-        spm.SentencePieceTrainer.train(
+        SentencePieceTrainer.train(
             input=data,
             model_writer=model_writer,
             vocab_size=vocabulary_size,

--- a/keras_hub/src/tokenizers/v2/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/v2/sentence_piece_tokenizer.py
@@ -4,7 +4,12 @@ import os
 
 import keras
 import numpy as np
-import sentencepiece as spm
+
+try:
+    from sentencepiece import SentencePieceProcessor
+except ImportError:
+    SentencePieceProcessor = None
+
 from keras.src.saving import serialization_lib
 
 from keras_hub.src.api_export import keras_hub_export
@@ -120,7 +125,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
                 f"Received unknown type: {type(proto)}"
             )
 
-        self._sentence_piece = spm.SentencePieceProcessor()
+        self._sentence_piece = SentencePieceProcessor()
         self._sentence_piece.Init(
             model_proto=proto_bytes,
             out_type=str if is_string_dtype(self.compute_dtype) else int,


### PR DESCRIPTION
This pull request refactors how the `sentencepiece` library is imported and used throughout the codebase, improving clarity and reducing ambiguity. Instead of importing the entire `sentencepiece` module, the code now imports specific classes (`SentencePieceTrainer` and `SentencePieceProcessor`) directly where needed. This change also updates all relevant usage and test code to match the new import style.

**Refactoring of sentencepiece imports and usage:**

* Replaced all `import sentencepiece` or `import sentencepiece as spm` statements with direct imports of `SentencePieceTrainer` and `SentencePieceProcessor` as needed in `keras_hub/src/models/t5gemma/t5gemma_tokenizer.py`, `keras_hub/src/tokenizers/sentence_piece_tokenizer.py`, `keras_hub/src/tokenizers/sentence_piece_tokenizer_trainer.py`, and `keras_hub/src/tokenizers/v2/sentence_piece_tokenizer.py`. [[1]](diffhunk://#diff-71f71857c6b1a60c11c5d4eb7cf7ed537adb9989c812dd8ba461a647244d4569L40-R40) [[2]](diffhunk://#diff-71f71857c6b1a60c11c5d4eb7cf7ed537adb9989c812dd8ba461a647244d4569L57-R57) [[3]](diffhunk://#diff-f91e54f6347cf121411b90278e032a41d6057827cf43964080b226bfd2fc897cR64-R66) [[4]](diffhunk://#diff-f91e54f6347cf121411b90278e032a41d6057827cf43964080b226bfd2fc897cR84-R86) [[5]](diffhunk://#diff-a556954ba0c0da86fbfe502b4fb62c007383fd1f01bd6b80cf12052f6397c9c4L6-L9) [[6]](diffhunk://#diff-acfc909c5be26ad2e01ada2b7053d09dc7409efd7ca7f924e14a0e8f14a2c101L7-R12)
* Updated all usages of `sentencepiece.SentencePieceTrainer.train` and `spm.SentencePieceTrainer.train` to use `SentencePieceTrainer.train` directly. [[1]](diffhunk://#diff-71f71857c6b1a60c11c5d4eb7cf7ed537adb9989c812dd8ba461a647244d4569L57-R57) [[2]](diffhunk://#diff-f91e54f6347cf121411b90278e032a41d6057827cf43964080b226bfd2fc897cR64-R66) [[3]](diffhunk://#diff-f91e54f6347cf121411b90278e032a41d6057827cf43964080b226bfd2fc897cR84-R86) [[4]](diffhunk://#diff-a556954ba0c0da86fbfe502b4fb62c007383fd1f01bd6b80cf12052f6397c9c4L108-R111) [[5]](diffhunk://#diff-a556954ba0c0da86fbfe502b4fb62c007383fd1f01bd6b80cf12052f6397c9c4L120-R123)
* Updated the initialization of `SentencePieceProcessor` to use the directly imported class instead of referencing it from the module.

**Testing and docstring updates:**

* Updated test imports and doctest environments to use the new import style for `SentencePieceTrainer` and `SentencePieceProcessor` in `keras_hub/src/tests/doc_tests/docstring_test.py`. [[1]](diffhunk://#diff-5e9ddee1880caf563bb9c5a9db871b480192bbdd5e2cabeb83377da67ffcfad9L10-R11) [[2]](diffhunk://#diff-5e9ddee1880caf563bb9c5a9db871b480192bbdd5e2cabeb83377da67ffcfad9L124-R126)

**Error handling improvements:**

* Improved ImportError handling by checking for the presence of `SentencePieceTrainer` and `SentencePieceProcessor` instead of the whole module, providing clearer error messages if the classes are unavailable. [[1]](diffhunk://#diff-a556954ba0c0da86fbfe502b4fb62c007383fd1f01bd6b80cf12052f6397c9c4L6-L9) [[2]](diffhunk://#diff-a556954ba0c0da86fbfe502b4fb62c007383fd1f01bd6b80cf12052f6397c9c4L84-R87)## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
