### PR TITLE
Add Gemma4 Assistant Model and Speculative Decoding

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -334,6 +334,9 @@ from keras_hub.src.models.gemma3n.gemma3n_causal_lm_preprocessor import (
 from keras_hub.src.models.gemma3n.gemma3n_tokenizer import (
     Gemma3nTokenizer as Gemma3nTokenizer,
 )
+from keras_hub.src.models.gemma4.gemma4_assistant_causal_lm import (
+    Gemma4AssistantCausalLM as Gemma4AssistantCausalLM,
+)
 from keras_hub.src.models.gemma4.gemma4_audio_encoder import (
     Gemma4AudioEncoder as Gemma4AudioEncoder,
 )

--- a/keras_hub/api/samplers/__init__.py
+++ b/keras_hub/api/samplers/__init__.py
@@ -14,5 +14,8 @@ from keras_hub.src.samplers.sampler import Sampler as Sampler
 from keras_hub.src.samplers.serialization import deserialize as deserialize
 from keras_hub.src.samplers.serialization import get as get
 from keras_hub.src.samplers.serialization import serialize as serialize
+from keras_hub.src.samplers.speculative_sampler import (
+    SpeculativeSampler as SpeculativeSampler,
+)
 from keras_hub.src.samplers.top_k_sampler import TopKSampler as TopKSampler
 from keras_hub.src.samplers.top_p_sampler import TopPSampler as TopPSampler

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -235,6 +235,22 @@ class Gemma4AssistantCausalLM(CausalLM):
         output = ops.scatter_update(output, coords, updates)
         return ops.reshape(output, (batch, seq, vocab_size))
 
+    def call(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Gemma4AssistantCausalLM is an MTP draft model that requires a "
+            "target model and cannot be called standalone. Use "
+            "`target_model.generate(..., assistant_model=assistant_model)` "
+            "instead."
+        )
+
+    def generate_step(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Gemma4AssistantCausalLM is an MTP draft model that requires a "
+            "target model and cannot be called standalone. Use "
+            "`target_model.generate(..., assistant_model=assistant_model)` "
+            "instead."
+        )
+
     def call_with_cache(
         self,
         last_token_embedding,
@@ -328,27 +344,6 @@ class Gemma4AssistantCausalLM(CausalLM):
         next_hidden_state = self.post_projection(hidden_states)
 
         return logits, next_hidden_state
-
-    @property
-    def _layers(self):
-        base = self.__dict__.get("_layers_storage", [])
-        extra = []
-        for attr in ("pre_projection", "post_projection", "centroids"):
-            layer = getattr(self, attr, None)
-            if layer is not None and layer not in base:
-                extra.append(layer)
-        return base + extra
-
-    @_layers.setter
-    def _layers(self, value):
-        # Use object.__setattr__ to bypass __setattr__ → tracker recursion.
-        object.__setattr__(self, "_layers_storage", value)
-
-    def _flatten_layers(self, include_self=True, recursive=True):
-        """Delegate to super(); the ``_layers`` property already adds extras."""
-        return super()._flatten_layers(
-            include_self=include_self, recursive=recursive
-        )
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -140,10 +140,14 @@ class Gemma4AssistantCausalLM(CausalLM):
             )
             self.centroids.build((None, 1, hidden_size))
 
+            # Store as float32 so TensorFlow places this variable on GPU
+            # alongside other model weights. Cast to int32 at use time in
+            # _apply_centroid_logits. Using int32 here causes TF to place
+            # the variable on CPU, which breaks XLA execution on GPU.
             self.token_ordering = self.add_weight(
                 name="token_ordering",
                 shape=(vocabulary_size,),
-                dtype="int32",
+                dtype="float32",
                 trainable=False,
                 initializer="zeros",
             )

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -1,0 +1,366 @@
+from keras import layers
+from keras import ops
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.causal_lm import CausalLM
+from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+
+
+@keras_hub_export("keras_hub.models.Gemma4AssistantCausalLM")
+class Gemma4AssistantCausalLM(CausalLM):
+    """An MTP assistant model for speculative decoding with Gemma4.
+
+    This model drafts candidate tokens to be verified by a larger target model.
+    It conditions on the target model's last hidden state and last token
+    embedding, and borrows the target model's KV cache via the KV-sharing
+    mechanism in `Gemma4Backbone`.
+
+    This model must NOT be used standalone. Each `call_with_cache()` step
+    requires:
+      - `last_hidden_state`: target model last-position hidden state,
+        shape `(batch, 1, backbone_hidden_size)`.
+      - `last_token_id`: last accepted token id, shape `(batch, 1)`.
+      - `target_cache`: target model full KV cache tensor, shape
+        `(batch, num_target_layers, 2, max_len, num_heads, head_dim)`.
+
+    Args:
+        backbone: A `keras_hub.models.Gemma4Backbone` configured with the
+            assistant's own dimensions (e.g. `hidden_dim=256`, `num_layers=4`)
+            and `num_kv_shared_layers=4`.
+        backbone_hidden_size: int. Hidden dimension of the **target** model
+            (e.g. `1536` for Gemma4 2B). Used to size the projection layers.
+            Defaults to `1536`.
+        num_centroids: int. Number of vocabulary centroids for the ordered
+            embedding head. Defaults to `2048`.
+        centroid_intermediate_top_k: int. Number of active centroids per
+            forward pass. Defaults to `32`.
+        use_ordered_embeddings: bool. Whether to use sparse centroid-based
+            embedding routing for logits. Larger variants (e.g. 26B) disable
+            this for a standard output head. Defaults to `True`.
+        sampler: A `keras_hub.samplers.Sampler` instance or string. The
+            sampling strategy. Defaults to `"greedy"`.
+        num_speculative_tokens: int. Number of draft tokens proposed per
+            speculative decoding step. Passed to `SpeculativeSampler` by
+            the target model's `generate()`. Defaults to `5`.
+
+    Examples:
+    ```python
+    import keras_hub
+
+    target_lm = keras_hub.models.Gemma4CausalLM.from_preset(
+        "gemma4_instruct_2b"
+    )
+    assistant_lm = keras_hub.models.Gemma4AssistantCausalLM.from_preset(
+        "gemma4_instruct_2b_assistant"
+    )
+    response = target_lm.generate(
+        "What is the capital of France?",
+        assistant_model=assistant_lm,
+        max_length=128,
+    )
+    ```
+    """
+
+    backbone_cls = Gemma4Backbone
+
+    def __init__(
+        self,
+        backbone,
+        backbone_hidden_size,
+        num_centroids,
+        centroid_intermediate_top_k,
+        use_ordered_embeddings,
+        num_speculative_tokens=5,
+        sampler="greedy",
+        **kwargs,
+    ):
+        self.backbone_hidden_size = backbone_hidden_size
+        self.num_centroids = num_centroids
+        self.centroid_intermediate_top_k = centroid_intermediate_top_k
+        self.use_ordered_embeddings = use_ordered_embeddings
+        self.num_speculative_tokens = num_speculative_tokens
+        self.backbone = backbone
+
+        hidden_size = backbone.hidden_dim
+        vocabulary_size = backbone.token_embedding.input_dim
+        self._vocab_size_per_centroid = vocabulary_size // num_centroids
+
+        for layer in self.backbone.transformer_layers:
+            layer.attention.is_kv_shared_layer = True
+
+        # Build the functional model (used for weight loading / summary).
+        inputs = backbone.input
+        hidden_state = backbone(inputs=inputs)
+        outputs = backbone.token_embedding(hidden_state, reverse=True)
+
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            sampler=sampler,
+            backbone=backbone,
+            **kwargs,
+        )
+
+        # Non-graph projection layers created AFTER super().__init__() so
+        # Keras registers them as tracked sub-layers of this model.  They are
+        # used only in call_with_cache (not in the functional inputs→outputs
+        # graph), but must be saved/loaded as part of the model weights.
+        #
+        # pre_projection: concat(embed_tokens(last_id), last_hidden) → hidden.
+        # Input dim = 2 * backbone_hidden_size.
+        self.pre_projection = layers.Dense(
+            hidden_size,
+            use_bias=False,
+            dtype=backbone.dtype_policy,
+            name="pre_projection",
+        )
+        self.pre_projection.build((None, 1, 2 * backbone_hidden_size))
+
+        # post_projection: hidden → backbone_hidden_size.
+        self.post_projection = layers.Dense(
+            backbone_hidden_size,
+            use_bias=False,
+            dtype=backbone.dtype_policy,
+            name="post_projection",
+        )
+        self.post_projection.build((None, 1, hidden_size))
+        self.centroids = None
+        self.token_ordering = None
+        if use_ordered_embeddings:
+            self.centroids = layers.Dense(
+                num_centroids,
+                use_bias=False,
+                dtype=backbone.dtype_policy,
+                name="centroids",
+            )
+            self.centroids.build((None, 1, hidden_size))
+
+            self.token_ordering = self.add_weight(
+                name="token_ordering",
+                shape=(vocabulary_size,),
+                dtype="int32",
+                trainable=False,
+                initializer="zeros",
+            )
+
+    def _apply_centroid_logits(self, hidden_states):
+        """Compute sparse logits via centroid-based vocabulary masking.
+
+          1. Route hidden_states to `num_centroids` cluster scores.
+          2. Select the top-k active clusters per token position.
+          3. For each active cluster, retrieve the canonical token positions
+             stored in `token_ordering`.
+          4. Dot-product with the lm_head (tied embedding) weights.
+          5. Scatter into a full-vocab output; non-active positions are masked
+             with a value below the minimum active logit.
+
+        Args:
+            hidden_states: float tensor `(batch, seq, hidden_size)`.
+
+        Returns:
+            logits: float tensor `(batch, seq, vocabulary_size)`.
+        """
+        vocab_size = self.backbone.vocabulary_size
+        top_k = self.centroid_intermediate_top_k  # active centroids per step
+        k_per_centroid = (
+            self._vocab_size_per_centroid
+        )  # vocab_size // num_centroids
+
+        # (batch, seq, num_centroids)
+        centroid_logits = self.centroids(hidden_states)
+        # top-k active centroid indices: (batch, seq, top_k)
+        top_k_indices = ops.top_k(centroid_logits, k=top_k)[1]
+
+        # token_ordering: (vocab_size,) → (num_centroids, k_per_centroid)
+        token_ord = ops.reshape(
+            ops.cast(self.token_ordering, "int32"),
+            (self.num_centroids, k_per_centroid),
+        )
+
+        # For each position, gather the canonical token ids of active clusters.
+        # Shape: (batch, seq, top_k, k_per_centroid)
+        selected_canonical = ops.take(token_ord, top_k_indices, axis=0)
+
+        # Gather lm_head embedding weights at selected canonical positions.
+        embedding_weights = self.backbone.token_embedding.embeddings
+        batch = ops.shape(hidden_states)[0]
+        seq = ops.shape(hidden_states)[1]
+        n_tokens = top_k * k_per_centroid
+
+        selected_flat = ops.reshape(selected_canonical, (-1,))
+        gathered = ops.take(embedding_weights, selected_flat, axis=0)
+        # (batch, seq, n_tokens, hidden_size)
+        gathered = ops.reshape(gathered, (batch, seq, n_tokens, -1))
+
+        # Dot-product: (batch, seq, n_tokens)
+        hs_exp = ops.expand_dims(hidden_states, axis=-2)
+        selected_logits = ops.squeeze(
+            ops.matmul(hs_exp, ops.transpose(gathered, (0, 1, 3, 2))),
+            axis=-2,
+        )
+
+        # Scatter active logits into a full-vocab output tensor.
+        # Non-active positions are filled with min(active_logits) - 1.0 so
+        # that inactive tokens receive a finite value just below the minimum
+        # active logit, preventing probability collapse onto active positions.
+        flat_hs = batch * seq
+        scatter_idx = ops.reshape(selected_canonical, (flat_hs, n_tokens))
+        flat_logits = ops.reshape(selected_logits, (flat_hs, n_tokens))
+        # Global min across all active logits in the batch (scalar tensor).
+        min_active = ops.min(flat_logits) - ops.cast(1.0, flat_logits.dtype)
+        output = (
+            ops.ones((flat_hs, vocab_size), dtype=hidden_states.dtype)
+            * min_active
+        )
+
+        # Memory-efficient sparse scatter to avoid full OOM one-hot allocation.
+        row_idx = ops.expand_dims(ops.arange(flat_hs, dtype="int32"), axis=-1)
+        row_idx = ops.broadcast_to(row_idx, (flat_hs, n_tokens))
+
+        # Form sparse coordinates: (flat_hs * n_tokens, 2)
+        coords = ops.stack(
+            [ops.reshape(row_idx, (-1,)), ops.reshape(scatter_idx, (-1,))],
+            axis=1,
+        )
+        updates = ops.reshape(flat_logits, (-1,))
+
+        output = ops.scatter_update(output, coords, updates)
+        return ops.reshape(output, (batch, seq, vocab_size))
+
+    def call_with_cache(
+        self,
+        last_token_embedding,
+        last_hidden_state,
+        target_cache,
+        cache_update_index,
+        padding_mask=None,
+        target_kv_source_full_idx=None,
+        target_kv_source_local_idx=None,
+    ):
+        """Single-step forward pass for speculative decoding.
+
+        Drafts one candidate token given the target model's state.
+
+        Args:
+            last_token_embedding: float tensor
+                `(batch, 1, backbone_hidden_size)`.
+                The target model's embedding of the last accepted token.
+            last_hidden_state: float tensor
+                `(batch, 1, backbone_hidden_size)`. Target model's last
+                position hidden state.
+            target_cache: float tensor
+                `(batch, num_target_layers, 2, max_len, num_heads, head_dim)`.
+                The target model's full KV cache. The last non-KV-shared
+                full/sliding attention layers' K/V slices are injected into
+                the assistant's KV-shared layers.
+            cache_update_index: int or int tensor. The current decode position.
+            padding_mask: optional int tensor `(batch, seq_len)`.
+
+        Returns:
+            `(logits, next_hidden_state)` where `logits` has shape
+            `(batch, 1, vocabulary_size)` and `next_hidden_state` has shape
+            `(batch, 1, backbone_hidden_size)`.
+        """
+        # Concatenate target token embedding and target hidden state:
+        # (batch, 1, 2 * backbone_hidden_size).
+        inputs_embeds = ops.concatenate(
+            [last_token_embedding, last_hidden_state], axis=-1
+        )
+
+        x = self.pre_projection(inputs_embeds)
+
+        # Build a shared KV map from the target model's KV cache.
+        # `target_kv_source_full_idx` / `target_kv_source_local_idx` point to
+        # the last non-KV-shared full/sliding attention layers in the target,
+        # which are the correct source for shared K/V.
+        num_target = ops.shape(target_cache)[1]
+        if target_kv_source_full_idx is not None:
+            shared_kv_global = target_cache[:, target_kv_source_full_idx, ...]
+        else:
+            shared_kv_global = target_cache[:, num_target - 1, ...]
+        if target_kv_source_local_idx is not None:
+            shared_kv_local = target_cache[:, target_kv_source_local_idx, ...]
+        else:
+            shared_kv_local = target_cache[:, num_target - 2, ...]
+
+        layer_types = self.backbone.layer_types or []
+        shared_kv_map = {
+            i: (shared_kv_global if lt == "full_attention" else shared_kv_local)
+            for i, lt in enumerate(layer_types)
+        }
+
+        # Run through all 4 KV-shared transformer layers (no cache write).
+        for i, transformer_layer in enumerate(self.backbone.transformer_layers):
+            layer_shared_kv = shared_kv_map.get(i)
+            x, _ = transformer_layer(
+                x,
+                padding_mask=padding_mask,
+                # Pass shared_kv also as `cache` so the decoder block can
+                # compute the correct attention mask using the full target
+                # key sequence length (cache_seq).  The attention module
+                # will use `shared_kv` for actual K/V (is_kv_shared_layer
+                # path) and will return `cache` unchanged.
+                cache=layer_shared_kv,
+                cache_update_index=cache_update_index,
+                shared_kv=layer_shared_kv,
+            )
+
+        hidden_states = self.backbone.layer_norm(x)
+        # Conditionally utilize sparse centroid projection
+        if self.use_ordered_embeddings:
+            logits = self._apply_centroid_logits(hidden_states)
+        else:
+            logits = self.backbone.token_embedding(hidden_states, reverse=True)
+        next_hidden_state = self.post_projection(hidden_states)
+
+        return logits, next_hidden_state
+
+    @property
+    def _layers(self):
+        base = self.__dict__.get("_layers_storage", [])
+        extra = []
+        for attr in ("pre_projection", "post_projection", "centroids"):
+            layer = getattr(self, attr, None)
+            if layer is not None and layer not in base:
+                extra.append(layer)
+        return base + extra
+
+    @_layers.setter
+    def _layers(self, value):
+        # Use object.__setattr__ to bypass __setattr__ → tracker recursion.
+        object.__setattr__(self, "_layers_storage", value)
+
+    def _flatten_layers(self, include_self=True, recursive=True):
+        """Delegate to super(); the ``_layers`` property already adds extras."""
+        return super()._flatten_layers(
+            include_self=include_self, recursive=recursive
+        )
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "backbone_hidden_size": self.backbone_hidden_size,
+                "num_centroids": self.num_centroids,
+                "centroid_intermediate_top_k": (
+                    self.centroid_intermediate_top_k
+                ),
+                "use_ordered_embeddings": self.use_ordered_embeddings,
+                "num_speculative_tokens": self.num_speculative_tokens,
+                "sampler": self._serialize_sampler(),
+            }
+        )
+        return config
+
+    def _serialize_sampler(self):
+        from keras_hub.src.samplers.serialization import serialize
+
+        return serialize(self.sampler)
+
+    @classmethod
+    def from_config(cls, config):
+        if "sampler" in config and isinstance(config["sampler"], dict):
+            from keras_hub.src.samplers.serialization import deserialize
+
+            config["sampler"] = deserialize(config["sampler"])
+        return super().from_config(config)

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -269,6 +269,12 @@ class Gemma4AssistantCausalLM(CausalLM):
             `(batch, 1, vocabulary_size)` and `next_hidden_state` has shape
             `(batch, 1, backbone_hidden_size)`.
         """
+        last_token_embedding = ops.cast(
+            last_token_embedding, self.compute_dtype
+        )
+        last_hidden_state = ops.cast(last_hidden_state, self.compute_dtype)
+        target_cache = ops.cast(target_cache, self.compute_dtype)
+
         # Concatenate target token embedding and target hidden state:
         # (batch, 1, 2 * backbone_hidden_size).
         inputs_embeds = ops.concatenate(

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -83,6 +83,11 @@ class Gemma4AssistantCausalLM(CausalLM):
 
         hidden_size = backbone.hidden_dim
         vocabulary_size = backbone.token_embedding.input_dim
+        if use_ordered_embeddings and vocabulary_size % num_centroids != 0:
+            raise ValueError(
+                f"`vocabulary_size` ({vocabulary_size}) must be divisible by "
+                f"`num_centroids` ({num_centroids})."
+            )
         self._vocab_size_per_centroid = vocabulary_size // num_centroids
 
         for layer in self.backbone.transformer_layers:

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -345,6 +345,27 @@ class Gemma4AssistantCausalLM(CausalLM):
 
         return logits, next_hidden_state
 
+    @property
+    def _layers(self):
+        base = self.__dict__.get("_layers_storage", [])
+        extra = []
+        for attr in ("pre_projection", "post_projection", "centroids"):
+            layer = getattr(self, attr, None)
+            if layer is not None and layer not in base:
+                extra.append(layer)
+        return base + extra
+
+    @_layers.setter
+    def _layers(self, value):
+        # Use object.__setattr__ to bypass __setattr__ → tracker recursion.
+        object.__setattr__(self, "_layers_storage", value)
+
+    def _flatten_layers(self, include_self=True, recursive=True):
+        """Delegate to super(); the ``_layers`` property already adds extras."""
+        return super()._flatten_layers(
+            include_self=include_self, recursive=recursive
+        )
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -209,17 +209,16 @@ class Gemma4AssistantCausalLM(CausalLM):
         )
 
         # Scatter active logits into a full-vocab output tensor.
-        # Non-active positions are filled with min(active_logits) - 1.0 so
-        # that inactive tokens receive a finite value just below the minimum
-        # active logit, preventing probability collapse onto active positions.
+        # Inactive positions are set far below the active range so their
+        # softmax probability is negligible.
         flat_hs = batch * seq
         scatter_idx = ops.reshape(selected_canonical, (flat_hs, n_tokens))
         flat_logits = ops.reshape(selected_logits, (flat_hs, n_tokens))
-        # Global min across all active logits in the batch (scalar tensor).
-        min_active = ops.min(flat_logits) - ops.cast(1.0, flat_logits.dtype)
+        min_active = ops.min(flat_logits)
+        inactive_fill = min_active - ops.cast(100.0, flat_logits.dtype)
         output = (
             ops.ones((flat_hs, vocab_size), dtype=hidden_states.dtype)
-            * min_active
+            * inactive_fill
         )
 
         # Memory-efficient sparse scatter to avoid full OOM one-hot allocation.

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm.py
@@ -209,13 +209,13 @@ class Gemma4AssistantCausalLM(CausalLM):
         )
 
         # Scatter active logits into a full-vocab output tensor.
-        # Inactive positions are set far below the active range so their
-        # softmax probability is negligible.
+        # Inactive positions are filled with min(active_logits) - 1.0,
+        # matching HF's masked_embedding behaviour.
         flat_hs = batch * seq
         scatter_idx = ops.reshape(selected_canonical, (flat_hs, n_tokens))
         flat_logits = ops.reshape(selected_logits, (flat_hs, n_tokens))
         min_active = ops.min(flat_logits)
-        inactive_fill = min_active - ops.cast(100.0, flat_logits.dtype)
+        inactive_fill = min_active - ops.cast(1.0, flat_logits.dtype)
         output = (
             ops.ones((flat_hs, vocab_size), dtype=hidden_states.dtype)
             * inactive_fill

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm_test.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 from absl.testing import parameterized
 from keras import ops
@@ -120,3 +122,45 @@ class Gemma4AssistantTest(TestCase, parameterized.TestCase):
             stop_token_ids=None,
         )
         self.assertIsNotNone(output)
+
+    def test_model_saving(self):
+        import keras
+
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        self.model.save(path)
+        loaded_model = keras.saving.load_model(path)
+
+        self.assertIsInstance(loaded_model, Gemma4AssistantCausalLM)
+
+        batch_size = 2
+        target_num_layers = 6
+        max_head_dim = 8
+        target_kv_heads = 1
+        cache_seq = 5
+        target_cache = ops.zeros(
+            (
+                batch_size,
+                target_num_layers,
+                2,
+                cache_seq,
+                target_kv_heads,
+                max_head_dim,
+            )
+        )
+        last_token_embedding = ops.zeros((batch_size, 1, 16))
+        last_hidden_state = ops.zeros((batch_size, 1, 16))
+
+        logits_orig, h_orig = self.model.call_with_cache(
+            last_token_embedding=last_token_embedding,
+            last_hidden_state=last_hidden_state,
+            target_cache=target_cache,
+            cache_update_index=cache_seq - 1,
+        )
+        logits_loaded, h_loaded = loaded_model.call_with_cache(
+            last_token_embedding=last_token_embedding,
+            last_hidden_state=last_hidden_state,
+            target_cache=target_cache,
+            cache_update_index=cache_seq - 1,
+        )
+        self.assertAllClose(logits_orig, logits_loaded)
+        self.assertAllClose(h_orig, h_loaded)

--- a/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_assistant_causal_lm_test.py
@@ -1,0 +1,122 @@
+import numpy as np
+from absl.testing import parameterized
+from keras import ops
+
+from keras_hub.src.models.gemma4.gemma4_assistant_causal_lm import (
+    Gemma4AssistantCausalLM,
+)
+from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.models.gemma4.gemma4_causal_lm import Gemma4CausalLM
+from keras_hub.src.tests.test_case import TestCase
+
+
+class Gemma4AssistantTest(TestCase, parameterized.TestCase):
+    def setUp(self):
+        self.backbone = Gemma4Backbone(
+            vocabulary_size=256,
+            num_layers=4,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+            head_dim=4,
+            global_head_dim=8,
+            image_size=16,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+        )
+        # backbone_hidden_size=16 matches the target hidden_dim used in tests.
+        self.model = Gemma4AssistantCausalLM(
+            preprocessor=None,
+            backbone=self.backbone,
+            backbone_hidden_size=16,
+            num_centroids=4,
+            centroid_intermediate_top_k=2,
+            use_ordered_embeddings=True,
+        )
+
+    def test_call_with_cache(self):
+        batch_size = 2
+        target_num_layers = 6
+        max_head_dim = 8  # max(head_dim=4, global_head_dim=8)
+        target_kv_heads = 1
+        cache_seq = 5
+
+        target_cache = np.zeros(
+            (
+                batch_size,
+                target_num_layers,
+                2,
+                cache_seq,
+                target_kv_heads,
+                max_head_dim,
+            ),
+            dtype="float32",
+        )
+        target_cache = ops.convert_to_tensor(target_cache)
+
+        last_token_embedding = ops.convert_to_tensor(
+            np.random.randn(batch_size, 1, 16).astype("float32")
+        )
+        last_hidden_state = ops.convert_to_tensor(
+            np.random.randn(batch_size, 1, 16).astype("float32")
+        )
+
+        logits, next_hidden = self.model.call_with_cache(
+            last_token_embedding=last_token_embedding,
+            last_hidden_state=last_hidden_state,
+            target_cache=target_cache,
+            cache_update_index=cache_seq - 1,
+        )
+
+        self.assertEqual(ops.shape(logits), (batch_size, 1, 256))
+        self.assertEqual(ops.shape(next_hidden), (batch_size, 1, 16))
+
+    def test_speculative_generate(self):
+        target_backbone = Gemma4Backbone(
+            vocabulary_size=256,
+            num_layers=6,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=16,
+            intermediate_dim=32,
+            head_dim=8,
+            image_size=16,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+        )
+        target_model = Gemma4CausalLM(
+            preprocessor=None,
+            backbone=target_backbone,
+        )
+
+        batch_size = 1
+        max_length = 20
+        seq_len = 5
+        token_ids_raw = np.random.randint(0, 100, (batch_size, seq_len))
+        token_ids = np.zeros((batch_size, max_length), dtype="int32")
+        token_ids[:, :seq_len] = token_ids_raw
+        padding_mask = np.zeros((batch_size, max_length), dtype="bool")
+        padding_mask[:, :seq_len] = True
+        token_ids = ops.convert_to_tensor(token_ids)
+        padding_mask = ops.convert_to_tensor(padding_mask)
+
+        output = target_model.generate(
+            {
+                "token_ids": token_ids,
+                "padding_mask": padding_mask,
+            },
+            assistant_model=self.model,
+            stop_token_ids=None,
+        )
+        self.assertIsNotNone(output)

--- a/keras_hub/src/models/gemma4/gemma4_backbone.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone.py
@@ -414,6 +414,14 @@ class Gemma4Backbone(Backbone):
             )
             self.transformer_layers.append(layer)
 
+        if self.layer_types is None:
+            self.layer_types = [
+                "full_attention"
+                if (i % sliding_window_pattern) == (sliding_window_pattern - 1)
+                else "sliding_attention"
+                for i in range(num_layers)
+            ]
+
         self.layer_norm = RMSNormalization(
             epsilon=layer_norm_epsilon,
             dtype=dtype,

--- a/keras_hub/src/models/gemma4/gemma4_backbone.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone.py
@@ -76,6 +76,11 @@ class Gemma4Backbone(Backbone):
             attention pattern. The last layer in each group of this many
             consecutive layers uses global attention; all others use local
             (sliding-window) attention. Defaults to `6`.
+        layer_types: list of str or `None`. Explicit specification of the
+            attention type for every layer sequentially
+            (e.g. `"full_attention"`, `"sliding_attention"`). When `None`,
+            type sequence is derived from `sliding_window_pattern`.
+            Defaults to `None`.
         global_head_dim: int or `None`. Per-head dimension used specifically
             for global attention layers. When `None`, `head_dim` is used
             for all layers. Defaults to `None`.
@@ -194,6 +199,7 @@ class Gemma4Backbone(Backbone):
         use_sliding_window_attention=True,
         sliding_window_size=512,
         sliding_window_pattern=6,
+        layer_types=None,
         global_head_dim=None,
         local_rope_scaling_factor=1.0,
         global_rope_scaling_factor=1.0,
@@ -269,6 +275,7 @@ class Gemma4Backbone(Backbone):
 
         self.vision_encoder = vision_encoder
         self.audio_encoder = audio_encoder
+        self.layer_types = layer_types
         text_only_model = vision_encoder is None and audio_encoder is None
         if vision_encoder is not None:
             self.interleave_embeddings = Gemma4InterleaveEmbeddings(
@@ -294,34 +301,62 @@ class Gemma4Backbone(Backbone):
         # The last `num_kv_shared_layers` layers reuse K/V from the most
         # recent non-shared layer of the same attention type.
         _first_kv_shared = num_layers - num_kv_shared_layers
+        _kv_source = {}
         if num_kv_shared_layers > 0:
-            _non_shared_types = [
-                "global"
-                if (j % sliding_window_pattern) == (sliding_window_pattern - 1)
-                else "local"
-                for j in range(_first_kv_shared)
-            ]
-            # Map each shared layer index → the absolute index of its KV source.
-            _kv_source = {}
-            for j in range(_first_kv_shared, num_layers):
-                _is_g = (j % sliding_window_pattern) == (
-                    sliding_window_pattern - 1
-                )
-                _type = "global" if _is_g else "local"
-                for k in range(len(_non_shared_types) - 1, -1, -1):
-                    if _non_shared_types[k] == _type:
-                        _kv_source[j] = k
-                        break
-        else:
-            _kv_source = {}
+            if _first_kv_shared == 0:
+                # Assistant mode: all layers share KV externally.
+                # Mirror HF's hardcoded logic: assign arbitrary indices
+                # 0 and 1 based on type.
+                for j in range(num_layers):
+                    if layer_types is not None:
+                        _is_g = layer_types[j] == "full_attention"
+                    else:
+                        _is_g = (j % sliding_window_pattern) == (
+                            sliding_window_pattern - 1
+                        )
+                    _kv_source[j] = 1 if _is_g else 0
+            else:
+                if layer_types is not None:
+                    _non_shared_types = [
+                        "global" if t == "full_attention" else "local"
+                        for t in layer_types[:_first_kv_shared]
+                    ]
+                else:
+                    _non_shared_types = [
+                        "global"
+                        if (j % sliding_window_pattern)
+                        == (sliding_window_pattern - 1)
+                        else "local"
+                        for j in range(_first_kv_shared)
+                    ]
+                # Map shared layer index → absolute index of its KV source.
+                for j in range(_first_kv_shared, num_layers):
+                    if layer_types is not None:
+                        _type = (
+                            "global"
+                            if layer_types[j] == "full_attention"
+                            else "local"
+                        )
+                    else:
+                        _is_g = (j % sliding_window_pattern) == (
+                            sliding_window_pattern - 1
+                        )
+                        _type = "global" if _is_g else "local"
+                    for k in range(len(_non_shared_types) - 1, -1, -1):
+                        if _non_shared_types[k] == _type:
+                            _kv_source[j] = k
+                            break
 
         self.transformer_layers = []
         for i in range(num_layers):
             # A layer is global when it's the last in each group of
             # `sliding_window_pattern` consecutive layers.
-            is_global = (i % sliding_window_pattern) == (
-                sliding_window_pattern - 1
-            )
+            if layer_types is not None:
+                is_global = layer_types[i] == "full_attention"
+            else:
+                is_global = (i % sliding_window_pattern) == (
+                    sliding_window_pattern - 1
+                )
             sliding_window = use_sliding_window_attention and not is_global
             rope_wavelength = (
                 (global_rope_wavelength or 1_000_000.0)
@@ -692,6 +727,7 @@ class Gemma4Backbone(Backbone):
                 ),
                 "sliding_window_size": self.sliding_window_size,
                 "sliding_window_pattern": self.sliding_window_pattern,
+                "layer_types": self.layer_types,
                 "global_head_dim": self.global_head_dim,
                 "local_rope_scaling_factor": self.local_rope_scaling_factor,
                 "global_rope_scaling_factor": self.global_rope_scaling_factor,

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -606,6 +606,16 @@ class Gemma4CausalLM(CausalLM):
                 last_token_embedding = self.backbone.token_embedding(
                     last_token_id
                 )
+                # Scale to match Gemma4TextScaledWordEmbedding: the target
+                # backbone's call() does x *= sqrt(hidden_dim), so callers
+                # that bypass call() must apply this factor explicitly.
+                _embed_scale = ops.cast(
+                    ops.sqrt(
+                        ops.cast(self.backbone.hidden_dim, "float32")
+                    ),
+                    last_token_embedding.dtype,
+                )
+                last_token_embedding = last_token_embedding * _embed_scale
                 logits, next_hidden = _assistant.call_with_cache(
                     last_token_embedding=last_token_embedding,
                     last_hidden_state=last_hidden,

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -7,6 +7,8 @@ from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
 from keras_hub.src.models.gemma4.gemma4_causal_lm_preprocessor import (
     Gemma4CausalLMPreprocessor,
 )
+from keras_hub.src.samplers.greedy_sampler import GreedySampler
+from keras_hub.src.samplers.speculative_sampler import SpeculativeSampler
 from keras_hub.src.utils.tensor_utils import any_equal
 
 try:
@@ -610,9 +612,7 @@ class Gemma4CausalLM(CausalLM):
                 # backbone's call() does x *= sqrt(hidden_dim), so callers
                 # that bypass call() must apply this factor explicitly.
                 _embed_scale = ops.cast(
-                    ops.sqrt(
-                        ops.cast(self.backbone.hidden_dim, "float32")
-                    ),
+                    ops.sqrt(ops.cast(self.backbone.hidden_dim, "float32")),
                     last_token_embedding.dtype,
                 )
                 last_token_embedding = last_token_embedding * _embed_scale
@@ -745,10 +745,6 @@ class Gemma4CausalLM(CausalLM):
             ]
 
         if assistant_model is not None:
-            from keras_hub.src.samplers.speculative_sampler import (
-                SpeculativeSampler,
-            )
-
             # Save current (sampler, compiled graph) as a consistent pair so
             # we can restore them after the speculative call without
             # discarding either compiled graph.
@@ -763,6 +759,8 @@ class Gemma4CausalLM(CausalLM):
             # caller to manually recompile the target model with the correct
             # temperature/top_p/top_k settings.
             spec_base_sampler = getattr(assistant_model, "sampler", None)
+            if isinstance(self.sampler, GreedySampler):
+                spec_base_sampler = None
 
             # Reuse a previously compiled speculative graph when
             # num_speculative_tokens and base_sampler both match, avoiding a

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -606,13 +606,6 @@ class Gemma4CausalLM(CausalLM):
                 last_token_embedding = self.backbone.token_embedding(
                     last_token_id
                 )
-                # Apply embedding scale (sqrt(hidden_dim)) to match the target
-                # model's token embedding convention.
-                embed_scale = ops.cast(
-                    ops.sqrt(self.backbone.hidden_dim),
-                    last_token_embedding.dtype,
-                )
-                last_token_embedding = last_token_embedding * embed_scale
                 logits, next_hidden = _assistant.call_with_cache(
                     last_token_embedding=last_token_embedding,
                     last_hidden_state=last_hidden,
@@ -754,15 +747,23 @@ class Gemma4CausalLM(CausalLM):
 
             num_spec = getattr(assistant_model, "num_speculative_tokens", 5)
 
+            # Use the sampler stored on the assistant model (loaded from
+            # generation_config.json during from_preset) as the base_sampler
+            # for stochastic rejection sampling. This avoids requiring the
+            # caller to manually recompile the target model with the correct
+            # temperature/top_p/top_k settings.
+            spec_base_sampler = getattr(assistant_model, "sampler", None)
+
             # Reuse a previously compiled speculative graph when
-            # num_speculative_tokens matches, avoiding a full JIT recompile.
+            # num_speculative_tokens and base_sampler both match, avoiding a
+            # full JIT recompile.
             cached_spec_sampler = getattr(self, "_cached_spec_sampler", None)
             cached_spec_fn = getattr(self, "_cached_spec_generate_fn", None)
 
             if (
                 cached_spec_sampler is not None
                 and cached_spec_sampler.num_speculative_tokens == num_spec
-                and cached_spec_sampler.base_sampler is original_sampler
+                and cached_spec_sampler.base_sampler is spec_base_sampler
             ):
                 # Reuse compiled speculative graph.
                 self.sampler = cached_spec_sampler
@@ -771,7 +772,7 @@ class Gemma4CausalLM(CausalLM):
                 # Compile a new speculative graph.
                 self.sampler = SpeculativeSampler(
                     num_speculative_tokens=num_spec,
-                    base_sampler=original_sampler,
+                    base_sampler=spec_base_sampler,
                 )
                 self.generate_function = None  # force recompile
 

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -107,8 +107,6 @@ class Gemma4CausalLM(CausalLM):
         self.final_logit_cap = final_logit_cap
 
         # === Functional Model ===
-        # This must be "backbone.input" i.e. the full input structure,
-        # rather than "backbone.inputs" which is the flattened list of inputs.
         inputs = backbone.input
         hidden_state = backbone(inputs=inputs)
         outputs = backbone.token_embedding(hidden_state, reverse=True)
@@ -248,9 +246,9 @@ class Gemma4CausalLM(CausalLM):
 
         text_embeddings = self.backbone.token_embedding(token_ids)
 
-        # Interleave image embeddings. Pre-scale by 1/sqrt(hidden_dim) so that
-        # after the global x *= sqrt(hidden_dim) below, vision positions remain
-        # at their natural (unscaled) embed_vision magnitude.
+        # Pre-scale vision/audio embeddings by 1/sqrt(hidden_dim) so that
+        # after the global x *= sqrt(hidden_dim) below, their magnitude is
+        # preserved at the natural embed_vision scale.
         if img_embeddings is not None:
             scaled_img_embeddings = img_embeddings * ops.cast(
                 float(self.backbone.hidden_dim) ** -0.5, img_embeddings.dtype
@@ -274,8 +272,8 @@ class Gemma4CausalLM(CausalLM):
                 vision_indices=audio_indices,
             )
 
-        # Per-layer token embeddings. Vision positions use pad_token_id (0),
-        # mirroring HF's llm_input_ids masking before embed_tokens_per_layer.
+        # Per-layer token embeddings; vision/audio positions use pad_token_id
+        # (0) to zero out their per-layer contribution.
         _hpl = self.backbone.hidden_size_per_layer_input
         if _hpl > 0:
             _per_layer_ids = token_ids
@@ -410,7 +408,7 @@ class Gemma4CausalLM(CausalLM):
         )
         return config
 
-    def generate_step(self, inputs, stop_token_ids=[106]):
+    def generate_step(self, inputs, stop_token_ids=None):
         """A compilable generation function for a single batch of inputs.
 
         This function represents the inner, XLA-compilable, generation function
