### PR TITLE
Vit preset followup

### DIFF
--- a/tools/checkpoint_conversion/convert_vit_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vit_checkpoints.py
@@ -4,7 +4,7 @@ export KAGGLE_USERNAME=XXX
 export KAGGLE_KEY=XXX
 
 python tools/checkpoint_conversion/convert_vit_checkpoints.py \
-    --preset vit_base_patch16_224
+    --preset vit_base_patch16_224_imagenet
 """
 
 import os
@@ -30,17 +30,17 @@ from keras_hub.src.models.vit.vit_image_converter import ViTImageConverter
 FLAGS = flags.FLAGS
 
 PRESET_MAP = {
-    "vit_base_patch16_224": "google/vit-base-patch16-224",
-    "vit_base_patch16_384": "google/vit-base-patch16-384",
-    "vit_base_patch32_384": "google/vit-base-patch32-384",
-    "vit_large_patch16_224": "google/vit-large-patch16-224",
-    "vit_large_patch16_384": "google/vit-large-patch16-384",
-    "vit_large_patch32_384": "google/vit-large-patch32-384",
-    "vit_base_patch16_224_in21k": "google/vit-base-patch16-224-in21k",
-    "vit_base_patch32_224_in21k": "google/vit-base-patch32-224-in21k",
-    "vit_large_patch16_224_in21k": "google/vit-large-patch16-224-in21k",
-    "vit_large_patch32_224_in21k": "google/vit-large-patch32-224-in21k",
-    "vit_huge_patch14_224_in21k": "google/vit-huge-patch14-224-in21k",
+    "vit_base_patch16_224_imagenet": "google/vit-base-patch16-224",
+    "vit_base_patch16_384_imagenet": "google/vit-base-patch16-384",
+    "vit_base_patch32_384_imagenet": "google/vit-base-patch32-384",
+    "vit_large_patch16_224_imagenet": "google/vit-large-patch16-224",
+    "vit_large_patch16_384_imagenet": "google/vit-large-patch16-384",
+    "vit_large_patch32_384_imagenet": "google/vit-large-patch32-384",
+    "vit_base_patch16_224__imagenet21k": "google/vit-base-patch16-224-in21k",
+    "vit_base_patch32_224__imagenet21k": "google/vit-base-patch32-224-in21k",
+    "vit_large_patch16_224__imagenet21k": "google/vit-large-patch16-224-in21k",
+    "vit_large_patch32_224__imagenet21k": "google/vit-large-patch32-224-in21k",
+    "vit_huge_patch14_224__imagenet21k": "google/vit-huge-patch14-224-in21k",
 }
 
 flags.DEFINE_string(

--- a/tools/checkpoint_conversion/convert_vit_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vit_checkpoints.py
@@ -36,11 +36,11 @@ PRESET_MAP = {
     "vit_large_patch16_224_imagenet": "google/vit-large-patch16-224",
     "vit_large_patch16_384_imagenet": "google/vit-large-patch16-384",
     "vit_large_patch32_384_imagenet": "google/vit-large-patch32-384",
-    "vit_base_patch16_224__imagenet21k": "google/vit-base-patch16-224-in21k",
-    "vit_base_patch32_224__imagenet21k": "google/vit-base-patch32-224-in21k",
-    "vit_large_patch16_224__imagenet21k": "google/vit-large-patch16-224-in21k",
-    "vit_large_patch32_224__imagenet21k": "google/vit-large-patch32-224-in21k",
-    "vit_huge_patch14_224__imagenet21k": "google/vit-huge-patch14-224-in21k",
+    "vit_base_patch16_224_imagenet21k": "google/vit-base-patch16-224-in21k",
+    "vit_base_patch32_224_imagenet21k": "google/vit-base-patch32-224-in21k",
+    "vit_large_patch16_224_imagenet21k": "google/vit-large-patch16-224-in21k",
+    "vit_large_patch32_224_imagenet21k": "google/vit-large-patch32-224-in21k",
+    "vit_huge_patch14_224_imagenet21k": "google/vit-huge-patch14-224-in21k",
 }
 
 flags.DEFINE_string(

--- a/tools/checkpoint_conversion/convert_vit_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_vit_checkpoints.py
@@ -41,6 +41,17 @@ PRESET_MAP = {
     "vit_large_patch16_224_imagenet21k": "google/vit-large-patch16-224-in21k",
     "vit_large_patch32_224_imagenet21k": "google/vit-large-patch32-224-in21k",
     "vit_huge_patch14_224_imagenet21k": "google/vit-huge-patch14-224-in21k",
+    "vit_base_patch16_224": "google/vit-base-patch16-224",
+    "vit_base_patch16_384": "google/vit-base-patch16-384",
+    "vit_base_patch32_384": "google/vit-base-patch32-384",
+    "vit_large_patch16_224": "google/vit-large-patch16-224",
+    "vit_large_patch16_384": "google/vit-large-patch16-384",
+    "vit_large_patch32_384": "google/vit-large-patch32-384",
+    "vit_base_patch16_224_in21k": "google/vit-base-patch16-224-in21k",
+    "vit_base_patch32_224_in21k": "google/vit-base-patch32-224-in21k",
+    "vit_large_patch16_224_in21k": "google/vit-large-patch16-224-in21k",
+    "vit_large_patch32_224_in21k": "google/vit-large-patch32-224-in21k",
+    "vit_huge_patch14_224_in21k": "google/vit-huge-patch14-224-in21k",
 }
 
 flags.DEFINE_string(


### PR DESCRIPTION
This PR builds on top of #2418.

#2418 updates ViT checkpoint conversion preset names to align with the official Keras naming convention.

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
