### PR TITLE
Add yarn RoPE and tie_word_embeddings to MistralBackbone

### DIFF
--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -35,7 +35,7 @@ class CachedMistralAttention(keras.layers.Layer):
         self._num_key_value_heads = num_key_value_heads
         self._sliding_window = sliding_window
         self._dropout = dropout
-        self._configured_head_dim = head_dim
+        self._head_dim = head_dim
 
         self._num_key_value_groups = num_query_heads // num_key_value_heads
         self._rope_max_wavelength = rope_max_wavelength
@@ -56,9 +56,7 @@ class CachedMistralAttention(keras.layers.Layer):
         # v = num key/value heads
         # h = head dim
         self._hidden_dim = inputs_shape[-1]
-        if self._configured_head_dim is not None:
-            self._head_dim = self._configured_head_dim
-        else:
+        if self._head_dim is None:
             self._head_dim = self._hidden_dim // self._num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(self._head_dim)
 
@@ -244,7 +242,7 @@ class CachedMistralAttention(keras.layers.Layer):
                 ),
                 "sliding_window": self._sliding_window,
                 "dropout": self._dropout,
-                "head_dim": self._configured_head_dim,
+                "head_dim": self._head_dim,
             }
         )
         return config

--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -27,6 +27,7 @@ class CachedMistralAttention(keras.layers.Layer):
         kernel_initializer="glorot_uniform",
         sliding_window=512,
         dropout=0,
+        head_dim=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -34,6 +35,7 @@ class CachedMistralAttention(keras.layers.Layer):
         self._num_key_value_heads = num_key_value_heads
         self._sliding_window = sliding_window
         self._dropout = dropout
+        self._configured_head_dim = head_dim
 
         self._num_key_value_groups = num_query_heads // num_key_value_heads
         self._rope_max_wavelength = rope_max_wavelength
@@ -54,7 +56,10 @@ class CachedMistralAttention(keras.layers.Layer):
         # v = num key/value heads
         # h = head dim
         self._hidden_dim = inputs_shape[-1]
-        self._head_dim = self._hidden_dim // self._num_query_heads
+        if self._configured_head_dim is not None:
+            self._head_dim = self._configured_head_dim
+        else:
+            self._head_dim = self._hidden_dim // self._num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(self._head_dim)
 
         self._query_dense = keras.layers.EinsumDense(
@@ -239,6 +244,7 @@ class CachedMistralAttention(keras.layers.Layer):
                 ),
                 "sliding_window": self._sliding_window,
                 "dropout": self._dropout,
+                "head_dim": self._configured_head_dim,
             }
         )
         return config

--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -28,6 +28,10 @@ class CachedMistralAttention(keras.layers.Layer):
         sliding_window=512,
         dropout=0,
         head_dim=None,
+        rope_type="linear",
+        rope_beta_fast=32.0,
+        rope_beta_slow=1.0,
+        rope_original_max_position_embeddings=4096,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -45,6 +49,12 @@ class CachedMistralAttention(keras.layers.Layer):
         )
 
         self._rope_scaling_factor = rope_scaling_factor
+        self._rope_type = rope_type
+        self._rope_beta_fast = rope_beta_fast
+        self._rope_beta_slow = rope_beta_slow
+        self._rope_original_max_position_embeddings = (
+            rope_original_max_position_embeddings
+        )
 
     def build(self, inputs_shape):
         # Einsum variables:
@@ -120,6 +130,12 @@ class CachedMistralAttention(keras.layers.Layer):
         self.rotary_embedding_layer = RotaryEmbedding(
             max_wavelength=self._rope_max_wavelength,
             scaling_factor=self._rope_scaling_factor,
+            rope_type=self._rope_type,
+            beta_fast=self._rope_beta_fast,
+            beta_slow=self._rope_beta_slow,
+            original_max_position_embeddings=(
+                self._rope_original_max_position_embeddings
+            ),
             dtype=self.dtype_policy,
         )
 
@@ -243,6 +259,12 @@ class CachedMistralAttention(keras.layers.Layer):
                 "sliding_window": self._sliding_window,
                 "dropout": self._dropout,
                 "head_dim": self._head_dim,
+                "rope_type": self._rope_type,
+                "rope_beta_fast": self._rope_beta_fast,
+                "rope_beta_slow": self._rope_beta_slow,
+                "rope_original_max_position_embeddings": (
+                    self._rope_original_max_position_embeddings
+                ),
             }
         )
         return config

--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -30,6 +30,10 @@ class CachedMistralAttention(keras.layers.Layer):
         sliding_window=512,
         dropout=0,
         head_dim=None,
+        rope_type="linear",
+        rope_beta_fast=32.0,
+        rope_beta_slow=1.0,
+        rope_original_max_position_embeddings=4096,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -47,6 +51,12 @@ class CachedMistralAttention(keras.layers.Layer):
         )
 
         self._rope_scaling_factor = rope_scaling_factor
+        self._rope_type = rope_type
+        self._rope_beta_fast = rope_beta_fast
+        self._rope_beta_slow = rope_beta_slow
+        self._rope_original_max_position_embeddings = (
+            rope_original_max_position_embeddings
+        )
 
     def build(self, inputs_shape):
         # Einsum variables:
