### PR TITLE
Replace eval() with ast.literal_eval() in RWKVTokenizer

### DIFF
--- a/keras_hub/src/models/rwkv7/rwkv7_tokenizer.py
+++ b/keras_hub/src/models/rwkv7/rwkv7_tokenizer.py
@@ -1,3 +1,4 @@
+import ast
 import os
 
 import keras
@@ -114,7 +115,7 @@ class RWKVTokenizerBase:
         self.idx2token = {}
         for line in vocabs:
             idx = int(line[: line.index(" ")])
-            x = eval(line[line.index(" ") : line.rindex(" ")])
+            x = ast.literal_eval(line[line.index(" ") : line.rindex(" ")])
             x = x.encode("utf-8") if isinstance(x, str) else x
             assert isinstance(x, bytes)
             assert len(x) == int(line[line.rindex(" ") :])
@@ -272,7 +273,9 @@ class RWKVTokenizer(tokenizer.Tokenizer):
         if self.end_token_id is None or self.end_token_id == self.pad_token_id:
             for line in vocabulary:
                 idx = int(line[: line.index(" ")])
-                repr_str = eval(line[line.index(" ") : line.rindex(" ")])
+                repr_str = ast.literal_eval(
+                    line[line.index(" ") : line.rindex(" ")]
+                )
                 if repr_str == "\n\n":
                     self.end_token_id = idx
                     break

--- a/keras_hub/src/models/rwkv7/rwkv7_tokenizer.py
+++ b/keras_hub/src/models/rwkv7/rwkv7_tokenizer.py
@@ -271,12 +271,8 @@ class RWKVTokenizer(tokenizer.Tokenizer):
         self.vocabulary = vocabulary
         self._tokenizer = RWKVTokenizerBase(vocabulary)
         if self.end_token_id is None or self.end_token_id == self.pad_token_id:
-            for line in vocabulary:
-                idx = int(line[: line.index(" ")])
-                repr_str = ast.literal_eval(
-                    line[line.index(" ") : line.rindex(" ")]
-                )
-                if repr_str == "\n\n":
+            for idx, token in self._tokenizer.idx2token.items():
+                if token.decode("utf-8", errors="replace") == "\n\n":
                     self.end_token_id = idx
                     break
 

--- a/keras_hub/src/models/rwkv7/rwkv7_tokenizer_test.py
+++ b/keras_hub/src/models/rwkv7/rwkv7_tokenizer_test.py
@@ -77,3 +77,24 @@ class RWKVTokenizerTest(TestCase):
             input_data=["hello world", "def function", "pythoncodereturn"],
             expected_output=[[5, 1, 6], [3, 1, 9], [7, 4, 8]],
         )
+
+    def test_rejects_non_literal_vocab_entries(self):
+        malicious_vocab = [
+            "0 __import__('os').system('echo pwned') 1",
+        ]
+        with self.assertRaises((ValueError, SyntaxError)):
+            RWKVTokenizer(
+                vocabulary=malicious_vocab,
+                pad_token_id=0,
+            )
+
+    def test_bytes_literal_vocab(self):
+        vocab = [
+            r"0 b'\x00' 1",
+            r"1 b'\x01' 1",
+        ]
+        tok = RWKVTokenizer(
+            vocabulary=vocab,
+            pad_token_id=0,
+        )
+        self.assertEqual(tok.vocabulary_size(), 2)


### PR DESCRIPTION
## Description of the change

Replace `eval()` with `ast.literal_eval()` in `RWKVTokenizerBase.__init__`
and `RWKVTokenizer.set_vocabulary` for parsing vocabulary file entries.

`ast.literal_eval()` safely evaluates only Python literal structures
(strings, bytes, numbers, tuples, lists, dicts, sets, booleans, and None),
which is sufficient for the vocabulary format (`<idx> <repr> <len>`) while
being a safer alternative to `eval()`. This follows Python security best
practices for parsing untrusted string representations.

## Reference

- [Python docs: ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval)
- [CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code](https://cwe.mitre.org/data/definitions/95.html)

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).