### PR TITLE
Fix parallelization of input data in generate()

### DIFF
--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -360,16 +360,20 @@ class CausalLM(Task):
             distribution = distribution_lib.distribution()
             if distribution is None:
                 return x
-            result = {}
-            for key, value in x.items():
+
+            def _distribute_tensor(value):
                 if value is None:
-                    result[key] = None
-                    continue
+                    return None
                 if not ops.is_tensor(value):
                     value = ops.convert_to_tensor(value)
                 layout = distribution.get_data_layout(value.shape)
-                result[key] = distribution_lib.distribute_tensor(value, layout) if layout else value
-            return result
+                return (
+                    distribution_lib.distribute_tensor(value, layout)
+                    if layout
+                    else value
+                )
+
+            return tree.map_structure(_distribute_tensor, x)
 
         def generate(x):
             return generate_function(x, stop_token_ids=stop_token_ids)

--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -362,6 +362,11 @@ class CausalLM(Task):
                 return x
             result = {}
             for key, value in x.items():
+                if value is None:
+                    result[key] = None
+                    continue
+                if not ops.is_tensor(value):
+                    value = ops.convert_to_tensor(value)
                 layout = distribution.get_data_layout(value.shape)
                 result[key] = distribution_lib.distribute_tensor(value, layout) if layout else value
             return result

--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -8,6 +8,7 @@ from keras import tree
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.models.task import Task
 from keras_hub.src.samplers.serialization import get as get_sampler
+from keras.src.distribution import distribution_lib
 
 try:
     import tensorflow as tf
@@ -354,6 +355,17 @@ class CausalLM(Task):
                 x, sequence_length=max_length
             )
 
+        def distribute(x):
+            """Distribute tensors according to the distribution library."""
+            distribution = distribution_lib.distribution()
+            if distribution is None:
+                return x
+            result = {}
+            for key, value in x.items():
+                layout = distribution.get_data_layout(value.shape)
+                result[key] = distribution_lib.distribute_tensor(value, layout) if layout else value
+            return result
+
         def generate(x):
             return generate_function(x, stop_token_ids=stop_token_ids)
 
@@ -393,6 +405,8 @@ class CausalLM(Task):
 
         if self.preprocessor is not None:
             inputs = [preprocess(x) for x in inputs]
+
+        inputs = [distribute(x) for x in inputs]
 
         if strip_prompt:
             outputs = [strip_prompt_function(generate(x), x) for x in inputs]

--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -4,11 +4,11 @@ from functools import partial
 import keras
 from keras import ops
 from keras import tree
+from keras.src.distribution import distribution_lib
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.models.task import Task
 from keras_hub.src.samplers.serialization import get as get_sampler
-from keras.src.distribution import distribution_lib
 
 try:
     import tensorflow as tf

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -303,14 +303,12 @@ class GPT2CausalLMDistributionTest(TestCase):
 
     def test_e2e_data_parallel_generate(self):
         with self.distribution.scope():
-            # keras.distribution.set_distribution(self.distribution)
-
             causal_lm = GPT2CausalLM(**self.init_kwargs)
 
-            # Pass prompts to match the number of devices
+            # Pass prompts to match the number of devices.
             prompts = [" airplane at airport"] * self.device_count
 
-            # This should run without errors and use the distribution
+            # This should run without errors and use the distribution.
             output = causal_lm.generate(prompts)
             self.assertIsInstance(output, (list, tuple))
             self.assertLen(output, self.device_count)
@@ -322,7 +320,8 @@ class GPT2CausalLMDistributionTest(TestCase):
             keras.distribution.set_distribution(self.distribution)
             causal_lm = GPT2CausalLM(**self.init_kwargs)
 
-            # Pass only 1 prompt, which is not divisible by the number of devices
+            # Pass only 1 prompt, which is not divisible by the number of
+            # devices.
             prompt = " airplane at airport"
 
             with self.assertRaises(Exception):

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -252,7 +252,7 @@ class GPT2CausalLMDistributionTest(TestCase):
         if keras.config.backend() != "jax":
             pytest.skip("This test requires the JAX backend")
 
-        self.device_count = jax.device_count()
+        self.device_count = len(keras.distribution.list_devices())
 
         # Initialize kwargs for model creation
         self.merges = ["Ġ a", "Ġ t", "Ġ i", "Ġ b", "a i", "p l", "n e"]

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -246,12 +246,11 @@ class GPT2CausalLMTest(TestCase):
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
 
 
+@pytest.mark.skipif(keras.src.backend.backend() != "jax", reason="JAX only")
+@pytest.mark.multi_device
 class GPT2CausalLMDistributionTest(TestCase):
     def setUp(self):
         super().setUp()