@@ -453,16 +451,14 @@ class Gemma4CausalLM(CausalLM):
         # After preprocessing, pixel_values shape is
         # (batch, num_images, n**2, dim).
         # For text-only input, num_images=0 (static shape).
-        # We use static shape check which returns a Python int, not a tensor.
+        # We use a static shape check which returns a Python int, not a tensor.
         num_images = 0
         if (
             pixel_values is not None
             and hasattr(pixel_values, "shape")
             and len(pixel_values.shape) > 1
         ):
-            num_images = pixel_values.shape[
-                1
-            ]  # Static shape; Python int or None.
+            num_images = pixel_values.shape[1]  # static shape; Python int
 
         if not self.backbone.text_only_model and num_images:
             # Handle an unbatched image.
@@ -487,12 +483,10 @@ class Gemma4CausalLM(CausalLM):
             vision_indices = None
 
         # Determine if we have actual audio clips to process.
-        # After preprocessing, audio_mel shape is (batch, num_clips, T, feat)
-        # when batched, or (num_clips, T, feat) when unbatched (batch dim was
-        # squeezed out in generate_preprocess). For no-audio input, num_clips=0.
-        # We must key on axis 0 for the unbatched (3-D) case because axis 1
-        # is the mel-time axis, which is dynamic and would evaluate to None,
-        # silently disabling audio.
+        # audio_mel is (B, num_clips, T, feat) when batched, or
+        # (num_clips, T, feat) when unbatched. Key on axis 0 for the 3-D
+        # case — axis 1 is the dynamic mel-time dimension and evaluates to
+        # None, which would silently disable audio.
         num_clips = 0
         if audio_mel is not None and hasattr(audio_mel, "shape"):
             if len(audio_mel.shape) == 4:
@@ -516,6 +510,7 @@ class Gemma4CausalLM(CausalLM):
         else:
             audio_embeddings = None
             audio_indices = None
+            audio_mask = None
 
         # Create and seed cache with a single forward pass.
         hidden_states, cache = self._build_cache(
@@ -554,6 +549,143 @@ class Gemma4CausalLM(CausalLM):
                 cache,
             )
 
+        draft_next = None
+        draft_cache = None
+        verify_next = None
+
+        # Speculative decoding: build draft_next and verify_next when an
+        # assistant model is attached via generate().
+        _assistant = getattr(self, "_assistant_model", None)
+        if _assistant is not None:
+            # Compute the correct KV source indices for the assistant.
+            # KV-shared target layers never write to their own cache slots;
+            # find the last non-KV-shared full/sliding attention layer instead.
+            _target_kv_src_full_idx = None
+            _target_kv_src_local_idx = None
+            _target_layer_types = self.backbone.layer_types or []
+            for _i, _tl in enumerate(self.backbone.transformer_layers):
+                if not getattr(_tl, "is_kv_shared_layer", False):
+                    _lt = (
+                        _target_layer_types[_i]
+                        if _i < len(_target_layer_types)
+                        else None
+                    )
+                    if _lt == "full_attention":
+                        _target_kv_src_full_idx = _i
+                    else:
+                        _target_kv_src_local_idx = _i
+
+            # The draft model borrows the target's KV cache (MTP / KV-sharing)
+            # and does not maintain its own. draft_cache carries
+            # (last_hidden, target_cache, fixed_pos) between steps, seeded from
+            # the target's hidden state at the last prompt position.
+            batch_size_ = ops.shape(token_ids)[0]
+            start_pos = ops.cast(index - 1, "int32")
+            init_last_hidden = ops.slice(
+                hidden_states,
+                [0, start_pos, 0],
+                [batch_size_, 1, self.backbone.hidden_dim],
+            )
+
+            def draft_next(prompt, draft_state, index):
+                """One draft step: produce a candidate token from the assistant.
+
+                `draft_state` is a tuple
+                `(last_hidden, cur_target_cache, fixed_pos)`:
+                  - `last_hidden`: target model hidden state from the
+                    previous step.
+                  - `cur_target_cache`: the target model's KV cache.
+                  - `fixed_pos`: RoPE position shared across all k draft steps.
+                """
+                last_hidden, cur_target_cache, fixed_pos = draft_state
+                batch = ops.shape(prompt)[0]
+                # Extract the last token id at position `index - 1`.
+                last_token_id = ops.slice(
+                    prompt, [0, ops.cast(index - 1, "int32")], [batch, 1]
+                )
+                last_token_embedding = self.backbone.token_embedding(
+                    last_token_id
+                )
+                # Apply embedding scale (sqrt(hidden_dim)) to match the target
+                # model's token embedding convention.
+                embed_scale = ops.cast(
+                    ops.sqrt(self.backbone.hidden_dim),
+                    last_token_embedding.dtype,
+                )
+                last_token_embedding = last_token_embedding * embed_scale
+                logits, next_hidden = _assistant.call_with_cache(
+                    last_token_embedding=last_token_embedding,
+                    last_hidden_state=last_hidden,
+                    target_cache=cur_target_cache,
+                    cache_update_index=fixed_pos,
+                    target_kv_source_full_idx=_target_kv_src_full_idx,
+                    target_kv_source_local_idx=_target_kv_src_local_idx,
+                )
+                # Apply the same final logit soft-cap as the target model so
+                # that draft and verify logits are on the same scale.
+                if self.final_logit_cap is not None:
+                    cap = ops.cast(self.final_logit_cap, logits.dtype)
+                    logits = ops.tanh(logits / cap) * cap
+                return (
+                    ops.squeeze(logits, axis=1),
+                    next_hidden,
+                    (next_hidden, cur_target_cache, fixed_pos),
+                )
+
+            def verify_next(prompt, target_cache, index, k):
+                """Verify K+1 positions with the target model in parallel.
+
+                ``safe_start`` is clamped so that the k+1-token window never
+                overflows the buffer, preventing out-of-bounds in the
+                sliding-window mask and key-cache update slices when generation
+                nears the end of the pre-allocated sequence.
+                """
+                batch = ops.shape(prompt)[0]
+                max_len = ops.shape(prompt)[1]
+                safe_start = ops.maximum(
+                    ops.cast(0, "int32"),
+                    ops.minimum(
+                        ops.cast(index - 1, "int32"),
+                        ops.cast(max_len - k - 1, "int32"),
+                    ),
+                )
+                prompt_slice = ops.slice(
+                    prompt, [0, safe_start], [batch, k + 1]
+                )
+                # cache_update_mask: True=write; False=keep existing.
+                cache_update_slice = ops.slice(
+                    ~padding_mask, [0, safe_start], [batch, k + 1]
+                )
+                vision_mask_slice = (
+                    ops.slice(vision_mask, [0, safe_start], [batch, k + 1])
+                    if vision_mask is not None
+                    else None
+                )
+                audio_mask_slice = (
+                    ops.slice(audio_mask, [0, safe_start], [batch, k + 1])
+                    if audio_mask is not None
+                    else None
+                )
+                logits, hidden_states, updated_cache = self.call_with_cache(
+                    token_ids=prompt_slice,
+                    cache=target_cache,
+                    cache_update_index=safe_start,
+                    img_embeddings=None,
+                    vision_mask=vision_mask_slice,
+                    padding_mask=None,
+                    vision_indices=None,
+                    audio_embeddings=None,
+                    audio_indices=None,
+                    audio_mask=audio_mask_slice,
+                    cache_update_mask=cache_update_slice,
+                )
+                return logits, hidden_states, updated_cache
+
+            # `fixed_pos` is held constant across all k draft steps within
+            # a cycle so every draft token uses the same RoPE position.
+            initial_fixed_pos = ops.cast(index - 1, "int32")
+            draft_cache = (init_last_hidden, cache, initial_fixed_pos)
+
         token_ids = self.sampler(
             next=next,
             prompt=token_ids,
@@ -563,6 +695,9 @@ class Gemma4CausalLM(CausalLM):
             stop_token_ids=stop_token_ids,
             hidden_states=hidden_states,
             model=self,
+            draft_next=draft_next,
+            draft_cache=draft_cache,
+            verify_next=verify_next,
         )
 
         # Compute an updated padding mask.
@@ -588,6 +723,7 @@ class Gemma4CausalLM(CausalLM):
         max_length=None,
         stop_token_ids="auto",
         strip_prompt=False,
+        assistant_model=None,
     ):
         # If `auto`, add `<turn|>` as a stop token too.
         if self.preprocessor is None and stop_token_ids == "auto":
@@ -605,9 +741,57 @@ class Gemma4CausalLM(CausalLM):
                 self.preprocessor.tokenizer.token_to_id("<turn|>"),
             ]
 
-        return super().generate(
+        if assistant_model is not None:
+            from keras_hub.src.samplers.speculative_sampler import (
+                SpeculativeSampler,
+            )
+
+            # Save current (sampler, compiled graph) as a consistent pair so
+            # we can restore them after the speculative call without
+            # discarding either compiled graph.
+            original_sampler = self.sampler
+            original_generate_function = self.generate_function
+
+            num_spec = getattr(assistant_model, "num_speculative_tokens", 5)
+
+            # Reuse a previously compiled speculative graph when
+            # num_speculative_tokens matches, avoiding a full JIT recompile.
+            cached_spec_sampler = getattr(self, "_cached_spec_sampler", None)
+            cached_spec_fn = getattr(self, "_cached_spec_generate_fn", None)
+
+            if (
+                cached_spec_sampler is not None
+                and cached_spec_sampler.num_speculative_tokens == num_spec
+                and cached_spec_sampler.base_sampler is original_sampler
+            ):
+                # Reuse compiled speculative graph.
+                self.sampler = cached_spec_sampler
+                self.generate_function = cached_spec_fn
+            else:
+                # Compile a new speculative graph.
+                self.sampler = SpeculativeSampler(
+                    num_speculative_tokens=num_spec,
+                    base_sampler=original_sampler,
+                )
+                self.generate_function = None  # force recompile
+
+            self._assistant_model = assistant_model
+
+        outputs = super().generate(
             inputs,
             max_length=max_length,
             stop_token_ids=stop_token_ids,
             strip_prompt=strip_prompt,
         )
+
+        if assistant_model is not None:
+            self._cached_spec_sampler = self.sampler
+            self._cached_spec_generate_fn = self.generate_function
+            # Restore the original sampler and compiled graph.
+            # Do not set generate_function = None — that would discard
+            # the baseline compiled graph and force a recompile.
+            self._assistant_model = None
+            self.sampler = original_sampler
+            self.generate_function = original_generate_function
+
+        return outputs

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -8,7 +8,6 @@ from keras_hub.src.models.gemma4.gemma4_causal_lm_preprocessor import (
     Gemma4CausalLMPreprocessor,
 )
 from keras_hub.src.samplers.greedy_sampler import GreedySampler
-from keras_hub.src.samplers.speculative_sampler import SpeculativeSampler
 from keras_hub.src.utils.tensor_utils import any_equal
 
 try:
@@ -753,6 +752,10 @@ class Gemma4CausalLM(CausalLM):
             ]
 
         if assistant_model is not None:
