### PR TITLE
Standardize rope_theta extraction for transformers >= 5.0 compatibility

### DIFF
--- a/keras_hub/src/utils/transformers/convert_dinov3.py
+++ b/keras_hub/src/utils/transformers/convert_dinov3.py
@@ -7,6 +7,12 @@ backbone_cls = DINOV3Backbone
 
 def convert_backbone_config(transformers_config):
     image_size = transformers_config["image_size"]
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
+
     return {
         "patch_size": transformers_config["patch_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -27,7 +33,7 @@ def convert_backbone_config(transformers_config):
         "drop_path_rate": transformers_config["drop_path_rate"],
         "layer_norm_eps": transformers_config["layer_norm_eps"],
         "image_shape": (image_size, image_size, 3),
-        "rope_theta": transformers_config["rope_theta"],
+        "rope_theta": rope_theta,
         "apply_layernorm": False,
     }
 

--- a/keras_hub/src/utils/transformers/convert_dinov3_test.py
+++ b/keras_hub/src/utils/transformers/convert_dinov3_test.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
 
+from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.dinov3.dinov3_backbone import DINOV3Backbone
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_dinov3
 
 
 class TestTask(TestCase):
@@ -33,3 +35,67 @@ class TestTask(TestCase):
             ],
             atol=1e-2,
         )
+
+    @pytest.mark.extra_large
+    def test_class_detection(self):
+        model = Backbone.from_preset(
+            "hf://facebook/dinov3-vits16-pretrain-lvd1689m",
+            image_shape=(224, 224, 3),
+            load_weights=False,
+        )
+        self.assertIsInstance(model, DINOV3Backbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "image_size": 224,
+            "patch_size": 16,
+            "num_hidden_layers": 2,
+            "hidden_size": 32,
+            "num_attention_heads": 4,
+            "intermediate_size": 48,
+            "layerscale_value": 1.0,
+            "num_register_tokens": 0,
+            "hidden_act": "gelu",
+            "use_gated_mlp": False,
+            "query_bias": True,
+            "key_bias": True,
+            "value_bias": True,
+            "proj_bias": True,
+            "mlp_bias": True,
+            "attention_dropout": 0.0,
+            "drop_path_rate": 0.0,
+            "layer_norm_eps": 1e-6,
+            "rope_theta": 10000.0,
+        }
+        keras_config = convert_dinov3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_theta"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config = {
+            "image_size": 224,
+            "patch_size": 16,
+            "num_hidden_layers": 2,
+            "hidden_size": 32,
+            "num_attention_heads": 4,
+            "intermediate_size": 48,
+            "layerscale_value": 1.0,
+            "num_register_tokens": 0,
+            "hidden_act": "gelu",
+            "use_gated_mlp": False,
+            "query_bias": True,
+            "key_bias": True,
+            "value_bias": True,
+            "proj_bias": True,
+            "mlp_bias": True,
+            "attention_dropout": 0.0,
+            "drop_path_rate": 0.0,
+            "layer_norm_eps": 1e-6,
+            "rope_parameters": {"rope_theta": 20000.0},
+        }
+        keras_config = convert_dinov3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_theta"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_gemma3.py
+++ b/keras_hub/src/utils/transformers/convert_gemma3.py
@@ -56,7 +56,9 @@ def convert_backbone_config(transformers_config):
     # global rotary embedding. `rope_parameters` is optional and not used
     # by HF for global scaling when `rope_scaling` is None.
     rope_scaling = transformer_config.get("rope_scaling", None)
-    rope_params = transformer_config.get("rope_parameters") or {}
+    rope_params = transformer_config.get("rope_parameters", {})
+    if rope_params is None:
+        rope_params = {}
 
     if rope_scaling is not None:
         rope_global_config = rope_scaling or {}

--- a/keras_hub/src/utils/transformers/convert_gemma3n.py
+++ b/keras_hub/src/utils/transformers/convert_gemma3n.py
@@ -181,6 +181,10 @@ def convert_backbone_config(transformers_config):
             "hidden_activation", "gelu_approximate"
         )
 