@@ -122,6 +132,12 @@ class CachedMistralAttention(keras.layers.Layer):
         self.rotary_embedding_layer = RotaryEmbedding(
             max_wavelength=self._rope_max_wavelength,
             scaling_factor=self._rope_scaling_factor,
+            rope_type=self._rope_type,
+            beta_fast=self._rope_beta_fast,
+            beta_slow=self._rope_beta_slow,
+            original_max_position_embeddings=(
+                self._rope_original_max_position_embeddings
+            ),
             dtype=self.dtype_policy,
         )
 
@@ -287,6 +303,12 @@ class CachedMistralAttention(keras.layers.Layer):
                 "sliding_window": self._sliding_window,
                 "dropout": self._dropout,
                 "head_dim": self._head_dim,
+                "rope_type": self._rope_type,
+                "rope_beta_fast": self._rope_beta_fast,
+                "rope_beta_slow": self._rope_beta_slow,
+                "rope_original_max_position_embeddings": (
+                    self._rope_original_max_position_embeddings
+                ),
             }
         )
         return config

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -52,7 +52,13 @@ class MistralBackbone(Backbone):
             attention layers. This controls the maximum cache size for the
             attention layers in each transformer decoder. Only `sliding_window`
             number of tokens are saved in the cache and used to generate the
-            next token. Defaults to `512`.
+            next token. Defaults to `512`. Pass `None` to disable sliding
+            window attention entirely (e.g. Magistral).
+        head_dim (int, optional): The size of each attention head. When
+            `None` (the default), falls back to `hidden_dim // num_query_heads`.
+            Set explicitly when the model's head size is not a multiple of
+            `hidden_dim / num_query_heads` — e.g. Magistral uses
+            `head_dim=128` with `hidden_dim=5120` and `num_query_heads=32`.
         dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
             for model computations and weights. Note that some computations,
             such as softmax and layer normalization, will always be done at
@@ -98,6 +104,7 @@ class MistralBackbone(Backbone):
         rope_scaling_factor=1.0,
         layer_norm_epsilon=1e-6,
         sliding_window=512,
+        head_dim=None,
         dropout=0,
         dtype=None,
         **kwargs,
@@ -123,6 +130,7 @@ class MistralBackbone(Backbone):
                 activation=ops.silu,
                 kernel_initializer=_mistral_kernel_initializer(stddev=0.02),
                 sliding_window=sliding_window,
+                head_dim=head_dim,
                 dropout=dropout,
                 dtype=dtype,
                 name=f"transformer_layer_{i}",
@@ -165,6 +173,7 @@ class MistralBackbone(Backbone):
         self.num_key_value_heads = num_key_value_heads
         self.rope_scaling_factor = rope_scaling_factor
         self.sliding_window = sliding_window
+        self.head_dim = head_dim
         self.layer_norm_epsilon = layer_norm_epsilon
         self.dropout = dropout
 
@@ -181,6 +190,7 @@ class MistralBackbone(Backbone):
                 "rope_scaling_factor": self.rope_scaling_factor,
                 "num_key_value_heads": self.num_key_value_heads,
                 "sliding_window": self.sliding_window,
+                "head_dim": self.head_dim,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "dropout": self.dropout,
             }

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -56,8 +56,8 @@ class MistralBackbone(Backbone):
             window attention entirely (e.g. Magistral).
         head_dim (int, optional): The size of each attention head. When
             `None` (the default), falls back to `hidden_dim // num_query_heads`.
-            Set explicitly when the model's head size is not a multiple of
-            `hidden_dim / num_query_heads` — e.g. Magistral uses
+            Set explicitly when the model's head size is not equal to
+            `hidden_dim // num_query_heads` — e.g. Magistral uses
             `head_dim=128` with `hidden_dim=5120` and `num_query_heads=32`.
         dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
             for model computations and weights. Note that some computations,

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -59,6 +59,19 @@ class MistralBackbone(Backbone):
             Set explicitly when the model's head size is not equal to
             `hidden_dim // num_query_heads` — e.g. Magistral uses
             `head_dim=128` with `hidden_dim=5120` and `num_query_heads=32`.
+        rope_type (str, optional): RoPE scaling type — one of `"linear"`,
+            `"dynamic"`, or `"yarn"`. Defaults to `"linear"` (no scaling).
+            Ministral 3 uses `"yarn"`.
+        rope_beta_fast (float, optional): YaRN `beta_fast`. Only used when
+            `rope_type="yarn"`. Defaults to `32.0`.
+        rope_beta_slow (float, optional): YaRN `beta_slow`. Only used when
+            `rope_type="yarn"`. Defaults to `1.0`.
+        rope_original_max_position_embeddings (int, optional): Original
+            context length used to compute the YaRN scaling. Only used when
+            `rope_type="yarn"`. Defaults to `4096`.
+        tie_word_embeddings (bool, optional): Whether the token embedding
+            matrix is shared with the output projection. Defaults to `False`.
+            Ministral 3 uses `True`.
         dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
             for model computations and weights. Note that some computations,
             such as softmax and layer normalization, will always be done at
@@ -105,6 +118,11 @@ class MistralBackbone(Backbone):
         layer_norm_epsilon=1e-6,
         sliding_window=512,
         head_dim=None,
+        rope_type="linear",
+        rope_beta_fast=32.0,
+        rope_beta_slow=1.0,
+        rope_original_max_position_embeddings=4096,
+        tie_word_embeddings=False,
         dropout=0,
         dtype=None,
         **kwargs,