-
-        if keras.config.backend() != "jax":
-            pytest.skip("This test requires the JAX backend")
 
         self.device_count = len(keras.distribution.list_devices())
 
@@ -302,30 +301,29 @@ class GPT2CausalLMDistributionTest(TestCase):
             self.layout_map,
         )
 
-    def tearDown(self):
-        keras.distribution.set_distribution(None)
-
     def test_e2e_data_parallel_generate(self):
-        keras.distribution.set_distribution(self.distribution)
+        with self.distribution.scope():
+            # keras.distribution.set_distribution(self.distribution)
 
-        causal_lm = GPT2CausalLM(**self.init_kwargs)
+            causal_lm = GPT2CausalLM(**self.init_kwargs)
 
-        # Pass prompts to match the number of devices
-        prompts = [" airplane at airport"] * self.device_count
+            # Pass prompts to match the number of devices
+            prompts = [" airplane at airport"] * self.device_count
 
-        # This should run without errors and use the distribution
-        output = causal_lm.generate(prompts)
-        self.assertIsInstance(output, (list, tuple))
-        self.assertLen(output, self.device_count)
+            # This should run without errors and use the distribution
+            output = causal_lm.generate(prompts)
+            self.assertIsInstance(output, (list, tuple))
+            self.assertLen(output, self.device_count)
 
     def test_e2e_data_parallel_generate_indivisible_error(self):
-        if self.device_count < 2:
-            pytest.skip("This test requires at least 2 devices")
-        keras.distribution.set_distribution(self.distribution)
-        causal_lm = GPT2CausalLM(**self.init_kwargs)
+        with self.distribution.scope():
+            if self.device_count < 2:
+                pytest.skip("This test requires at least 2 devices")
+            keras.distribution.set_distribution(self.distribution)
+            causal_lm = GPT2CausalLM(**self.init_kwargs)
 
-        # Pass only 1 prompt, which is not divisible by the number of devices
-        prompt = " airplane at airport"
+            # Pass only 1 prompt, which is not divisible by the number of devices
+            prompt = " airplane at airport"
 
-        with self.assertRaises(Exception):
-            causal_lm.generate(prompt)
+            with self.assertRaises(Exception):
+                causal_lm.generate(prompt)

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -302,6 +302,9 @@ class GPT2CausalLMDistributionTest(TestCase):
             self.layout_map,
         )
 
+    def tearDown(self):
+        keras.distribution.set_distribution(None)
+
     def test_e2e_data_parallel_generate(self):
         keras.distribution.set_distribution(self.distribution)
 

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -252,6 +252,8 @@ class GPT2CausalLMDistributionTest(TestCase):
         if keras.config.backend() != "jax":
             pytest.skip("This test requires the JAX backend")
 
+        self.device_count = jax.device_count()
+
         # Initialize kwargs for model creation
         self.merges = ["Ġ a", "Ġ t", "Ġ i", "Ġ b", "a i", "p l", "n e"]
         self.merges += ["Ġa t", "p o", "r t", "Ġt h", "ai r", "pl a", "po rt"]
@@ -286,7 +288,6 @@ class GPT2CausalLMDistributionTest(TestCase):
             "preprocessor": self.preprocessor,
         }
 
-        self.device_count = len(keras.distribution.list_devices())
         self.device_mesh = keras.distribution.DeviceMesh(
             shape=(self.device_count,), axis_names=["batch"], devices=keras.distribution.list_devices()
         )
@@ -303,13 +304,13 @@ class GPT2CausalLMDistributionTest(TestCase):
 
         causal_lm = GPT2CausalLM(**self.init_kwargs)
 
-        # Pass 2 prompts to match the 2 devices
-        prompts = [" airplane at airport", " airplane at airport"]
+        # Pass prompts to match the number of devices
+        prompts = [" airplane at airport"] * self.device_count
 
         # This should run without errors and use the distribution
         output = causal_lm.generate(prompts)
         self.assertIsInstance(output, (list, tuple))
-        self.assertLen(output, 2)
+        self.assertLen(output, self.device_count)
 
     def test_e2e_data_parallel_generate_indivisible_error(self):
         if self.device_count < 2:

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -245,6 +245,7 @@ class GPT2CausalLMTest(TestCase):
 
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
 
