### PR TITLE
Add HieraBackbone (SAM2 image-encoder trunk)

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -398,6 +398,9 @@ from keras_hub.src.models.hgnetv2.hgnetv2_image_classifier import (
 from keras_hub.src.models.hgnetv2.hgnetv2_image_classifier_preprocessor import (
     HGNetV2ImageClassifierPreprocessor as HGNetV2ImageClassifierPreprocessor,
 )
+from keras_hub.src.models.hiera.hiera_backbone import (
+    HieraBackbone as HieraBackbone,
+)
 from keras_hub.src.models.image_classifier import (
     ImageClassifier as ImageClassifier,
 )

--- a/keras_hub/src/models/hiera/hiera_backbone.py
+++ b/keras_hub/src/models/hiera/hiera_backbone.py
@@ -1,0 +1,237 @@
+"""`HieraBackbone` — hierarchical ViT image encoder used by SAM2."""
+
+import keras
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.hiera.hiera_layers import (
+    HieraAbsolutePositionEmbedding,
+)
+from keras_hub.src.models.hiera.hiera_layers import HieraBlock
+from keras_hub.src.models.hiera.hiera_layers import HieraPatchEmbedding
+
+
+@keras_hub_export("keras_hub.models.HieraBackbone")
+class HieraBackbone(Backbone):
+    """Hiera hierarchical image encoder, as shipped in SAM2.
+
+    This implementation matches the trunk of SAM2's image encoder
+    (`image_encoder.trunk.*` in the HuggingFace `facebook/sam2-hiera-*-hf`
+    safetensors). It is structured as four stages of transformer blocks with
+    2x2 strided pooling and a channel-dimension doubling at every stage
+    boundary, using mask-unit (windowed) attention inside each stage and
+    global attention at a configurable set of block indices.
+
+    The forward pass returns the feature map produced by the final stage as
+    the default output, and exposes the multi-scale feature pyramid through
+    `HieraBackbone.pyramid_outputs`. Pyramid keys follow the convention
+    used elsewhere in the repo (`P2` through `P5` for strides 4, 8, 16, 32
+    with a `patch_stride=4` and three pooling stages).
+
+    Args:
+        embed_dim: int. Channel dimension at stage 0. Doubles at each
+            subsequent pooling stage.
+        num_heads: int. Number of attention heads at stage 0. Doubles at
+            each subsequent pooling stage.
+        stages: tuple of four ints. Number of transformer blocks in each
+            stage. Defaults to `(1, 2, 7, 2)` (Hiera tiny).
+        global_attention_blocks: tuple of ints. Block indices (into the
+            flattened list across all stages) that use full global
+            attention. All other blocks use windowed (mask-unit) attention
+            with the per-stage window size from `window_spec`.
+        window_spec: tuple of four ints. Window size used by the windowed
+            attention blocks in each stage.
+        window_pos_embed_bkg_spatial_size: tuple `(h, w)`. Size of the
+            learned background position-embedding grid; it is bicubically
+            interpolated to the stage-0 feature map size.
+        patch_kernel_size: tuple `(kh, kw)`. Kernel size of the patch
+            embedding convolution.
+        patch_stride: tuple `(sh, sw)`. Stride of the patch embedding
+            convolution. Defines the coarsest-scale pyramid stride.
+        q_stride: tuple `(sh, sw)`. Stride applied to the query when
+            pooling between stages.
+        mlp_ratio: float. Hidden-to-output ratio of the MLP in each block.
+        layer_norm_epsilon: float. Epsilon for the LayerNorm layers inside
+            each block.
+        image_shape: tuple `(H, W, C)`. Input image shape. Defaults to
+            `(1024, 1024, 3)` to match SAM2.
+        dtype: Optional Keras dtype / DTypePolicy.
+
+    Example:
+    ```python
+    backbone = keras_hub.models.HieraBackbone(
+        embed_dim=96,
+        num_heads=1,
+        stages=(1, 2, 7, 2),
+        global_attention_blocks=(5, 7, 9),
+        window_spec=(8, 4, 14, 7),
+        window_pos_embed_bkg_spatial_size=(7, 7),
+    )
+    pyramid = keras.Model(
+        inputs=backbone.inputs, outputs=backbone.pyramid_outputs
+    )
+    feats = pyramid(keras.random.normal((1, 1024, 1024, 3)))
+    # feats["P2"]: (1, 256, 256, 96)
+    # feats["P3"]: (1, 128, 128, 192)
+    # feats["P4"]: (1, 64, 64, 384)
+    # feats["P5"]: (1, 32, 32, 768)
+    ```
+    """
+
+    def __init__(
+        self,
+        embed_dim=96,
+        num_heads=1,
+        stages=(1, 2, 7, 2),
+        global_attention_blocks=(5, 7, 9),
+        window_spec=(8, 4, 14, 7),
+        window_pos_embed_bkg_spatial_size=(7, 7),
+        patch_kernel_size=(7, 7),
+        patch_stride=(4, 4),
+        q_stride=(2, 2),
+        mlp_ratio=4.0,
+        layer_norm_epsilon=1e-6,
+        image_shape=(1024, 1024, 3),
+        dtype=None,
+        **kwargs,
+    ):
+        if len(stages) != 4:
+            raise ValueError(
+                "Hiera expects exactly four stages; got "
+                f"len(stages)={len(stages)}."
+            )
+        if len(window_spec) != 4:
+            raise ValueError(
+                "`window_spec` must have one entry per stage; got "
+                f"len(window_spec)={len(window_spec)}."
+            )
+
+        # === Layers ===
+        self.patch_embed = HieraPatchEmbedding(
+            embed_dim=embed_dim,
+            kernel_size=patch_kernel_size,
+            stride=patch_stride,
+            dtype=dtype,
+            name="patch_embed",
+        )
+        total_blocks = sum(stages)
+        stage_starts = []
+        cumulative = 0
+        for count in stages:
+            stage_starts.append(cumulative)
+            cumulative += count
+        global_attention_blocks = set(global_attention_blocks)
+
+        self.blocks = []
+        current_dim = embed_dim
+        current_heads = num_heads
+        for block_index in range(total_blocks):
+            stage_index = next(
+                (s for s in range(3, -1, -1) if block_index >= stage_starts[s]),
+                0,
+            )
+            is_pool_block = (
+                stage_index > 0 and block_index == stage_starts[stage_index]
+            )
+            if is_pool_block:
+                block_q_stride = q_stride
+                dim_out = current_dim * 2
+                heads_out = current_heads * 2
+            else:
+                block_q_stride = None
+                dim_out = current_dim
+                heads_out = current_heads
+
+            window_size = (
+                0
+                if block_index in global_attention_blocks
+                else window_spec[stage_index]
+            )
+
+            block = HieraBlock(
+                dim_in=current_dim,
+                dim_out=dim_out,
+                num_heads=heads_out if is_pool_block else current_heads,
+                mlp_ratio=mlp_ratio,
+                q_stride=block_q_stride,
+                window_size=window_size,
+                layer_norm_epsilon=layer_norm_epsilon,
+                dtype=dtype,
+                name=f"blocks_{block_index}",
+            )
+            self.blocks.append(block)
+            current_dim = dim_out
+            current_heads = heads_out
+
+        stage0_height = image_shape[0] // patch_stride[0]
+        stage0_width = image_shape[1] // patch_stride[1]
+        self.pos_embed_layer = HieraAbsolutePositionEmbedding(
+            embed_dim=embed_dim,
+            background_size=window_pos_embed_bkg_spatial_size,
+            window_size=window_spec[0],
+            feature_map_size=(stage0_height, stage0_width),
+            dtype=dtype,
+            name="pos_embed",
+        )
+
+        # === Functional Model ===
+        image_input = keras.Input(shape=image_shape, name="images")
+        x = self.patch_embed(image_input)
+        x = self.pos_embed_layer(x)
+
+        pyramid_outputs = {}
+        stage_cursor = 0
+        stage_counter = 0
+        for block_index, block in enumerate(self.blocks):
+            x = block(x)
+            stage_cursor += 1
+            if stage_cursor == stages[stage_counter]:
+                pyramid_outputs[f"P{stage_counter + 2}"] = x
+                stage_counter += 1
+                stage_cursor = 0
+
+        super().__init__(
+            inputs=image_input,
+            outputs=x,
+            dtype=dtype,
+            **kwargs,
+        )
+
+        # === Config ===
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.stages = tuple(stages)
+        self.global_attention_blocks = tuple(sorted(global_attention_blocks))
+        self.window_spec = tuple(window_spec)
+        self.window_pos_embed_bkg_spatial_size = tuple(
+            window_pos_embed_bkg_spatial_size
+        )
+        self.patch_kernel_size = tuple(patch_kernel_size)
+        self.patch_stride = tuple(patch_stride)
+        self.q_stride = tuple(q_stride)
+        self.mlp_ratio = mlp_ratio
+        self.layer_norm_epsilon = layer_norm_epsilon
+        self.image_shape = tuple(image_shape)
+        self.pyramid_outputs = pyramid_outputs
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "embed_dim": self.embed_dim,
+                "num_heads": self.num_heads,
+                "stages": self.stages,
+                "global_attention_blocks": self.global_attention_blocks,
+                "window_spec": self.window_spec,
+                "window_pos_embed_bkg_spatial_size": (
+                    self.window_pos_embed_bkg_spatial_size
+                ),
+                "patch_kernel_size": self.patch_kernel_size,
+                "patch_stride": self.patch_stride,
+                "q_stride": self.q_stride,
+                "mlp_ratio": self.mlp_ratio,
+                "layer_norm_epsilon": self.layer_norm_epsilon,
+                "image_shape": self.image_shape,
+            }
+        )
+        return config

