### PR TITLE
Fix dynamic batch dim crash on OpenVINO backend

### DIFF
--- a/keras_hub/src/layers/modeling/non_max_supression.py
+++ b/keras_hub/src/layers/modeling/non_max_supression.py
@@ -238,7 +238,7 @@ def non_max_suppression(
     num_boxes = boxes.shape[-2]
     boxes = ops.reshape(boxes, [-1, num_boxes, 4])
     scores = ops.reshape(scores, [-1, num_boxes])
-    batch_size = boxes.shape[0]
+    batch_size = ops.shape(boxes)[0]
     if score_threshold != float("-inf"):
         score_mask = ops.cast(scores > score_threshold, scores.dtype)
         scores *= score_mask
@@ -469,7 +469,7 @@ def _suppression_loop_body(boxes, iou_threshold, output_size, idx, tile_size):
         idx: the updated induction variable.
     """
     num_tiles = boxes.shape[1] // tile_size
-    batch_size = boxes.shape[0]
+    batch_size = ops.shape(boxes)[0]
 
     def cross_suppression_func(boxes, box_slice, iou_threshold, inner_idx):
         return _cross_suppression(

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -451,9 +451,9 @@ def target_gather(
 
         def assign_when_rows_empty():
             if len(labels.shape) > 1:
-                mask_shape = [match_indices.shape[0], labels.shape[-1]]
+                mask_shape = [ops.shape(match_indices)[0], labels.shape[-1]]
             else:
-                mask_shape = [match_indices.shape[0]]
+                mask_shape = [ops.shape(match_indices)[0]]
             return ops.cast(mask_val, labels.dtype) * ops.ones(
                 mask_shape, dtype=labels.dtype
             )


### PR DESCRIPTION
## Description of the change
This PR addresses a fix for the temporary turnaround introduced in keras-team/keras/pull/22681.

Replaced tensor.shape[0] with ops.shape(tensor)[0] in non_max_suppression and target_gather so tensor allocation works when the batch dim is None during OpenVINO graph tracing. ops.shape() returns a graph node on compiled backends and a plain int on eager backends.




## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change. NA
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