+            from keras_hub.src.samplers.speculative_sampler import (
+                SpeculativeSampler,
+            )
+
             # Save current (sampler, compiled graph) as a consistent pair so
             # we can restore them after the speculative call without
             # discarding either compiled graph.
@@ -789,6 +792,7 @@ class Gemma4CausalLM(CausalLM):
                 self.sampler = SpeculativeSampler(
                     num_speculative_tokens=num_spec,
                     base_sampler=spec_base_sampler,
+                    temperature=getattr(original_sampler, "temperature", 1.0),
                 )
                 self.generate_function = None  # force recompile
 

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -682,6 +682,12 @@ class Gemma4CausalLM(CausalLM):
                     audio_mask=audio_mask_slice,
                     cache_update_mask=cache_update_slice,
                 )
+                # Align position 0 of logits and hidden_states with index - 1.
+                start_offset = ops.cast(index - 1, "int32") - safe_start
+                logits = ops.roll(logits, shift=-start_offset, axis=1)
+                hidden_states = ops.roll(
+                    hidden_states, shift=-start_offset, axis=1
+                )
                 return logits, hidden_states, updated_cache
 
             # `fixed_pos` is held constant across all k draft steps within

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -777,21 +777,22 @@ class Gemma4CausalLM(CausalLM):
 
             self._assistant_model = assistant_model
 
-        outputs = super().generate(
-            inputs,
-            max_length=max_length,
-            stop_token_ids=stop_token_ids,
-            strip_prompt=strip_prompt,
-        )
-
-        if assistant_model is not None:
-            self._cached_spec_sampler = self.sampler
-            self._cached_spec_generate_fn = self.generate_function
-            # Restore the original sampler and compiled graph.
-            # Do not set generate_function = None — that would discard
-            # the baseline compiled graph and force a recompile.
-            self._assistant_model = None
-            self.sampler = original_sampler
-            self.generate_function = original_generate_function
+        try:
+            outputs = super().generate(
+                inputs,
+                max_length=max_length,
+                stop_token_ids=stop_token_ids,
+                strip_prompt=strip_prompt,
+            )
+        finally:
+            if assistant_model is not None:
+                self._cached_spec_sampler = self.sampler
+                self._cached_spec_generate_fn = self.generate_function
+                # Restore the original sampler and compiled graph.
+                # Do not set generate_function = None — that would discard
+                # the baseline compiled graph and force a recompile.
+                self._assistant_model = None
+                self.sampler = original_sampler
+                self.generate_function = original_generate_function
 
         return outputs

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm.py
@@ -684,10 +684,12 @@ class Gemma4CausalLM(CausalLM):
                 )
                 # Align position 0 of logits and hidden_states with index - 1.
                 start_offset = ops.cast(index - 1, "int32") - safe_start
-                logits = ops.roll(logits, shift=-start_offset, axis=1)
-                hidden_states = ops.roll(
-                    hidden_states, shift=-start_offset, axis=1
+                indices = ops.arange(k + 1, dtype="int32")
+                indices = ops.minimum(
+                    indices + start_offset, ops.cast(k, "int32")
                 )
+                logits = ops.take(logits, indices, axis=1)
+                hidden_states = ops.take(hidden_states, indices, axis=1)
                 return logits, hidden_states, updated_cache
 
             # `fixed_pos` is held constant across all k draft steps within

--- a/keras_hub/src/models/gemma4/gemma4_decoder_block.py
+++ b/keras_hub/src/models/gemma4/gemma4_decoder_block.py
@@ -439,6 +439,7 @@ class Gemma4TextDecoderBlock(keras.layers.Layer):
         # (e.g. HF 2B has use_bidirectional_attention=None → purely causal.)
         if (
             vision_mask is not None
+            and cache is None
             and self.use_vision_bidirectional_attention
             and not self.is_global_attention
         ):

--- a/keras_hub/src/models/gemma4/gemma4_presets.py
+++ b/keras_hub/src/models/gemma4/gemma4_presets.py
@@ -121,9 +121,12 @@ backbone_presets = {
             "description": (
                 "Gemma 4 E2B MTP Assistant model: 4-layer speculative-decoding "
                 "assistant for the 2B-it model. Uses Multi-Token Prediction to "
-                "propose candidate tokens and achieve inference speedups."
+                "propose candidate tokens and achieve inference speedups. "
+                "This model must NOT be used standalone. It is designed "
+                "exclusively as a draft model to be passed to the target "
+                "model's generate() method via the assistant_model argument."
             ),
-            "params": 76027396,
+            "params": 77731332,
             "path": "gemma4",
         },
         "kaggle_handle": (
@@ -135,9 +138,12 @@ backbone_presets = {
             "description": (
                 "Gemma 4 E4B MTP Assistant model: 4-layer speculative-decoding "
                 "assistant for the 4B-it model. Uses Multi-Token Prediction to "
-                "propose candidate tokens and achieve inference speedups."
+                "propose candidate tokens and achieve inference speedups. "
+                "This model must NOT be used standalone. It is designed "
+                "exclusively as a draft model to be passed to the target "
+                "model's generate() method via the assistant_model argument."
             ),
-            "params": 76027396,
+            "params": 77731332,
             "path": "gemma4",
         },
         "kaggle_handle": (
@@ -149,9 +155,12 @@ backbone_presets = {
             "description": (
                 "Gemma 4 26B A4B MTP Assistant model: 4-layer speculative-"
                 "decoding assistant for the 26B MoE model. Uses Multi-Token "
-                "Prediction and a standard logit head to propose candidates."
+                "Prediction and a standard logit head to propose candidates. "
+                "This model must NOT be used standalone. It is designed "
+                "exclusively as a draft model to be passed to the target "
+                "model's generate() method via the assistant_model argument."
             ),
-            "params": 411060484,
+            "params": 412764420,
             "path": "gemma4",
         },
         "kaggle_handle": (
@@ -163,9 +172,12 @@ backbone_presets = {
             "description": (
                 "Gemma 4 31B MTP Assistant model: 4-layer speculative-decoding "
                 "assistant for the 31B dense model. Uses Multi-Token "
-                "Prediction and a standard logit head to propose candidates."
+                "Prediction and a standard logit head to propose candidates. "
+                "This model must NOT be used standalone. It is designed "
+                "exclusively as a draft model to be passed to the target "
+                "model's generate() method via the assistant_model argument."
             ),
-            "params": 453003524,
+            "params": 454707460,
             "path": "gemma4",
         },
         "kaggle_handle": (

--- a/keras_hub/src/models/gemma4/gemma4_presets.py
+++ b/keras_hub/src/models/gemma4/gemma4_presets.py
@@ -116,4 +116,60 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/gemma4/keras/gemma4_instruct_31b/2",
     },
+    "gemma4_instruct_2b_assistant": {
+        "metadata": {
+            "description": (
+                "Gemma 4 E2B MTP Assistant model: 4-layer speculative-decoding "
+                "assistant for the 2B-it model. Uses Multi-Token Prediction to "
+                "propose candidate tokens and achieve inference speedups."
+            ),
+            "params": 1330000000,
+            "path": "gemma4",
+        },
+        "kaggle_handle": (
+            "kaggle://keras/gemma4/keras/gemma4_instruct_2b_assistant/1"
+        ),
+    },
+    "gemma4_instruct_4b_assistant": {
+        "metadata": {
+            "description": (
+                "Gemma 4 E4B MTP Assistant model: 4-layer speculative-decoding "
+                "assistant for the 4B-it model. Uses Multi-Token Prediction to "
+                "propose candidate tokens and achieve inference speedups."
+            ),
+            "params": 1330000000,
+            "path": "gemma4",
+        },
+        "kaggle_handle": (
+            "kaggle://keras/gemma4/keras/gemma4_instruct_4b_assistant/1"
+        ),
+    },
+    "gemma4_instruct_26b_a4b_assistant": {
+        "metadata": {
+            "description": (
+                "Gemma 4 26B A4B MTP Assistant model: 4-layer speculative-"
+                "decoding assistant for the 26B MoE model. Uses Multi-Token "
+                "Prediction and a standard logit head to propose candidates."
+            ),
+            "params": 1330000000,
+            "path": "gemma4",
+        },
+        "kaggle_handle": (
+            "kaggle://keras/gemma4/keras/gemma4_instruct_26b_a4b_assistant/1"
+        ),
+    },
+    "gemma4_instruct_31b_assistant": {
+        "metadata": {
+            "description": (
+                "Gemma 4 31B MTP Assistant model: 4-layer speculative-decoding "
+                "assistant for the 31B dense model. Uses Multi-Token "
+                "Prediction and a standard logit head to propose candidates."
+            ),
+            "params": 1330000000,
+            "path": "gemma4",
+        },
+        "kaggle_handle": (
+            "kaggle://keras/gemma4/keras/gemma4_instruct_31b_assistant/1"
+        ),
+    },
 }

--- a/keras_hub/src/models/gemma4/gemma4_presets.py
+++ b/keras_hub/src/models/gemma4/gemma4_presets.py
@@ -123,7 +123,7 @@ backbone_presets = {
                 "assistant for the 2B-it model. Uses Multi-Token Prediction to "
                 "propose candidate tokens and achieve inference speedups."
             ),
-            "params": 1330000000,
+            "params": 76027396,
             "path": "gemma4",
         },
         "kaggle_handle": (
@@ -137,7 +137,7 @@ backbone_presets = {
                 "assistant for the 4B-it model. Uses Multi-Token Prediction to "
                 "propose candidate tokens and achieve inference speedups."
             ),
-            "params": 1330000000,
+            "params": 76027396,
             "path": "gemma4",
         },
         "kaggle_handle": (
@@ -151,7 +151,7 @@ backbone_presets = {
                 "decoding assistant for the 26B MoE model. Uses Multi-Token "
                 "Prediction and a standard logit head to propose candidates."
             ),
-            "params": 1330000000,
+            "params": 411060484,
             "path": "gemma4",
         },
         "kaggle_handle": (
@@ -165,7 +165,7 @@ backbone_presets = {
                 "assistant for the 31B dense model. Uses Multi-Token "
                 "Prediction and a standard logit head to propose candidates."
             ),
-            "params": 1330000000,
+            "params": 453003524,
             "path": "gemma4",
         },
         "kaggle_handle": (

--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -204,11 +204,11 @@ class Task(PipelineModel):
                 "The filename must end in `.weights.h5`. "
                 f"Received: filepath={filepath}"
             )
-        backbone_layer_ids = set(id(w) for w in self.backbone._flatten_layers())
+        backbone_layers = list(self.backbone._flatten_layers())
         keras.saving.load_weights(
             self,
             filepath,
-            objects_to_skip=backbone_layer_ids,
+            objects_to_skip=backbone_layers,
         )
 
     def has_task_weights(self):
@@ -224,7 +224,7 @@ class Task(PipelineModel):
                 f"Received: filepath={filepath}"
             )
 
-        backbone_layer_ids = set(id(w) for w in self.backbone._flatten_layers())
+        backbone_layers = list(self.backbone._flatten_layers())
         if not self.has_task_weights():
             raise ValueError(
                 f"Task {self} has no weights not in the `backbone`. "
@@ -233,7 +233,7 @@ class Task(PipelineModel):
         keras.saving.save_weights(
             self,
             filepath=filepath,
-            objects_to_skip=backbone_layer_ids,
+            objects_to_skip=backbone_layers,
         )
 
     def save_to_preset(self, preset_dir, max_shard_size=10):

--- a/keras_hub/src/samplers/sampler.py
+++ b/keras_hub/src/samplers/sampler.py
@@ -80,6 +80,7 @@ class Sampler:
         stop_token_ids=None,
         hidden_states=None,
         model=None,
+        **kwargs,
     ):
         max_length = ops.shape(prompt)[-1]
         # Make sure `max_length` and `index` are the same dtype.

--- a/keras_hub/src/samplers/serialization.py
+++ b/keras_hub/src/samplers/serialization.py
@@ -5,6 +5,7 @@ from keras_hub.src.samplers.beam_sampler import BeamSampler
 from keras_hub.src.samplers.contrastive_sampler import ContrastiveSampler
 from keras_hub.src.samplers.greedy_sampler import GreedySampler
 from keras_hub.src.samplers.random_sampler import RandomSampler
+from keras_hub.src.samplers.speculative_sampler import SpeculativeSampler
 from keras_hub.src.samplers.top_k_sampler import TopKSampler
 from keras_hub.src.samplers.top_p_sampler import TopPSampler
 
@@ -22,6 +23,7 @@ def deserialize(config, custom_objects=None):
         "contrastive": ContrastiveSampler,
         "greedy": GreedySampler,
         "random": RandomSampler,
+        "speculative": SpeculativeSampler,
         "top_k": TopKSampler,
         "top_p": TopPSampler,
     }

