### PR TITLE
fix(models): Fix Gemma3n TF backend .fit() crash with GQA

### DIFF
--- a/keras_hub/src/models/gemma3n/gemma3n_attention.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_attention.py
@@ -365,7 +365,7 @@ class Gemma3nTextAttention(keras.layers.Layer):
         for grouped-query attention."""
         if self.num_key_value_groups == 1:
             return hidden_states
-        batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+        batch, num_key_value_heads, slen, head_dim = ops.shape(hidden_states)
         hidden_states = ops.expand_dims(hidden_states, 2)
         hidden_states = ops.repeat(
             hidden_states, self.num_key_value_groups, axis=2

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_test.py
@@ -377,3 +377,46 @@ class Gemma3nCausalLMTest(TestCase, parameterized.TestCase):
         }
         output = causal_lm.generate(inputs)
         self.assertIsInstance(output, str)
+
+    def test_gqa_fit(self):
+        # Test fit() with GQA (num_heads != num_kv_heads).
+        preprocessor = Gemma3nCausalLMPreprocessor(
+            tokenizer=self.tokenizer,
+            image_converter=None,
+            audio_converter=None,
+            sequence_length=20,
+            max_images_per_prompt=0,
+            num_vision_tokens_per_image=0,
+            max_audios_per_prompt=0,
+            num_audio_tokens_per_audio=0,
+        )
+        backbone = Gemma3nBackbone(
+            text_vocab_size=preprocessor.tokenizer.vocabulary_size(),
+            text_hidden_size=8,
+            num_hidden_layers=1,
+            pad_token_id=0,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=2,
+            intermediate_size=[16],
+            hidden_activation="gelu_approximate",
+            layer_types=["full_attention"],
+            sliding_window=4,
+            rope_theta=10000.0,
+            max_position_embeddings=20,
+            vocab_size_per_layer_input=10,
+            hidden_size_per_layer_input=2,
+            altup_num_inputs=2,
+            laurel_rank=1,
+        )
+        causal_lm = Gemma3nCausalLM(
+            preprocessor=preprocessor,
+            backbone=backbone,
+        )
+        train_data = (
+            {
+                "prompts": ["the quick brown fox", "the quick brown fox"],
+                "responses": ["the earth is round", "the earth is round"],
+            },
+        )
+        causal_lm.fit(x=train_data[0], batch_size=2)

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_test.py
@@ -409,14 +409,24 @@ class Gemma3nCausalLMTest(TestCase, parameterized.TestCase):
             altup_num_inputs=2,
             laurel_rank=1,
         )
-        causal_lm = Gemma3nCausalLM(
-            preprocessor=preprocessor,
-            backbone=backbone,
-        )
-        train_data = (
-            {
-                "prompts": ["the quick brown fox", "the quick brown fox"],
-                "responses": ["the earth is round", "the earth is round"],
+        self.run_task_test(
+            cls=Gemma3nCausalLM,
+            init_kwargs={
+                "preprocessor": preprocessor,
+                "backbone": backbone,
             },
+            train_data=(
+                {
+                    "prompts": ["the quick brown fox", "the quick brown fox"],
+                    "responses": [
+                        "the earth is round",
+                        "the earth is round",
+                    ],
+                },
+            ),
+            expected_output_shape=(
+                2,
+                20,
+                preprocessor.tokenizer.vocabulary_size(),
+            ),
         )
-        causal_lm.fit(x=train_data[0], batch_size=2)


### PR DESCRIPTION
### Description of the change

The following use case was identified and fixed in this PR:

→ Changed `hidden_states.shape` to `ops.shape()` to match the canonical pattern, and since this bug broke `fit()` on the TF backend for every Gemma3n preset (all presets use GQA).
→ The existing tests did not catch this because they use `num_attention_heads=1, num_key_value_heads=1`
→ Added scope-limited test coverage, and made sure there's no other model in KH which has the same bug (all the models, [T5Gemma 2](https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/models/t5gemma2/t5gemma2_attention.py#L28), [T5Gemma](https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/models/t5gemma/t5gemma_attention.py#L33) and [SmolLM3](https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/models/smollm3/smollm3_utils.py#L26) correctly use `ops.shape()`)

Fixes #2711.

cc: @divyashreepathihalli @laxmareddyp

**Current Output:**

<img alt="Image" src="https://github.com/user-attachments/assets/aaa392ca-770f-4ac8-960d-cd8e83dd5f15" /><br>

**Output After Fix:**

<img alt="1-1" src="https://github.com/user-attachments/assets/e1068abb-f06b-4cdd-b1be-6b627ee8d97c" />

###  Checklist
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).