### PR TITLE
fix(models): Fix D-FINE crash when num_classes differs from backbone num_labels

### DIFF
--- a/keras_hub/src/models/d_fine/d_fine_object_detector.py
+++ b/keras_hub/src/models/d_fine/d_fine_object_detector.py
@@ -416,7 +416,7 @@ class DFineObjectDetector(ObjectDetector):
         if num_classes != backbone.num_labels:
             config = backbone.get_config()
             config["num_labels"] = num_classes
-            backbone = DFineBackbone.from_config(config)
+            backbone = backbone.__class__.from_config(config)
 
         # === Functional Model ===
         image_input = keras.layers.Input(

--- a/keras_hub/src/models/d_fine/d_fine_object_detector.py
+++ b/keras_hub/src/models/d_fine/d_fine_object_detector.py
@@ -413,6 +413,11 @@ class DFineObjectDetector(ObjectDetector):
     ):
         assert_bounding_box_support(self.__class__.__name__)
 
+        if num_classes != backbone.num_labels:
+            config = backbone.get_config()
+            config["num_labels"] = num_classes
+            backbone = DFineBackbone.from_config(config)
+
         # === Functional Model ===
         image_input = keras.layers.Input(
             shape=backbone.image_shape, name="images"

--- a/keras_hub/src/models/d_fine/d_fine_object_detector_test.py
+++ b/keras_hub/src/models/d_fine/d_fine_object_detector_test.py
@@ -138,6 +138,27 @@ class DFineObjectDetectorTest(TestCase):
             },
         )
 
+    def test_num_classes_mismatch(self):
+        backbone = DFineBackbone(**self.base_backbone_kwargs)
+        self.assertEqual(backbone.num_labels, 4)
+        init_kwargs = {
+            "backbone": backbone,
+            "num_classes": 2,
+            "bounding_box_format": self.bounding_box_format,
+            "preprocessor": self.preprocessor,
+        }
+        self.run_task_test(
+            cls=DFineObjectDetector,
+            init_kwargs=init_kwargs,
+            train_data=self.train_data,
+            expected_output_shape={
+                "boxes": (1, 10, 4),
+                "labels": (1, 10),
+                "confidence": (1, 10),
+                "num_detections": (1,),
+            },
+        )
+
     @pytest.mark.large
     def test_saved_model(self):
         backbone = DFineBackbone(**self.base_backbone_kwargs)


### PR DESCRIPTION
### Description of the change
Yooo :)))))
→ Fix shape mismatch when fine-tuning `DFineObjectDetector` with a custom `num_classes` that differs from the pretrained  backbone's `num_labels` (e.g., using `dfine_nano_coco` with 80 classes but fine-tuning on 5).                                             
→ We rebuild the backbone from its config with the updated num_labels when a mismatch is detected in `DFineObjectDetector.init`, pretty similar to the pattern I had accounted for in the seminal PR [here](https://github.com/keras-team/keras-hub/blob/v0.27.1/keras_hub/src/models/d_fine/d_fine_backbone.py#L347-L361).          
→ Add test coverage for the `num_classes != num_labels` so we don't see any future regressions :)
  
<img alt="image" src="https://github.com/user-attachments/assets/eecf63ab-8247-4ff7-ad8f-600e7bd53bcd" /><br>
  
Fixes #2654.

cc: @divyashreepathihalli @abheesht17

### Checklist
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about)