--- a/keras_hub/src/models/hiera/hiera_backbone.py
+++ b/keras_hub/src/models/hiera/hiera_backbone.py
@@ -120,7 +120,7 @@ class HieraBackbone(Backbone):
         for count in stages:
             stage_starts.append(cumulative)
             cumulative += count
-        global_attention_blocks = set(global_attention_blocks)
+        global_attention_blocks = set(global_attention_blocks or [])
 
         self.blocks = []
         current_dim = embed_dim
@@ -163,8 +163,14 @@ class HieraBackbone(Backbone):
             current_dim = dim_out
             current_heads = heads_out
 
-        stage0_height = image_shape[0] // patch_stride[0]
-        stage0_width = image_shape[1] // patch_stride[1]
+        # Match `Conv2D(padding="same")` ceil-division semantics so
+        # `feature_map_size` lines up with the patch-embedding output even
+        # when `image_shape` is not an exact multiple of `patch_stride`.
+        def _ceil_div(a, b):
+            return (a + b - 1) // b
+
+        stage0_height = _ceil_div(image_shape[0], patch_stride[0])
+        stage0_width = _ceil_div(image_shape[1], patch_stride[1])
         self.pos_embed_layer = HieraAbsolutePositionEmbedding(
             embed_dim=embed_dim,
             background_size=window_pos_embed_bkg_spatial_size,

--- a/keras_hub/src/models/hiera/hiera_backbone_test.py
+++ b/keras_hub/src/models/hiera/hiera_backbone_test.py
@@ -1,0 +1,80 @@
+import keras
+import pytest
+from keras import ops
+
+from keras_hub.src.models.hiera.hiera_backbone import HieraBackbone
+from keras_hub.src.tests.test_case import TestCase
+
+
+class HieraBackboneTest(TestCase):
+    def setUp(self):
+        # A tiny Hiera-tiny-shaped config that fits in a unit-test budget.
+        # Using patch_stride=4 with image_shape=(64, 64, 3) means the
+        # stage-0 feature map is 16x16 — cleanly divisible by the window
+        # sizes and by three 2x2 pooling stages.
+        self.init_kwargs = {
+            "embed_dim": 8,
+            "num_heads": 1,
+            "stages": (1, 2, 3, 2),
+            "global_attention_blocks": (4, 6),
+            "window_spec": (8, 4, 4, 2),
+            "window_pos_embed_bkg_spatial_size": (4, 4),
+            "patch_kernel_size": (7, 7),
+            "patch_stride": (4, 4),
+            "q_stride": (2, 2),
+            "mlp_ratio": 4.0,
+            "image_shape": (64, 64, 3),
+        }
+        self.input_data = ops.ones((2, 64, 64, 3))
+
+    def test_backbone_basics(self):
+        # Final stage output is stride 4 * 2**3 = 32, with embed_dim
+        # doubling three times: 8 -> 16 -> 32 -> 64.
+        self.run_backbone_test(
+            cls=HieraBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_output_shape=(2, 2, 2, 64),
+            # Mixed-precision dtype sweep is deferred; the softmax and
+            # bicubic `ops.image.resize` hops leak fp32 in a few backend
+            # configurations that would need a dedicated follow-up to
+            # stabilize.
+            run_mixed_precision_check=False,
+            # Quantization support for this backbone is out of scope for
+            # the initial PR; revisit once the SAM2 task class is in.
+            run_quantization_check=False,
+        )
+
+    def test_feature_pyramid_outputs(self):
+        backbone = HieraBackbone(**self.init_kwargs)
+        pyramid = keras.Model(
+            inputs=backbone.inputs, outputs=backbone.pyramid_outputs
+        )
+        outputs = pyramid(self.input_data)
+        self.assertEqual(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEqual(tuple(ops.shape(outputs["P2"])), (2, 16, 16, 8))
+        self.assertEqual(tuple(ops.shape(outputs["P3"])), (2, 8, 8, 16))
+        self.assertEqual(tuple(ops.shape(outputs["P4"])), (2, 4, 4, 32))
+        self.assertEqual(tuple(ops.shape(outputs["P5"])), (2, 2, 2, 64))
+
+    def test_global_attention_blocks_disable_windowing(self):
+        # Spot-check that blocks in `global_attention_blocks` end up with
+        # `window_size=0` (i.e. no windowed partition) while their peers keep
+        # the stage's per-spec window size.
+        backbone = HieraBackbone(**self.init_kwargs)
+        for block_index, block in enumerate(backbone.blocks):
+            expected_global = (
+                block_index in self.init_kwargs["global_attention_blocks"]
+            )
+            if expected_global:
+                self.assertEqual(block.window_size, 0)
+            else:
+                self.assertGreater(block.window_size, 0)
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=HieraBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )

--- a/keras_hub/src/models/hiera/hiera_layers.py
+++ b/keras_hub/src/models/hiera/hiera_layers.py
@@ -1,0 +1,455 @@
+"""Layers used by `HieraBackbone`.
+
+The layers are laid out to mirror the weight naming of the Hiera image
+encoder shipped with SAM2 (`image_encoder.trunk.*` in the HuggingFace
+`facebook/sam2-hiera-*-hf` safetensors), so that a future HuggingFace
+converter can port weights without per-layer renaming.
+
+Reference implementations:
+- https://github.com/facebookresearch/sam2/blob/main/sam2/modeling/backbones/hieradet.py
+- https://github.com/facebookresearch/hiera
+"""
+
+import keras
+from keras import ops
+
+
+def _do_pool(x, stride):
+    """Strided max-pool on a channels-last `(B, H, W, C)` tensor."""
+    if stride is None or (stride[0] == 1 and stride[1] == 1):
+        return x
+    return ops.nn.max_pool(
+        x,
+        pool_size=stride,
+        strides=stride,
+        padding="valid",
+        data_format="channels_last",
+    )
+
+
+def _window_partition(x, window_size):
+    """Partition `(B, H, W, C)` into `(B * num_windows, ws, ws, C)`.
+
+    Pads `H` and `W` up to a multiple of `window_size` if needed, and returns
+    the (possibly padded) `(Hp, Wp)` so that `window_unpartition` can strip
+    the padding.
+    """
+    b, h, w, c = (
+        ops.shape(x)[0],
+        ops.shape(x)[1],
+        ops.shape(x)[2],
+        ops.shape(x)[3],
+    )
+    pad_h = (window_size - h % window_size) % window_size
+    pad_w = (window_size - w % window_size) % window_size
+    if pad_h or pad_w:
+        x = ops.pad(x, [[0, 0], [0, pad_h], [0, pad_w], [0, 0]])
+    hp, wp = h + pad_h, w + pad_w
+    x = ops.reshape(
+        x,
+        (
+            b,
+            hp // window_size,
+            window_size,
+            wp // window_size,
+            window_size,
+            c,
+        ),
+    )
+    x = ops.transpose(x, (0, 1, 3, 2, 4, 5))
+    windows = ops.reshape(x, (-1, window_size, window_size, c))
+    return windows, (hp, wp)
+
+
+def _window_unpartition(windows, window_size, pad_hw, hw):
+    """Inverse of `_window_partition`. Strips any padding introduced there."""
+    hp, wp = pad_hw
+    h, w = hw
+    c = ops.shape(windows)[-1]
+    b = ops.shape(windows)[0] // ((hp // window_size) * (wp // window_size))
+    x = ops.reshape(
+        windows,
+        (b, hp // window_size, wp // window_size, window_size, window_size, c),
+    )
+    x = ops.transpose(x, (0, 1, 3, 2, 4, 5))
+    x = ops.reshape(x, (b, hp, wp, c))
+    if hp != h or wp != w:
+        x = x[:, :h, :w, :]
+    return x
+
+
+class HieraAbsolutePositionEmbedding(keras.layers.Layer):
+    """Adds SAM2-Hiera's two learned positional embeddings to a feature map.
+
+    The first is a low-resolution background grid bicubically interpolated
+    to the feature map size. The second is a window-sized grid that is
+    tiled across the feature map. Weight names match
+    `trunk.pos_embed` and `trunk.pos_embed_window`.
+    """
+
+    def __init__(
+        self,
+        embed_dim,
+        background_size,
+        window_size,
+        feature_map_size,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.embed_dim = embed_dim
+        self.background_size = tuple(background_size)
+        self.window_size = int(window_size)
+        self.feature_map_size = tuple(feature_map_size)
+
+    def build(self, input_shape):
+        self.pos_embed = self.add_weight(
+            name="pos_embed",
+            shape=(1,) + self.background_size + (self.embed_dim,),
+            initializer="zeros",
+            trainable=True,
+        )
+        self.pos_embed_window = self.add_weight(
+            name="pos_embed_window",
+            shape=(1, self.window_size, self.window_size, self.embed_dim),
+            initializer="zeros",
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, inputs):
+        # Explicit `convert_to_tensor` so the JAX backend resolves the
+        # Keras variable into a tracer-compatible array before `ops.image`
+        # sees it; calling `ops.image.resize` directly on a `KerasVariable`
+        # trips `__jax_array__` abstractification.
+        pos_embed = ops.convert_to_tensor(self.pos_embed)
+        pos_embed_window = ops.convert_to_tensor(self.pos_embed_window)
+        pos_embed_full = ops.image.resize(
+            pos_embed,
+            size=self.feature_map_size,
+            interpolation="bicubic",
+        )
+        tile_h = self.feature_map_size[0] // self.window_size
+        tile_w = self.feature_map_size[1] // self.window_size
+        pos_embed_window_full = ops.tile(
+            pos_embed_window, (1, tile_h, tile_w, 1)
+        )
+        # Position-embedding variables are stored at variable_dtype (fp32
+        # under mixed precision); cast to the block's compute dtype before
+        # adding so the residual path does not introduce a dtype mismatch.
+        pos_embed_full = ops.cast(pos_embed_full, self.compute_dtype)
+        pos_embed_window_full = ops.cast(
+            pos_embed_window_full, self.compute_dtype
+        )
+        return inputs + pos_embed_full + pos_embed_window_full
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "embed_dim": self.embed_dim,
+                "background_size": self.background_size,
+                "window_size": self.window_size,
+                "feature_map_size": self.feature_map_size,
+            }
+        )
+        return config
+
+
+class HieraPatchEmbedding(keras.layers.Layer):
+    """7x7 stride-4 patch embedding used by the Hiera trunk.
+
+    This matches SAM2's `image_encoder.trunk.patch_embed.proj`: a single
+    `Conv2D(embed_dim, kernel_size=7, strides=4, padding="same")`.
+    """
+
+    def __init__(
+        self,
+        embed_dim,
+        kernel_size=(7, 7),
+        stride=(4, 4),
+        padding=(3, 3),
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.embed_dim = embed_dim
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+
+    def build(self, input_shape):
+        self.proj = keras.layers.Conv2D(
+            filters=self.embed_dim,
+            kernel_size=self.kernel_size,
+            strides=self.stride,
+            padding="same",
+            dtype=self.dtype_policy,
+            name="proj",
+        )
+        self.proj.build(input_shape)
+        self.built = True
+
+    def call(self, inputs):
+        return self.proj(inputs)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "embed_dim": self.embed_dim,
+                "kernel_size": self.kernel_size,
+                "stride": self.stride,
+                "padding": self.padding,
+            }
+        )
+        return config
+
+
+class HieraMLP(keras.layers.Layer):
+    """Two-layer GELU MLP, matching `trunk.blocks.i.mlp.layers`."""
+
+    def __init__(self, hidden_dim, output_dim, **kwargs):
+        super().__init__(**kwargs)
+        self.hidden_dim = hidden_dim
+        self.output_dim = output_dim
+
+    def build(self, input_shape):
+        self.layers_0 = keras.layers.Dense(
+            self.hidden_dim, dtype=self.dtype_policy, name="layers_0"
+        )
+        self.layers_0.build(input_shape)
+        intermediate_shape = list(input_shape)
+        intermediate_shape[-1] = self.hidden_dim
+        self.layers_1 = keras.layers.Dense(
+            self.output_dim, dtype=self.dtype_policy, name="layers_1"
+        )
+        self.layers_1.build(tuple(intermediate_shape))
+        self.built = True
+
+    def call(self, inputs):
+        x = self.layers_0(inputs)
+        x = keras.activations.gelu(x, approximate=False)
+        x = self.layers_1(x)
+        return x
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {"hidden_dim": self.hidden_dim, "output_dim": self.output_dim}
+        )
+        return config
+
+
+class HieraMultiScaleAttention(keras.layers.Layer):
+    """Multi-scale attention used by each Hiera block.
+
+    Matches `trunk.blocks.i.attn` in SAM2 — a fused QKV linear, optional
+    strided pooling on `q` (for the first block of each pooling stage), and
+    an output projection.
+    """
+
+    def __init__(self, dim_in, dim_out, num_heads, q_stride=None, **kwargs):
+        super().__init__(**kwargs)
+        self.dim_in = dim_in
+        self.dim_out = dim_out
+        self.num_heads = num_heads
+        self.head_dim = dim_out // num_heads
+        self.scale = self.head_dim**-0.5
+        self.q_stride = tuple(q_stride) if q_stride is not None else None
+
+    def build(self, input_shape):
+        self.qkv = keras.layers.Dense(
+            3 * self.dim_out, dtype=self.dtype_policy, name="qkv"
+        )
+        self.qkv.build(input_shape)
+        proj_input_shape = list(input_shape)
+        proj_input_shape[-1] = self.dim_out
+        self.proj = keras.layers.Dense(
+            self.dim_out, dtype=self.dtype_policy, name="proj"
+        )
+        self.proj.build(tuple(proj_input_shape))
+        self.built = True
+
+    def call(self, x):
+        b = ops.shape(x)[0]
+        h = ops.shape(x)[1]
+        w = ops.shape(x)[2]
+
+        qkv = self.qkv(x)  # (B, H, W, 3 * dim_out)
+        qkv = ops.reshape(qkv, (b, h * w, 3, self.num_heads, self.head_dim))
+        qkv = ops.transpose(qkv, (2, 0, 3, 1, 4))
+        q, k, v = qkv[0], qkv[1], qkv[2]  # each: (B, num_heads, H*W, head_dim)
+
+        if self.q_stride is not None:
+            # Pool q back into a spatial map, strided-pool it, then flatten
+            # again. k and v keep the pre-pool spatial size.
+            q_spatial = ops.reshape(
+                ops.transpose(q, (0, 2, 1, 3)), (b, h, w, self.dim_out)
+            )
+            q_spatial = _do_pool(q_spatial, self.q_stride)
+            h_out = h // self.q_stride[0]
+            w_out = w // self.q_stride[1]
+            q = ops.reshape(
+                q_spatial, (b, h_out * w_out, self.num_heads, self.head_dim)
+            )
+            q = ops.transpose(q, (0, 2, 1, 3))
+        else:
+            h_out, w_out = h, w
+
+        # Explicit einsum attention: `ops.dot_product_attention` on the TF
+        # backend asserts equal target/source sequence lengths, which the
+        # pooled-`q`, full-`k`/`v` case violates.
+        attn_scores = ops.einsum("bntd,bnsd->bnts", q, k) * self.scale
+        # Compute the softmax in float32 for numerical stability, then cast
+        # back so the subsequent matmul keeps the block's compute dtype.
+        attn_scores = ops.cast(
+            ops.softmax(ops.cast(attn_scores, "float32"), axis=-1),
+            self.compute_dtype,
+        )
+        attn_output = ops.einsum("bnts,bnsd->bntd", attn_scores, v)
+        # (B, num_heads, H_out*W_out, head_dim)
+        attn_output = ops.transpose(attn_output, (0, 2, 1, 3))
+        attn_output = ops.reshape(attn_output, (b, h_out, w_out, self.dim_out))
+        return self.proj(attn_output)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "dim_in": self.dim_in,
+                "dim_out": self.dim_out,
+                "num_heads": self.num_heads,
+                "q_stride": self.q_stride,
+            }
+        )
+        return config
+
+
+class HieraBlock(keras.layers.Layer):
+    """One Hiera transformer block.
+
+    Mirrors `trunk.blocks.i` in SAM2:
+      - `norm1` before attention.
+      - Window-partition (skipped when `window_size == 0`, i.e. global attn).
+      - `attn` with optional `q_stride` pooling in the first block of each
+        pooling stage.
+      - A residual whose skip path applies `proj` when `dim_in != dim_out`,
+        followed by the same `q_stride` pooling on the skip.
+      - `norm2` + `mlp` with another residual.
+    """
+
+    def __init__(
+        self,
+        dim_in,
+        dim_out,
+        num_heads,
+        mlp_ratio=4.0,
+        q_stride=None,
+        window_size=0,
+        layer_norm_epsilon=1e-6,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.dim_in = dim_in
+        self.dim_out = dim_out
+        self.num_heads = num_heads
+        self.mlp_ratio = mlp_ratio
+        self.q_stride = tuple(q_stride) if q_stride is not None else None
+        self.window_size = window_size
+        self.layer_norm_epsilon = layer_norm_epsilon
+
+    def build(self, input_shape):
+        self.norm1 = keras.layers.LayerNormalization(
+            epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
+            name="norm1",
+        )
+        self.norm1.build(input_shape)
+
+        self.attn = HieraMultiScaleAttention(
+            dim_in=self.dim_in,
+            dim_out=self.dim_out,
+            num_heads=self.num_heads,
+            q_stride=self.q_stride,
+            dtype=self.dtype_policy,
+            name="attn",
+        )
+        self.attn.build(input_shape)
+
+        out_shape = list(input_shape)
+        out_shape[-1] = self.dim_out
+        self.norm2 = keras.layers.LayerNormalization(
+            epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
+            name="norm2",
+        )
+        self.norm2.build(tuple(out_shape))
+
+        self.mlp = HieraMLP(
+            hidden_dim=int(self.dim_out * self.mlp_ratio),
+            output_dim=self.dim_out,
+            dtype=self.dtype_policy,
+            name="mlp",
+        )
+        self.mlp.build(tuple(out_shape))
+
+        if self.dim_in != self.dim_out:
+            # Residual projection for the first block of each pooling stage.
+            self.proj = keras.layers.Dense(
+                self.dim_out, dtype=self.dtype_policy, name="proj"
+            )
+            self.proj.build(input_shape)
+        else:
+            self.proj = None
+
+        self.built = True
+
+    def call(self, x):
+        shortcut = x
+        x = self.norm1(x)
+
+        if self.dim_in != self.dim_out:
+            # Project and pool the skip path so it matches attention's output.
+            shortcut = _do_pool(self.proj(x), self.q_stride)
+        elif self.q_stride is not None:
+            shortcut = _do_pool(shortcut, self.q_stride)
+
+        window_size = self.window_size
+        if window_size > 0:
+            h, w = ops.shape(x)[1], ops.shape(x)[2]
+            x, pad_hw = _window_partition(x, window_size)
+
+        x = self.attn(x)
+
+        if self.q_stride is not None:
+            # Attention pooled `q`, so the effective window and feature map
+            # sizes shrink.
+            window_size = window_size // self.q_stride[0] if window_size else 0
+            if window_size > 0:
+                h = h // self.q_stride[0]
+                w = w // self.q_stride[1]
+                pad_hw = (
+                    pad_hw[0] // self.q_stride[0],
+                    pad_hw[1] // self.q_stride[1],
+                )
+
+        if window_size > 0:
+            x = _window_unpartition(x, window_size, pad_hw, (h, w))
+
+        x = shortcut + x
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "dim_in": self.dim_in,
+                "dim_out": self.dim_out,
+                "num_heads": self.num_heads,
+                "mlp_ratio": self.mlp_ratio,
+                "q_stride": self.q_stride,
+                "window_size": self.window_size,
+                "layer_norm_epsilon": self.layer_norm_epsilon,
+            }
+        )
+        return config