+    rope_theta = text_config.get("rope_parameters", {}).get("rope_theta")
+    if rope_theta is None:
+        rope_theta = text_config["rope_theta"]
+
     return {
         "text_vocab_size": text_config["vocab_size"],
         "text_hidden_size": text_config["hidden_size"],
@@ -193,7 +197,7 @@ def convert_backbone_config(transformers_config):
         "hidden_activation": hidden_activation,
         "layer_types": text_config["layer_types"],
         "sliding_window": text_config["sliding_window"],
-        "rope_theta": text_config["rope_theta"],
+        "rope_theta": rope_theta,
         "max_position_embeddings": text_config["max_position_embeddings"],
         "vocab_size_per_layer_input": text_config["vocab_size_per_layer_input"],
         "hidden_size_per_layer_input": text_config[

--- a/keras_hub/src/utils/transformers/convert_gemma3n_test.py
+++ b/keras_hub/src/utils/transformers/convert_gemma3n_test.py
@@ -1,0 +1,95 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.gemma3n.gemma3n_backbone import Gemma3nBackbone
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_gemma3n
+
+
+class TestGemma3nConverter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = Gemma3nBackbone.from_preset(
+            "hf://yujiepan/gemma-3n-tiny-random-dim4",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, Gemma3nBackbone)
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = Backbone.from_preset(
+            "hf://yujiepan/gemma-3n-tiny-random-dim4",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, Gemma3nBackbone)
+
+    def test_gemma3n_rope_theta(self):
+        # transformers < 5 format
+        text_cfg = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "intermediate_size": 48,
+            "layer_types": ["full_attention", "full_attention"],
+            "sliding_window": 4096,
+            "rope_theta": 10000.0,
+            "rms_norm_eps": 1e-5,
+            "max_position_embeddings": 32,
+            "vocab_size_per_layer_input": 100,
+            "hidden_size_per_layer_input": 32,
+            "altup_num_inputs": 1,
+            "laurel_rank": 1,
+            "attention_bias": False,
+            "attention_dropout": 0.0,
+            "altup_coef_clip": 1.0,
+            "altup_active_idx": 0,
+            "altup_correct_scale": False,
+            "num_kv_shared_layers": 1,
+        }
+        transformers_config = {
+            "text_config": text_cfg,
+            "vision_config": {
+                "hidden_size": 32,
+                "vocab_size": 100,
+                "vocab_offset": 0,
+            },
+            "audio_config": {
+                "hidden_size": 32,
+                "input_feat_size": 32,
+                "sscp_conv_channel_size": 32,
+                "sscp_conv_kernel_size": 3,
+                "sscp_conv_stride_size": 2,
+                "sscp_conv_group_norm_eps": 1e-5,
+                "conf_num_hidden_layers": 2,
+                "rms_norm_eps": 1e-5,
+                "gradient_clipping": 1.0,
+                "conf_residual_weight": 0.1,
+                "conf_num_attention_heads": 4,
+                "conf_attention_chunk_size": 16,
+                "conf_attention_context_right": 8,
+                "conf_attention_context_left": 8,
+                "conf_attention_logit_cap": 10.0,
+                "conf_conv_kernel_size": 3,
+                "conf_reduction_factor": 2,
+                "vocab_size": 100,
+                "vocab_offset": 0,
+            },
+            "vision_soft_tokens_per_image": 16,
+            "image_token_id": 1,
+            "audio_soft_tokens_per_image": 16,
+            "audio_token_id": 2,
+        }
+        keras_config = convert_gemma3n.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_theta"], 10000.0)
+
+        # transformers >= 5 format
+        text_cfg["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_gemma3n.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_theta"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_gemma4.py
+++ b/keras_hub/src/utils/transformers/convert_gemma4.py
@@ -231,7 +231,9 @@ def convert_backbone_config(transformers_config):
 
     # Partial RoPE factor for global (full) attention layers.
     # Stored under rope_parameters["full_attention"]["partial_rotary_factor"].
-    rope_params = text_cfg.get("rope_parameters", {}) or {}
+    rope_params = text_cfg.get("rope_parameters", {})
+    if rope_params is None:
+        rope_params = {}
     global_rope_partial_rotary_factor = rope_params.get(
         "full_attention", {}
     ).get("partial_rotary_factor")
@@ -243,6 +245,8 @@ def convert_backbone_config(transformers_config):
     # If it's missing in `full_attention`, safely fall back to top-level cfg.
     if global_rope_theta is None:
         global_rope_theta = text_cfg.get("rope_theta")
+    if local_rope_theta is None:
+        local_rope_theta = text_cfg.get("rope_theta")
 
     # HF `use_bidirectional_attention` controls vision-token attention only:
     #   null     → purely causal for all tokens (E2B, E4B).

--- a/keras_hub/src/utils/transformers/convert_gpt_oss.py
+++ b/keras_hub/src/utils/transformers/convert_gpt_oss.py
@@ -12,6 +12,11 @@ backbone_cls = GptOssBackbone
 
 def convert_backbone_config(transformers_config):
     """Convert a Hugging Face Gpt-Oss config to a KerasHub config."""
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     config = {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -21,7 +26,7 @@ def convert_backbone_config(transformers_config):
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "num_experts": transformers_config["num_local_experts"],
         "top_k": transformers_config["num_experts_per_tok"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
         "sliding_window": transformers_config.get("sliding_window"),
         "output_router_logits": transformers_config.get(

--- a/keras_hub/src/utils/transformers/convert_gpt_oss_test.py
+++ b/keras_hub/src/utils/transformers/convert_gpt_oss_test.py
@@ -5,6 +5,7 @@ from keras_hub.src.models.causal_lm import CausalLM
 from keras_hub.src.models.gpt_oss.gpt_oss_backbone import GptOssBackbone
 from keras_hub.src.models.gpt_oss.gpt_oss_causal_lm import GptOssCausalLM
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_gpt_oss
 
 
 class TestTask(TestCase):
@@ -27,3 +28,42 @@ class TestTask(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, GptOssBackbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "num_local_experts": 2,
+            "num_experts_per_tok": 1,
+            "rope_theta": 10000.0,
+            "rms_norm_eps": 1e-5,
+            "sliding_window": 4096,
+        }
+        keras_config = convert_gpt_oss.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "num_local_experts": 2,
+            "num_experts_per_tok": 1,
+            "rope_parameters": {"rope_theta": 20000.0},
+            "rms_norm_eps": 1e-5,
+            "sliding_window": 4096,
+        }
+        keras_config = convert_gpt_oss.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_llama3.py
+++ b/keras_hub/src/utils/transformers/convert_llama3.py
@@ -7,6 +7,11 @@ backbone_cls = Llama3Backbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     backbone_config = {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -15,7 +20,7 @@ def convert_backbone_config(transformers_config):
         "intermediate_dim": transformers_config["intermediate_size"],
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "tie_word_embeddings": transformers_config["tie_word_embeddings"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
     }
 
     if transformers_config.get("rope_scaling", None) is not None:

--- a/keras_hub/src/utils/transformers/convert_llama3_test.py
+++ b/keras_hub/src/utils/transformers/convert_llama3_test.py
@@ -5,6 +5,7 @@ from keras_hub.src.models.causal_lm import CausalLM
 from keras_hub.src.models.llama3.llama3_backbone import Llama3Backbone
 from keras_hub.src.models.llama3.llama3_causal_lm import Llama3CausalLM
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_llama3
 
 
 class TestTask(TestCase):
@@ -26,5 +27,40 @@ class TestTask(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, Llama3Backbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "rope_theta": 10000.0,
+            "rms_norm_eps": 1e-5,
+            "tie_word_embeddings": True,
+        }
+        keras_config = convert_llama3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "rope_parameters": {"rope_theta": 20000.0},
+            "rms_norm_eps": 1e-5,
+            "tie_word_embeddings": True,
+        }
+        keras_config = convert_llama3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)
 
     # TODO: compare numerics with huggingface model

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -7,6 +7,11 @@ backbone_cls = MistralBackbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -14,7 +19,7 @@ def convert_backbone_config(transformers_config):
         "hidden_dim": transformers_config["hidden_size"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "num_key_value_heads": transformers_config["num_key_value_heads"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
         "sliding_window": transformers_config["sliding_window"],
     }

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -5,6 +5,7 @@ from keras_hub.src.models.causal_lm import CausalLM
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.models.mistral.mistral_causal_lm import MistralCausalLM
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_mistral
 
 
 class TestTask(TestCase):
@@ -26,5 +27,43 @@ class TestTask(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, MistralBackbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "rope_theta": 10000.0,
+            "rms_norm_eps": 1e-5,
+            "sliding_window": 4096,
+        }
+        keras_config = convert_mistral.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "rope_parameters": {"rope_theta": 20000.0},
+            "rms_norm_eps": 1e-5,
+            "sliding_window": 4096,
+        }
+        # In the real transformers >= 5, rope_theta might still be present at
+        # top level for some models, but the source of truth moved to
+        # rope_parameters.
+        keras_config = convert_mistral.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)
 
     # TODO: compare numerics with huggingface model

--- a/keras_hub/src/utils/transformers/convert_mixtral.py
+++ b/keras_hub/src/utils/transformers/convert_mixtral.py
@@ -7,6 +7,11 @@ backbone_cls = MixtralBackbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "num_layers": transformers_config["num_hidden_layers"],
@@ -16,7 +21,7 @@ def convert_backbone_config(transformers_config):
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "num_experts": transformers_config["num_local_experts"],
         "top_k": transformers_config["num_experts_per_tok"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
         "sliding_window": transformers_config["sliding_window"],
         "output_router_logits": transformers_config["output_router_logits"],

--- a/keras_hub/src/utils/transformers/convert_mixtral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mixtral_test.py
@@ -1,0 +1,56 @@
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.causal_lm import CausalLM
+from keras_hub.src.models.mixtral.mixtral_backbone import MixtralBackbone
+from keras_hub.src.models.mixtral.mixtral_causal_lm import MixtralCausalLM
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_mixtral
+
+
+class TestMixtralConverter(TestCase):
+    def test_convert_tiny_preset(self):
+        model = MixtralCausalLM.from_preset(
+            "hf://hf-internal-testing/tiny-random-MixtralForCausalLM",
+            load_weights=False,
+        )
+        prompt = "What is your favorite condiment?"
+        model.generate([prompt], max_length=15)
+
+    def test_class_detection(self):
+        model = CausalLM.from_preset(
+            "hf://hf-internal-testing/tiny-random-MixtralForCausalLM",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, MixtralCausalLM)
+        model = Backbone.from_preset(
+            "hf://hf-internal-testing/tiny-random-MixtralForCausalLM",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, MixtralBackbone)
+
+    def test_mixtral_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_key_value_heads": 2,
+            "num_local_experts": 4,
+            "num_experts_per_tok": 2,
+            "rope_theta": 10000.0,
+            "rms_norm_eps": 1e-5,
+            "sliding_window": 4096,
+            "output_router_logits": False,
+        }
+        keras_config = convert_mixtral.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_mixtral.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_qwen.py
+++ b/keras_hub/src/utils/transformers/convert_qwen.py
@@ -7,6 +7,11 @@ backbone_cls = QwenBackbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "hidden_dim": transformers_config["hidden_size"],
@@ -15,7 +20,7 @@ def convert_backbone_config(transformers_config):
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "use_sliding_window": transformers_config["use_sliding_window"],
         "sliding_window_size": transformers_config["sliding_window"],
         "tie_word_embeddings": transformers_config["tie_word_embeddings"],
@@ -132,6 +137,12 @@ def convert_tokenizer(cls, preset, **kwargs):
     tokenizer_config = load_json(preset, "tokenizer.json")
     vocab = tokenizer_config["model"]["vocab"]
     merges = tokenizer_config["model"]["merges"]
+
+    # Handle different merge formats
+    if merges and isinstance(merges[0], list) and len(merges[0]) == 2:
+        # Convert list of lists format [["Ġ", "a"], ["Ġ", "b"]]
+        # to space-separated strings
+        merges = [" ".join(merge) for merge in merges]
 
     # Load all special tokens with the exception of "reserved" ones.
     special_tokens = set()

--- a/keras_hub/src/utils/transformers/convert_qwen3.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3.py
@@ -7,6 +7,11 @@ backbone_cls = Qwen3Backbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "head_dim": transformers_config["head_dim"],
@@ -16,7 +21,7 @@ def convert_backbone_config(transformers_config):
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "sliding_window_size": transformers_config["sliding_window"]
         if transformers_config["use_sliding_window"]
         else None,

--- a/keras_hub/src/utils/transformers/convert_qwen3_5.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_5.py
@@ -110,7 +110,18 @@ def convert_backbone_config(transformers_config):
 
     # rope_theta and partial_rotary_factor are nested under
     # rope_parameters in the HF config.
-    rope_params = transformers_config["rope_parameters"]
+    rope_params = transformers_config.get("rope_parameters", {})
+    rope_theta = rope_params.get("rope_theta")
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
+
+    # explicit access for partial_rotary_factor to raise KeyError if missing.
+    if "rope_parameters" in transformers_config:
+        partial_rotary_factor = transformers_config["rope_parameters"][
+            "partial_rotary_factor"
+        ]
+    else:
+        partial_rotary_factor = transformers_config["partial_rotary_factor"]
 
     # M-RoPE section lives inside rope_parameters in HF config.
     mrope_section = rope_params.get("mrope_section", None)
@@ -155,8 +166,8 @@ def convert_backbone_config(transformers_config):
         "num_key_value_heads": transformers_config["num_key_value_heads"],
         "intermediate_dim": transformers_config["intermediate_size"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "rope_max_wavelength": rope_params["rope_theta"],
-        "partial_rotary_factor": rope_params["partial_rotary_factor"],
+        "rope_max_wavelength": rope_theta,
+        "partial_rotary_factor": partial_rotary_factor,
         "tie_word_embeddings": tie_word_embeddings,
         "layer_types": layer_types,
         "linear_num_key_heads": transformers_config["linear_num_key_heads"],

--- a/keras_hub/src/utils/transformers/convert_qwen3_5_test.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_5_test.py
@@ -1,0 +1,60 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_qwen3_5
+
+
+class TestQwen3_5Converter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = Qwen3_5Backbone.from_preset(
+            "hf://yujiepan/qwen3.5-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, Qwen3_5Backbone)
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = Backbone.from_preset(
+            "hf://yujiepan/qwen3.5-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, Qwen3_5Backbone)
+
+    def test_qwen3_5_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "head_dim": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 48,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 0.5,
+            "rope_parameters": {"partial_rotary_factor": 0.5},
+            "tie_word_embeddings": True,
+            "linear_num_key_heads": 1,
+            "linear_num_value_heads": 1,
+            "linear_key_head_dim": 8,
+            "linear_value_head_dim": 8,
+            "linear_conv_kernel_dim": 4,
+        }
+        keras_config = convert_qwen3_5.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {
+            "rope_theta": 20000.0,
+            "partial_rotary_factor": 0.5,
+        }
+        keras_config = convert_qwen3_5.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_qwen3_moe.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_moe.py
@@ -7,6 +7,11 @@ backbone_cls = Qwen3MoeBackbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "hidden_dim": transformers_config["hidden_size"],
@@ -21,7 +26,7 @@ def convert_backbone_config(transformers_config):
         "norm_top_k_prob": transformers_config["norm_topk_prob"],
         "decoder_sparse_step": transformers_config["decoder_sparse_step"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "sliding_window_size": transformers_config["sliding_window"],
         "router_aux_loss_coefficient": transformers_config[
             "router_aux_loss_coef"

--- a/keras_hub/src/utils/transformers/convert_qwen3_moe_test.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_moe_test.py
@@ -6,6 +6,7 @@ from keras_hub.src.models.causal_lm import CausalLM
 from keras_hub.src.models.qwen3_moe.qwen3_moe_backbone import Qwen3MoeBackbone
 from keras_hub.src.models.qwen3_moe.qwen3_moe_causal_lm import Qwen3MoeCausalLM
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_qwen3_moe
 
 
 # NOTE: This test is valid and should pass locally. It is skipped only on
@@ -35,3 +36,37 @@ class TestTask(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, Qwen3MoeBackbone)
+
+
+class TestQwen3MoeRopeTheta(TestCase):
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "head_dim": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 48,
+            "moe_intermediate_size": 64,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "norm_topk_prob": True,
+            "decoder_sparse_step": 1,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "sliding_window": 4096,
+            "router_aux_loss_coef": 0.001,
+        }
+        keras_config = convert_qwen3_moe.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_qwen3_moe.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_qwen3_test.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_test.py
@@ -1,0 +1,52 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.qwen3.qwen3_backbone import Qwen3Backbone
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_qwen3
+
+
+class TestQwen3Converter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = Qwen3Backbone.from_preset(
+            "hf://yujiepan/qwen3-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, Qwen3Backbone)
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = Backbone.from_preset(
+            "hf://yujiepan/qwen3-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, Qwen3Backbone)
+
+    def test_qwen3_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "head_dim": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 48,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "use_sliding_window": False,
+            "sliding_window": 4096,
+            "tie_word_embeddings": True,
+        }
+        keras_config = convert_qwen3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_qwen3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_qwen_moe.py
+++ b/keras_hub/src/utils/transformers/convert_qwen_moe.py
@@ -7,6 +7,11 @@ backbone_cls = QwenMoeBackbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "hidden_dim": transformers_config["hidden_size"],
@@ -23,7 +28,7 @@ def convert_backbone_config(transformers_config):
         "norm_top_k_prob": transformers_config["norm_topk_prob"],
         "decoder_sparse_step": transformers_config["decoder_sparse_step"],
         "layer_norm_epsilon": transformers_config["rms_norm_eps"],
-        "rope_max_wavelength": transformers_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
         "use_sliding_window": transformers_config["use_sliding_window"],
         "sliding_window_size": transformers_config["sliding_window"],
         "output_router_logits": transformers_config["output_router_logits"],
@@ -236,6 +241,12 @@ def convert_tokenizer(cls, preset, **kwargs):
     tokenizer_config = load_json(preset, "tokenizer.json")
     vocab = tokenizer_config["model"]["vocab"]
     merges = tokenizer_config["model"]["merges"]
+
+    # Handle different merge formats
+    if merges and isinstance(merges[0], list) and len(merges[0]) == 2:
+        # Convert list of lists format [["Ġ", "a"], ["Ġ", "b"]]
+        # to space-separated strings
+        merges = [" ".join(merge) for merge in merges]
 
     # Load all special tokens with the exception of "reserved" ones.
     special_tokens = set()

--- a/keras_hub/src/utils/transformers/convert_qwen_moe_test.py
+++ b/keras_hub/src/utils/transformers/convert_qwen_moe_test.py
@@ -1,0 +1,58 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.qwen_moe.qwen_moe_backbone import QwenMoeBackbone
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_qwen_moe
+
+
+class TestQwenMoeConverter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = QwenMoeBackbone.from_preset(
+            "hf://yujiepan/qwen1.5-moe-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, QwenMoeBackbone)
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = Backbone.from_preset(
+            "hf://yujiepan/qwen1.5-moe-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, QwenMoeBackbone)
+
+    def test_qwen_moe_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 48,
+            "moe_intermediate_size": 64,
+            "shared_expert_intermediate_size": 32,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "norm_topk_prob": True,
+            "decoder_sparse_step": 1,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "use_sliding_window": False,
+            "sliding_window": 4096,
+            "output_router_logits": False,
+            "router_aux_loss_coef": 0.001,
+        }
+        keras_config = convert_qwen_moe.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_qwen_moe.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_qwen_test.py
+++ b/keras_hub/src/utils/transformers/convert_qwen_test.py
@@ -1,0 +1,47 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.qwen.qwen_backbone import QwenBackbone
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_qwen
+
+
+class TestQwenConverter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = QwenBackbone.from_preset(
+            "hf://yujiepan/qwen2-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, QwenBackbone)
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = Backbone.from_preset(
+            "hf://yujiepan/qwen2-tiny-random",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, QwenBackbone)
+
+    def test_qwen_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 48,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "use_sliding_window": False,
+            "sliding_window": 4096,
+            "tie_word_embeddings": True,
+        }
+        keras_config = convert_qwen.convert_backbone_config(transformers_config)
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_qwen.convert_backbone_config(transformers_config)
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_sam3.py
+++ b/keras_hub/src/utils/transformers/convert_sam3.py
@@ -40,6 +40,12 @@ def convert_backbone_config(transformers_config, cls, **kwargs):
                 3,
             )
 
+        rope_theta = backbone_config.get("rope_parameters", {}).get(
+            "rope_theta"
+        )
+        if rope_theta is None:
+            rope_theta = backbone_config["rope_theta"]
+
         # Vision Encoder.
         vision_encoder_config = {
             "image_shape": image_shape,
@@ -56,7 +62,7 @@ def convert_backbone_config(transformers_config, cls, **kwargs):
                 3,
             ),
             "hidden_activation": backbone_config["hidden_act"],
-            "rope_theta": backbone_config["rope_theta"],
+            "rope_theta": rope_theta,
             "window_size": backbone_config["window_size"],
             "global_attn_indexes": backbone_config["global_attn_indexes"],
             "attention_dropout_rate": backbone_config["attention_dropout"],

--- a/keras_hub/src/utils/transformers/convert_sam3_test.py
+++ b/keras_hub/src/utils/transformers/convert_sam3_test.py
@@ -10,6 +10,7 @@ from keras_hub.src.models.sam3.sam3_pc_image_segmenter import (
     SAM3PromptableConceptImageSegmenter,
 )
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_sam3
 
 
 class SAM3ConverterTest(TestCase):
@@ -46,3 +47,105 @@ class SAM3ConverterTest(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, SAM3PromptableConceptBackbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        backbone_config = {
+            "image_size": 32,
+            "patch_size": 16,
+            "num_hidden_layers": 2,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_attention_heads": 4,
+            "pretrain_image_size": 32,
+            "hidden_act": "gelu",
+            "rope_theta": 10000.0,
+            "window_size": 0,
+            "global_attn_indexes": [],
+            "attention_dropout": 0.0,
+            "hidden_dropout": 0.0,
+            "layer_norm_eps": 1e-6,
+        }
+        transformers_config = {
+            "detector_config": {
+                "vision_config": {
+                    "backbone_config": backbone_config,
+                    "fpn_hidden_size": 32,
+                    "scale_factors": [1, 2],
+                },
+                "text_config": {
+                    "vocab_size": 100,
+                    "hidden_size": 32,
+                    "num_hidden_layers": 2,
+                    "num_attention_heads": 4,
+                    "intermediate_size": 48,
+                    "hidden_act": "gelu",
+                    "max_position_embeddings": 32,
+                    "layer_norm_eps": 1e-6,
+                },
+                "geometry_encoder_config": {
+                    "num_layers": 2,
+                    "hidden_size": 32,
+                    "intermediate_size": 48,
+                    "num_attention_heads": 4,
+                    "roi_size": 7,
+                    "hidden_act": "gelu",
+                    "hidden_dropout": 0.0,
+                    "layer_norm_eps": 1e-6,
+                },
+                "detr_encoder_config": {
+                    "num_layers": 2,
+                    "hidden_size": 32,
+                    "intermediate_size": 48,
+                    "num_attention_heads": 4,
+                    "hidden_act": "gelu",
+                    "dropout": 0.0,
+                    "layer_norm_eps": 1e-6,
+                },
+                "detr_decoder_config": {
+                    "num_layers": 2,
+                    "hidden_size": 32,
+                    "intermediate_size": 48,
+                    "num_attention_heads": 4,
+                    "num_queries": 100,
+                    "hidden_act": "gelu",
+                    "dropout": 0.0,
+                    "layer_norm_eps": 1e-6,
+                },
+                "mask_decoder_config": {
+                    "num_upsampling_stages": 2,
+                    "hidden_size": 32,
+                    "num_attention_heads": 4,
+                    "layer_norm_eps": 1e-6,
+                },
+            }
+        }
+        keras_config = convert_sam3.convert_backbone_config(
+            transformers_config, cls=SAM3PromptableConceptBackbone
+        )
+        self.assertEqual(keras_config["vision_encoder"].rope_theta, 10000.0)
+
+        # transformers >= 5 format
+        backbone_config = {
+            "image_size": 32,
+            "patch_size": 16,
+            "num_hidden_layers": 2,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_attention_heads": 4,
+            "pretrain_image_size": 32,
+            "hidden_act": "gelu",
+            "rope_parameters": {"rope_theta": 20000.0},
+            "window_size": 0,
+            "global_attn_indexes": [],
+            "attention_dropout": 0.0,
+            "hidden_dropout": 0.0,
+            "layer_norm_eps": 1e-6,
+        }
+        transformers_config["detector_config"]["vision_config"][
+            "backbone_config"
+        ] = backbone_config
+        keras_config = convert_sam3.convert_backbone_config(
+            transformers_config, cls=SAM3PromptableConceptBackbone
+        )
+        self.assertEqual(keras_config["vision_encoder"].rope_theta, 20000.0)

--- a/keras_hub/src/utils/transformers/convert_smollm3.py
+++ b/keras_hub/src/utils/transformers/convert_smollm3.py
@@ -7,6 +7,11 @@ backbone_cls = SmolLM3Backbone
 
 
 def convert_backbone_config(transformers_config):
+    rope_theta = transformers_config.get("rope_parameters", {}).get(
+        "rope_theta"
+    )
+    if rope_theta is None:
+        rope_theta = transformers_config["rope_theta"]
     return {
         "vocabulary_size": transformers_config["vocab_size"],
         "hidden_dim": transformers_config["hidden_size"],
@@ -20,7 +25,7 @@ def convert_backbone_config(transformers_config):
         "max_position_embeddings": transformers_config[
             "max_position_embeddings"
         ],
-        "rope_theta": transformers_config["rope_theta"],
+        "rope_theta": rope_theta,
         # partial_rotary_factor is not explicitly in config.json
         # but is inherited from the default value in the
         # `_compute_default_rope_parameters()` function

--- a/keras_hub/src/utils/transformers/convert_smollm3_test.py
+++ b/keras_hub/src/utils/transformers/convert_smollm3_test.py
@@ -5,9 +5,16 @@ from keras_hub.src.models.causal_lm import CausalLM
 from keras_hub.src.models.smollm3.smollm3_backbone import SmolLM3Backbone
 from keras_hub.src.models.smollm3.smollm3_causal_lm import SmolLM3CausalLM
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_smollm3
 
 
 class TestSmollm3Converter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = SmolLM3CausalLM.from_preset("hf://yujiepan/smollm3-tiny-random")
+        prompt = "What is your favorite condiment?"
+        model.generate([prompt], max_length=15)
+
     @pytest.mark.extra_large
     def test_convert_preset(self):
         model = SmolLM3CausalLM.from_preset("hf://HuggingFaceTB/SmolLM3-3B")
@@ -26,3 +33,33 @@ class TestSmollm3Converter(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, SmolLM3Backbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        transformers_config = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 48,
+            "rms_norm_eps": 1e-5,
+            "max_position_embeddings": 32,
+            "rope_theta": 10000.0,
+            "attention_bias": False,
+            "attention_dropout": 0.0,
+            "no_rope_layers": [1, 1],
+            "layer_types": ["full_attention", "full_attention"],
+            "mlp_bias": False,
+        }
+        keras_config = convert_smollm3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_theta"], 10000.0)
+
+        # transformers >= 5 format
+        transformers_config["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_smollm3.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_theta"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_t5gemma.py
+++ b/keras_hub/src/utils/transformers/convert_t5gemma.py
@@ -14,6 +14,10 @@ def convert_backbone_config(transformers_config):
     if encoder_config.get("hidden_activation") == "gelu_pytorch_tanh":
         encoder_config["hidden_activation"] = "gelu_approximate"
 
+    rope_theta = decoder_config.get("rope_parameters", {}).get("rope_theta")
+    if rope_theta is None:
+        rope_theta = decoder_config["rope_theta"]
+
     backbone_config = {
         "vocabulary_size": decoder_config["vocab_size"],
         "encoder_hidden_dim": encoder_config["hidden_size"],
@@ -44,7 +48,7 @@ def convert_backbone_config(transformers_config):
         "cross_attention_hidden_size": encoder_config["hidden_size"],
         "attn_logit_softcapping": decoder_config["attn_logit_softcapping"],
         "final_logit_softcapping": decoder_config["final_logit_softcapping"],
-        "rope_max_wavelength": decoder_config["rope_theta"],
+        "rope_max_wavelength": rope_theta,
     }
     return backbone_config
 

--- a/keras_hub/src/utils/transformers/convert_t5gemma2.py
+++ b/keras_hub/src/utils/transformers/convert_t5gemma2.py
@@ -67,6 +67,44 @@ def convert_backbone_config(transformers_config):
             layer_norm_epsilon=vision_config["layer_norm_eps"],
         )
 
+    # rope_theta extraction for decoder
+    rope_theta = (
+        decoder_config.get("rope_parameters", {})
+        .get("sliding_attention", {})
+        .get("rope_theta")
+    )
+    if rope_theta is None:
+        rope_theta = decoder_config["rope_theta"]
+
+    # rope_scaling_factor extraction for decoder
+    rope_scaling_factor = (
+        decoder_config.get("rope_parameters", {})
+        .get("full_attention", {})
+        .get("factor")
+    )
+    if rope_scaling_factor is None:
+        rope_scaling_factor = decoder_config.get("rope_scaling", {}).get(
+            "factor"
+        )
+
+    # rope_theta extraction for encoder
+    enc_rope_theta = (
+        enc_text.get("rope_parameters", {})
+        .get("sliding_attention", {})
+        .get("rope_theta")
+    )
+    if enc_rope_theta is None:
+        enc_rope_theta = enc_text["rope_theta"]
+
+    # rope_scaling_factor extraction for encoder
+    enc_rope_scaling_factor = (
+        enc_text.get("rope_parameters", {})
+        .get("full_attention", {})
+        .get("factor")
+    )
+    if enc_rope_scaling_factor is None:
+        enc_rope_scaling_factor = enc_text.get("rope_scaling", {}).get("factor")
+
     backbone_config = {
         "vocabulary_size": decoder_config["vocab_size"],
         "encoder_hidden_dim": enc_text["hidden_size"],
@@ -95,18 +133,10 @@ def convert_backbone_config(transformers_config):
         "cross_attention_hidden_size": enc_text["hidden_size"],
         "attn_logit_softcapping": decoder_config["attn_logit_softcapping"],
         "final_logit_softcapping": decoder_config["final_logit_softcapping"],
-        "rope_max_wavelength": (
-            decoder_config["rope_parameters"]["sliding_attention"]["rope_theta"]
-        ),
-        "global_rope_scaling_factor": (
-            decoder_config["rope_parameters"]["full_attention"]["factor"]
-        ),
-        "encoder_rope_max_wavelength": (
-            enc_text["rope_parameters"]["sliding_attention"]["rope_theta"]
-        ),
-        "encoder_global_rope_scaling_factor": (
-            enc_text["rope_parameters"]["full_attention"]["factor"]
-        ),
+        "rope_max_wavelength": rope_theta,
+        "global_rope_scaling_factor": rope_scaling_factor,
+        "encoder_rope_max_wavelength": enc_rope_theta,
+        "encoder_global_rope_scaling_factor": enc_rope_scaling_factor,
         # use_qk_norm may not be in config JSON; default True.
         "use_query_key_norm": enc_text.get("use_qk_norm", True),
         "vision_encoder": vision_encoder,

--- a/keras_hub/src/utils/transformers/convert_t5gemma2_test.py
+++ b/keras_hub/src/utils/transformers/convert_t5gemma2_test.py
@@ -8,6 +8,7 @@ from keras_hub.src.models.t5gemma2.t5gemma2_seq_2_seq_lm import (
     T5Gemma2Seq2SeqLM,
 )
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_t5gemma2
 
 
 class TestT5Gemma2Converter(TestCase):
@@ -34,3 +35,63 @@ class TestT5Gemma2Converter(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, T5Gemma2Backbone)
+
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format (flat)
+        enc_text_cfg = {
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "layer_types": ["full_attention", "sliding_attention"],
+            "tie_word_embeddings": True,
+            "rope_theta": 10000.0,
+        }
+        decoder_cfg = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "layer_types": ["full_attention", "sliding_attention"],
+            "dropout_rate": 0.1,
+            "rms_norm_eps": 1e-5,
+            "query_pre_attn_scalar": 1.0,
+            "attention_bias": False,
+            "hidden_activation": "gelu",
+            "initializer_range": 0.02,
+            "attention_dropout": 0.1,
+            "sliding_window": 4096,
+            "attn_logit_softcapping": 50.0,
+            "final_logit_softcapping": 30.0,
+            "rope_theta": 10000.0,
+        }
+        transformers_config = {
+            "encoder": {"text_config": enc_text_cfg},
+            "decoder": decoder_cfg,
+            "eoi_token_index": 1,
+        }
+        keras_config = convert_t5gemma2.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+        self.assertEqual(keras_config["encoder_rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format (nested)
+        enc_text_cfg["rope_parameters"] = {
+            "sliding_attention": {"rope_theta": 20000.0},
+            "full_attention": {"factor": 1.0},
+        }
+        decoder_cfg["rope_parameters"] = {
+            "sliding_attention": {"rope_theta": 20000.0},
+            "full_attention": {"factor": 1.0},
+        }
+        keras_config = convert_t5gemma2.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)
+        self.assertEqual(keras_config["encoder_rope_max_wavelength"], 20000.0)

--- a/keras_hub/src/utils/transformers/convert_t5gemma_test.py
+++ b/keras_hub/src/utils/transformers/convert_t5gemma_test.py
@@ -6,6 +6,7 @@ from keras_hub.src.models.seq_2_seq_lm import Seq2SeqLM
 from keras_hub.src.models.t5gemma.t5gemma_backbone import T5GemmaBackbone
 from keras_hub.src.models.t5gemma.t5gemma_seq_2_seq_lm import T5GemmaSeq2SeqLM
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.transformers import convert_t5gemma
 
 
 # NOTE: This test is valid and should pass locally. It is skipped only on
@@ -37,3 +38,53 @@ class TestTask(TestCase):
             load_weights=False,
         )
         self.assertIsInstance(model, T5GemmaBackbone)
+
+
+class TestT5GemmaRopeTheta(TestCase):
+    def test_convert_backbone_config_rope_theta(self):
+        # transformers < 5 format
+        encoder_cfg = {
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "layer_types": ["full_attention", "full_attention"],
+        }
+        decoder_cfg = {
+            "vocab_size": 100,
+            "hidden_size": 32,
+            "intermediate_size": 48,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "layer_types": ["full_attention", "full_attention"],
+            "dropout_rate": 0.1,
+            "rms_norm_eps": 1e-5,
+            "query_pre_attn_scalar": 1.0,
+            "attention_bias": False,
+            "hidden_activation": "gelu",
+            "initializer_range": 0.02,
+            "attention_dropout": 0.1,
+            "sliding_window": 4096,
+            "attn_logit_softcapping": 50.0,
+            "final_logit_softcapping": 30.0,
+            "rope_theta": 10000.0,
+        }
+        transformers_config = {
+            "encoder": encoder_cfg,
+            "decoder": decoder_cfg,
+        }
+        keras_config = convert_t5gemma.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 10000.0)
+
+        # transformers >= 5 format
+        decoder_cfg["rope_parameters"] = {"rope_theta": 20000.0}
+        keras_config = convert_t5gemma.convert_backbone_config(
+            transformers_config
+        )
+        self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)

--- a/tools/checkpoint_conversion/convert_llama3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_llama3_checkpoints.py
@@ -227,6 +227,18 @@ def main(_):
     hf_model.eval()
     print("\n-> Huggingface model and tokenizer loaded")
 
+    rope_max_wavelength = None
+    if hasattr(hf_model.config, "rope_parameters") and getattr(
+        hf_model.config, "rope_parameters"
+    ):
+        rope_params = getattr(hf_model.config, "rope_parameters")
+        if isinstance(rope_params, dict):
+            rope_max_wavelength = rope_params.get("rope_theta")
+        else:
+            rope_max_wavelength = getattr(rope_params, "rope_theta", None)
+    if rope_max_wavelength is None:
+        rope_max_wavelength = hf_model.config.rope_theta
+
     # === Load the KerasHub model ===
     backbone_kwargs = dict(
         vocabulary_size=hf_model.config.vocab_size,
@@ -236,7 +248,7 @@ def main(_):
         num_key_value_heads=hf_model.config.num_key_value_heads,
         intermediate_dim=hf_model.config.intermediate_size,
         layer_norm_epsilon=hf_model.config.rms_norm_eps,
-        rope_max_wavelength=hf_model.config.rope_theta,
+        rope_max_wavelength=rope_max_wavelength,
         dtype="bfloat16",
     )
     keras_hub_model = Llama3Backbone(**backbone_kwargs)

--- a/tools/checkpoint_conversion/convert_llama_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_llama_checkpoints.py
@@ -224,6 +224,18 @@ def main(_):
             f"{FLAGS.validate_dtype}"
         )
 
+        rope_max_wavelength = None
+        if hasattr(hf_model.config, "rope_parameters") and getattr(
+            hf_model.config, "rope_parameters"
+        ):
+            rope_params = getattr(hf_model.config, "rope_parameters")
+            if isinstance(rope_params, dict):
+                rope_max_wavelength = rope_params.get("rope_theta")
+            else:
+                rope_max_wavelength = getattr(rope_params, "rope_theta", None)
+        if rope_max_wavelength is None:
+            rope_max_wavelength = hf_model.config.rope_theta
+
         # === Load the KerasHub model ===
         backbone_kwargs = dict(
             vocabulary_size=hf_model.config.vocab_size,
@@ -233,7 +245,7 @@ def main(_):
             num_key_value_heads=hf_model.config.num_key_value_heads,
             intermediate_dim=hf_model.config.intermediate_size,
             layer_norm_epsilon=hf_model.config.rms_norm_eps,
-            rope_max_wavelength=hf_model.config.rope_theta,
+            rope_max_wavelength=rope_max_wavelength,
             dtype=FLAGS.validate_dtype,
         )
         keras_hub_model = LlamaBackbone(**backbone_kwargs)

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -224,6 +224,18 @@ def main(_):
         hf_model.eval()
         print("\n-> Huggingface model and tokenizer loaded")
 
+        rope_max_wavelength = None
+        if hasattr(hf_model.config, "rope_parameters") and getattr(
+            hf_model.config, "rope_parameters"
+        ):
+            rope_params = getattr(hf_model.config, "rope_parameters")
+            if isinstance(rope_params, dict):
+                rope_max_wavelength = rope_params.get("rope_theta")
+            else:
+                rope_max_wavelength = getattr(rope_params, "rope_theta", None)
+        if rope_max_wavelength is None:
+            rope_max_wavelength = hf_model.config.rope_theta
+
         # === Load the KerasHub model ===
         backbone_kwargs = dict(
             vocabulary_size=hf_model.config.vocab_size,
@@ -234,7 +246,7 @@ def main(_):
             intermediate_dim=hf_model.config.intermediate_size,
             sliding_window=hf_model.config.sliding_window,
             layer_norm_epsilon=hf_model.config.rms_norm_eps,
-            rope_max_wavelength=hf_model.config.rope_theta,
+            rope_max_wavelength=rope_max_wavelength,
             dtype="float32",
         )
         keras_hub_backbone = MistralBackbone(**backbone_kwargs)

--- a/tools/checkpoint_conversion/convert_moonshine_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_moonshine_checkpoints.py
@@ -115,7 +115,10 @@ for preset in presets:
     cfg["intermediate_dim"] = pt_cfg["intermediate_size"]
     cfg["max_sequence_length"] = pt_cfg["max_position_embeddings"]
     cfg["partial_rotary_factor"] = pt_cfg["partial_rotary_factor"]
-    cfg["rope_theta"] = pt_cfg["rope_theta"]
+    rope_theta = pt_cfg.get("rope_parameters", {}).get("rope_theta")
+    if rope_theta is None:
+        rope_theta = pt_cfg["rope_theta"]
+    cfg["rope_theta"] = rope_theta
     cfg["encoder_num_layers"] = pt_cfg["encoder_num_hidden_layers"]
     cfg["decoder_num_layers"] = pt_cfg["decoder_num_hidden_layers"]
     cfg["encoder_num_heads"] = pt_cfg.get("encoder_num_attention_heads", 8)

--- a/tools/checkpoint_conversion/convert_phi3_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_phi3_checkpoints.py
@@ -90,7 +90,10 @@ def convert_model(hf_model, device, dtype):
     kwargs["original_max_sequence_length"] = hf_config[
         "original_max_position_embeddings"
     ]
-    kwargs["rope_max_wavelength"] = hf_config["rope_theta"]
+    rope_theta = hf_config.get("rope_parameters", {}).get("rope_theta")
+    if rope_theta is None:
+        rope_theta = hf_config["rope_theta"]
+    kwargs["rope_max_wavelength"] = rope_theta
     if hf_config["rope_scaling"] is not None:
         kwargs["rope_scaling_type"] = hf_config["rope_scaling"]["type"]
         kwargs["rope_scaling_short_factor"] = hf_config["rope_scaling"][

--- a/tools/checkpoint_conversion/convert_t5gemma_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_t5gemma_checkpoints.py
@@ -80,6 +80,20 @@ def convert_checkpoints(hf_model):
     if encoder_config.hidden_activation == "gelu_pytorch_tanh":
         encoder_config.hidden_activation = "gelu_approximate"
     keras.config.set_floatx("float32")
+
+    # rope_theta extraction
+    rope_max_wavelength = None
+    if hasattr(decoder_config, "rope_parameters") and getattr(
+        decoder_config, "rope_parameters"
+    ):
+        rope_params = getattr(decoder_config, "rope_parameters")
+        if isinstance(rope_params, dict):
+            rope_max_wavelength = rope_params.get("rope_theta")
+        else:
+            rope_max_wavelength = getattr(rope_params, "rope_theta", None)
+    if rope_max_wavelength is None:
+        rope_max_wavelength = decoder_config.rope_theta
+
     keras_hub_model = keras_hub.models.T5GemmaBackbone(
         vocabulary_size=decoder_config.vocab_size,
         encoder_hidden_dim=encoder_config.hidden_size,
@@ -110,7 +124,7 @@ def convert_checkpoints(hf_model):
         cross_attention_hidden_size=encoder_config.hidden_size,
         attn_logit_softcapping=decoder_config.attn_logit_softcapping,
         final_logit_softcapping=decoder_config.final_logit_softcapping,
-        rope_max_wavelength=decoder_config.rope_theta,
+        rope_max_wavelength=rope_max_wavelength,
         dtype="float32",
     )
 


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras-hub/issues/2729

This PR standardizes the extraction of rope_theta across all Hugging Face converters and checkpoint conversion scripts.

Problem:
Hugging Face transformers v5.0+ moved rope_theta from the top-level configuration to a nested rope_parameters dictionary. This caused KeyError: 'rope_theta' when trying to load presets or convert checkpoints using modern versions of the transformers library.

Solution:
Implemented a defensive extraction pattern that checks both the new nested location and the old top-level location, ensuring compatibility with both transformers < 5 and transformers >= 5.

Colab notebook testing the fix: https://colab.research.google.com/drive/12laeufmT6sz9RaOOBLzlLtK6E-33-fTD?usp=sharing

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
