### PR TITLE
Fix for GQA while using fused attention path.

### DIFF
--- a/keras_hub/src/models/gemma3/gemma3_attention.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention.py
@@ -198,7 +198,10 @@ class CachedGemma3Attention(keras.layers.Layer):
                 kwargs = {"attn_logits_soft_cap": self.logit_soft_cap}
             else:
                 kwargs = {}
-            if self.num_key_value_groups > 1:
+            if (
+                self.num_key_value_groups > 1
+                and keras.config.backend() != "jax"
+            ):
                 k = ops.repeat(k, self.num_key_value_groups, axis=-2)
                 v = ops.repeat(v, self.num_key_value_groups, axis=-2)
             return ops.dot_product_attention(

--- a/keras_hub/src/models/gemma3/gemma3_attention.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention.py
@@ -198,6 +198,9 @@ class CachedGemma3Attention(keras.layers.Layer):
                 kwargs = {"attn_logits_soft_cap": self.logit_soft_cap}
             else:
                 kwargs = {}
+            if self.num_key_value_groups > 1:
+                k = ops.repeat(k, self.num_key_value_groups, axis=-2)
+                v = ops.repeat(v, self.num_key_value_groups, axis=-2)
             return ops.dot_product_attention(
                 query=q,
                 key=k,

--- a/keras_hub/src/models/gemma3/gemma3_attention_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention_test.py
@@ -1,8 +1,5 @@
 from unittest.mock import patch
 
-import keras
-import numpy as np
-import pytest
 from absl.testing import parameterized
 from keras import ops
 
@@ -11,93 +8,90 @@ from keras_hub.src.tests.test_case import TestCase
 
 
 class CachedGemma3AttentionTest(TestCase, parameterized.TestCase):
-    def setUp(self):
-        self.head_dim = 64
-        self.num_query_heads = 4
-        self.num_key_value_heads = 2
-        self.hidden_dim = 128
-        self.batch_size = 2
-        self.seq_len = 16
 
-    @parameterized.named_parameters(
-        ("standard_attention", False),
-        ("fused_attention", True),
+  def setUp(self):
+    self.head_dim = 64
+    self.num_query_heads = 4
+    self.num_key_value_heads = 2
+    self.hidden_dim = 128
+    self.batch_size = 2
+    self.seq_len = 16
+
+  @parameterized.named_parameters(
+      ("standard_attention", False),
+      ("fused_attention", True),
+  )
+  def test_gqa_forward_pass(self, use_fused_attention):
+    """Tests that GQA executes correctly without shape mismatches."""
+    layer = CachedGemma3Attention(
+        head_dim=self.head_dim,
+        num_query_heads=self.num_query_heads,
+        num_key_value_heads=self.num_key_value_heads,
     )
-    def test_gqa_forward_pass(self, use_fused_attention):
-        """Tests that GQA executes correctly without shape mismatches."""
-        layer = CachedGemma3Attention(
-            head_dim=self.head_dim,
-            num_query_heads=self.num_query_heads,
-            num_key_value_heads=self.num_key_value_heads,
-        )
-        layer.build((self.batch_size, self.seq_len, self.hidden_dim))
+    layer.build((self.batch_size, self.seq_len, self.hidden_dim))
 
-        x = ops.ones(
-            (self.batch_size, self.seq_len, self.hidden_dim), dtype="float32"
-        )
-        attention_mask = ops.ones(
-            (self.batch_size, self.seq_len, self.seq_len), dtype="int32"
-        )
-
-        with patch.object(
-            layer, "_use_fused_attention_op", return_value=use_fused_attention
-        ):
-            output = layer(x, attention_mask=attention_mask)
-
-            self.assertEqual(
-                output.shape, (self.batch_size, self.seq_len, self.hidden_dim)
-            )
-
-    @parameterized.named_parameters(
-        ("standard_attention_cache", False),
-        ("fused_attention_cache", True),
+    x = ops.ones(
+        (self.batch_size, self.seq_len, self.hidden_dim), dtype="float32"
     )
-    def test_gqa_cached_generation(self, use_fused_attention):
-        """Tests GQA execution with key-value cache during generation."""
-        layer = CachedGemma3Attention(
-            head_dim=self.head_dim,
-            num_query_heads=self.num_query_heads,
-            num_key_value_heads=self.num_key_value_heads,
-        )
-        layer.build((self.batch_size, self.seq_len, self.hidden_dim))
+    attention_mask = ops.ones(
+        (self.batch_size, self.seq_len, self.seq_len), dtype="int32"
+    )
 
-        # Input is a single newly generated token
-        x = ops.ones((self.batch_size, 1, self.hidden_dim), dtype="float32")
-        attention_mask = ops.ones(
-            (self.batch_size, 1, self.seq_len), dtype="int32"
-        )
+    with patch.object(
+        layer, "_use_fused_attention_op", return_value=use_fused_attention
+    ):
+      output = layer(x, attention_mask=attention_mask)
 
-        cache = ops.zeros(
-            (
-                self.batch_size,
-                2,
-                self.seq_len,
-                self.num_key_value_heads,
-                self.head_dim,
-            ),
-            dtype="float32",
-        )
+      self.assertEqual(
+          output.shape, (self.batch_size, self.seq_len, self.hidden_dim)
+      )
 
-        with patch.object(
-            layer, "_use_fused_attention_op", return_value=use_fused_attention
-        ):
-            output, updated_cache = layer(
-                x=x,
-                attention_mask=attention_mask,
-                cache=cache,
-                cache_update_index=5,
-            )
+  @parameterized.named_parameters(
+      ("standard_attention_cache", False),
+      ("fused_attention_cache", True),
+  )
+  def test_gqa_cached_generation(self, use_fused_attention):
+    """Tests GQA execution with key-value cache during generation."""
+    layer = CachedGemma3Attention(
+        head_dim=self.head_dim,
+        num_query_heads=self.num_query_heads,
+        num_key_value_heads=self.num_key_value_heads,
+    )
+    layer.build((self.batch_size, self.seq_len, self.hidden_dim))
 
-            self.assertEqual(
-                output.shape, (self.batch_size, 1, self.hidden_dim)
-            )
-            self.assertEqual(
-                updated_cache.shape,
-                (
-                    self.batch_size,
-                    2,
-                    self.seq_len,
-                    self.num_key_value_heads,
-                    self.head_dim,
-                ),
-            )
+    # Input is a single newly generated token
+    x = ops.ones((self.batch_size, 1, self.hidden_dim), dtype="float32")
+    attention_mask = ops.ones((self.batch_size, 1, self.seq_len), dtype="int32")
+
+    cache = ops.zeros(
+        (
+            self.batch_size,
+            2,
+            self.seq_len,
+            self.num_key_value_heads,
+            self.head_dim,
+        ),
+        dtype="float32",
+    )
+
+    with patch.object(
+        layer, "_use_fused_attention_op", return_value=use_fused_attention
+    ):
+      output, updated_cache = layer(
+          x=x,
+          attention_mask=attention_mask,
+          cache=cache,
+          cache_update_index=5,
+      )
+
+      self.assertEqual(output.shape, (self.batch_size, 1, self.hidden_dim))
+      self.assertEqual(
+          updated_cache.shape,
+          (
+              self.batch_size,
+              2,
+              self.seq_len,
+              self.num_key_value_heads,
+              self.head_dim,
+          ),
+      )

--- a/keras_hub/src/models/gemma3/gemma3_attention_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention_test.py
@@ -8,90 +8,93 @@ from keras_hub.src.tests.test_case import TestCase
 
 
 class CachedGemma3AttentionTest(TestCase, parameterized.TestCase):
+    def setUp(self):
+        self.head_dim = 64
+        self.num_query_heads = 4
+        self.num_key_value_heads = 2
+        self.hidden_dim = 128
+        self.batch_size = 2
+        self.seq_len = 16
 
-  def setUp(self):
-    self.head_dim = 64
-    self.num_query_heads = 4
-    self.num_key_value_heads = 2
-    self.hidden_dim = 128
-    self.batch_size = 2
-    self.seq_len = 16
-
-  @parameterized.named_parameters(
-      ("standard_attention", False),
-      ("fused_attention", True),
-  )
-  def test_gqa_forward_pass(self, use_fused_attention):
-    """Tests that GQA executes correctly without shape mismatches."""
-    layer = CachedGemma3Attention(
-        head_dim=self.head_dim,
-        num_query_heads=self.num_query_heads,
-        num_key_value_heads=self.num_key_value_heads,
+    @parameterized.named_parameters(
+        ("standard_attention", False),
+        ("fused_attention", True),
     )
-    layer.build((self.batch_size, self.seq_len, self.hidden_dim))
+    def test_gqa_forward_pass(self, use_fused_attention):
+        """Tests that GQA executes correctly without shape mismatches."""
+        layer = CachedGemma3Attention(
+            head_dim=self.head_dim,
+            num_query_heads=self.num_query_heads,
+            num_key_value_heads=self.num_key_value_heads,
+        )
+        layer.build((self.batch_size, self.seq_len, self.hidden_dim))
 
-    x = ops.ones(
-        (self.batch_size, self.seq_len, self.hidden_dim), dtype="float32"
+        x = ops.ones(
+            (self.batch_size, self.seq_len, self.hidden_dim), dtype="float32"
+        )
+        attention_mask = ops.ones(
+            (self.batch_size, self.seq_len, self.seq_len), dtype="int32"
+        )
+
+        with patch.object(
+            layer, "_use_fused_attention_op", return_value=use_fused_attention
+        ):
+            output = layer(x, attention_mask=attention_mask)
+
+            self.assertEqual(
+                output.shape, (self.batch_size, self.seq_len, self.hidden_dim)
+            )
+
+    @parameterized.named_parameters(
+        ("standard_attention_cache", False),
+        ("fused_attention_cache", True),
     )
-    attention_mask = ops.ones(
-        (self.batch_size, self.seq_len, self.seq_len), dtype="int32"
-    )
+    def test_gqa_cached_generation(self, use_fused_attention):
+        """Tests GQA execution with key-value cache during generation."""
+        layer = CachedGemma3Attention(
+            head_dim=self.head_dim,
+            num_query_heads=self.num_query_heads,
+            num_key_value_heads=self.num_key_value_heads,
+        )
+        layer.build((self.batch_size, self.seq_len, self.hidden_dim))
 
-    with patch.object(
-        layer, "_use_fused_attention_op", return_value=use_fused_attention
-    ):
-      output = layer(x, attention_mask=attention_mask)
+        # Input is a single newly generated token
+        x = ops.ones((self.batch_size, 1, self.hidden_dim), dtype="float32")
+        attention_mask = ops.ones(
+            (self.batch_size, 1, self.seq_len), dtype="int32"
+        )
 
-      self.assertEqual(
-          output.shape, (self.batch_size, self.seq_len, self.hidden_dim)
-      )
+        cache = ops.zeros(
+            (
+                self.batch_size,
+                2,
+                self.seq_len,
+                self.num_key_value_heads,
+                self.head_dim,
+            ),
+            dtype="float32",
+        )
 
-  @parameterized.named_parameters(
-      ("standard_attention_cache", False),
-      ("fused_attention_cache", True),
-  )
-  def test_gqa_cached_generation(self, use_fused_attention):
-    """Tests GQA execution with key-value cache during generation."""
-    layer = CachedGemma3Attention(
-        head_dim=self.head_dim,
-        num_query_heads=self.num_query_heads,
-        num_key_value_heads=self.num_key_value_heads,
-    )
-    layer.build((self.batch_size, self.seq_len, self.hidden_dim))
+        with patch.object(
+            layer, "_use_fused_attention_op", return_value=use_fused_attention
+        ):
+            output, updated_cache = layer(
+                x=x,
+                attention_mask=attention_mask,
+                cache=cache,
+                cache_update_index=5,
+            )
 
-    # Input is a single newly generated token
-    x = ops.ones((self.batch_size, 1, self.hidden_dim), dtype="float32")
-    attention_mask = ops.ones((self.batch_size, 1, self.seq_len), dtype="int32")
-
-    cache = ops.zeros(
-        (
-            self.batch_size,
-            2,
-            self.seq_len,
-            self.num_key_value_heads,
-            self.head_dim,
-        ),
-        dtype="float32",
-    )
-
-    with patch.object(
-        layer, "_use_fused_attention_op", return_value=use_fused_attention
-    ):
-      output, updated_cache = layer(
-          x=x,
-          attention_mask=attention_mask,
-          cache=cache,
-          cache_update_index=5,
-      )
-
-      self.assertEqual(output.shape, (self.batch_size, 1, self.hidden_dim))
-      self.assertEqual(
-          updated_cache.shape,
-          (
-              self.batch_size,
-              2,
-              self.seq_len,
-              self.num_key_value_heads,
-              self.head_dim,
-          ),
-      )
+            self.assertEqual(
+                output.shape, (self.batch_size, 1, self.hidden_dim)
+            )
+            self.assertEqual(
+                updated_cache.shape,
+                (
+                    self.batch_size,
+                    2,
+                    self.seq_len,
+                    self.num_key_value_heads,
+                    self.head_dim,
+                ),
+            )

--- a/keras_hub/src/models/gemma3/gemma3_attention_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention_test.py
@@ -1,0 +1,103 @@
+from unittest.mock import patch
+
+import keras
+import numpy as np
+import pytest
+from absl.testing import parameterized
+from keras import ops
+
+from keras_hub.src.models.gemma3.gemma3_attention import CachedGemma3Attention
+from keras_hub.src.tests.test_case import TestCase
+
+
+class CachedGemma3AttentionTest(TestCase, parameterized.TestCase):
+    def setUp(self):
+        self.head_dim = 64
+        self.num_query_heads = 4
+        self.num_key_value_heads = 2
+        self.hidden_dim = 128
+        self.batch_size = 2
+        self.seq_len = 16
+
+    @parameterized.named_parameters(
+        ("standard_attention", False),
+        ("fused_attention", True),
+    )
+    def test_gqa_forward_pass(self, use_fused_attention):
+        """Tests that GQA executes correctly without shape mismatches."""
+        layer = CachedGemma3Attention(
+            head_dim=self.head_dim,
+            num_query_heads=self.num_query_heads,
+            num_key_value_heads=self.num_key_value_heads,
+        )
+        layer.build((self.batch_size, self.seq_len, self.hidden_dim))
+
+        x = ops.ones(
+            (self.batch_size, self.seq_len, self.hidden_dim), dtype="float32"
+        )
+        attention_mask = ops.ones(
+            (self.batch_size, self.seq_len, self.seq_len), dtype="int32"
+        )
+
+        with patch.object(
+            layer, "_use_fused_attention_op", return_value=use_fused_attention
+        ):
+            output = layer(x, attention_mask=attention_mask)
+
+            self.assertEqual(
+                output.shape, (self.batch_size, self.seq_len, self.hidden_dim)
+            )
+
+    @parameterized.named_parameters(
+        ("standard_attention_cache", False),
+        ("fused_attention_cache", True),
+    )
+    def test_gqa_cached_generation(self, use_fused_attention):
+        """Tests GQA execution with key-value cache during generation."""
+        layer = CachedGemma3Attention(
+            head_dim=self.head_dim,
+            num_query_heads=self.num_query_heads,
+            num_key_value_heads=self.num_key_value_heads,
+        )
+        layer.build((self.batch_size, self.seq_len, self.hidden_dim))
+
+        # Input is a single newly generated token
+        x = ops.ones((self.batch_size, 1, self.hidden_dim), dtype="float32")
+        attention_mask = ops.ones(
+            (self.batch_size, 1, self.seq_len), dtype="int32"
+        )
+
+        cache = ops.zeros(
+            (
+                self.batch_size,
+                2,
+                self.seq_len,
+                self.num_key_value_heads,
+                self.head_dim,
+            ),
+            dtype="float32",
+        )
+
+        with patch.object(
+            layer, "_use_fused_attention_op", return_value=use_fused_attention
+        ):
+            output, updated_cache = layer(
+                x=x,
+                attention_mask=attention_mask,
+                cache=cache,
+                cache_update_index=5,
+            )
+
+            self.assertEqual(
+                output.shape, (self.batch_size, 1, self.hidden_dim)
+            )
+            self.assertEqual(
+                updated_cache.shape,
+                (
+                    self.batch_size,
+                    2,
+                    self.seq_len,
+                    self.num_key_value_heads,
+                    self.head_dim,
+                ),
+            )


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
`CachedGemma3Attention` uses Grouped-Query Attention (GQA), where multiple Query heads share a smaller number of Key/Value heads (e.g., 8 Query heads sharing 4 Key/Value heads).

While our standard non-fused einsum fallback path handles GQA grouping flawlessly, the fused attention path offloads the mixing to PyTorch's native `scaled_dot_product_attention (SDPA)`. PyTorch's compiled C++ SDPA kernel requires Query and Key tensors to have either equal head dimensions or be automatically broadcastable (which only works for Multi-Query Attention where `num_kv_heads == 1`). Because `num_kv_heads > 1 `in Gemma 3, PyTorch fails to broadcast and throws a shape mismatch crash.

Reproduction Script:

```
import os
os.environ["KERAS_BACKEND"] = "torch"

import torch
import keras
import numpy as np

from keras import ops
from keras_hub.src.models.gemma3.gemma3_attention import CachedGemma3Attention

def run_reproduction():
    print("Initializing CachedGemma3Attention with GQA (8 query heads, 4 KV heads)...")
    layer = CachedGemma3Attention(
        head_dim=256,
        num_query_heads=8,
        num_key_value_heads=4,
    )
    
    # Build layer with hidden_dim = 2560
    batch_size = 1
    seq_len = 96
    hidden_dim = 2560
    
    layer.build((batch_size, seq_len, hidden_dim))
    
    # Force _use_fused_attention_op to return True to trigger ops.dot_product_attention
    layer._use_fused_attention_op = lambda: True

    # Create dummy inputs matching the traceback
    x = ops.ones((batch_size, seq_len, hidden_dim), dtype="float32")
    attention_mask = ops.ones((batch_size, seq_len, seq_len), dtype="int32")
    
    # Cache shape: (batch_size, 2, max_seq_len, num_key_value_heads, head_dim)
    cache = ops.zeros((batch_size, 2, seq_len, 4, 256), dtype="float32")
    
    print("\nCalling layer with key/value cache...")
    try:
        output, updated_cache = layer(
            x=x,
            attention_mask=attention_mask,
            cache=cache,
            cache_update_index=0,
            training=False,
        )
        print("Success! No bug reproduced.")
    except Exception as e:
        print("\n" + "="*50)
        print("BUG REPRODUCED SUCCESSFULLY!")
        print("="*50)
        import traceback
        traceback.print_exc()

if __name__ == "__main__":
    run_reproduction()
```

Fix: 
In `CachedGemma3Attention._compute_attention`, whenever we enter the *fused attention path* and `num_key_value_groups > 1`, we explicitly materialize the grouped Key and Value tensors along the head axis (axis=-2) using `ops.repeat`

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