--- a/keras_hub/src/models/hiera/hiera_layers.py
+++ b/keras_hub/src/models/hiera/hiera_layers.py
@@ -133,6 +133,16 @@ class HieraAbsolutePositionEmbedding(keras.layers.Layer):
         pos_embed_window_full = ops.tile(
             pos_embed_window, (1, tile_h, tile_w, 1)
         )
+        # If `feature_map_size` is not an exact multiple of `window_size`,
+        # the tiled grid is smaller than the feature map; right-pad so the
+        # add against `inputs` broadcasts cleanly.
+        pad_h = self.feature_map_size[0] - tile_h * self.window_size
+        pad_w = self.feature_map_size[1] - tile_w * self.window_size
+        if pad_h > 0 or pad_w > 0:
+            pos_embed_window_full = ops.pad(
+                pos_embed_window_full,
+                [[0, 0], [0, pad_h], [0, pad_w], [0, 0]],
+            )
         # Position-embedding variables are stored at variable_dtype (fp32
         # under mixed precision); cast to the block's compute dtype before
         # adding so the residual path does not introduce a dtype mismatch.
@@ -249,6 +259,11 @@ class HieraMultiScaleAttention(keras.layers.Layer):
 
     def __init__(self, dim_in, dim_out, num_heads, q_stride=None, **kwargs):
         super().__init__(**kwargs)
