### PR TITLE
 Update VIT presets versions and Map correct preset names in conversion script with kaggle preset names

### DIFF
--- a/keras_hub/src/models/vit/vit_presets.py
+++ b/keras_hub/src/models/vit/vit_presets.py
@@ -11,7 +11,7 @@ backbone_presets = {
             "params": 85798656,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch16_224_imagenet/3",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch16_224_imagenet/4",
     },
     "vit_base_patch16_384_imagenet": {
         "metadata": {
@@ -22,7 +22,7 @@ backbone_presets = {
             "params": 86090496,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch16_384_imagenet/3",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch16_384_imagenet/4",
     },
     "vit_large_patch16_224_imagenet": {
         "metadata": {
@@ -33,7 +33,7 @@ backbone_presets = {
             "params": 303301632,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch16_224_imagenet/3",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch16_224_imagenet/4",
     },
     "vit_large_patch16_384_imagenet": {
         "metadata": {
@@ -44,7 +44,7 @@ backbone_presets = {
             "params": 303690752,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch16_384_imagenet/3",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch16_384_imagenet/4",
     },
     "vit_base_patch32_384_imagenet": {
         "metadata": {
@@ -55,7 +55,7 @@ backbone_presets = {
             "params": 87528192,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch32_384_imagenet/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch32_384_imagenet/3",
     },
     "vit_large_patch32_384_imagenet": {
         "metadata": {
@@ -66,7 +66,7 @@ backbone_presets = {
             "params": 305607680,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch32_384_imagenet/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch32_384_imagenet/3",
     },
     "vit_base_patch16_224_imagenet21k": {
         "metadata": {
@@ -77,7 +77,7 @@ backbone_presets = {
             "params": 85798656,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch16_224_imagenet21k/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch16_224_imagenet21k/3",
     },
     "vit_base_patch32_224_imagenet21k": {
         "metadata": {
@@ -88,7 +88,7 @@ backbone_presets = {
             "params": 87455232,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch32_224_imagenet21k/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_base_patch32_224_imagenet21k/3",
     },
     "vit_huge_patch14_224_imagenet21k": {
         "metadata": {
@@ -99,7 +99,7 @@ backbone_presets = {
             "params": 630764800,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_huge_patch14_224_imagenet21k/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_huge_patch14_224_imagenet21k/3",
     },
     "vit_large_patch16_224_imagenet21k": {
         "metadata": {
@@ -110,7 +110,7 @@ backbone_presets = {
             "params": 303301632,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch16_224_imagenet21k/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch16_224_imagenet21k/3",
     },
     "vit_large_patch32_224_imagenet21k": {
         "metadata": {
@@ -121,6 +121,6 @@ backbone_presets = {
             "params": 305510400,
             "path": "vit",
         },
-        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch32_224_imagenet21k/2",
+        "kaggle_handle": "kaggle://keras/vit/keras/vit_large_patch32_224_imagenet21k/3",
     },
 }

--- a/tools/checkpoint_conversion/convert_vit_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vit_checkpoints.py
@@ -30,17 +30,17 @@ from keras_hub.src.models.vit.vit_image_converter import ViTImageConverter
 FLAGS = flags.FLAGS
 
 PRESET_MAP = {
-    "vit_base_patch16_224": "google/vit-base-patch16-224",
-    "vit_base_patch16_384": "google/vit-base-patch16-384",
-    "vit_base_patch32_384": "google/vit-base-patch32-384",
-    "vit_large_patch16_224": "google/vit-large-patch16-224",
-    "vit_large_patch16_384": "google/vit-large-patch16-384",
-    "vit_large_patch32_384": "google/vit-large-patch32-384",
-    "vit_base_patch16_224_in21k": "google/vit-base-patch16-224-in21k",
-    "vit_base_patch32_224_in21k": "google/vit-base-patch32-224-in21k",
-    "vit_large_patch16_224_in21k": "google/vit-large-patch16-224-in21k",
-    "vit_large_patch32_224_in21k": "google/vit-large-patch32-224-in21k",
-    "vit_huge_patch14_224_in21k": "google/vit-huge-patch14-224-in21k",
+    "vit_base_patch16_224_imagenet": "google/vit-base-patch16-224",
+    "vit_base_patch16_384_imagenet": "google/vit-base-patch16-384",
+    "vit_base_patch32_384_imagenet": "google/vit-base-patch32-384",
+    "vit_large_patch16_224_imagenet": "google/vit-large-patch16-224",
+    "vit_large_patch16_384_imagenet": "google/vit-large-patch16-384",
+    "vit_large_patch32_384_imagenet": "google/vit-large-patch32-384",
+    "vit_base_patch16_224_imagenet21k": "google/vit-base-patch16-224-in21k",
+    "vit_base_patch32_224_imagenet21k": "google/vit-base-patch32-224-in21k",
+    "vit_large_patch16_224_imagenet21k": "google/vit-large-patch16-224-in21k",
+    "vit_large_patch32_224_imagenet21k": "google/vit-large-patch32-224-in21k",
+    "vit_huge_patch14_224_imagenet21k": "google/vit-huge-patch14-224-in21k",
 }
 
 flags.DEFINE_string(


### PR DESCRIPTION
## Description of the change

This PR Fixes #2727 

Updated the checkpoints conversion script preset mapping same as  the uploaded kaggle presets naming convention.

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