+
 class GPT2CausalLMDistributionTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -289,7 +290,9 @@ class GPT2CausalLMDistributionTest(TestCase):
         }
 
         self.device_mesh = keras.distribution.DeviceMesh(
-            shape=(self.device_count,), axis_names=["batch"], devices=keras.distribution.list_devices()
+            shape=(self.device_count,),
+            axis_names=["batch"],
+            devices=keras.distribution.list_devices(),
         )
 
         self.layout_map = keras.distribution.LayoutMap(self.device_mesh)

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -244,3 +244,81 @@ class GPT2CausalLMTest(TestCase):
         )
 
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
+
+class GPT2CausalLMDistributionTest(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        if keras.config.backend() != "jax":
+            pytest.skip("This test requires the JAX backend")
+
+        # Initialize kwargs for model creation
+        self.merges = ["Ġ a", "Ġ t", "Ġ i", "Ġ b", "a i", "p l", "n e"]
+        self.merges += ["Ġa t", "p o", "r t", "Ġt h", "ai r", "pl a", "po rt"]
+        self.merges += ["Ġai r", "Ġa i", "pla ne"]
+        self.vocab = []
+        for merge in self.merges:
+            a, b = merge.split(" ")
+            self.vocab.extend([a, b, a + b])
+        self.vocab += ["!", "<|endoftext|>"]
+        self.vocab = sorted(set(self.vocab))  # Remove duplicates
+        self.vocab = dict([(token, i) for i, token in enumerate(self.vocab)])
+        self.vocabulary_size = len(self.vocab)
+
+        self.tokenizer = GPT2Tokenizer(
+            vocabulary=self.vocab,
+            merges=self.merges,
+        )
+        self.preprocessor = GPT2CausalLMPreprocessor(
+            tokenizer=self.tokenizer,
+            sequence_length=8,
+        )
+        self.backbone = GPT2Backbone(
+            vocabulary_size=self.vocabulary_size,
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=4,
+            intermediate_dim=4,
+            max_sequence_length=8,
+        )
+        self.init_kwargs = {
+            "backbone": self.backbone,
+            "preprocessor": self.preprocessor,
+        }
+
+        self.device_count = len(keras.distribution.list_devices())
+        self.device_mesh = keras.distribution.DeviceMesh(
+            shape=(self.device_count,), axis_names=["batch"], devices=keras.distribution.list_devices()
+        )
+
+        self.layout_map = keras.distribution.LayoutMap(self.device_mesh)
+
+        self.distribution = keras.distribution.DataParallel(
+            self.device_mesh,
+            self.layout_map,
+        )
+
+    def test_e2e_data_parallel_generate(self):
+        keras.distribution.set_distribution(self.distribution)
+
+        causal_lm = GPT2CausalLM(**self.init_kwargs)
+
+        # Pass 2 prompts to match the 2 devices
+        prompts = [" airplane at airport", " airplane at airport"]
+
+        # This should run without errors and use the distribution
+        output = causal_lm.generate(prompts)
+        self.assertIsInstance(output, (list, tuple))
+        self.assertLen(output, 2)
+
+    def test_e2e_data_parallel_generate_indivisible_error(self):
+        if self.device_count < 2:
+            pytest.skip("This test requires at least 2 devices")
+        keras.distribution.set_distribution(self.distribution)
+        causal_lm = GPT2CausalLM(**self.init_kwargs)
+
+        # Pass only 1 prompt, which is not divisible by the number of devices
+        prompt = " airplane at airport"
+
+        with self.assertRaises(Exception):
+            causal_lm.generate(prompt)


### PR DESCRIPTION
## Description of the change

**Current behavior:** there is no Data Parallelization over Accelerators for any Causal models on inference with Jax Backend.  

**The reason:** there is no sharding of `inputs`, as a result when embeddings computed ([code](https://github.com/keras-team/keras/blob/66ba40521d5817934e20d487a8188f5bedd65762/keras/src/layers/core/embedding.py#L169)) `embeddings' replicated (i.e. not distributed) over multiple accelerators. 
And further all computations are replicated (i.e. not distributed) on all accelerators. So essentially only 1 accelerator is used

This change implements parallelization (distribution) of `inputs`  for causal_lm.py model for inference. 

Since Keras Distribution is implemented only for Jax, so this PR is no-op for other backends. 

I tested with Gemma3.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
