### PR TITLE
 Exclude kagglehub 1.0.1 due to broken kagglesdk 0.1.24 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "packaging",
     "regex",
     "rich",
-    "kagglehub",
+    "kagglehub!=1.0.1",
     "sentencepiece",
     "tokenizers",
     "tensorflow-text;platform_system != 'Windows'",

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -2,7 +2,7 @@
 dm-tree
 regex
 rich
-kagglehub
+kagglehub!=1.0.1
 tokenizers
 sentencepiece
 # Tooling deps.


### PR DESCRIPTION
## Description of the change

kagglehub 1.0.1 is incompatible with kagglesdk 0.1.24 — it
imports `get_web_endpoint` which was renamed to `get_endpoint`
in kagglesdk 0.1.24, causing `import kagglehub` to fail.


## Reference
 https://github.com/Kaggle/kagglehub/issues/301

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
