### PR TITLE
Fix shape passed to inner EinsumDense in XLNET attention.

### DIFF
--- a/keras_hub/src/models/xlnet/relative_attention.py
+++ b/keras_hub/src/models/xlnet/relative_attention.py
@@ -192,7 +192,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
             **self._get_common_kwargs_for_sublayer(),
         )
         self._output_dense.build(
-            self._value_dense.compute_output_shape(self._value_dim)
+            self._value_dense.compute_output_shape(self._value_shape)
         )
 
         einsum_equation, _, output_rank = _build_proj_equation(


### PR DESCRIPTION
A reccent fix in Keras https://github.com/keras-team/keras/pull/23000 uncovered an issue whereby a call to EinsumDense.compute_output_shape was passing an int instead of an input shape.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