@@ -113,7 +131,7 @@ class MistralBackbone(Backbone):
         self.token_embedding = ReversibleEmbedding(
             input_dim=vocabulary_size,
             output_dim=hidden_dim,
-            tie_weights=False,
+            tie_weights=tie_word_embeddings,
             embeddings_initializer=_mistral_kernel_initializer(stddev=0.01),
             dtype=dtype,
             name="token_embedding",
@@ -131,6 +149,12 @@ class MistralBackbone(Backbone):
                 kernel_initializer=_mistral_kernel_initializer(stddev=0.02),
                 sliding_window=sliding_window,
                 head_dim=head_dim,
+                rope_type=rope_type,
+                rope_beta_fast=rope_beta_fast,
+                rope_beta_slow=rope_beta_slow,
+                rope_original_max_position_embeddings=(
+                    rope_original_max_position_embeddings
+                ),
                 dropout=dropout,
                 dtype=dtype,
                 name=f"transformer_layer_{i}",
@@ -174,6 +198,13 @@ class MistralBackbone(Backbone):
         self.rope_scaling_factor = rope_scaling_factor
         self.sliding_window = sliding_window
         self.head_dim = head_dim
+        self.rope_type = rope_type
+        self.rope_beta_fast = rope_beta_fast
+        self.rope_beta_slow = rope_beta_slow
+        self.rope_original_max_position_embeddings = (
+            rope_original_max_position_embeddings
+        )
+        self.tie_word_embeddings = tie_word_embeddings
         self.layer_norm_epsilon = layer_norm_epsilon
         self.dropout = dropout
 
@@ -191,6 +222,13 @@ class MistralBackbone(Backbone):
                 "num_key_value_heads": self.num_key_value_heads,
                 "sliding_window": self.sliding_window,
                 "head_dim": self.head_dim,
+                "rope_type": self.rope_type,
+                "rope_beta_fast": self.rope_beta_fast,
+                "rope_beta_slow": self.rope_beta_slow,
+                "rope_original_max_position_embeddings": (
+                    self.rope_original_max_position_embeddings
+                ),
+                "tie_word_embeddings": self.tie_word_embeddings,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "dropout": self.dropout,
             }

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -42,6 +42,26 @@ class MistralBackboneTest(TestCase):
         # Reference value calculated using the PyTorch model
         self.assertEqual(model.count_params(), 2704)
 
