### PR TITLE
 Add build()method  to Qwen3.5 vision encoder and remove workarounds

### DIFF
--- a/keras_hub/src/models/qwen3_5/qwen3_5_vision_encoder.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_vision_encoder.py
@@ -532,6 +532,32 @@ class Qwen3_5VisionEncoder(keras.Model):
             name="merger",
         )
 
+    def build(self, input_shape=None):
+        """Build all sublayers explicitly.
+
+        This ensures all weight variables are created immediately, so
+        they can be accessed for serialization/export without needing
+        a forward pass first.
+        """
+        if not self.patch_embed.built:
+            self.patch_embed.build(
+                (
+                    None,
+                    self.temporal_patch_size,
+                    self.patch_size,
+                    self.patch_size,
+                    self.in_channels,
+                )
+            )
+        if not self.pos_embed.built:
+            self.pos_embed.build((None,))
+        for blk in self.blocks:
+            if not blk.built:
+                blk.build((None, self.hidden_size))
+        if not self.merger.built:
+            self.merger.build((None, self.hidden_size))
+        super().build(input_shape)
+
     def _fast_pos_embed_interpolate(self, grid_thw):
         """Bilinear interpolation of absolute position embeddings.
 

--- a/keras_hub/src/utils/transformers/convert_qwen3_5.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_5.py
@@ -359,25 +359,6 @@ def convert_weights(backbone, loader, transformers_config):
         vis = backbone.vision_encoder
         vis_prefix = "model.visual"
 
-        # Explicitly build sublayers since they use lazy build().
-        if not vis.patch_embed.built:
-            vis.patch_embed.build(
-                (
-                    None,
-                    vis.temporal_patch_size,
-                    vis.patch_size,
-                    vis.patch_size,
-                    vis.in_channels,
-                )
-            )
-        if not vis.pos_embed.built:
-            vis.pos_embed.build((None,))
-        for blk in vis.blocks:
-            if not blk.built:
-                blk.build((None, vis.hidden_size))
-        if not vis.merger.built:
-            vis.merger.build((None, vis.hidden_size))
-
         # Patch embedding Conv3D.
         # HF: (hidden_size, in_channels, temporal, patch, patch)
         # Keras Conv3D: (temporal, patch, patch, in_channels, hidden_size)


### PR DESCRIPTION
## Description of the change



The Qwen3_5VisionEncoder sublayers (patch_embed, pos_embed, blocks, merger) use lazy initialization — their weights are only created on first call() with real tensors. While this works fine for inference, it prevents direct access to weight variables (e.g., blk.norm1.gamma) needed by the converter and exporter.

Changes:

`qwen3_5_vision_encoder.py:` Added a build() method that explicitly builds all sublayers with their expected input shapes, ensuring weight variables are available immediately after construction.

`convert_qwen3_5.py:`  Removed the manual build workaround that was compensating for the missing build() method.

Both the import converter (convert_qwen3_5.py) and the upcoming export pipeline need to access sublayer weights directly. Previously, each had to duplicate the same manual build workaround. Moving this logic into the encoder's build() method is the proper fix and eliminates the need for workarounds in any consuming code.

Testing:

Verified with `verify_qwen3_5_export.py` — all config, token ID, and numerical parity checks pass (text, image, video).


Re-generating weighst:

We don't need to re-generate or re-upload anything.

The build() method doesn't change:

`Weights` — same values, same variable names, same shapes
`Architecture `— same layers, same get_config() output
`Serialization format `— Keras saves/loads weights by variable path, which hasn't changed

All it does is ensure the weight variables are created eagerly (in build()) instead of lazily (on first call()). The existing Kaggle presets will load and work exactly the same way — when load_weights() is called, the build() method will call first, create the variables, and then the weights get assigned.