### PR TITLE
fix: convert_preprocessing_outputs to safely handle Python-native outputs and prevent .dtype errors.

### DIFF
--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -207,10 +207,17 @@ def convert_preprocessing_outputs(x):
     def convert(x):
         if x is None:
             return x
-        if isinstance(x, tf.RaggedTensor) or x.dtype == tf.string:
+
+        if isinstance(x, tf.RaggedTensor):
             return tensor_to_list(x)
-        dtype = keras.backend.standardize_dtype(x.dtype)
-        return ops.convert_to_tensor(x, dtype=dtype)
+
+        if hasattr(x, "dtype"):
+            if x.dtype == tf.string:
+                return tensor_to_list(x)
+            dtype = keras.backend.standardize_dtype(x.dtype)
+            return ops.convert_to_tensor(x, dtype=dtype)
+
+        return x
 
     return keras.tree.map_structure(convert, x)
 

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -207,17 +207,18 @@ def convert_preprocessing_outputs(x):
     def convert(x):
         if x is None:
             return x
-
         if isinstance(x, tf.RaggedTensor):
             return tensor_to_list(x)
+        dtype = getattr(x, "dtype", None)
 
-        if hasattr(x, "dtype"):
-            if x.dtype == tf.string:
-                return tensor_to_list(x)
-            dtype = keras.backend.standardize_dtype(x.dtype)
-            return ops.convert_to_tensor(x, dtype=dtype)
+        if dtype is None:
+            return x
 
-        return x
+        if dtype == tf.string:
+            return tensor_to_list(x)
+
+        dtype = keras.backend.standardize_dtype(dtype)
+        return ops.convert_to_tensor(x, dtype=dtype)
 
     return keras.tree.map_structure(convert, x)
 

--- a/keras_hub/src/utils/tensor_utils_test.py
+++ b/keras_hub/src/utils/tensor_utils_test.py
@@ -85,6 +85,16 @@ class ConvertHelpers(TestCase):
         self.assertTrue(is_tensor_type(outputs[1]))
         self.assertTrue(is_tensor_type(outputs[2]))
 
+    def test_python_native_outputs(self):
+        inputs = "hello world"
+        outputs = convert_preprocessing_outputs(inputs)
+        self.assertEqual(outputs, "hello world")
+        self.assertIsInstance(outputs, str)
+        inputs = ["hello", "world"]
+        outputs = convert_preprocessing_outputs(inputs)
+        self.assertEqual(outputs, ["hello", "world"])
+        self.assertIsInstance(outputs, list)
+
         def to_list(x):
             return ops.convert_to_numpy(x).tolist() if is_tensor_type(x) else x
 


### PR DESCRIPTION
This PR fixes  an `AttributeError` that occurs when preprocessing outputs are Python-native types under the enabled Python workflow. It ensures that both `tensor-based` and `Python-native outputs` are handled safely without breaking existing preprocessing behavior.

Fixes - https://github.com/keras-team/keras-hub/issues/2719

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
