### PR TITLE
test: add FileNotFoundError test for get_file preset utility

### DIFF
--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -124,7 +124,6 @@ def find_subclass(preset, cls, backbone_cls):
 
 def get_file(preset, path):
     """Download a preset file in necessary and return the local path."""
-    # TODO: Add tests for FileNotFound exceptions.
     if not isinstance(preset, str):
         raise ValueError(
             f"A preset identifier must be a string. Received: preset={preset}"

--- a/keras_hub/src/utils/preset_utils_test.py
+++ b/keras_hub/src/utils/preset_utils_test.py
@@ -14,6 +14,7 @@ from keras_hub.src.models.gemma.gemma_backbone import GemmaBackbone
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.keras_utils import sharded_weights_available
 from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
 from keras_hub.src.utils.preset_utils import upload_preset
 
 
@@ -193,3 +194,10 @@ class PresetUtilsTest(TestCase):
         # Verify error handling.
         with self.assertRaisesRegex(ValueError, "is an invalid json"):
             upload_preset("kaggle://test/test/test", local_preset_dir)
+
+    def test_get_file_raises_file_not_found(self):
+        local_dir = self.get_temp_dir()
+        fake_path = "does_not_exist.json"
+
+        with self.assertRaises(FileNotFoundError):
+            get_file(local_dir, fake_path)


### PR DESCRIPTION
## Description of the change

This PR resolves an inline TODO in keras_hub/src/utils/preset_utils.py by adding a unit test to ensure the get_file utility correctly raises a FileNotFoundError. The test verifies that passing an invalid file path within a valid preset architecture triggers the appropriate exception rather than failing silently or causing a downstream parsing error.

## Reference
Resolves inline TODO in preset_utils.py.
Relates to the broader KerasHub Call for Contributions (Issue #1835).

## Colab Notebook
N/A - This PR is strictly a testing coverage enhancement for an existing internal utility function.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