+    def test_explicit_head_dim(self):
+        # Magistral-style config: `head_dim` is set explicitly and does not
+        # equal `hidden_dim // num_query_heads`. `sliding_window=None` is
+        # also exercised here.
+        kwargs = {
+            "vocabulary_size": 10,
+            "num_layers": 2,
+            "num_query_heads": 8,
+            "num_key_value_heads": 4,
+            "hidden_dim": 16,
+            "intermediate_dim": 8,
+            "sliding_window": None,
+            "head_dim": 4,
+        }
+        model = MistralBackbone(**kwargs)
+        output = model(self.input_data)
+        self.assertEqual(tuple(ops.shape(output)), (2, 5, 16))
+        attention = model.transformer_layers[0]._self_attention_layer
+        self.assertEqual(attention._head_dim, 4)
+
     @pytest.mark.extra_large
     def test_smallest_preset(self):
         self.run_preset_test(

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -42,6 +42,33 @@ class MistralBackboneTest(TestCase):
         # Reference value calculated using the PyTorch model
         self.assertEqual(model.count_params(), 2704)
 
+    def test_yarn_rope_and_tied_embeddings(self):
+        # Ministral 3 text-side config: YaRN RoPE + tied word embeddings.
+        kwargs = {
+            "vocabulary_size": 10,
+            "num_layers": 2,
+            "num_query_heads": 8,
+            "num_key_value_heads": 4,
+            "hidden_dim": 16,
+            "intermediate_dim": 8,
+            "sliding_window": None,
+            "head_dim": 4,
+            "rope_type": "yarn",
+            "rope_max_wavelength": 1_000_000,
+            "rope_scaling_factor": 8.0,
+            "rope_original_max_position_embeddings": 64,
+            "tie_word_embeddings": True,
+        }
+        model = MistralBackbone(**kwargs)
+        output = model(self.input_data)
+        self.assertEqual(tuple(ops.shape(output)), (2, 5, 16))
+        rope = model.transformer_layers[
+            0
+        ]._self_attention_layer.rotary_embedding_layer
+        self.assertEqual(rope.rope_type, "yarn")
+        # Tied embeddings share storage — no separate reverse_embeddings var.
+        self.assertFalse(hasattr(model.token_embedding, "reverse_embeddings"))
+
     def test_explicit_head_dim(self):
         # Magistral-style config: `head_dim` is set explicitly and does not
         # equal `hidden_dim // num_query_heads`. `sliding_window=None` is

--- a/keras_hub/src/models/mistral/mistral_transformer_decoder.py
+++ b/keras_hub/src/models/mistral/mistral_transformer_decoder.py
@@ -31,6 +31,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
         kernel_initializer="glorot_uniform",
         sliding_window=512,
         dropout=0,
+        head_dim=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -44,6 +45,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
         self.dropout = dropout
 
         self.sliding_window = sliding_window
+        self.head_dim = head_dim
         self.activation = keras.activations.get(activation)
         self.layer_norm_epsilon = layer_norm_epsilon
         self.kernel_initializer = keras.initializers.get(kernel_initializer)
@@ -61,6 +63,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
             rope_max_wavelength=self.rope_max_wavelength,
             rope_scaling_factor=self.rope_scaling_factor,
             sliding_window=self.sliding_window,
+            head_dim=self.head_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             dropout=self.dropout,
             dtype=self.dtype_policy,
@@ -242,6 +245,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
                 "rope_scaling_factor": self.rope_scaling_factor,
                 "num_key_value_heads": self.num_key_value_heads,
                 "sliding_window": self.sliding_window,
+                "head_dim": self.head_dim,
                 "activation": keras.activations.serialize(self.activation),
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "kernel_initializer": keras.initializers.serialize(

--- a/keras_hub/src/models/mistral/mistral_transformer_decoder.py
+++ b/keras_hub/src/models/mistral/mistral_transformer_decoder.py
@@ -32,6 +32,10 @@ class MistralTransformerDecoder(keras.layers.Layer):
         sliding_window=512,
         dropout=0,
         head_dim=None,
+        rope_type="linear",
+        rope_beta_fast=32.0,
+        rope_beta_slow=1.0,
+        rope_original_max_position_embeddings=4096,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -41,6 +45,12 @@ class MistralTransformerDecoder(keras.layers.Layer):
 
         self.rope_max_wavelength = rope_max_wavelength
         self.rope_scaling_factor = rope_scaling_factor
+        self.rope_type = rope_type
+        self.rope_beta_fast = rope_beta_fast
+        self.rope_beta_slow = rope_beta_slow
+        self.rope_original_max_position_embeddings = (
+            rope_original_max_position_embeddings
+        )
 
         self.dropout = dropout
 
@@ -64,6 +74,12 @@ class MistralTransformerDecoder(keras.layers.Layer):
             rope_scaling_factor=self.rope_scaling_factor,
             sliding_window=self.sliding_window,
             head_dim=self.head_dim,
+            rope_type=self.rope_type,
+            rope_beta_fast=self.rope_beta_fast,
+            rope_beta_slow=self.rope_beta_slow,
+            rope_original_max_position_embeddings=(
+                self.rope_original_max_position_embeddings
+            ),
             kernel_initializer=clone_initializer(self.kernel_initializer),
             dropout=self.dropout,
             dtype=self.dtype_policy,
@@ -246,6 +262,12 @@ class MistralTransformerDecoder(keras.layers.Layer):
                 "num_key_value_heads": self.num_key_value_heads,
                 "sliding_window": self.sliding_window,
                 "head_dim": self.head_dim,
+                "rope_type": self.rope_type,
+                "rope_beta_fast": self.rope_beta_fast,
+                "rope_beta_slow": self.rope_beta_slow,
+                "rope_original_max_position_embeddings": (
+                    self.rope_original_max_position_embeddings
+                ),
                 "activation": keras.activations.serialize(self.activation),
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "kernel_initializer": keras.initializers.serialize(

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -16,7 +16,8 @@ def convert_backbone_config(transformers_config):
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "rope_max_wavelength": transformers_config["rope_theta"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "sliding_window": transformers_config["sliding_window"],
+        "sliding_window": transformers_config.get("sliding_window"),
+        "head_dim": transformers_config.get("head_dim"),
     }
 
 

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -7,12 +7,23 @@ backbone_cls = MistralBackbone
 
 
 def convert_backbone_config(transformers_config):
-    # `rope_theta` is nested under `rope_parameters` in transformers 5.x; older
-    # checkpoints expose it at the top level.
-    rope_parameters = transformers_config.get("rope_parameters") or {}
-    rope_theta = transformers_config.get("rope_theta") or rope_parameters.get(
+    # Multimodal Mistral variants (e.g. Ministral 3) nest the text model's
+    # hyperparameters under `text_config`.
+    if "text_config" in transformers_config:
+        transformers_config = transformers_config["text_config"]
+
+    # `transformers_config` is the raw `config.json` dict, not a populated
+    # `MistralConfig`, so older checkpoints may omit fields that HF defaults
+    # at runtime. We use `.get(...)` for any field that may be missing from
+    # disk and read it directly only for ones every Mistral preset sets.
+    rope_params = transformers_config.get("rope_parameters") or {}
+
+    # `rope_theta` is top-level in transformers < 5 and nested under
+    # `rope_parameters` in 5.x; fall back across both.
+    rope_theta = transformers_config.get("rope_theta") or rope_params.get(
         "rope_theta"
     )
+
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -20,10 +31,23 @@ def convert_backbone_config(transformers_config):
         "hidden_dim": transformers_config["hidden_size"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "num_key_value_heads": transformers_config["num_key_value_heads"],
-        "rope_max_wavelength": rope_theta,
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "sliding_window": transformers_config.get("sliding_window"),
+        # Optional / cross-version fields.
         "head_dim": transformers_config.get("head_dim"),
+        "tie_word_embeddings": transformers_config.get(
+            "tie_word_embeddings", False
+        ),
+        "sliding_window": transformers_config.get("sliding_window"),
+        "rope_max_wavelength": rope_theta,
+        # YaRN-specific; only populated when `rope_parameters` is set. Defaults
+        # match the no-scaling (linear) regime that base Mistral uses.
+        "rope_type": rope_params.get("rope_type", "linear"),
+        "rope_scaling_factor": rope_params.get("factor", 1.0),
+        "rope_beta_fast": rope_params.get("beta_fast", 32.0),
+        "rope_beta_slow": rope_params.get("beta_slow", 1.0),
+        "rope_original_max_position_embeddings": rope_params.get(
+            "original_max_position_embeddings", 4096
+        ),
     }
 
 
@@ -34,13 +58,17 @@ def convert_weights(backbone, loader, transformers_config):
         hf_weight_key="model.embed_tokens.weight",
         hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
     )
-    loader.port_weight(
-        keras_variable=backbone.token_embedding.reverse_embeddings,
-        hf_weight_key="lm_head.weight",
-        hook_fn=lambda hf_tensor, _: np.transpose(
-            hf_tensor.astype(np.float16), axes=(1, 0)
-        ),
-    )
+    # When `tie_word_embeddings=True`, HF does not store `lm_head.weight`
+    # separately; the output projection shares `model.embed_tokens.weight`,
+    # and `ReversibleEmbedding` in keras-hub does the same.
+    if not backbone.tie_word_embeddings:
+        loader.port_weight(
+            keras_variable=backbone.token_embedding.reverse_embeddings,
+            hf_weight_key="lm_head.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(
+                hf_tensor.astype(np.float16), axes=(1, 0)
+            ),
+        )
 
     # Attention blocks
     for index in range(backbone.num_layers):

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -7,6 +7,12 @@ backbone_cls = MistralBackbone
 
 
 def convert_backbone_config(transformers_config):
+    # `rope_theta` is nested under `rope_parameters` in transformers 5.x; older
+    # checkpoints expose it at the top level.
+    rope_parameters = transformers_config.get("rope_parameters") or {}
+    rope_theta = transformers_config.get("rope_theta") or rope_parameters.get(
+        "rope_theta"
+    )
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -14,7 +20,7 @@ def convert_backbone_config(transformers_config):
         "hidden_dim": transformers_config["hidden_size"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "num_key_value_heads": transformers_config["num_key_value_heads"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
         "sliding_window": transformers_config.get("sliding_window"),
         "head_dim": transformers_config.get("head_dim"),

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -11,11 +11,23 @@ backbone_cls = MistralBackbone
 
 
 def convert_backbone_config(transformers_config):
-    rope_theta = transformers_config.get("rope_parameters", {}).get(
-        "rope_theta"
-    )
+    # Multimodal Mistral variants (e.g. Ministral 3) nest the text model's
+    # hyperparameters under `text_config`.
+    if "text_config" in transformers_config:
+        transformers_config = transformers_config["text_config"]
+
+    # `transformers_config` is the raw `config.json` dict, not a populated
+    # `MistralConfig`, so older checkpoints may omit fields that HF defaults
+    # at runtime. We use `.get(...)` for any field that may be missing from
+    # disk and read it directly only for ones every Mistral preset sets.
+    rope_params = transformers_config.get("rope_parameters") or {}
+
+    # `rope_theta` moved under `rope_parameters` in transformers 5.x, and is
+    # top level in earlier versions.
+    rope_theta = rope_params.get("rope_theta")
     if rope_theta is None:
         rope_theta = transformers_config["rope_theta"]
+
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -23,10 +35,23 @@ def convert_backbone_config(transformers_config):
         "hidden_dim": transformers_config["hidden_size"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "num_key_value_heads": transformers_config["num_key_value_heads"],
-        "rope_max_wavelength": rope_theta,
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "sliding_window": transformers_config.get("sliding_window"),
+        # Optional / cross-version fields.
         "head_dim": transformers_config.get("head_dim"),
+        "tie_word_embeddings": transformers_config.get(
+            "tie_word_embeddings", False
+        ),
+        "sliding_window": transformers_config.get("sliding_window"),
+        "rope_max_wavelength": rope_theta,
+        # YaRN-specific; only populated when `rope_parameters` is set. Defaults
+        # match the no-scaling (linear) regime that base Mistral uses.
+        "rope_type": rope_params.get("rope_type", "linear"),
+        "rope_scaling_factor": rope_params.get("factor", 1.0),
+        "rope_beta_fast": rope_params.get("beta_fast", 32.0),
+        "rope_beta_slow": rope_params.get("beta_slow", 1.0),
+        "rope_original_max_position_embeddings": rope_params.get(
+            "original_max_position_embeddings", 4096
+        ),
     }
 
 
@@ -37,13 +62,17 @@ def convert_weights(backbone, loader, transformers_config):
         hf_weight_key="model.embed_tokens.weight",
         hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
     )
-    loader.port_weight(
-        keras_variable=backbone.token_embedding.reverse_embeddings,
-        hf_weight_key="lm_head.weight",
-        hook_fn=lambda hf_tensor, _: np.transpose(
-            hf_tensor.astype(np.float16), axes=(1, 0)
-        ),
-    )
+    # When `tie_word_embeddings=True`, HF does not store `lm_head.weight`
+    # separately; the output projection shares `model.embed_tokens.weight`,
+    # and `ReversibleEmbedding` in keras-hub does the same.
+    if not backbone.tie_word_embeddings:
+        loader.port_weight(
+            keras_variable=backbone.token_embedding.reverse_embeddings,
+            hf_weight_key="lm_head.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(
+                hf_tensor.astype(np.float16), axes=(1, 0)
+            ),
+        )
 
     # Attention blocks
     for index in range(backbone.num_layers):

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -1,3 +1,6 @@
+import tempfile
+
+import numpy as np
 import pytest
 
 from keras_hub.src.models.backbone import Backbone
@@ -27,4 +30,51 @@ class TestTask(TestCase):
         )
         self.assertIsInstance(model, MistralBackbone)
 
-    # TODO: compare numerics with huggingface model
+    @pytest.mark.large
+    def test_explicit_head_dim_matches_hf(self):
+        # Magistral-style config: `head_dim` is set explicitly and does not
+        # equal `hidden_size // num_attention_heads`, and sliding window is
+        # disabled. Build a small HF Mistral, convert, and check that the
+        # keras-hub forward pass matches the HF reference to within the
+        # precision of the fp16 hops used by the converter.
+        torch = pytest.importorskip("torch")
+        transformers = pytest.importorskip("transformers")
+
+        cfg = transformers.MistralConfig(
+            vocab_size=100,
+            hidden_size=32,
+            intermediate_size=48,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=12,
+            sliding_window=None,
+            rope_theta=1_000_000.0,
+            rms_norm_eps=1e-5,
+        )
+        self.assertNotEqual(
+            cfg.head_dim, cfg.hidden_size // cfg.num_attention_heads
+        )
+        torch.manual_seed(0)
+        hf_model = transformers.MistralForCausalLM(cfg).eval()
+
+        with tempfile.TemporaryDirectory() as preset_dir:
+            hf_model.save_pretrained(preset_dir)
+            keras_backbone = MistralBackbone.from_preset(preset_dir)
+
+        input_ids = np.array([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int32")
+        padding = np.ones_like(input_ids)
+        keras_out = np.asarray(
+            keras_backbone({"token_ids": input_ids, "padding_mask": padding})
+        )
+        with torch.no_grad():
+            hf_out = (
+                hf_model.model(torch.tensor(input_ids))
+                .last_hidden_state.detach()
+                .cpu()
+                .numpy()
+            )
+        self.assertEqual(keras_out.shape, hf_out.shape)
+        # The converter stores weights in float16, so the parity bound is
+        # dominated by fp16 quantization rather than implementation error.
+        self.assertAllClose(keras_out, hf_out, atol=1e-2)

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -32,6 +32,107 @@ class TestTask(TestCase):
         self.assertIsInstance(model, MistralBackbone)
 
     @pytest.mark.large
+    def test_yarn_rope_and_tied_embeddings_match_hf(self):
+        # Ministral 3 text-side config: YaRN RoPE scaling, explicit head_dim,
+        # tied word embeddings, and no sliding window. Build a small HF
+        # Mistral with the same options, convert through the preset loader,
+        # and assert parity on the forward pass.
+        torch = pytest.importorskip("torch")
+        transformers = pytest.importorskip("transformers")
+
+        cfg = transformers.MistralConfig(
+            vocab_size=100,
+            hidden_size=32,
+            intermediate_size=48,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=12,
+            sliding_window=None,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=True,
+            rope_parameters={
+                "rope_type": "yarn",
+                "rope_theta": 1_000_000.0,
+                "factor": 8.0,
+                "beta_fast": 32.0,
+                "beta_slow": 1.0,
+                "original_max_position_embeddings": 64,
+            },
+        )
+        torch.manual_seed(0)
+        hf_model = transformers.MistralForCausalLM(cfg).eval()
+
+        with tempfile.TemporaryDirectory() as preset_dir:
+            hf_model.save_pretrained(preset_dir)
+            keras_backbone = MistralBackbone.from_preset(preset_dir)
+
+        self.assertTrue(keras_backbone.tie_word_embeddings)
+        self.assertEqual(keras_backbone.rope_type, "yarn")
+        input_ids = np.array([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int32")
+        padding = np.ones_like(input_ids)
+        keras_out = ops.convert_to_numpy(
+            keras_backbone({"token_ids": input_ids, "padding_mask": padding})
+        )
+        with torch.no_grad():
+            hf_out = (
+                hf_model.model(torch.tensor(input_ids))
+                .last_hidden_state.detach()
+                .cpu()
+                .numpy()
+            )
+        self.assertEqual(keras_out.shape, hf_out.shape)
+        self.assertAllClose(keras_out, hf_out, atol=1e-2)
+
+    @pytest.mark.large
+    def test_text_config_nesting_matches_hf(self):
+        # Multimodal configs (e.g. Ministral 3) nest the text backbone's
+        # hyperparameters under `text_config`. Verify the converter reads
+        # them correctly by building a tiny HF Mistral, wrapping its config
+        # dict under `text_config`, and loading through the preset loader.
+        torch = pytest.importorskip("torch")
+        transformers = pytest.importorskip("transformers")
+
+        cfg = transformers.MistralConfig(
+            vocab_size=100,
+            hidden_size=24,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            sliding_window=None,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=True,
+            rope_theta=1_000_000.0,
+        )
+        torch.manual_seed(0)
+        hf_model = transformers.MistralForCausalLM(cfg).eval()
+
+        with tempfile.TemporaryDirectory() as preset_dir:
+            hf_model.save_pretrained(preset_dir)
+            # Rewrite `config.json` to nest the text config, simulating the
+            # multimodal layout used by Ministral 3 and other VLMs.
+            import json as _json
+
+            cfg_path = f"{preset_dir}/config.json"
+            with open(cfg_path) as fh:
+                full = _json.load(fh)
+            wrapped = {
+                "architectures": ["MistralForCausalLM"],
+                "model_type": "mistral",
+                "text_config": {k: v for k, v in full.items()},
+            }
+            with open(cfg_path, "w") as fh:
+                _json.dump(wrapped, fh)
+
+            keras_backbone = MistralBackbone.from_preset(preset_dir)
+
+        self.assertEqual(keras_backbone.num_layers, 2)
+        self.assertEqual(keras_backbone.hidden_dim, 24)
+        self.assertTrue(keras_backbone.tie_word_embeddings)
+
+    @pytest.mark.large
     def test_explicit_head_dim_matches_hf(self):
         # Magistral-style config: `head_dim` is set explicitly and does not
         # equal `hidden_size // num_attention_heads`, and sliding window is

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -2,6 +2,7 @@ import tempfile
 
 import numpy as np
 import pytest
+from keras import ops
 
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.causal_lm import CausalLM
@@ -64,7 +65,7 @@ class TestTask(TestCase):
 
         input_ids = np.array([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int32")
         padding = np.ones_like(input_ids)
-        keras_out = np.asarray(
+        keras_out = ops.convert_to_numpy(
             keras_backbone({"token_ids": input_ids, "padding_mask": padding})
         )
         with torch.no_grad():

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -94,6 +94,107 @@ class TestTask(TestCase):
         self.assertIsInstance(model, MistralBackbone)
 
     @pytest.mark.large
+    def test_yarn_rope_and_tied_embeddings_match_hf(self):
+        # Ministral 3 text-side config: YaRN RoPE scaling, explicit head_dim,
+        # tied word embeddings, and no sliding window. Build a small HF
+        # Mistral with the same options, convert through the preset loader,
+        # and assert parity on the forward pass.
+        torch = pytest.importorskip("torch")
+        transformers = pytest.importorskip("transformers")
+
+        cfg = transformers.MistralConfig(
+            vocab_size=100,
+            hidden_size=32,
+            intermediate_size=48,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=12,
+            sliding_window=None,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=True,
+            rope_parameters={
+                "rope_type": "yarn",
+                "rope_theta": 1_000_000.0,
+                "factor": 8.0,
+                "beta_fast": 32.0,
+                "beta_slow": 1.0,
+                "original_max_position_embeddings": 64,
+            },
+        )
+        torch.manual_seed(0)
+        hf_model = transformers.MistralForCausalLM(cfg).eval()
+
+        with tempfile.TemporaryDirectory() as preset_dir:
+            hf_model.save_pretrained(preset_dir)
+            keras_backbone = MistralBackbone.from_preset(preset_dir)
+
+        self.assertTrue(keras_backbone.tie_word_embeddings)
+        self.assertEqual(keras_backbone.rope_type, "yarn")
+        input_ids = np.array([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int32")
+        padding = np.ones_like(input_ids)
+        keras_out = ops.convert_to_numpy(
+            keras_backbone({"token_ids": input_ids, "padding_mask": padding})
+        )
+        with torch.no_grad():
+            hf_out = (
+                hf_model.model(torch.tensor(input_ids))
+                .last_hidden_state.detach()
+                .cpu()
+                .numpy()
+            )
+        self.assertEqual(keras_out.shape, hf_out.shape)
+        self.assertAllClose(keras_out, hf_out, atol=1e-2)
+
+    @pytest.mark.large
+    def test_text_config_nesting_matches_hf(self):
+        # Multimodal configs (e.g. Ministral 3) nest the text backbone's
+        # hyperparameters under `text_config`. Verify the converter reads
+        # them correctly by building a tiny HF Mistral, wrapping its config
+        # dict under `text_config`, and loading through the preset loader.
+        torch = pytest.importorskip("torch")
+        transformers = pytest.importorskip("transformers")
+
+        cfg = transformers.MistralConfig(
+            vocab_size=100,
+            hidden_size=24,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            sliding_window=None,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=True,
+            rope_theta=1_000_000.0,
+        )
+        torch.manual_seed(0)
+        hf_model = transformers.MistralForCausalLM(cfg).eval()
+
+        with tempfile.TemporaryDirectory() as preset_dir:
+            hf_model.save_pretrained(preset_dir)
+            # Rewrite `config.json` to nest the text config, simulating the
+            # multimodal layout used by Ministral 3 and other VLMs.
+            import json as _json
+
+            cfg_path = f"{preset_dir}/config.json"
+            with open(cfg_path) as fh:
+                full = _json.load(fh)
+            wrapped = {
+                "architectures": ["MistralForCausalLM"],
+                "model_type": "mistral",
+                "text_config": {k: v for k, v in full.items()},
+            }
+            with open(cfg_path, "w") as fh:
+                _json.dump(wrapped, fh)
+
+            keras_backbone = MistralBackbone.from_preset(preset_dir)
+
+        self.assertEqual(keras_backbone.num_layers, 2)
+        self.assertEqual(keras_backbone.hidden_dim, 24)
+        self.assertTrue(keras_backbone.tie_word_embeddings)
+
+    @pytest.mark.large
     def test_explicit_head_dim_matches_hf(self):
         # Magistral-style config: `head_dim` is set explicitly and does not
         # equal `hidden_size // num_attention_heads`, and sliding window is

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -22,6 +22,7 @@ PRESET_MAP = {
     "mistral_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.1",
     "mistral_0.2_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.2",
     "mistral_0.3_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.3",
+    "magistral_small_2506_en": "mistralai/Magistral-Small-2506",
 }
 
 FLAGS = flags.FLAGS
@@ -32,6 +33,9 @@ flags.DEFINE_string(
 
 def convert_checkpoints(keras_hub_model, hf_model):
     config = hf_model.config
+    head_dim = getattr(config, "head_dim", None) or (
+        config.hidden_size // config.num_attention_heads
+    )
 
     keras_hub_model.token_embedding.embeddings.assign(
         hf_model.model.embed_tokens.weight.detach().cpu().numpy()
@@ -46,7 +50,7 @@ def convert_checkpoints(keras_hub_model, hf_model):
                 .self_attn.k_proj.weight.T.reshape(
                     config.hidden_size,
                     config.num_key_value_heads,
-                    config.hidden_size // config.num_attention_heads,
+                    head_dim,
                 )
                 .detach()
                 .cpu()
@@ -61,7 +65,7 @@ def convert_checkpoints(keras_hub_model, hf_model):
                 .self_attn.q_proj.weight.T.reshape(
                     config.hidden_size,
                     config.num_attention_heads,
-                    config.hidden_size // config.num_attention_heads,
+                    head_dim,
                 )
                 .detach()
                 .cpu()
@@ -76,7 +80,7 @@ def convert_checkpoints(keras_hub_model, hf_model):
                 .self_attn.v_proj.weight.T.reshape(
                     config.hidden_size,
                     config.num_key_value_heads,
-                    config.hidden_size // config.num_attention_heads,
+                    head_dim,
                 )
                 .detach()
                 .cpu()
@@ -90,7 +94,7 @@ def convert_checkpoints(keras_hub_model, hf_model):
                 hf_model.model.layers[i]
                 .self_attn.o_proj.weight.T.reshape(
                     config.num_attention_heads,
-                    config.hidden_size // config.num_attention_heads,
+                    head_dim,
                     config.hidden_size,
                 )
                 .detach()
@@ -225,6 +229,14 @@ def main(_):
         print("\n-> Huggingface model and tokenizer loaded")
 
         # === Load the KerasHub model ===
+        # `rope_theta` is nested under `rope_parameters` in transformers 5.x;
+        # older checkpoints expose it as a top-level attribute.
+        rope_parameters = (
+            getattr(hf_model.config, "rope_parameters", None) or {}
+        )
+        rope_theta = getattr(
+            hf_model.config, "rope_theta", None
+        ) or rope_parameters.get("rope_theta")
         backbone_kwargs = dict(
             vocabulary_size=hf_model.config.vocab_size,
             hidden_dim=hf_model.config.hidden_size,
@@ -233,8 +245,9 @@ def main(_):
             num_key_value_heads=hf_model.config.num_key_value_heads,
             intermediate_dim=hf_model.config.intermediate_size,
             sliding_window=hf_model.config.sliding_window,
+            head_dim=getattr(hf_model.config, "head_dim", None),
             layer_norm_epsilon=hf_model.config.rms_norm_eps,
-            rope_max_wavelength=hf_model.config.rope_theta,
+            rope_max_wavelength=rope_theta,
             dtype="float32",
         )
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)


### PR DESCRIPTION
## Summary

Extends the Mistral infra to cover Ministral 3's text-side architecture (mistralai/Ministral-3-3B-Instruct-2512 and siblings). First PR in the Ministral 3 roadmap item (#1836, #2505); the Pixtral vision tower, multimodal projector, and VLM task class are follow-ups.

Ministral 3's text model is still Mistral-family GQA with RMSNorm and SiLU MLP, but differs from the classic Mistral configs in three ways that this PR picks up:

1. **YaRN RoPE scaling** — adds `rope_type`, `rope_beta_fast`, `rope_beta_slow`, `rope_original_max_position_embeddings` on `MistralBackbone`, `MistralTransformerDecoder`, and `CachedMistralAttention`. Default `rope_type="linear"` keeps existing behavior; `rope_type="yarn"` activates the existing `keras_hub.layers.RotaryEmbedding` yarn path with matching beta/factor semantics.
2. **Tied word embeddings** — adds `tie_word_embeddings`; flows into `ReversibleEmbedding(tie_weights=...)` and makes the HF converter skip `lm_head.weight` (which is absent from the safetensors when tying is enabled).
3. **Multimodal config nesting** — Ministral 3 (and other VLMs) nest text hyperparameters under `text_config`. `convert_backbone_config` now unwraps that and reads the newer `rope_parameters` dict form alongside the legacy top-level `rope_theta`.

## Tests

- Unit test on `MistralBackbone` exercising yarn + tied embeddings + explicit head_dim + `sliding_window=None` together; asserts `ReversibleEmbedding` does not allocate a separate reverse table when tied.
- Numerical-parity test: builds a small HF Mistral with `rope_parameters={rope_type: "yarn", ...}` and `tie_word_embeddings=True`, converts through the preset loader, asserts the keras-hub forward pass matches the HF reference to within fp16 precision (the converter stores weights as fp16).
- Second parity test wraps the same config under `text_config` to cover the multimodal nesting path used by Ministral 3.

## Usage after merge

```python
keras_hub.models.MistralBackbone.from_preset(
    "hf://mistralai/Ministral-3-3B-Instruct-2512-BF16"
)
```

## Stack

Builds on #2692 (explicit `head_dim` support on `MistralBackbone`) — the diff here is on top of that branch. Once #2692 merges, this PR will rebase cleanly onto master.
