### PR TITLE
 Track untracked EOI variables in T5Gemma2 backbone

### DIFF
--- a/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
@@ -467,13 +467,10 @@ class T5Gemma2Backbone(Backbone):
             self.num_vision_tokens_per_image = (
                 self.vision_encoder.num_vision_tokens_per_image
             )
-            # EOI variables are created before super().__init__() (which builds
-            # the Functional graph). Functional Models only auto-track layers
-            # found during graph construction, so standalone keras.Variable
-            # objects must be tracked manually to ensure they are included in
-            # save_weights / load_weights.
-            self._track_variable(self.encoder_eoi_embedding)
-            self._track_variable(self.decoder_eoi_embedding)
+            # Re-assign EOI variables after super().__init__() to trigger
+            # automatic tracking by the Functional model for serialization.
+            self.encoder_eoi_embedding = self.encoder_eoi_embedding
+            self.decoder_eoi_embedding = self.decoder_eoi_embedding
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
@@ -467,6 +467,13 @@ class T5Gemma2Backbone(Backbone):
             self.num_vision_tokens_per_image = (
                 self.vision_encoder.num_vision_tokens_per_image
             )
+            # EOI variables are created before super().__init__() (which builds
+            # the Functional graph). Functional Models only auto-track layers
+            # found during graph construction, so standalone keras.Variable
+            # objects must be tracked manually to ensure they are included in
+            # save_weights / load_weights.
+            self._track_variable(self.encoder_eoi_embedding)
+            self._track_variable(self.decoder_eoi_embedding)
 
     def get_config(self):
         config = super().get_config()


### PR DESCRIPTION
## Description of the change

This PR fixes a serialization bug in the T5Gemma2Backbone where the End-of-Image (EOI) embeddings were being silently dropped during save_weights() and load_weights().

The Issue
The encoder_eoi_embedding and decoder_eoi_embedding were instantiated as raw keras.Variable objects before super().__init__() was called. Because they were created prior to the Functional Model graph construction and were not tied to a specific Keras Layer, the variables were not automatically tracked by the framework. As a result, when the model was serialized to a preset, the EOI embeddings were left out, causing them to default to zeros upon reloading.

The Fix
Added self._track_variable() calls immediately after super().__init__() for both the encoder and decoder EOI embeddings. This explicitly registers the standalone variables with the Functional Model, ensuring they are correctly captured and restored during standard Keras weight serialization.

HF Model Link: https://huggingface.co/collections/google/t5gemma-2
HF source code:  https://github.com/huggingface/transformers/tree/main/src/transformers/models/t5gemma2