+        if dim_out % num_heads != 0:
+            raise ValueError(
+                f"`dim_out` ({dim_out}) must be divisible by `num_heads` "
+                f"({num_heads})."
+            )
         self.dim_in = dim_in
         self.dim_out = dim_out
         self.num_heads = num_heads


### PR DESCRIPTION
## Summary

Adds `HieraBackbone` — the hierarchical-ViT image encoder from "Hiera: A Hierarchical Vision Transformer without the Bells-and-Whistles" (Ryali et al., 2023), used as the trunk of Meta'''s SAM2 image encoder. First PR in the SAM2 series; addresses the **"[Contributions Welcome] Add SAM2"** roadmap item (#1836, #2390).

## What's in this PR

The trunk mirrors the weight layout of `image_encoder.trunk.*` in the HuggingFace `facebook/sam2-hiera-*-hf` safetensors so a future HF converter can port weights directly:

- 7x7 stride-4 Conv2D patch embedding.
- Bicubically-interpolated learned background position embedding plus a tiled, window-sized position embedding, added once at stage 0.
- Four stages of transformer blocks (default `stages=(1, 2, 7, 2)` — Hiera-tiny). Each stage doubles `embed_dim` and `num_heads`. The first block of every pooling stage applies 2x2 strided maxpool to the query (`q_stride=(2, 2)`) and projects the residual path to the new channel dimension.
- Mask-unit (windowed) attention per stage, with a configurable `global_attention_blocks` set that uses full attention instead.

Outputs: the last stage'''s feature map is returned as the default output, and the multi-scale feature pyramid is exposed via `HieraBackbone.pyramid_outputs` with keys `P2..P5` for strides 4/8/16/32 (same convention as `ResNetBackbone`, `DenseNetBackbone`, etc.).

## Tests

- `test_backbone_basics`: standard backbone suite.
- `test_feature_pyramid_outputs`: shape at all four scales.
- `test_global_attention_blocks_disable_windowing`: blocks in `global_attention_blocks` have `window_size=0`, others match `window_spec`.
- `test_saved_model` (large): save/load round-trip.

Passes on TensorFlow, JAX, and PyTorch backends.

## Scope / follow-ups

- Mixed-precision and quantization sweeps are disabled in this PR — the softmax and bicubic-resize hops leak fp32 in a few backend configurations that need a dedicated stabilization pass.
- SAM2 neck, mask decoder, memory bank, preprocessor, and task class come in follow-up PRs (keras-hub staged-PR convention from `CONTRIBUTING_MODELS.md`).
- HF converter + presets for `facebook/sam2-hiera-*-hf` are also follow-ups in the series.
