### PR TITLE
Add safe_mode guard to PARSeq and Whisper tokenizer file loading

### DIFF
--- a/keras_hub/src/models/parseq/parseq_tokenizer.py
+++ b/keras_hub/src/models/parseq/parseq_tokenizer.py
@@ -3,6 +3,7 @@ import re
 from typing import Iterable
 
 import keras
+from keras.src.saving import serialization_lib
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.tokenizers import tokenizer
@@ -101,6 +102,17 @@ class PARSeqTokenizer(tokenizer.Tokenizer):
             return
 
         if isinstance(vocabulary, str):
+            if serialization_lib.in_safe_mode():
+                raise ValueError(
+                    "Requested the loading of a vocabulary file outside of the "
+                    "model archive. This carries a potential risk of loading "
+                    "arbitrary and sensitive files and thus it is disallowed "
+                    "by default. If you trust the source of the artifact, you "
+                    "can override this error by passing `safe_mode=False` to "
+                    "the loading function, or calling "
+                    "`keras.config.enable_unsafe_deserialization()`. "
+                    f"Vocabulary file: '{vocabulary}'"
+                )
             with open(vocabulary, "r", encoding="utf-8") as file:
                 self.vocabulary = [line.rstrip() for line in file]
                 self.vocabulary = "".join(self.vocabulary)

--- a/keras_hub/src/models/parseq/parseq_tokenizer_test.py
+++ b/keras_hub/src/models/parseq/parseq_tokenizer_test.py
@@ -1,0 +1,23 @@
+import os
+
+from keras.src.saving import serialization_lib
+
+from keras_hub.src.models.parseq.parseq_tokenizer import PARSeqTokenizer
+from keras_hub.src.tests.test_case import TestCase
+
+
+class PARSeqTokenizerTest(TestCase):
+    def test_safe_mode_vocabulary_file_disallowed(self):
+        temp_dir = self.get_temp_dir()
+        vocab_path = os.path.join(temp_dir, "vocab.txt")
+        with open(vocab_path, "w") as file:
+            file.write("a\nb\nc\n")
+
+        tokenizer = PARSeqTokenizer()
+        with serialization_lib.SafeModeScope(True):
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Requested the loading of a vocabulary file outside of the "
+                r"model archive.*Vocabulary file: .*vocab\.txt",
+            ):
+                tokenizer.set_vocabulary(vocab_path)

--- a/keras_hub/src/models/whisper/whisper_tokenizer.py
+++ b/keras_hub/src/models/whisper/whisper_tokenizer.py
@@ -1,5 +1,7 @@
 import json
 
+from keras.src.saving import serialization_lib
+
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.models.whisper.whisper_backbone import WhisperBackbone
 from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -7,6 +9,17 @@ from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 
 def _load_dict(dict_or_path):
     if isinstance(dict_or_path, str):
+        if serialization_lib.in_safe_mode():
+            raise ValueError(
+                "Requested the loading of a vocabulary file outside of the "
+                "model archive. This carries a potential risk of loading "
+                "arbitrary and sensitive files and thus it is disallowed "
+                "by default. If you trust the source of the artifact, you "
+                "can override this error by passing `safe_mode=False` to "
+                "the loading function, or calling "
+                "`keras.config.enable_unsafe_deserialization()`. "
+                f"Vocabulary file: '{dict_or_path}'"
+            )
         with open(dict_or_path, "r", encoding="utf-8") as f:
             dict_or_path = json.load(f)
     return dict_or_path

--- a/keras_hub/src/models/whisper/whisper_tokenizer_test.py
+++ b/keras_hub/src/models/whisper/whisper_tokenizer_test.py
@@ -1,4 +1,8 @@
+import json
+import os
+
 import pytest
+from keras.src.saving import serialization_lib
 
 from keras_hub.src.models.whisper.whisper_tokenizer import WhisperTokenizer
 from keras_hub.src.tests.test_case import TestCase
@@ -67,6 +71,22 @@ class WhisperTokenizerTest(TestCase):
             WhisperTokenizer(
                 vocabulary=["a", "b", "c"], merges=[], special_tokens={}
             )
+
+    def test_safe_mode_vocabulary_file_disallowed(self):
+        temp_dir = self.get_temp_dir()
+        special_tokens_path = os.path.join(temp_dir, "special_tokens.json")
+        with open(special_tokens_path, "w") as file:
+            json.dump(self.special_tokens, file)
+
+        init_kwargs = dict(self.init_kwargs)
+        init_kwargs["special_tokens"] = special_tokens_path
+        with serialization_lib.SafeModeScope(True):
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Requested the loading of a vocabulary file outside of the "
+                r"model archive.*Vocabulary file: .*special_tokens\.json",
+            ):
+                WhisperTokenizer(**init_kwargs)
 
     @pytest.mark.extra_large
     def test_smallest_preset(self):


### PR DESCRIPTION
## What this does

`PARSeqTokenizer.set_vocabulary` and the Whisper tokenizer's `_load_dict`
helper open a file path taken from the `vocabulary` argument (and, for
Whisper, also `special_tokens` / `language_tokens`) during `__init__`,
without checking `serialization_lib.in_safe_mode()`.

Both tokenizers are serializable Keras objects, so a crafted `.keras`
model can set that argument to an arbitrary path. The file is then read
when the model is loaded, even with the default `safe_mode=True`, and the
bytes end up in the tokenizer vocabulary where they can be read back.

The generic tokenizers (`WordPieceTokenizer`, `SentencePieceTokenizer`,
`BytePairTokenizer`) and `keras.layers.StringLookup` already guard this in
#2517, raising when a path is passed under safe mode. That guard was never
added to these two model-specific tokenizers. This PR adds the same check
and the same error message to both, with a test for each.

## Repro (before this change)

```python
import keras
open("/tmp/secret", "w").write("SECRET\n")
from keras_hub.src.models.parseq.parseq_tokenizer import PARSeqTokenizer

cfg = keras.saving.serialize_keras_object(PARSeqTokenizer())
cfg["config"]["vocabulary"] = "/tmp/secret"
out = keras.saving.deserialize_keras_object(cfg, safe_mode=True)
print(out.vocabulary)   # -> SECRET   (file read under safe_mode=True)
```

After this change the same input raises `ValueError` and names the
vocabulary file, matching the behaviour of the generic tokenizers. The
Whisper path behaves the same way via `special_tokens` / `language_tokens`
/ `vocabulary`.

## Tests

- `parseq_tokenizer_test.py::PARSeqTokenizerTest::test_safe_mode_vocabulary_file_disallowed`
- `whisper_tokenizer_test.py::WhisperTokenizerTest::test_safe_mode_vocabulary_file_disallowed`

Both pass, and the existing PARSeq/Whisper tokenizer tests still pass.
