### PR TITLE
Fix for tokenizers>=0.23

### DIFF
--- a/keras_hub/src/models/clip/clip_tokenizer.py
+++ b/keras_hub/src/models/clip/clip_tokenizer.py
@@ -1,3 +1,5 @@
+import inspect
+
 import tokenizers
 from tokenizers import decoders
 from tokenizers import models
@@ -152,11 +154,22 @@ class CLIPTokenizer(BytePairTokenizer):
         if self.pad_with_end_token:
             self.pad_token_id = self.end_token_id
         if getattr(self, "_tokenizer") is not None:
+            # tokenizers <=0.22 use `cls`, >= 0.23 use `cls_token` because `cls`
+            # collides with the first argument of the Python `__new__`.
+            cls_token_arg = (
+                "cls"
+                if "cls"
+                in inspect.signature(processors.RobertaProcessing).parameters
+                else "cls_token"
+            )
+            preprocessing_args = {
+                "sep": (str(self.end_token), self.end_token_id),
+                cls_token_arg: (str(self.start_token), self.start_token_id),
+                "add_prefix_space": False,
+                "trim_offsets": False,
+            }
             self._tokenizer.post_processor = processors.RobertaProcessing(
-                sep=(str(self.end_token), self.end_token_id),
-                cls=(str(self.start_token), self.start_token_id),
-                add_prefix_space=False,
-                trim_offsets=False,
+                **preprocessing_args
             )
 
     def _bpe_merge_and_update_cache_tf(self, tokens):


### PR DESCRIPTION
The constructor argument in `RobertaProcessing` for the CLS token in `tokenizers` <=0.22 was `cls`. However, for `tokenizers` >= 0.23 it is now `cls_token`. That's because `cls` would collide with the first argument of the Python `__new__`.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