--- a/keras_hub/src/samplers/speculative_sampler.py
+++ b/keras_hub/src/samplers/speculative_sampler.py
@@ -1,0 +1,452 @@
+from keras import ops
+from keras import random
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.samplers.sampler import Sampler
+from keras_hub.src.utils.tensor_utils import any_equal
+
+
+@keras_hub_export("keras_hub.samplers.SpeculativeSampler")
+class SpeculativeSampler(Sampler):
+    """Speculative decoding sampler.
+
+    Accelerates autoregressive inference by running a small draft model to
+    propose K candidate tokens, then verifying all K+1 positions with the
+    large target model in a single parallel forward pass.
+
+    References:
+    - [Fast Inference from Transformers via Speculative Decoding]
+        (https://arxiv.org/abs/2211.17192) (Leviathan et al., 2022)
+
+    The algorithm follows three phases per outer iteration:
+      1. **Draft phase**: The draft model auto-regressively generates K tokens.
+      2. **Verify phase**: The target model scores all K+1 positions in one
+         parallel forward pass via `verify_next`.
+      3. **Accept phase**: Tokens are accepted/rejected via rejection sampling
+         (stochastic) or greedy matching. A bonus token is always appended.
+
+    When `base_sampler` is provided, stochastic rejection sampling is used.
+    Otherwise greedy acceptance is used.
+
+    Args:
+        num_speculative_tokens: int. Number of draft tokens per outer
+            iteration. Defaults to `5`.
+        base_sampler: optional `keras_hub.samplers.Sampler`. When set,
+            enables stochastic rejection sampling using this sampler's
+            temperature, top-k, and top-p parameters. Defaults to `None`
+            (greedy acceptance).
+        seed: optional int. Random seed for stochastic sampling.
+
+    Call arguments:
+        next: callable `(prompt, cache, index) → (logits, hidden, cache)`.
+            Target model single-token forward pass (used as fallback when
+            `verify_next` is not provided).
+        prompt: int tensor `(batch, max_length)`. Running token sequence.
+        cache: optional cache tensor.
+        index: int. Current generation position.
+        mask: bool tensor `(batch, max_length)`. True at prompt positions.
+        stop_token_ids: optional sequence of int stop-token ids.
+        model: optional Keras model (needed for JAX stateless scopes).
+        draft_next: **required** callable
+            `(prompt, cache, index) → (logits, hidden, cache)`.
+            Draft model single-token forward pass.
+        draft_cache: optional draft model cache.
+        verify_next: optional callable
+            `(prompt, cache, index, k) → (logits, cache)` or
+            `(prompt, cache, index, k) → (logits, hidden_states, cache)`.
+            If provided, the target model verifies K+1 positions in a single
+            parallel forward pass (strongly recommended for performance).
+    """
+
+    def __init__(
+        self,
+        num_speculative_tokens=5,
+        base_sampler=None,
+        seed=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.num_speculative_tokens = num_speculative_tokens
+        self.base_sampler = base_sampler
+        self.seed = seed
+        self.seed_generator = random.SeedGenerator(seed)
+
+    def __call__(
+        self,
+        next,
+        prompt,
+        cache=None,
+        index=0,
+        mask=None,
+        stop_token_ids=None,
+        hidden_states=None,
+        model=None,
+        draft_next=None,
+        draft_cache=None,
+        verify_next=None,
+    ):
+        if draft_next is None:
+            raise ValueError(
+                "`SpeculativeSampler` requires a `draft_next` callable."
+            )
+
+        batch_size = ops.shape(prompt)[0]
+        max_length = ops.shape(prompt)[-1]
+        index = ops.cast(index, "int32")
+        k = self.num_speculative_tokens
+
+        if mask is None:
+            mask = ops.zeros_like(prompt, dtype="bool")
+        mask = ops.cast(mask, "bool")
+
+        has_cache = cache is not None
+        has_draft_cache = draft_cache is not None
+        cache = cache if has_cache else ()
+        draft_cache = draft_cache if has_draft_cache else ()
+
+        def cond(prompt, cache, draft_cache, index):
+            if stop_token_ids is None:
+                return index < max_length
+            end_tokens = any_equal(prompt, stop_token_ids, ~mask)
+            prompt_done = ops.any(end_tokens, axis=-1)
+            return ops.logical_and(
+                ops.logical_not(ops.all(prompt_done)),
+                index < max_length,
+            )
+
+        def body(prompt, cache, draft_cache, index):
+            current_draft_cache = draft_cache if has_draft_cache else None
+
+            # ── Phase 1: Draft K tokens ───────────────────────────────────
+            # Run the draft model K times autoregressively. Collect draft
+            # token ids and probabilities for the accept step.
+            current_prompt = prompt
+            draft_ids_list = []
+            draft_probs_list = []
+
+            for i in range(k):
+                # Clamp the index to [0, max_length - 1] for safety.
+                safe_idx = ops.minimum(
+                    ops.cast(index + i, "int32"), max_length - 1
+                )
+                logits, _, current_draft_cache = draft_next(
+                    current_prompt, current_draft_cache, safe_idx
+                )
+                # Apply temperature to get q_probs for the acceptance ratio
+                # p(x)/q(x).  Temperature comes from base_sampler when set.
+                if self.base_sampler is not None:
+                    dt = getattr(self.base_sampler, "temperature", 1.0)
+                    probs = ops.softmax(
+                        ops.cast(logits, "float32") / ops.cast(dt, "float32")
+                    )
+                else:
+                    probs = self.compute_probabilities(logits)
+
+                # Draft token: always greedy (argmax). This is correct for
+                # both sparse-vocab (MTP) and dense-vocab assistants.
+                next_token = ops.argmax(probs, axis=-1)
+
+                next_token = ops.cast(next_token, prompt.dtype)
+
+                # Respect existing prompt tokens (mask).
+                mask_val = mask[:, safe_idx]
+                existing = current_prompt[:, safe_idx]
+                in_bounds = ops.cast((index + i) < max_length, next_token.dtype)
+                next_token = ops.where(mask_val, existing, next_token)
+                next_token = ops.where(
+                    ops.cast(in_bounds, "bool"), next_token, existing
+                )
+
+                current_prompt = ops.slice_update(
+                    current_prompt, [0, safe_idx], next_token[:, None]
+                )
+                draft_ids_list.append(next_token)
+                draft_probs_list.append(probs)
+
+            # Stack: (batch, k), (batch, k, vocab)
+            draft_ids = ops.stack(draft_ids_list, axis=1)
+            q_probs = ops.stack(draft_probs_list, axis=1)
+
+            # ── Phase 2: Verify with target model ─────────────────────────
+            verify_hidden_states = None
+            if verify_next is not None:
+                # Single parallel forward pass covering positions
+                # [index-1 .. index+k-1] (k+1 positions total).
+                # verify_next may return (logits, cache) or
+                # (logits, hidden_states, cache) — handle both.
+                _verify_result = verify_next(
+                    current_prompt,
+                    cache if has_cache else None,
+                    index,
+                    k,
+                )
+                if len(_verify_result) == 3:
+                    target_logits, verify_hidden_states, updated_cache = (
+                        _verify_result
+                    )
+                else:
+                    target_logits, updated_cache = _verify_result
+            else:
+                # Fallback: serial verification (slower).
+                logits_list = []
+                current_cache = cache if has_cache else None
+                for i in range(k + 1):
+                    safe_idx = ops.minimum(
+                        ops.cast(index + i, "int32"), max_length - 1
+                    )
+                    logits, _, current_cache = next(
+                        current_prompt, current_cache, safe_idx
+                    )
+                    logits_list.append(logits)
+                target_logits = ops.stack(logits_list, axis=1)
+                updated_cache = current_cache
+
+            # target_logits: (batch, k+1, vocab)
+            target_probs = self.compute_probabilities(target_logits)
+            # p_probs: (batch, k, vocab)  — the K verification distributions
+            p_probs = target_probs[:, :k, :]
+
+            # Refresh the target cache in draft_cache so the next draft cycle
+            # uses the updated K/V entries. Supports 2-tuple and 3-tuple forms.
+            if (
+                has_draft_cache
+                and has_cache
+                and isinstance(draft_cache, tuple)
+                and len(draft_cache) == 2
+            ):
+                current_draft_cache = (current_draft_cache[0], updated_cache)
+            elif (
+                has_draft_cache
+                and has_cache
+                and isinstance(draft_cache, tuple)
+                and len(draft_cache) == 3
+            ):
+                current_draft_cache = (
+                    current_draft_cache[0],
+                    updated_cache,
+                    current_draft_cache[2],
+                )
+
+            # ── Phase 3: Accept / reject via rejection sampling ───────────
+            if self.base_sampler is not None:
+                # Stochastic acceptance (Leviathan et al., 2022 Algorithm 1).
+                # For each draft position i:
+                #   Accept token t_i if Uniform(0,1) < p(t_i) / q(t_i).
+                gather_idx = ops.expand_dims(
+                    ops.cast(draft_ids, "int32"), axis=-1
+                )
+                p_target = ops.take_along_axis(p_probs, gather_idx, axis=-1)[
+                    :, :, 0
+                ]
+                q_draft = ops.take_along_axis(q_probs, gather_idx, axis=-1)[
+                    :, :, 0
+                ]
+
+                r = random.uniform(
+                    shape=ops.shape(p_target),
+                    seed=self.seed_generator,
+                    dtype="float32",
+                )
+                matches = (r * q_draft) < p_target
+            else:
+                # Greedy acceptance: token matches if argmax(p) == draft_id.
+                target_tokens = ops.cast(
+                    ops.argmax(p_probs, axis=-1), prompt.dtype
+                )
+                matches = ops.equal(draft_ids, target_tokens)
+
+            # Compute the prefix of accepted tokens (all must match up to i).
+            # num_accepted[b] = length of the accepted prefix for item b.
+            matches_int = ops.cast(matches, "int32")
+            prefix_mask = ops.cumprod(matches_int, axis=1)
+            num_accepted = ops.sum(prefix_mask, axis=1)  # (batch,)
+
+            # Write accepted draft tokens back into the output prompt.
+            final_prompt = prompt
+            for i in range(k):
+                safe_idx = ops.minimum(
+                    ops.cast(index + i, "int32"), max_length - 1
+                )
+                is_accepted = ops.logical_and(
+                    ops.cast(i, "int32") < num_accepted,
+                    (index + i) < max_length,
+                )
+                token = ops.where(
+                    is_accepted,
+                    draft_ids[:, i],
+                    final_prompt[:, safe_idx],
+                )
+                final_prompt = ops.slice_update(
+                    final_prompt, [0, safe_idx], token[:, None]
+                )
+
+            # ── Bonus token (always appended) ─────────────────────────────
+            # Use the minimum accepted count across the batch so we advance
+            # the index by a common amount.
+            min_accepted = ops.min(num_accepted)  # scalar int
+            bonus_idx = ops.cast(index + min_accepted, "int32")
+            safe_bonus_idx = ops.minimum(bonus_idx, max_length - 1)
+
+            if self.base_sampler is not None:
+                # Residual distribution for rejected positions:
+                #   p_bonus = max(0, p_target - q_draft) / Z
+                # When all K tokens were accepted, sample from p_target
+                # directly (no residual needed).
+                # Use ops.gather with scalar min_accepted to stay in-graph.
+                gather_bonus = ops.expand_dims(
+                    ops.broadcast_to(
+                        ops.expand_dims(min_accepted, axis=0),
+                        (batch_size,),
+                    ),
+                    axis=-1,
+                )  # (batch, 1)
+                gather_bonus = ops.expand_dims(
+                    gather_bonus, axis=-1
+                )  # (batch, 1, 1)
+                vocab = ops.shape(target_probs)[-1]
+                gather_bonus_b = ops.broadcast_to(
+                    gather_bonus, (batch_size, 1, vocab)
+                )
+
+                p_b = ops.take_along_axis(target_probs, gather_bonus_b, axis=1)[
+                    :, 0, :
+                ]
+
+                # Clamp to avoid negative probabilities from floating-point
+                # error.
+                safe_q_idx = ops.minimum(
+                    ops.cast(min_accepted, "int32"),
+                    ops.cast(k - 1, "int32"),
+                )
+                gather_q = ops.expand_dims(
+                    ops.broadcast_to(
+                        ops.expand_dims(safe_q_idx, axis=0), (batch_size,)
+                    ),
+                    axis=-1,
+                )
+                gather_q = ops.expand_dims(gather_q, axis=-1)
+                gather_q_b = ops.broadcast_to(gather_q, (batch_size, 1, vocab))
+                q_b = ops.take_along_axis(q_probs, gather_q_b, axis=1)[:, 0, :]
+
+                all_accepted = ops.equal(min_accepted, ops.cast(k, "int32"))
+                res_probs = ops.maximum(
+                    ops.cast(0.0, p_b.dtype),
+                    ops.cast(p_b, p_b.dtype) - ops.cast(q_b, p_b.dtype),
+                )
+                res_sum = ops.sum(res_probs, axis=-1, keepdims=True) + ops.cast(
+                    1e-7, res_probs.dtype
+                )
+                res_probs = res_probs / res_sum
+
+                # When all K tokens accepted, fall through to p_b directly.
+                # all_accepted is a scalar bool; ops.where broadcasts it
+                # over (batch, vocab) without needing explicit indexing.
+                bonus_probs = ops.where(all_accepted, p_b, res_probs)
+
+                # Gumbel-max trick for differentiable argmax sampling.
+                uniform_noise = random.uniform(
+                    shape=ops.shape(bonus_probs),
+                    seed=self.seed_generator,
+                    dtype="float32",
+                )
+                gumbel = -ops.log(
+                    -ops.log(uniform_noise + ops.cast(1e-7, "float32"))
+                )
+                bonus_token = ops.argmax(
+                    ops.log(
+                        ops.cast(bonus_probs, "float32")
+                        + ops.cast(1e-7, "float32")
+                    )
+                    + gumbel,
+                    axis=-1,
+                )
+            else:
+                # Greedy bonus: argmax of the target distribution at position
+                # min_accepted.
+                gather_bonus = ops.expand_dims(
+                    ops.broadcast_to(
+                        ops.expand_dims(min_accepted, axis=0),
+                        (batch_size,),
+                    ),
+                    axis=-1,
+                )
+                gather_bonus = ops.expand_dims(gather_bonus, axis=-1)
+                vocab = ops.shape(target_probs)[-1]
+                gather_bonus_b = ops.broadcast_to(
+                    gather_bonus, (batch_size, 1, vocab)
+                )
+                bonus_probs = ops.take_along_axis(
+                    target_probs, gather_bonus_b, axis=1
+                )[:, 0, :]
+                bonus_token = ops.argmax(bonus_probs, axis=-1)
+
+            bonus_token = ops.cast(bonus_token, prompt.dtype)
+            existing_bonus = final_prompt[:, safe_bonus_idx]
+            in_bounds = ops.cast(bonus_idx < max_length, "bool")
+            bonus_token = ops.where(in_bounds, bonus_token, existing_bonus)
+            final_prompt = ops.slice_update(
+                final_prompt, [0, safe_bonus_idx], bonus_token[:, None]
+            )
+
+            # Advance by min_accepted + 1 (the bonus token).
+            new_index = ops.minimum(
+                bonus_idx + ops.cast(1, "int32"),
+                ops.cast(max_length, "int32"),
+            )
+
+            # Update fixed_pos to the new cycle-start position (new_index - 1)
+            # so the next cycle's draft steps share the correct RoPE anchor.
+            if (
+                has_draft_cache
+                and isinstance(current_draft_cache, tuple)
+                and len(current_draft_cache) == 3
+            ):
+                # Seed the next draft cycle with the target's hidden state
+                # at the accepted position:
+                # verify_hidden_states[:, min_accepted, :].
+                if verify_hidden_states is not None:
+                    h_dim = ops.shape(verify_hidden_states)[2]
+                    new_seed_hidden = ops.slice(
+                        verify_hidden_states,
+                        [0, ops.cast(min_accepted, "int32"), 0],
+                        [batch_size, 1, h_dim],
+                    )
+                else:
+                    new_seed_hidden = current_draft_cache[0]
+                current_draft_cache = (
+                    new_seed_hidden,
+                    current_draft_cache[1],
+                    new_index - ops.cast(1, "int32"),
+                )
+
+            return (
+                final_prompt,
+                updated_cache if has_cache else cache,
+                (current_draft_cache if has_draft_cache else draft_cache),
+                new_index,
+            )
+
+        prompt, _, _, _ = self.run_loop(
+            cond=cond,
+            body=body,
+            loop_vars=(prompt, cache, draft_cache, index),
+            maximum_iterations=(max_length - index),
+            model=model,
+        )
+        return prompt
+
+    def get_config(self):
+        base_sampler_config = None
+        if self.base_sampler is not None:
+            from keras_hub.src.samplers.serialization import serialize
+
+            base_sampler_config = serialize(self.base_sampler)
+        config = super().get_config()
+        config.update(
+            {
+                "num_speculative_tokens": self.num_speculative_tokens,
+                "base_sampler": base_sampler_config,
+                "seed": self.seed,
+            }
+        )
+        return config

--- a/keras_hub/src/samplers/speculative_sampler.py
+++ b/keras_hub/src/samplers/speculative_sampler.py
@@ -68,6 +68,10 @@ class SpeculativeSampler(Sampler):
         super().__init__(**kwargs)
         self.num_speculative_tokens = num_speculative_tokens
         self.base_sampler = base_sampler
+        if self.base_sampler is not None and hasattr(
+            self.base_sampler, "temperature"
+        ):
+            self.base_sampler.temperature = self.temperature
         self.seed = seed
         self.seed_generator = random.SeedGenerator(seed)
 
@@ -208,15 +212,22 @@ class SpeculativeSampler(Sampler):
 
             # Refresh the target cache in draft_cache so the next draft cycle
             # uses the updated K/V entries. Supports 2-tuple and 3-tuple forms.
+            from keras_hub.src.models.gemma4.gemma4_causal_lm import (
+                Gemma4CausalLM,
+            )
+
+            is_gemma4 = isinstance(model, Gemma4CausalLM)
             if (
-                has_draft_cache
+                is_gemma4
+                and has_draft_cache
                 and has_cache
                 and isinstance(draft_cache, tuple)
                 and len(draft_cache) == 2
             ):
                 current_draft_cache = (current_draft_cache[0], updated_cache)
             elif (
-                has_draft_cache
+                is_gemma4
+                and has_draft_cache
                 and has_cache
                 and isinstance(draft_cache, tuple)
                 and len(draft_cache) == 3
@@ -397,7 +408,8 @@ class SpeculativeSampler(Sampler):
             # Update fixed_pos to the new cycle-start position (new_index - 1)
             # so the next cycle's draft steps share the correct RoPE anchor.
             if (
-                has_draft_cache
+                is_gemma4
+                and has_draft_cache
                 and isinstance(current_draft_cache, tuple)
                 and len(current_draft_cache) == 3
             ):

--- a/keras_hub/src/samplers/speculative_sampler_test.py
+++ b/keras_hub/src/samplers/speculative_sampler_test.py
@@ -1,0 +1,199 @@
+from keras import ops
+
+from keras_hub.src.samplers.speculative_sampler import SpeculativeSampler
+from keras_hub.src.tests.test_case import TestCase
+
+
+class SpeculativeSamplerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use a simple alphabet of lowercase characters to [0, 26).
+        self.int_lookup = {i: chr(i + ord("a")) for i in range(26)}
+        self.char_lookup = {v: k for k, v in self.int_lookup.items()}
+        self.batch_size = 1
+        self.length = 12
+        self.vocab_size = len(self.int_lookup)
+
+    def _next_fn(self, target_chars):
+        """Create a next function that outputs specific characters."""
+        target_ids = ops.array([self.char_lookup[c] for c in target_chars])
+        max_idx = len(target_chars) - 1
+
+        def next_fn(prompt, cache, index):
+            hidden_states = ops.ones([self.batch_size, 5])
+            clamped_idx = ops.minimum(ops.cast(index, "int32"), max_idx)
+            target_id = ops.take(target_ids, clamped_idx)
+            logits = (
+                ops.one_hot(
+                    ops.broadcast_to(target_id, (self.batch_size,)),
+                    self.vocab_size,
+                )
+                * 1e9
+            )
+            return logits, hidden_states, cache
+
+        return next_fn
+
+    def join_as_string(self, x):
+        x = ops.convert_to_numpy(x)
+        return ["".join([self.int_lookup[i] for i in s]) for s in x]
+
+    def test_stateless_call(self):
+        target_chars = list("helloworldss")
+        target_next = self._next_fn(target_chars)
+        draft_next = self._next_fn(target_chars)
+
+        sampler = SpeculativeSampler(
+            num_speculative_tokens=3,
+            temperature=1.0,
+        )
+        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
+        output = sampler(
+            next=target_next,
+            prompt=prompt,
+            index=0,
+            draft_next=draft_next,
+        )
+        self.assertTrue(self.join_as_string(output)[0].startswith("hello"))
+
+    def test_all_accepted(self):
+        target_chars = list("abcdefghijkl")
+        target_next = self._next_fn(target_chars)
+        draft_next = self._next_fn(target_chars)
+
+        sampler = SpeculativeSampler(num_speculative_tokens=3, temperature=1.0)
+        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
+        output = sampler(
+            next=target_next,
+            prompt=prompt,
+            index=0,
+            draft_next=draft_next,
+        )
+        self.assertEqual(self.join_as_string(output), ["abcdefghijkl"])
+
+    def test_partial_acceptance(self):
+        target_chars = list("abcdefghijkl")
+        draft_chars = list("abxdefghijkl")
+
+        target_next = self._next_fn(target_chars)
+        draft_next = self._next_fn(draft_chars)
+
+        sampler = SpeculativeSampler(num_speculative_tokens=3, temperature=1.0)
+        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
+        output = sampler(
+            next=target_next,
+            prompt=prompt,
+            index=0,
+            draft_next=draft_next,
+        )
+        output_str = self.join_as_string(output)
+        self.assertTrue(output_str[0].startswith("ab"))
+
+    def test_early_stopping(self):
+        target_chars = list("hellozzzzzzzz")
+        target_next = self._next_fn(target_chars)
+        draft_next = self._next_fn(target_chars)
+
+        sampler = SpeculativeSampler(num_speculative_tokens=3, temperature=1.0)
+        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
+        output = sampler(
+            next=target_next,
+            prompt=prompt,
+            index=0,
+            stop_token_ids=[self.char_lookup["o"]],
+            draft_next=draft_next,
+        )
+        output_str = self.join_as_string(output)
+        self.assertTrue(
+            "hello" in output_str[0] or output_str[0].startswith("hell")
+        )
+
+    def test_requires_draft_next(self):
+        sampler = SpeculativeSampler(num_speculative_tokens=3)
+        prompt = ops.full((self.batch_size, self.length), 0)
+
+        def dummy_next(prompt, cache, index):
+            return ops.zeros((1, self.vocab_size)), ops.zeros((1, 5)), cache
+
+        with self.assertRaises(ValueError):
+            sampler(next=dummy_next, prompt=prompt, index=0)
+
+    def test_serialization(self):
+        from keras_hub.src.samplers.top_p_sampler import TopPSampler
+
+        base = TopPSampler(p=0.9, temperature=0.8)
+        sampler = SpeculativeSampler(
+            num_speculative_tokens=7,
+            base_sampler=base,
+            seed=42,
+        )
+        config = sampler.get_config()
+        self.assertEqual(config["num_speculative_tokens"], 7)
+        self.assertEqual(config["seed"], 42)
+        self.assertIsNotNone(config["base_sampler"])
+
+        restored = SpeculativeSampler.from_config(config)
+        self.assertEqual(restored.num_speculative_tokens, 7)
+        self.assertEqual(restored.seed, 42)
+
+    def test_output_shape(self):
+        target_chars = list("abcdefghijkl")
+        target_next = self._next_fn(target_chars)
+        draft_next = self._next_fn(target_chars)
+
+        sampler = SpeculativeSampler(num_speculative_tokens=3)
+        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
+        output = sampler(
+            next=target_next,
+            prompt=prompt,
+            index=0,
+            draft_next=draft_next,
+        )
+        self.assertEqual(ops.shape(output)[0], self.batch_size)
+        self.assertEqual(ops.shape(output)[1], self.length)
+
+    def test_batched_call(self):
+        batch_size = 2
+        length = 8
+
+        def batched_next(prompt, cache, index):
+            hidden_states = ops.ones([batch_size, 5])
+            logits = (
+                ops.one_hot(
+                    ops.zeros((batch_size,), dtype="int32"),
+                    self.vocab_size,
+                )
+                * 1e9
+            )
+            return logits, hidden_states, cache
+
+        sampler = SpeculativeSampler(num_speculative_tokens=2)
+        prompt = ops.full((batch_size, length), self.char_lookup["z"])
+        output = sampler(
+            next=batched_next,
+            prompt=prompt,
+            index=0,
+            draft_next=batched_next,
+        )
+        output_str = self.join_as_string(output)
+        self.assertEqual(output_str, ["aaaaaaaa", "aaaaaaaa"])
+
+    def test_short_circuit_rejection(self):
+        # If token 2 is wrong, tokens 3+ should be rejected even if correct.
+        target_chars = list("abcdefghijkl")
+        draft_chars = list("abxdefghijkl")
+
+        target_next = self._next_fn(target_chars)
+        draft_next = self._next_fn(draft_chars)
+
+        sampler = SpeculativeSampler(num_speculative_tokens=5, temperature=1.0)
+        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
+        output = sampler(
+            next=target_next,
+            prompt=prompt,
+            index=0,
+            draft_next=draft_next,
+        )
+        output_str = self.join_as_string(output)
+        self.assertTrue(output_str[0].startswith("ab"))
+        self.assertEqual(output_str[0][2], "c")

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -909,7 +909,7 @@ class KerasPresetSaver:
         # Save preprocessor.
         if task.preprocessor and hasattr(task.preprocessor, "save_to_preset"):
             task.preprocessor.save_to_preset(self.preset_dir)
-        else:
+        elif task.preprocessor is not None:
             # Allow saving a `keras.Layer` that is not a preprocessor subclass.
             self.save_preprocessor(task.preprocessor)
 
@@ -948,8 +948,8 @@ class KerasPresetSaver:
         tasks = list_subclasses(Task)
         tasks = filter(lambda x: x.backbone_cls is type(layer), tasks)
         tasks = [task.__base__.__name__ for task in tasks]
-        # Keep task list alphabetical.
-        tasks = sorted(tasks)
+        # Keep task list alphabetical and deduplicated.
+        tasks = sorted(set(tasks))
 
         keras_version = keras.version() if hasattr(keras, "version") else None
         metadata = {

--- a/keras_hub/src/utils/transformers/convert_gemma4.py
+++ b/keras_hub/src/utils/transformers/convert_gemma4.py
@@ -273,6 +273,7 @@ def convert_backbone_config(transformers_config):
         "sliding_window_size": text_cfg.get("sliding_window", 512) or 512,
         "sliding_window_pattern": sliding_window_pattern,
         "layer_norm_epsilon": text_cfg.get("rms_norm_eps", 1e-6),
+        "layer_types": text_cfg["layer_types"],
         "vision_encoder": vision_encoder,
         "audio_encoder": audio_encoder,
         "num_kv_shared_layers": text_cfg.get("num_kv_shared_layers", 0),

--- a/keras_hub/src/utils/transformers/convert_gemma4_assistant.py
+++ b/keras_hub/src/utils/transformers/convert_gemma4_assistant.py
@@ -1,0 +1,130 @@
+import numpy as np
+
+from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.samplers.top_k_sampler import TopKSampler
+from keras_hub.src.samplers.top_p_sampler import TopPSampler
+from keras_hub.src.utils.preset_utils import check_file_exists
+from keras_hub.src.utils.preset_utils import load_json
+from keras_hub.src.utils.transformers.convert_gemma4 import (
+    _convert_decoder_block,
+)
+from keras_hub.src.utils.transformers.convert_gemma4 import (
+    convert_backbone_config as target_convert_config,
+)
+
+backbone_cls = Gemma4Backbone
+
+
+def convert_backbone_config(transformers_config):
+    """Map a Transformers config dict → Gemma4Backbone keyword arguments
+    for assistant.
+    """
+    # Delegate to the target model's backbone config converter.
+    config = target_convert_config(transformers_config)
+    return config
+
+
+def convert_task_config(transformers_config):
+    """Map Transformers config.json to Gemma4AssistantCausalLM kwargs."""
+    return {
+        "centroid_intermediate_top_k": transformers_config[
+            "centroid_intermediate_top_k"
+        ],
+        "use_ordered_embeddings": transformers_config["use_ordered_embeddings"],
+        "backbone_hidden_size": transformers_config["backbone_hidden_size"],
+        "num_centroids": transformers_config["num_centroids"],
+    }
+
+
+def load_task_config(preset, transformers_config):
+    """Read generation_config.json and return extra Gemma4AssistantCausalLM
+    kwargs not present in config.json.
+
+    Maps:
+      ``num_assistant_tokens`` → ``num_speculative_tokens``
+      ``do_sample`` / ``top_k`` / ``top_p`` / ``temperature`` → ``sampler``
+    """
+    if not check_file_exists(preset, "generation_config.json"):
+        return {}
+    gen_cfg = load_json(preset, "generation_config.json")
+    kwargs = {}
+
+    if "num_assistant_tokens" in gen_cfg:
+        kwargs["num_speculative_tokens"] = gen_cfg["num_assistant_tokens"]
+
+    do_sample = gen_cfg.get("do_sample", False)
+    has_top_k = "top_k" in gen_cfg
+    has_top_p = "top_p" in gen_cfg
+    if not do_sample and (has_top_k or has_top_p):
+        do_sample = True
+    if do_sample:
+        top_k = gen_cfg.get("top_k", None)
+        top_p = gen_cfg.get("top_p", None)
+        temperature = gen_cfg.get("temperature", 1.0)
+        if top_p is not None and top_p < 1.0:
+            kwargs["sampler"] = TopPSampler(
+                p=top_p, k=top_k, temperature=temperature
+            )
+        elif top_k is not None:
+            kwargs["sampler"] = TopKSampler(k=top_k, temperature=temperature)
+
+    return kwargs
+
+
+def convert_weights(backbone, loader, transformers_config):
+    """Port Gemma4Assistant Backbone weights (inner model) from HF."""
+
+    def hf_key(suffix):
+        return f"model.{suffix}"
+
+    for i in range(backbone.num_layers):
+        decoder_layer = backbone.get_layer(f"decoder_block_{i}")
+        # Assistant weights have NO independent key/value tensors in the file.
+        # Force toggle the flag on temporarily during this specific port phase
+        # to bypass redundant safe-tensor load checks without altering the
+        # backbone.
+        decoder_layer.attention.is_kv_shared_layer = True
+        _convert_decoder_block(decoder_layer, i, loader, hf_key)
+
+    loader.port_weight(
+        keras_variable=backbone.get_layer("token_embedding").embeddings,
+        hf_weight_key=hf_key("embed_tokens.weight"),
+    )
+
+    loader.port_weight(
+        keras_variable=backbone.get_layer("final_normalization").scale,
+        hf_weight_key=hf_key("norm.weight"),
+    )
+
+
+def convert_head(model, loader, transformers_config):
+    """Port the dedicated Assistant top-level projection layers."""
+    # pre_projection
+    loader.port_weight(
+        keras_variable=model.pre_projection.kernel,
+        hf_weight_key="pre_projection.weight",
+        hook_fn=lambda x, _: np.transpose(x),
+    )
+
+    # post_projection
+    loader.port_weight(
+        keras_variable=model.post_projection.kernel,
+        hf_weight_key="post_projection.weight",
+        hook_fn=lambda x, _: np.transpose(x),
+    )
+
+    # centroids
+    if getattr(model, "centroids", None) is not None:
+        loader.port_weight(
+            keras_variable=model.centroids.kernel,
+            hf_weight_key="masked_embedding.centroids.weight",
+            hook_fn=lambda x, _: np.transpose(x),
+        )
+
+    # token_ordering
+    if getattr(model, "token_ordering", None) is not None:
+        loader.port_weight(
+            keras_variable=model.token_ordering,
+            hf_weight_key="masked_embedding.token_ordering",
+            hook_fn=lambda x, _: x.astype(np.int32),
+        )

--- a/keras_hub/src/utils/transformers/convert_gemma4_assistant.py
+++ b/keras_hub/src/utils/transformers/convert_gemma4_assistant.py
@@ -126,5 +126,5 @@ def convert_head(model, loader, transformers_config):
         loader.port_weight(
             keras_variable=model.token_ordering,
             hf_weight_key="masked_embedding.token_ordering",
-            hook_fn=lambda x, _: x.astype(np.int32),
+            hook_fn=lambda x, _: x.astype(np.float32),
         )

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -17,6 +17,7 @@ from keras_hub.src.utils.transformers import convert_gemma
 from keras_hub.src.utils.transformers import convert_gemma3
 from keras_hub.src.utils.transformers import convert_gemma3n
 from keras_hub.src.utils.transformers import convert_gemma4
+from keras_hub.src.utils.transformers import convert_gemma4_assistant
 from keras_hub.src.utils.transformers import convert_gpt2
 from keras_hub.src.utils.transformers import convert_gpt_oss
 from keras_hub.src.utils.transformers import convert_llama3
@@ -31,7 +32,6 @@ from keras_hub.src.utils.transformers import convert_qwen3_moe
 from keras_hub.src.utils.transformers import convert_qwen_moe
 from keras_hub.src.utils.transformers import convert_sam3
 from keras_hub.src.utils.transformers import convert_smollm3
-from keras_hub.src.utils.transformers import convert_swin_transformer
 from keras_hub.src.utils.transformers import convert_t5gemma
 from keras_hub.src.utils.transformers import convert_t5gemma2
 from keras_hub.src.utils.transformers import convert_vit
@@ -66,6 +66,8 @@ class TransformersPresetLoader(PresetLoader):
             self.converter = convert_gemma3n
         elif model_type in ("gemma4", "gemma4_text"):
             self.converter = convert_gemma4
+        elif model_type == "gemma4_assistant":
+            self.converter = convert_gemma4_assistant
         elif model_type == "gpt2":
             self.converter = convert_gpt2
         elif model_type == "gpt_oss":
@@ -79,8 +81,6 @@ class TransformersPresetLoader(PresetLoader):
             self.converter = convert_mistral
         elif model_type == "paligemma":
             self.converter = convert_pali_gemma
-        elif model_type == "swin":
-            self.converter = convert_swin_transformer
         elif model_type == "vit":
             self.converter = convert_vit
         elif model_type == "qwen2":
@@ -132,10 +132,22 @@ class TransformersPresetLoader(PresetLoader):
 
     def load_task(self, cls, load_weights, load_task_weights, **kwargs):
         architecture = self.config["architectures"][0]
-        if (
-            not load_task_weights
-            or not issubclass(cls, ImageClassifier)
-            or architecture == "ViTModel"
+        is_classifier = issubclass(cls, ImageClassifier)
+        is_assistant = architecture == "Gemma4AssistantForCausalLM"
+
+        if hasattr(self.converter, "convert_task_config"):
+            task_config = self.converter.convert_task_config(self.config)
+            kwargs = {**task_config, **kwargs}
+
+        if hasattr(self.converter, "load_task_config"):
+            extra = self.converter.load_task_config(self.preset, self.config)
+            if extra:
+                kwargs = {**extra, **kwargs}
+
+        if not load_task_weights or (
+            not is_classifier
+            and not is_assistant
+            and architecture != "ViTModel"
         ):
             return super().load_task(
                 cls, load_weights, load_task_weights, **kwargs

--- a/tools/checkpoint_conversion/convert_gemma4_hf_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_gemma4_hf_checkpoints.py
@@ -22,6 +22,7 @@ from absl import app
 from absl import flags
 from keras import ops
 from PIL import Image
+from transformers import AutoModelForCausalLM
 from transformers import AutoModelForMultimodalLM
 from transformers import AutoProcessor
 from transformers import AutoTokenizer
@@ -38,12 +39,16 @@ torch.set_default_device(device)
 PRESET_MAP = {
     "gemma4_2b": "google/gemma-4-E2B",
     "gemma4_instruct_2b": "google/gemma-4-E2B-it",
+    "gemma4_instruct_2b_assistant": "google/gemma-4-E2B-it-assistant",
     "gemma4_4b": "google/gemma-4-E4B",
     "gemma4_instruct_4b": "google/gemma-4-E4B-it",
+    "gemma4_instruct_4b_assistant": "google/gemma-4-E4B-it-assistant",
     "gemma4_26b_a4b": "google/gemma-4-26B-A4B",
     "gemma4_instruct_26b_a4b": "google/gemma-4-26B-A4B-it",
+    "gemma4_instruct_26b_a4b_assistant": "google/gemma-4-26B-A4B-it-assistant",
     "gemma4_31b": "google/gemma-4-31B",
     "gemma4_instruct_31b": "google/gemma-4-31B-it",
+    "gemma4_instruct_31b_assistant": "google/gemma-4-31B-it-assistant",
 }
 
 IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -336,7 +341,6 @@ def _precompute_hf_outputs(
             generated_ids = hf_model.generate(
                 **hf_inputs,
                 max_new_tokens=64,
-                do_sample=False,
             )
         prompt_length = hf_inputs["input_ids"].shape[1]
         hf_generated_text = hf_tokenizer.decode(
@@ -596,6 +600,7 @@ def _test_generate(
     prompt,
     hf_generated_text,
     max_length=2048 + 64,
+    assistant_model=None,
     **media_kwargs,
 ):
     """Run KH .generate() and compare output against HF-generated text.
@@ -605,9 +610,12 @@ def _test_generate(
     should pass a larger value so that generation isn't cut off before any
     response tokens are produced.
     """
+    generate_kwargs = {"max_length": max_length}
+    if assistant_model is not None:
+        generate_kwargs["assistant_model"] = assistant_model
     kh_output = kh_model.generate(
         {"prompts": [prompt], **{k: [v] for k, v in media_kwargs.items()}},
-        max_length=max_length,
+        **generate_kwargs,
     )
     kh_text = kh_output[0] if isinstance(kh_output, list) else kh_output
     if isinstance(kh_text, str):
@@ -663,6 +671,68 @@ def _load_test_assets():
 
 def _load_hf_model(hf_preset):
     """Load HF model/tokenizer/processor and detect modality capabilities."""
+    is_assistant = "assistant" in hf_preset
+
+    if is_assistant:
+        # For assistant presets load both the target (base instruct) model and
+        # the smaller assistant model.  Both use AutoModelForCausalLM because
+        # the assistant head does not have a vision encoder.
+        target_preset = hf_preset.replace("-assistant", "")
+        hf_target_model = AutoModelForCausalLM.from_pretrained(
+            target_preset,
+            device_map="cpu",
+            torch_dtype=torch.float32,
+            force_download=False,
+        )
+        hf_target_model.eval()
+        hf_model = AutoModelForCausalLM.from_pretrained(
+            hf_preset,
+            device_map="cpu",
+            torch_dtype=torch.float32,
+            force_download=False,
+        )
+        hf_model.eval()
+        hf_tokenizer = AutoTokenizer.from_pretrained(
+            target_preset, return_tensors="pt", force_download=False
+        )
+        # Load the target's processor for multimodal generation comparisons.
+        # The assistant itself has no encoders, but speculative generation
+        # uses the target model's multimodal processing pipeline.
+        processor = AutoProcessor.from_pretrained(
+            target_preset, force_download=False
+        )
+        is_audio_model = (
+            hasattr(hf_target_model.config, "audio_config")
+            and hf_target_model.config.audio_config is not None
+        )
+        is_video_model = (
+            hasattr(processor, "video_processor")
+            and processor.video_processor is not None
+        )
+        target_hidden_size = (
+            hf_target_model.config.get_text_config().hidden_size
+        )
+        final_logit_cap = getattr(
+            hf_target_model.config.get_text_config(),
+            "final_logit_softcapping",
+            None,
+        )
+        print(
+            f"-> HuggingFace assistant model loaded "
+            f"(target hidden_size={target_hidden_size})."
+        )
+        print(f"-> final_logit_softcapping: {final_logit_cap}")
+        return (
+            hf_model,
+            hf_tokenizer,
+            processor,
+            is_audio_model,
+            is_video_model,
+            final_logit_cap,
+            hf_target_model,
+            target_hidden_size,
+        )
+
     hf_model = AutoModelForMultimodalLM.from_pretrained(
         hf_preset,
         device_map="cpu",
@@ -699,6 +769,8 @@ def _load_hf_model(hf_preset):
         is_audio_model,
         is_video_model,
         final_logit_cap,
+        None,  # hf_target_model
+        None,  # target_hidden_size
     )
 
 
@@ -780,6 +852,418 @@ def _precompute_all_hf_outputs(
         hf_data_video["raw_video_sub"] = raw_video_sub
 
     return hf_data_text, hf_data_image, hf_data_audio, hf_data_video
+
+
+def _precompute_assistant_hf_outputs(
+    hf_target_model,
+    hf_model,
+    hf_tokenizer,
+    processor=None,
+    raw_image=None,
+    raw_audio=None,
+    raw_video=None,
+    is_audio_model=False,
+    is_video_model=False,
+    skip_generate=False,
+):
+    """Run HF forward pass for the assistant preset and return verification
+    data.
+
+    Runs the *target* model first to obtain shared KV states for the assistant
+    logit numerics check.  Then optionally runs HF speculative generation for
+    text, image, audio, and video prompts (matching the non-assistant path).
+    """
+    print("-> Precomputing HF assistant outputs ...")
+
+    # Tokenise a short text prompt.
+    inputs = hf_tokenizer(
+        PROMPT_TEXT, return_tensors="pt", add_special_tokens=True
+    )
+    input_ids = inputs["input_ids"]
+
+    # 1. Run target model to get shared KV states and the reference hidden
+    #    state / embedding that the assistant head will consume.
+    with torch.no_grad():
+        target_out = hf_target_model(
+            input_ids=input_ids,
+            output_hidden_states=True,
+            return_shared_kv_states=True,
+        )
+    # shared_kv_states is a dict
+    # {"full_attention": (k, v), "sliding_attention": (k, v)}.
+    shared_kv_states = target_out.shared_kv_states
+    # last hidden state at the final token position:
+    # (batch, 1, target_hidden_size)
+    hf_last_hs = target_out.hidden_states[-1][:, -1:].detach().numpy()
+
+    # 2. Build inputs_embeds for the assistant:
+    #    inputs_embeds = cat(
+    #        [target_embed(last_token), last_hidden_state], dim=-1)
+    #    This mirrors candidate_generator.py line 1379.
+    last_token_id = input_ids[:, -1:]
+    with torch.no_grad():
+        last_token_embedding = hf_target_model.get_input_embeddings()(
+            last_token_id
+        )
+        last_hidden_state_t = torch.from_numpy(hf_last_hs)
+        inputs_embeds = torch.cat(
+            [last_token_embedding, last_hidden_state_t], dim=-1
+        )
+
+    # 3. Run assistant model with inputs_embeds + shared KV states.
+    # Pass position_ids = [[seq_len - 1]] matching candidate_generator.py which
+    # explicitly sets position_ids = [[input_ids.shape[1] - 1]].  Without this
+    # the HF model defaults to position 0 (single-token input), diverging from
+    # the KerasHub cache_update_index = seq_len - 1 used in call_with_cache.
+    seq_len = input_ids.shape[1]
+    position_ids = torch.tensor([[seq_len - 1]], dtype=torch.long)
+    with torch.no_grad():
+        assistant_out = hf_model(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            shared_kv_states=shared_kv_states,
+        )
+    hf_logits = assistant_out.logits.detach().numpy()
+
+    # 4. Count HF parameters (excluding buffers to match KH counting).
+    hf_params = _count_hf_params(hf_model)
+
+    # 5. Optionally run HF speculative generation for text, image, audio,
+    #    and video prompts (target model drives generation; assistant drafts).
+    hf_generated_text = None
+    hf_generated_image = None
+    hf_generated_audio = None
+    hf_generated_video = None
+    # Metadata captured during _speculative_generate for KH alignment.
+    _gen_meta = {}
+    if not skip_generate and processor is not None:
+
+        def _speculative_generate(prompt, max_new_tokens=64, **media_kwargs):
+            """Run target+assistant speculative generation via processor."""
+            pv = media_kwargs.pop("raw_video", None)
+            ri = media_kwargs.get("raw_image")
+            if pv is not None and not isinstance(pv, torch.Tensor):
+                pv = torch.from_numpy(pv)
+            proc_inputs = processor(
+                text=prompt,
+                images=ri,
+                audio=media_kwargs.get("raw_audio"),
+                videos=pv,
+                return_mm_token_type_ids=True,
+                return_tensors="pt",
+            )
+            # Ensure BOS token is present (mirrors _precompute_hf_outputs).
+            bos_id = hf_tokenizer.bos_token_id
+            if (
+                bos_id is not None
+                and proc_inputs["input_ids"][0, 0].item() != bos_id
+            ):
+                bos = torch.full(
+                    (proc_inputs["input_ids"].shape[0], 1),
+                    bos_id,
+                    dtype=proc_inputs["input_ids"].dtype,
+                )
+                proc_inputs["input_ids"] = torch.cat(
+                    [bos, proc_inputs["input_ids"]], dim=1
+                )
+                if "attention_mask" in proc_inputs:
+                    proc_inputs["attention_mask"] = torch.ones_like(
+                        proc_inputs["input_ids"]
+                    )
+            prompt_len = proc_inputs["input_ids"].shape[1]
+            # Capture metadata for KH preprocessor alignment.
+            if ri is not None and "mm_token_type_ids" in proc_inputs:
+                _gen_meta["image_token_count"] = int(
+                    (proc_inputs["mm_token_type_ids"] == 1).sum()
+                )
+            if pv is not None:
+                _gen_meta["video_prompt_len"] = prompt_len
+                if "pixel_values_videos" in proc_inputs:
+                    _gen_meta["video_num_frames"] = int(
+                        proc_inputs["pixel_values_videos"].shape[1]
+                    )
+            with torch.no_grad():
+                gen_ids = hf_target_model.generate(
+                    **proc_inputs,
+                    assistant_model=hf_model,
+                    max_new_tokens=max_new_tokens,
+                )
+            return hf_tokenizer.decode(
+                gen_ids[0, prompt_len:], skip_special_tokens=True
+            )
+
+        print("-> Running HF speculative generation (text) ...")
+        hf_generated_text = _speculative_generate(PROMPT_TEXT)
+
+        print("-> Running HF speculative generation (image) ...")
+        hf_generated_image = _speculative_generate(
+            PROMPT_IMAGE, max_new_tokens=256, raw_image=raw_image
+        )
+
+        if is_audio_model and raw_audio is not None:
+            print("-> Running HF speculative generation (audio) ...")
+            hf_generated_audio = _speculative_generate(
+                PROMPT_AUDIO, raw_audio=raw_audio
+            )
+
+        raw_video_sub = None
+        if is_video_model and raw_video is not None:
+            print("-> Running HF speculative generation (video) ...")
+            if not isinstance(raw_video, np.ndarray):
+                raw_video = np.array(raw_video)
+            # Subsample to processor's expected frame count so that KH gets
+            # the same frames (mirrors _precompute_all_hf_outputs).
+            hf_num_frames = getattr(processor.video_processor, "num_frames", 32)
+            T = raw_video.shape[0]
+            if T > hf_num_frames:
+                sub_idx = np.arange(0, T, T / hf_num_frames).astype(int)[
+                    :hf_num_frames
+                ]
+                raw_video_sub = raw_video[sub_idx]  # channels-last
+            else:
+                raw_video_sub = raw_video
+            # HF expects channels-first (T, C, H, W).
+            raw_video_hf = np.transpose(raw_video_sub, (0, 3, 1, 2))
+            hf_generated_video = _speculative_generate(
+                PROMPT_VIDEO, max_new_tokens=256, raw_video=raw_video_hf
+            )
+    elif not skip_generate:
+        # Fallback: text-only with bare tokenizer (no processor available).
+        print(
+            "-> Running HF speculative generation (text only, no processor) ..."
+        )
+        gen_ids = hf_target_model.generate(
+            input_ids,
+            assistant_model=hf_model,
+            max_new_tokens=64,
+        )
+        hf_generated_text = hf_tokenizer.decode(
+            gen_ids[0, input_ids.shape[1] :], skip_special_tokens=True
+        )
+        print(f"   HF generated: {hf_generated_text!r}")
+
+    return {
+        "logits": hf_logits,
+        "last_hidden_state": hf_last_hs,
+        "last_token_embedding": last_token_embedding.detach().numpy(),
+        "input_ids": input_ids.numpy(),
+        "shared_kv_states": shared_kv_states,
+        "generated_text": hf_generated_text,
+        "generated_image": hf_generated_image,
+        "generated_audio": hf_generated_audio,
+        "generated_video": hf_generated_video,
+        "image_token_count": _gen_meta.get("image_token_count"),
+        "video_prompt_len": _gen_meta.get("video_prompt_len"),
+        "video_num_frames": _gen_meta.get("video_num_frames"),
+        "raw_video_sub": raw_video_sub if not skip_generate else None,
+        "param_count": hf_params,
+    }
+
+
+def _count_keras_hub_assistant_params(kh_assistant):
+    """Count KerasHub parameters for an assistant model.
+
+    Excludes `token_ordering`, which is a derived index buffer not counted
+    by HuggingFace's parameter count utilities.
+    """
+    unique_weights = {
+        id(w): w for w in kh_assistant.weights if "token_ordering" not in w.name
+    }.values()
+    return sum(w.numpy().size for w in unique_weights)
+
+
+def _verify_assistant_mode(
+    kh_assistant,
+    hf_data,
+    hf_tokenizer,
+    keras_hub_target_preset=None,
+    skip_generate=False,
+    raw_image=None,
+    raw_audio=None,
+    raw_video=None,
+    is_audio_model=False,
+    is_video_model=False,
+):
+    """Verify a Gemma4AssistantCausalLM against pre-computed HF outputs.
+
+    Checks:
+      1. Parameter count match with HF.
+      2. Logit numerics on finite positions (atol=1e-3, rtol=1e-3).
+      3. Speculative generation comparison for text, image, audio, and video.
+    """
+    print("\n--- Section 1: Parameter count ---")
+    kh_params = _count_keras_hub_assistant_params(kh_assistant)
+    hf_params = hf_data["param_count"]
+    print(f"   KH params: {kh_params:,}")
+    print(f"   HF params: {hf_params:,}")
+    np.testing.assert_equal(kh_params, hf_params)
+    print("✓ Parameter counts match.")
+
+    print("\n--- Section 2: Logit numerics ---")
+    input_ids = hf_data["input_ids"]  # (1, seq_len) numpy
+    shared_kv_states = hf_data[
+        "shared_kv_states"
+    ]  # dict[str, tuple[Tensor,Tensor]]
+    hf_logits = hf_data["logits"]  # (1, 1, vocab) — single assistant token
+    last_hidden_state_np = hf_data["last_hidden_state"]  # (1, 1, target_hidden)
+    last_token_embedding_np = hf_data[
+        "last_token_embedding"
+    ]  # (1, 1, target_hidden)
+
+    # Convert HF shared_kv_states to KH target_cache format.
+    # HF key/value shape: (batch, num_heads, seq_len, head_dim)
+    # KH cache shape:     (batch, 2, seq_len, num_heads, head_dim)
+    #   where [:, 0, ...] = key, [:, 1, ...] = value.
+    def _hf_kv_to_kh(k_t, v_t):
+        k = np.transpose(
+            k_t.detach().numpy(), (0, 2, 1, 3)
+        )  # → (batch, seq, heads, dim)
+        v = np.transpose(v_t.detach().numpy(), (0, 2, 1, 3))
+        return np.stack([k, v], axis=1)  # (batch, 2, seq, heads, dim)
+
+    sliding_kv = _hf_kv_to_kh(*shared_kv_states["sliding_attention"])
+    full_kv = _hf_kv_to_kh(*shared_kv_states["full_attention"])
+
+    # Pad to a common shape before stacking.  KH allocates all per-layer
+    # cache slots with max_head_dim = max(head_dim, global_head_dim) and
+    # max_num_kv_heads so ops.stack() works across heterogeneous layers.
+    # Mirror that padding here: zeros fill unused head/dim slots and are
+    # masked out when KH slices back to the actual head_dim/num_heads.
+    max_seq = max(sliding_kv.shape[2], full_kv.shape[2])
+    max_heads = max(sliding_kv.shape[3], full_kv.shape[3])
+    max_dim = max(sliding_kv.shape[4], full_kv.shape[4])
+
+    def _pad_kv(kv, t_seq, t_heads, t_dim):
+        _, _, s, h, d = kv.shape
+        return np.pad(
+            kv,
+            [(0, 0), (0, 0), (0, t_seq - s), (0, t_heads - h), (0, t_dim - d)],
+        )
+
+    sliding_kv = _pad_kv(sliding_kv, max_seq, max_heads, max_dim)
+    full_kv = _pad_kv(full_kv, max_seq, max_heads, max_dim)
+
+    # Stack as 2-layer target_cache: [0]=sliding, [1]=full.
+    # call_with_cache uses target_cache[:, num_target-2, ...] for sliding and
+    # target_cache[:, num_target-1, ...] for full, so 2 layers is sufficient.
+    target_cache_np = np.stack([sliding_kv, full_kv], axis=1)
+
+    seq_len = input_ids.shape[1]
+    last_token_embedding_t = ops.convert_to_tensor(
+        last_token_embedding_np, dtype=kh_assistant.compute_dtype
+    )
+    last_hidden_state_t = ops.convert_to_tensor(
+        last_hidden_state_np, dtype=kh_assistant.compute_dtype
+    )
+    target_cache_t = ops.convert_to_tensor(
+        target_cache_np, dtype=kh_assistant.compute_dtype
+    )
+    padding_mask_t = ops.ones((1, 1), dtype="bool")
+
+    kh_out = kh_assistant.call_with_cache(
+        last_token_embedding_t,
+        last_hidden_state_t,
+        target_cache_t,
+        cache_update_index=seq_len - 1,
+        padding_mask=padding_mask_t,
+    )
+    kh_logits = ops.convert_to_numpy(kh_out[0])
+
+    # Compare only on finite positions (sparse vocabulary logits may have
+    # -inf for disabled tokens).
+    active_mask = np.isfinite(hf_logits) & np.isfinite(kh_logits)
+    active_hf = hf_logits[active_mask]
+    active_kh = kh_logits[active_mask]
+    abs_diff = np.abs(active_kh - active_hf)
+    max_diff = float(np.max(abs_diff))
+    mean_diff = float(np.mean(abs_diff))
+    print(f"   max |Δlogit| = {max_diff:.6f},  mean |Δlogit| = {mean_diff:.6f}")
+    np.testing.assert_allclose(
+        active_kh,
+        active_hf,
+        atol=1e-3,
+        rtol=1e-3,
+        err_msg="Assistant logits differ from HF beyond tolerance.",
+    )
+    print("✓ Logits within tolerance (atol=1e-3, rtol=1e-3).")
+
+    # ── Section 3: Speculative generation comparison ────────────────────────
+    if skip_generate or keras_hub_target_preset is None:
+        print(
+            "\n--- Generation Comparison: SKIPPED "
+            "(--skip_generate or no target preset) ---"
+        )
+    else:
+        print("\n--- Section 3: Speculative generation ---")
+
+        # Load the KH target model once for all modality comparisons.
+        kh_target = keras_hub.models.Gemma4CausalLM.from_preset(
+            keras_hub_target_preset, dtype="float32"
+        )
+        preprocessor = keras_hub.models.Gemma4CausalLMPreprocessor.from_preset(
+            keras_hub_target_preset
+        )
+        if not is_audio_model:
+            preprocessor.audio_converter = None
+        kh_target.preprocessor = preprocessor
+
+        _test_generate(
+            "assistant-speculative-text",
+            kh_target,
+            PROMPT_TEXT,
+            hf_data.get("generated_text") or "(not available)",
+            assistant_model=kh_assistant,
+        )
+        image_token_count = hf_data.get("image_token_count")
+        saved_nv = preprocessor.num_vision_tokens_per_image
+        if image_token_count:
+            preprocessor.num_vision_tokens_per_image = image_token_count
+        _test_generate(
+            "assistant-speculative-image",
+            kh_target,
+            PROMPT_IMAGE,
+            hf_data.get("generated_image") or "(not available)",
+            assistant_model=kh_assistant,
+            images=raw_image,
+        )
+        preprocessor.num_vision_tokens_per_image = saved_nv
+
+        if is_audio_model and raw_audio is not None:
+            _test_generate(
+                "assistant-speculative-audio",
+                kh_target,
+                PROMPT_AUDIO,
+                hf_data.get("generated_audio") or "(not available)",
+                assistant_model=kh_assistant,
+                audio=raw_audio,
+            )
+        if is_video_model and raw_video is not None:
+            _raw_video_sub = hf_data.get("raw_video_sub")
+            raw_video_kh = (
+                _raw_video_sub if _raw_video_sub is not None else raw_video
+            )
+            video_prompt_len = hf_data.get("video_prompt_len") or 2048
+            video_num_frames = hf_data.get("video_num_frames")
+            saved_nf = preprocessor.num_frames_per_video
+            saved_sl = preprocessor.packer.sequence_length
+            if video_num_frames:
+                preprocessor.num_frames_per_video = video_num_frames
+            preprocessor.packer.sequence_length = video_prompt_len
+            _test_generate(
+                "assistant-speculative-video",
+                kh_target,
+                PROMPT_VIDEO,
+                hf_data.get("generated_video") or "(not available)",
+                max_length=video_prompt_len + 256,
+                assistant_model=kh_assistant,
+                videos=raw_video_kh,
+            )
+            preprocessor.num_frames_per_video = saved_nf
+            preprocessor.packer.sequence_length = saved_sl
+        del kh_target
+
+    print("\n✓ Assistant verification complete.")
+    return kh_assistant
 
 
 def _load_keras_hub_model(keras_hub_preset, is_audio_model):
@@ -1031,29 +1515,46 @@ def _verify_model(
 
 
 def _save_preset(
-    gemma4_lm, keras_hub_preset, preset, save_dtype, final_logit_cap
+    gemma4_lm,
+    keras_hub_preset,
+    preset,
+    save_dtype,
+    final_logit_cap,
 ):
     """Save the model to a local preset directory in the requested dtype."""
     preset_save_path = f"./{preset}"
     print(f"\n-> Saving model in {save_dtype} to {preset_save_path} ...")
+    is_assistant = "assistant" in preset
 
     if save_dtype == "bfloat16":
-        preprocessor_ref = gemma4_lm.preprocessor
-        # gemma4_lm is the only remaining reference to the float32 model
-        # (backbone/tokenizer/preprocessor were already deleted in main).
-        del gemma4_lm
-        gc.collect()
-        backbone_bf16 = keras_hub.models.Gemma4Backbone.from_preset(
-            keras_hub_preset, dtype="bfloat16"
-        )
-        gemma4_lm_bf16 = keras_hub.models.Gemma4CausalLM(
-            backbone=backbone_bf16,
-            preprocessor=preprocessor_ref,
-            sampler="greedy",
-            final_logit_cap=final_logit_cap,
-        )
-        gemma4_lm_bf16.save_to_preset(preset_save_path)
+        if is_assistant:
+            # Free the verified float32 assistant, then let from_preset
+            # rebuild and re-convert in bfloat16 via the registered
+            # convert_gemma4_assistant converter.
+            del gemma4_lm
+            gc.collect()
+            kh_save = keras_hub.models.Gemma4AssistantCausalLM.from_preset(
+                keras_hub_preset, dtype="bfloat16"
+            )
+            kh_save.save_to_preset(preset_save_path)
+        else:
+            preprocessor_ref = gemma4_lm.preprocessor
+            # gemma4_lm is the only remaining reference to the float32 model
+            # (backbone/tokenizer/preprocessor were already deleted in main).
+            del gemma4_lm
+            gc.collect()
+            backbone_bf16 = keras_hub.models.Gemma4Backbone.from_preset(
+                keras_hub_preset, dtype="bfloat16"
+            )
+            kh_save = keras_hub.models.Gemma4CausalLM(
+                backbone=backbone_bf16,
+                preprocessor=preprocessor_ref,
+                sampler="greedy",
+                final_logit_cap=final_logit_cap,
+            )
+            kh_save.save_to_preset(preset_save_path)
     else:
+        # float32: model is already verified — save directly.
         gemma4_lm.save_to_preset(preset_save_path)
 
     print(f"-> Saved {save_dtype} preset to {preset_save_path}")
@@ -1068,7 +1569,13 @@ def main(_):
         )
 
     hf_preset = PRESET_MAP[preset]
-    keras_hub_preset = f"hf://{hf_preset}"
+    is_assistant = "assistant" in preset
+    # For assistant presets keras_hub_preset points at the base instruct model
+    # (the backbone is shared; only the assistant head is new).
+    base_preset = (
+        hf_preset.replace("-assistant", "") if is_assistant else hf_preset
+    )
+    keras_hub_preset = f"hf://{base_preset}"
 
     raw_image, raw_audio, raw_video = _load_test_assets()
 
@@ -1079,7 +1586,59 @@ def main(_):
         is_audio_model,
         is_video_model,
         final_logit_cap,
+        hf_target_model,
+        _target_hidden_size,  # consumed by from_preset via convert_task_config
     ) = _load_hf_model(hf_preset)
+
+    if is_assistant:
+        hf_data_assistant = _precompute_assistant_hf_outputs(
+            hf_target_model,
+            hf_model,
+            hf_tokenizer,
+            processor=processor,
+            raw_image=raw_image,
+            raw_audio=raw_audio,
+            raw_video=raw_video,
+            is_audio_model=is_audio_model,
+            is_video_model=is_video_model,
+            skip_generate=FLAGS.skip_generate,
+        )
+        del hf_target_model, hf_model
+        gc.collect()
+
+        # from_preset reads model_type="gemma4_assistant" from the HF config
+        # and calls convert_backbone_config / convert_task_config /
+        # convert_weights / convert_head automatically.
+        kh_assistant = keras_hub.models.Gemma4AssistantCausalLM.from_preset(
+            f"hf://{hf_preset}", dtype="float32"
+        )
+
+        _verify_assistant_mode(
+            kh_assistant,
+            hf_data_assistant,
+            hf_tokenizer,
+            keras_hub_target_preset=keras_hub_preset,
+            skip_generate=FLAGS.skip_generate,
+            raw_image=raw_image,
+            raw_audio=raw_audio,
+            raw_video=raw_video,
+            is_audio_model=is_audio_model,
+            is_video_model=is_video_model,
+        )
+
+        del hf_data_assistant
+        gc.collect()
+
+        _save_preset(
+            kh_assistant,
+            f"hf://{hf_preset}",
+            preset,
+            FLAGS.save_dtype,
+            final_logit_cap,
+        )
+        return
+
+    # --- Non-assistant path (unchanged from master) ---
     hf_data_text, hf_data_image, hf_data_audio, hf_data_video = (
         _precompute_all_hf_outputs(
             hf_model,


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->

# Add Gemma4 Assistant Model and Speculative Decoding

## Overview

This PR introduces two new components for accelerated Gemma4 inference — a
dedicated MTP assistant model (`Gemma4AssistantCausalLM`) and a generic
`SpeculativeSampler`  along with a bug fix in `Task` that caused
`task.weights.h5` to incorrectly include backbone weights.

---

## 1. `Gemma4AssistantCausalLM`

Adds `keras_hub.models.Gemma4AssistantCausalLM`, a small companion model
designed exclusively for speculative decoding with Gemma4 target models.

**How it works:**

- The assistant is a lightweight 4-layer Gemma4 model that shares the target
  model's KV cache via the `num_kv_shared_layers` mechanism in
  `Gemma4Backbone`. This means the assistant never computes its own key/value
  projections, it reads directly from the target model's cache.
- At each draft step the assistant receives the **target model's last hidden
  state** and the **last accepted token embedding**, which are concatenated and
  projected into the assistant's hidden dimension. This conditions the draft on
  what the target model "knows", making proposals significantly more accurate
  than a cold start.
- The output head uses a sparse **centroid-based ordered embedding**
  (`_apply_centroid_logits`) that routes predictions through `num_centroids`
  vocabulary clusters, keeping only the top-k active centroids per step. This
  reduces the effective output dimension from ~262K to ~4K tokens, greatly
  accelerating each draft step.
- Compatible with `from_preset()` for loading from HuggingFace-format
  checkpoints alongside the target model.

**Preset example:**

```python
import keras_hub

target_lm = keras_hub.models.Gemma4CausalLM.from_preset("gemma4_instruct_2b")
assistant_lm = keras_hub.models.Gemma4AssistantCausalLM.from_preset(
    "gemma4_instruct_2b_assistant"
)
output = target_lm.generate(
    "Tell me about speculative decoding.",
    assistant_model=assistant_lm,
    max_length=256,
)
```

---

## 2. `SpeculativeSampler`

Adds `keras_hub.samplers.SpeculativeSampler`, a backend-agnostic sampler that
implements speculative decoding
([Leviathan et al., 2022](https://arxiv.org/abs/2211.17192)) as a first-class
Keras Hub primitive.

**Algorithm — three phases per outer iteration:**

1. **Draft phase** — Runs `draft_next` K times autoregressively to produce K
   candidate tokens and their probabilities.
2. **Verify phase** — Calls `verify_next` once to score all K+1 positions in a
   single parallel target forward pass.
3. **Accept/reject phase** — Each draft token is accepted or rejected via
   rejection sampling (stochastic, when `base_sampler` is set) or greedy
   matching. A guaranteed bonus token is always appended, so the minimum
   throughput is 1 token/step with best-case K+1 tokens/step.

**Key design choices:**

- Works with any target and draft model that expose a `call_with_cache`
  interface — not specific to Gemma4.
- `verify_next` can return a 2-tuple `(logits, cache)` or a 3-tuple
  `(logits, hidden_states, cache)`. When hidden states are returned they seed
  the next draft cycle, improving draft accuracy for MTP-style assistants.
- Draft tokens are always selected greedily (argmax); stochasticity enters only
  through the `p(target)/q(draft)` acceptance ratio, consistent with the
  original algorithm.
- Supports both stateless (JAX) and stateful (PyTorch/TensorFlow) backends.

**Example:**

```python
sampler = keras_hub.samplers.SpeculativeSampler(
    num_speculative_tokens=5,
    base_sampler=keras_hub.samplers.TopPSampler(p=0.95),
)
```

---

## 3. Bug fix: `task.weights.h5` incorrectly included backbone weights

`save_task_weights()` and `load_task_weights()` both passed a **set of weight
IDs** to `objects_to_skip`, but the Keras saving API expects a **list of layer
objects**. Passing IDs caused the skip logic to be silently ignored, so every
`task.weights.h5` save included the full backbone weights.

**Fix:** Pass `list(self.backbone._flatten_layers())` directly.

**Impact:** Task-only weight files now correctly contain only the task head
weights. For example, with `DenseNet121ImageClassifier` the `task.weights.h5`
file drops from ~33 MB to ~3 MB (~90% reduction). The same improvement applies
to all `ImageClassifier` and `TextClassifier` variants.

---

## Other changes

- **`Gemma4Backbone`**: adds `num_kv_shared_layers` and
  `return_shared_kv_states` support to enable KV cache sharing with the
  assistant model.
- **`Gemma4CausalLM`**: adds `generate()` integration for speculative decoding
  via an `assistant_model` kwarg — handles draft/verify coordination, cache
  management, and hot/cold path compilation.
- **`convert_gemma4_assistant.py`**: new HuggingFace → Keras Hub weight
  converter for assistant checkpoints.
- **`preset_loader.py` / `preset_utils.py`**: extended to support loading
  `Gemma4AssistantCausalLM` presets alongside target model presets, plus a
  path traversal security fix in the TF GFile cache path (upstream commit
  `66c641c`).
- **`sampler.py` / `serialization.py`**: minor updates to register
  `SpeculativeSampler` in the sampler registry and public API.


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
