### PR TITLE
fixing public export for tokenizers

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -624,6 +624,9 @@ from keras_hub.src.models.qwen3_moe.qwen3_moe_causal_lm import (
 from keras_hub.src.models.qwen3_moe.qwen3_moe_causal_lm_preprocessor import (
     Qwen3MoeCausalLMPreprocessor as Qwen3MoeCausalLMPreprocessor,
 )
+from keras_hub.src.models.qwen3_moe.qwen3_moe_tokenizer import (
+    Qwen3MoeTokenizer as Qwen3MoeTokenizer,
+)
 from keras_hub.src.models.qwen_moe.qwen_moe_backbone import (
     QwenMoeBackbone as QwenMoeBackbone,
 )
@@ -632,6 +635,9 @@ from keras_hub.src.models.qwen_moe.qwen_moe_causal_lm import (
 )
 from keras_hub.src.models.qwen_moe.qwen_moe_causal_lm_preprocessor import (
     QwenMoeCausalLMPreprocessor as QwenMoeCausalLMPreprocessor,
+)
+from keras_hub.src.models.qwen_moe.qwen_moe_tokenizer import (
+    QwenMoeTokenizer as QwenMoeTokenizer,
 )
 from keras_hub.src.models.resnet.resnet_backbone import (
     ResNetBackbone as ResNetBackbone,
@@ -701,6 +707,9 @@ from keras_hub.src.models.rwkv7.rwkv7_causal_lm import (
 )
 from keras_hub.src.models.rwkv7.rwkv7_causal_lm_preprocessor import (
     RWKV7CausalLMPreprocessor as RWKV7CausalLMPreprocessor,
+)
+from keras_hub.src.models.rwkv7.rwkv7_tokenizer import (
+    RWKVTokenizer as RWKVTokenizer,
 )
 from keras_hub.src.models.sam.sam_backbone import SAMBackbone as SAMBackbone
 from keras_hub.src.models.sam.sam_image_segmenter import (

--- a/keras_hub/api/tokenizers/__init__.py
+++ b/keras_hub/api/tokenizers/__init__.py
@@ -90,6 +90,12 @@ from keras_hub.src.models.qwen.qwen_tokenizer import (
 from keras_hub.src.models.qwen.qwen_tokenizer import (
     QwenTokenizer as QwenTokenizer,
 )
+from keras_hub.src.models.qwen3.qwen3_tokenizer import (
+    Qwen3Tokenizer as Qwen3Tokenizer,
+)
+from keras_hub.src.models.qwen3_5.qwen3_5_tokenizer import (
+    Qwen3_5Tokenizer as Qwen3_5Tokenizer,
+)
 from keras_hub.src.models.qwen3_moe.qwen3_moe_tokenizer import (
     Qwen3MoeTokenizer as Qwen3MoeTokenizer,
 )

--- a/keras_hub/src/models/qwen3/qwen3_tokenizer.py
+++ b/keras_hub/src/models/qwen3/qwen3_tokenizer.py
@@ -4,7 +4,10 @@ from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 
 
 @keras_hub_export(
-    "keras_hub.models.Qwen3Tokenizer",
+    [
+        "keras_hub.tokenizers.Qwen3Tokenizer",
+        "keras_hub.models.Qwen3Tokenizer",
+    ]
 )
 class Qwen3Tokenizer(BytePairTokenizer):
     """Tokenizer for Qwen3 models.

--- a/keras_hub/src/models/qwen3_5/qwen3_5_tokenizer.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_tokenizer.py
@@ -3,7 +3,12 @@ from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
 from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 
 
-@keras_hub_export("keras_hub.models.Qwen3_5Tokenizer")
+@keras_hub_export(
+    [
+        "keras_hub.tokenizers.Qwen3_5Tokenizer",
+        "keras_hub.models.Qwen3_5Tokenizer",
+    ]
+)
 class Qwen3_5Tokenizer(BytePairTokenizer):
     """Tokenizer for Qwen3.5 models.
 

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_tokenizer.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_tokenizer.py
@@ -4,7 +4,10 @@ from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 
 
 @keras_hub_export(
-    "keras_hub.tokenizers.Qwen3MoeTokenizer",
+    [
+        "keras_hub.tokenizers.Qwen3MoeTokenizer",
+        "keras_hub.models.Qwen3MoeTokenizer",
+    ]
 )
 class Qwen3MoeTokenizer(BytePairTokenizer):
     """Tokenizer for Qwen Moe model.

--- a/keras_hub/src/models/qwen_moe/qwen_moe_tokenizer.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_tokenizer.py
@@ -4,7 +4,10 @@ from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 
 
 @keras_hub_export(
-    "keras_hub.tokenizers.QwenMoeTokenizer",
+    [
+        "keras_hub.tokenizers.QwenMoeTokenizer",
+        "keras_hub.models.QwenMoeTokenizer",
+    ]
 )
 class QwenMoeTokenizer(BytePairTokenizer):
     """Tokenizer for Qwen Moe model.

--- a/keras_hub/src/models/rwkv7/rwkv7_tokenizer.py
+++ b/keras_hub/src/models/rwkv7/rwkv7_tokenizer.py
@@ -203,7 +203,12 @@ class RWKVTokenizerBase:
         print()
 
 
-@keras_hub_export("keras_hub.tokenizers.RWKVTokenizer")
+@keras_hub_export(
+    [
+        "keras_hub.tokenizers.RWKVTokenizer",
+        "keras_hub.models.RWKVTokenizer",
+    ]
+)
 class RWKVTokenizer(tokenizer.Tokenizer):
     """RWKV byte-level tokenizer with longest-match trie search.
 


### PR DESCRIPTION
## Description of the change
Updated `@keras_hub_export` decorator for some models to export tokenizer to both `keras_hub.tokenizers.*` and `keras_hub.models.*` namespaces

## Reference
Fixes #2684 

## Colab Notebook
N/A

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
