### PR TITLE
Improve validation for ByteTokenizer.sequence_length

### DIFF
--- a/keras_hub/src/tokenizers/byte_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer.py
@@ -179,16 +179,15 @@ class ByteTokenizer(tokenizer.Tokenizer):
                     "`sequence_length` must be an int, got bool: "
                     f"{sequence_length}"
                 )
-
             if not isinstance(sequence_length, numbers.Integral):
                 raise ValueError(
                     "`sequence_length` must be an int or None. "
                     f"{sequence_length}"
                 )
-
             if sequence_length <= 0:
                 raise ValueError(
-                    f"`sequence_length` must be > 0.{sequence_length}"
+                    "`sequence_length` must be > 0. "
+                    f"Received: {sequence_length}"
                 )
 
         super().__init__(dtype=dtype, **kwargs)

--- a/keras_hub/src/tokenizers/byte_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer.py
@@ -1,3 +1,5 @@
+import numbers
+
 import numpy as np
 
 from keras_hub.src.api_export import keras_hub_export
@@ -170,6 +172,25 @@ class ByteTokenizer(tokenizer.Tokenizer):
                 f"Received: errors={errors}"
             )
 
+        # Validate sequence_length
+        if sequence_length is not None:
+            if isinstance(sequence_length, bool):
+                raise ValueError(
+                    "`sequence_length` must be an int, got bool: "
+                    f"{sequence_length}"
+                )
+
+            if not isinstance(sequence_length, numbers.Integral):
+                raise ValueError(
+                    "`sequence_length` must be an int or None. "
+                    f"{sequence_length}"
+                )
+
+            if sequence_length <= 0:
+                raise ValueError(
+                    f"`sequence_length` must be > 0.{sequence_length}"
+                )
+
         super().__init__(dtype=dtype, **kwargs)
 
         self.lowercase = lowercase
@@ -215,7 +236,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
         tokens = tf.cast(tokens, self.compute_dtype)
 
         # Convert to a dense output if `sequence_length` is set.
-        if self.sequence_length:
+        if self.sequence_length is not None:
             output_shape = tokens.shape.as_list()
             output_shape[-1] = self.sequence_length
             tokens = tokens.to_tensor(shape=output_shape)

--- a/keras_hub/src/tokenizers/byte_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer.py
@@ -179,11 +179,21 @@ class ByteTokenizer(tokenizer.Tokenizer):
                     "`sequence_length` must be an int, got bool: "
                     f"{sequence_length}"
                 )
-            if not isinstance(sequence_length, numbers.Integral):
+
+            if isinstance(sequence_length, float):
+                if not sequence_length.is_integer():
+                    raise ValueError(
+                        "`sequence_length` must be a whole number. "
+                        f"Received: {sequence_length}"
+                    )
+                sequence_length = int(sequence_length)
+
+            elif not isinstance(sequence_length, numbers.Integral):
                 raise ValueError(
                     "`sequence_length` must be an int or None. "
-                    f"{sequence_length}"
+                    f"Received: {sequence_length}"
                 )
+
             if sequence_length <= 0:
                 raise ValueError(
                     "`sequence_length` must be > 0. "

--- a/keras_hub/src/tokenizers/byte_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer_test.py
@@ -216,3 +216,35 @@ class ByteTokenizerTest(TestCase):
         tokenizer = ByteTokenizer()
         tokens = [tokenizer.id_to_token(i) for i in input_ids]
         self.assertAllEqual(tokens, expected_tokens)
+
+    def test_sequence_length_valid_int(self):
+        tokenizer = ByteTokenizer(sequence_length=5)
+        self.assertEqual(tokenizer.sequence_length, 5)
+
+    def test_sequence_length_valid_float(self):
+        with self.assertRaises(ValueError):
+            ByteTokenizer(sequence_length=5.0)
+
+    def test_sequence_length_invalid_float(self):
+        with self.assertRaises(ValueError):
+            ByteTokenizer(sequence_length=5.5)
+
+    def test_sequence_length_none(self):
+        tokenizer = ByteTokenizer(sequence_length=None)
+        self.assertIsNone(tokenizer.sequence_length)
+
+    def test_sequence_length_invalid_string(self):
+        with self.assertRaises(ValueError):
+            ByteTokenizer(sequence_length="5")
+
+    def test_sequence_length_bool(self):
+        with self.assertRaises(ValueError):
+            ByteTokenizer(sequence_length=True)
+
+    def test_sequence_length_zero(self):
+        with self.assertRaises(ValueError):
+            ByteTokenizer(sequence_length=0)
+
+    def test_sequence_length_negative(self):
+        with self.assertRaises(ValueError):
+            ByteTokenizer(sequence_length=-1)

--- a/keras_hub/src/tokenizers/byte_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer_test.py
@@ -222,8 +222,8 @@ class ByteTokenizerTest(TestCase):
         self.assertEqual(tokenizer.sequence_length, 5)
 
     def test_sequence_length_valid_float(self):
-        with self.assertRaises(ValueError):
-            ByteTokenizer(sequence_length=5.0)
+        tokenizer = ByteTokenizer(sequence_length=5.0)
+        self.assertEqual(tokenizer.sequence_length, 5)
 
     def test_sequence_length_invalid_float(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR improves the handling of sequence_length in `ByteTokenizer` by allowing `float` values that represent whole numbers (5.0) and converting them to integers during initialization.

This change reduces friction in configuration-driven workflows where numeric hyperparameters are commonly serialized as floats.

Fixes: #374

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
