### PR TITLE
Fix Adam optimizer underflow for LoRA in bfloat16

### DIFF
--- a/keras_hub/src/layers/modeling/einsum_dense.py
+++ b/keras_hub/src/layers/modeling/einsum_dense.py
@@ -1,0 +1,91 @@
+import keras
+from keras import ops
+
+from keras_hub.src.api_export import keras_hub_export
+
+
+@keras_hub_export("keras_hub.layers.EinsumDense")
+class EinsumDense(keras.layers.EinsumDense):
+    """EinsumDense subclass that keeps LoRA weights in float32.
+
+    When using mixed precision (bfloat16/float16), the parent class creates
+    LoRA weights in the layer's dtype. Adam's second-moment estimate can
+    underflow in low precision, producing near-zero updates. This subclass
+    re-creates the LoRA variables in float32 after the parent initialises
+    them, and casts them back to compute_dtype inside ``call()``.
+    """
+
+    def enable_lora(
+        self, rank, a_initializer="he_uniform", b_initializer="zeros"
+    ):
+        super().enable_lora(rank, a_initializer, b_initializer)
+
+        # Determine the dtype string regardless of whether .dtype is a
+        # string or an object with a .name attribute.
+        lora_a_dtype = self.lora_kernel_a.dtype
+        if hasattr(lora_a_dtype, "name"):
+            lora_a_dtype = lora_a_dtype.name
+
+        if lora_a_dtype in ("float16", "bfloat16"):
+            self._tracker.unlock()
+
+            if self.lora_kernel_a in self._variables:
+                self._variables.remove(self.lora_kernel_a)
+            if self.lora_kernel_b in self._variables:
+                self._variables.remove(self.lora_kernel_b)
+            if self.lora_kernel_a in self._trainable_variables:
+                self._trainable_variables.remove(self.lora_kernel_a)
+            if self.lora_kernel_b in self._trainable_variables:
+                self._trainable_variables.remove(self.lora_kernel_b)
+
+            original_a_regularizer = getattr(self.lora_kernel_a, "regularizer", None)
+            original_b_regularizer = getattr(self.lora_kernel_b, "regularizer", None)
+
+            self.lora_kernel_a = self.add_weight(
+                name="lora_kernel_a",
+                shape=self.lora_kernel_a.shape,
+                initializer=a_initializer,
+                regularizer=original_a_regularizer,
+                trainable=True,
+                dtype="float32",
+            )
+            self.lora_kernel_b = self.add_weight(
+                name="lora_kernel_b",
+                shape=self.lora_kernel_b.shape,
+                initializer=b_initializer,
+                regularizer=original_b_regularizer,
+                trainable=True,
+                dtype="float32",
+            )
+            self._tracker.lock()
+
+    @property
+    def lora_kernel_a(self):
+        val = getattr(self, "_lora_kernel_a", None)
+        if val is not None and getattr(self, "_in_call", False):
+            return ops.cast(val, self.compute_dtype)
+        return val
+
+    @lora_kernel_a.setter
+    def lora_kernel_a(self, value):
+        self._lora_kernel_a = value
+
+    @property
+    def lora_kernel_b(self):
+        val = getattr(self, "_lora_kernel_b", None)
+        if val is not None and getattr(self, "_in_call", False):
+            return ops.cast(val, self.compute_dtype)
+        return val
+
+    @lora_kernel_b.setter
+    def lora_kernel_b(self, value):
+        self._lora_kernel_b = value
+
+    def call(self, inputs):
+        if getattr(self, "lora_rank", None):
+            self._in_call = True
+            try:
+                return super().call(inputs)
+            finally:
+                self._in_call = False
+        return super().call(inputs)

--- a/keras_hub/src/layers/modeling/einsum_dense.py
+++ b/keras_hub/src/layers/modeling/einsum_dense.py
@@ -1,10 +1,8 @@
 import keras
 from keras import ops
 
-from keras_hub.src.api_export import keras_hub_export
 
-
-@keras_hub_export("keras_hub.layers.EinsumDense")
+@keras.saving.register_keras_serializable(package="keras_hub")
 class EinsumDense(keras.layers.EinsumDense):
     """EinsumDense subclass that keeps LoRA weights in float32.
 
@@ -13,12 +11,29 @@ class EinsumDense(keras.layers.EinsumDense):
     underflow in low precision, producing near-zero updates. This subclass
     re-creates the LoRA variables in float32 after the parent initialises
     them, and casts them back to compute_dtype inside ``call()``.
+
+    This is an internal, keras-hub specific workaround (not a public API)
+    similar to keras-team/keras#22559.
     """
 
     def enable_lora(
-        self, rank, a_initializer="he_uniform", b_initializer="zeros"
+        self,
+        rank,
+        lora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
     ):
-        super().enable_lora(rank, a_initializer, b_initializer)
+        # NOTE: keras.layers.EinsumDense.enable_lora has the signature
+        # (rank, lora_alpha, a_initializer, b_initializer). Forward by keyword
+        # so the initializers are never mistakenly bound to ``lora_alpha`` (a
+        # bug that left ``lora_alpha`` as the string "he_uniform" and crashed
+        # the kernel property with `unsupported operand type(s) for /`).
+        super().enable_lora(
+            rank,
+            lora_alpha=lora_alpha,
+            a_initializer=a_initializer,
+            b_initializer=b_initializer,
+        )
 
         # Determine the dtype string regardless of whether .dtype is a
         # string or an object with a .name attribute.
@@ -38,8 +53,12 @@ class EinsumDense(keras.layers.EinsumDense):
             if self.lora_kernel_b in self._trainable_variables:
                 self._trainable_variables.remove(self.lora_kernel_b)
 
-            original_a_regularizer = getattr(self.lora_kernel_a, "regularizer", None)
-            original_b_regularizer = getattr(self.lora_kernel_b, "regularizer", None)
+            original_a_regularizer = getattr(
+                self.lora_kernel_a, "regularizer", None
+            )
+            original_b_regularizer = getattr(
+                self.lora_kernel_b, "regularizer", None
+            )
 
             self.lora_kernel_a = self.add_weight(
                 name="lora_kernel_a",

--- a/keras_hub/src/models/bloom/bloom_attention.py
+++ b/keras_hub/src/models/bloom/bloom_attention.py
@@ -4,6 +4,7 @@ import keras
 from keras import ops
 
 from keras_hub.src.layers.modeling.alibi_bias import AlibiBias
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.utils.keras_utils import clone_initializer
 
 
@@ -30,7 +31,7 @@ class BloomAttention(keras.layers.Layer):
         # Layer-wise attention scaling
         self.inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
 
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="btm,mnh->btnh",
             output_shape=(None, self.num_heads, self.head_dim),
             bias_axes="nh",
@@ -41,7 +42,7 @@ class BloomAttention(keras.layers.Layer):
         )
         self._query_dense.build(inputs_shape)
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bsm,mnh->bsnh",
             output_shape=(None, self.num_heads, self.head_dim),
             bias_axes="nh",
@@ -52,7 +53,7 @@ class BloomAttention(keras.layers.Layer):
         )
         self._key_dense.build(inputs_shape)
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bsm,mnh->bsnh",
             output_shape=(None, self.num_heads, self.head_dim),
             bias_axes="nh",

--- a/keras_hub/src/models/d_fine/d_fine_attention.py
+++ b/keras_hub/src/models/d_fine/d_fine_attention.py
@@ -2,6 +2,7 @@ import math
 
 import keras
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.models.d_fine.d_fine_utils import (
     multi_scale_deformable_attention_v2,
 )
@@ -77,7 +78,7 @@ class DFineMultiscaleDeformableAttention(keras.layers.Layer):
             sum(self.num_points),
             2,
         )
-        self.sampling_offsets = keras.layers.EinsumDense(
+        self.sampling_offsets = EinsumDense(
             "abc,cdef->abdef",
             output_shape=sampling_offsets_output_shape,
             bias_axes="def",
@@ -92,7 +93,7 @@ class DFineMultiscaleDeformableAttention(keras.layers.Layer):
             self.n_heads,
             sum(self.num_points),
         )
-        self.attention_weights = keras.layers.EinsumDense(
+        self.attention_weights = EinsumDense(
             "abc,cde->abde",
             output_shape=attention_weights_output_shape,
             bias_axes="de",
@@ -322,7 +323,7 @@ class DFineMultiheadAttention(keras.layers.Layer):
         proj_bias_axes = "de"
         proj_output_shape = (None, self.num_heads, self.head_dim)
         proj_input_shape = (None, None, embedding_dim)
-        self.q_proj = keras.layers.EinsumDense(
+        self.q_proj = EinsumDense(
             proj_equation,
             output_shape=proj_output_shape,
             bias_axes=proj_bias_axes if self.bias else None,
@@ -332,7 +333,7 @@ class DFineMultiheadAttention(keras.layers.Layer):
             name="q_proj",
         )
         self.q_proj.build(proj_input_shape)
-        self.k_proj = keras.layers.EinsumDense(
+        self.k_proj = EinsumDense(
             proj_equation,
             output_shape=proj_output_shape,
             bias_axes=proj_bias_axes if self.bias else None,
@@ -342,7 +343,7 @@ class DFineMultiheadAttention(keras.layers.Layer):
             name="k_proj",
         )
         self.k_proj.build(proj_input_shape)
-        self.v_proj = keras.layers.EinsumDense(
+        self.v_proj = EinsumDense(
             proj_equation,
             output_shape=proj_output_shape,
             bias_axes=proj_bias_axes if self.bias else None,
@@ -354,7 +355,7 @@ class DFineMultiheadAttention(keras.layers.Layer):
         self.v_proj.build(proj_input_shape)
         out_proj_input_shape = (None, None, self.num_heads * self.head_dim)
         out_proj_output_shape = (None, self.embedding_dim)
-        self.out_proj = keras.layers.EinsumDense(
+        self.out_proj = EinsumDense(
             "abc,cd->abd",
             output_shape=out_proj_output_shape,
             bias_axes="d" if self.bias else None,

--- a/keras_hub/src/models/deberta_v3/disentangled_self_attention.py
+++ b/keras_hub/src/models/deberta_v3/disentangled_self_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.utils.keras_utils import clone_initializer
 
 
@@ -68,7 +69,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
 
     def build(self, inputs_shape, rel_embeddings_shape=None):
         # Q, K, V linear layers.
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="abc,cde->abde",
             output_shape=(None, self.num_heads, self.attn_head_size),
             bias_axes="de",
@@ -77,7 +78,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
             name="query",
         )
         self._query_dense.build(inputs_shape)
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="abc,cde->abde",
             output_shape=(None, self.num_heads, self.attn_head_size),
             bias_axes="de",
@@ -86,7 +87,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
             name="key",
         )
         self._key_dense.build(inputs_shape)
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="abc,cde->abde",
             output_shape=(None, self.num_heads, self.attn_head_size),
             bias_axes="de",
@@ -114,7 +115,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
         )
 
         # Output.
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="abc,cd->abd",
             output_shape=(None, self.hidden_dim),
             bias_axes="d",

--- a/keras_hub/src/models/falcon/falcon_attention.py
+++ b/keras_hub/src/models/falcon/falcon_attention.py
@@ -1,8 +1,9 @@
 import math
 
 import keras
-from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras import ops
+
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 
 
 class FalconAttention(keras.layers.Layer):

--- a/keras_hub/src/models/falcon/falcon_attention.py
+++ b/keras_hub/src/models/falcon/falcon_attention.py
@@ -1,6 +1,7 @@
 import math
 
 import keras
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras import ops
 
 
@@ -31,7 +32,7 @@ class FalconAttention(keras.layers.Layer):
         # Layer-wise attention scaling
         self.inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="bqm,mnh->bqnh",
             output_shape=(None, self.num_heads, self.head_dim),
             bias_axes="nh",
@@ -40,7 +41,7 @@ class FalconAttention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bkm,mnh->bknh",
             output_shape=(None, self.num_heads, self.head_dim),
             bias_axes="nh",
@@ -49,7 +50,7 @@ class FalconAttention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bkm,mnh->bknh",
             output_shape=(None, self.num_heads, self.head_dim),
             bias_axes="nh",

--- a/keras_hub/src/models/gemma/gemma_attention.py
+++ b/keras_hub/src/models/gemma/gemma_attention.py
@@ -4,6 +4,7 @@ import keras
 import numpy as np
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
@@ -47,7 +48,7 @@ class CachedGemmaAttention(keras.layers.Layer):
     def build(self, inputs_shape):
         self.hidden_dim = inputs_shape[-1]
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             "btd,ndh->btnh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -56,7 +57,7 @@ class CachedGemmaAttention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             "bsd,kdh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -65,7 +66,7 @@ class CachedGemmaAttention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             "bsd,kdh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -79,7 +80,7 @@ class CachedGemmaAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=self._kernel_initializer,

--- a/keras_hub/src/models/gemma/gemma_decoder_block.py
+++ b/keras_hub/src/models/gemma/gemma_decoder_block.py
@@ -1,6 +1,7 @@
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.transformer_layer_utils import (
     compute_causal_mask,
 )
@@ -88,21 +89,21 @@ class GemmaDecoderBlock(keras.layers.Layer):
                 name="post_ffw_norm",
             )
 
-        self.gating_ffw = keras.layers.EinsumDense(
+        self.gating_ffw = EinsumDense(
             equation="btd,df->btf",
             output_shape=(None, self.intermediate_dim // 2),
             dtype=self.dtype_policy,
             name="ffw_gating",
         )
 
-        self.gating_ffw_2 = keras.layers.EinsumDense(
+        self.gating_ffw_2 = EinsumDense(
             equation="btd,df->btf",
             output_shape=(None, self.intermediate_dim // 2),
             dtype=self.dtype_policy,
             name="ffw_gating_2",
         )
 
-        self.ffw_linear = keras.layers.EinsumDense(
+        self.ffw_linear = EinsumDense(
             equation="btf,fd->btd",
             output_shape=(None, self.hidden_dim),
             dtype=self.dtype_policy,

--- a/keras_hub/src/models/gemma3/gemma3_attention.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention.py
@@ -4,6 +4,7 @@ import keras
 import numpy as np
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.gemma3.gemma3_layers import RMSNormalization
 from keras_hub.src.utils.keras_utils import clone_initializer
@@ -74,7 +75,7 @@ class CachedGemma3Attention(keras.layers.Layer):
     def build(self, inputs_shape):
         self.hidden_dim = inputs_shape[-1]
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             "btd,ndh->btnh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -83,7 +84,7 @@ class CachedGemma3Attention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             "bsd,kdh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -92,7 +93,7 @@ class CachedGemma3Attention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             "bsd,kdh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -125,7 +126,7 @@ class CachedGemma3Attention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=self._kernel_initializer,

--- a/keras_hub/src/models/gemma3/gemma3_decoder_block.py
+++ b/keras_hub/src/models/gemma3/gemma3_decoder_block.py
@@ -1,6 +1,7 @@
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.transformer_layer_utils import (
     compute_causal_mask,
 )
@@ -117,21 +118,21 @@ class Gemma3DecoderBlock(keras.layers.Layer):
                 name="post_ffw_norm",
             )
 
-        self.gating_ffw = keras.layers.EinsumDense(
+        self.gating_ffw = EinsumDense(
             equation="btd,df->btf",
             output_shape=(None, self.intermediate_dim // gate_dim_reduction),
             dtype=self.dtype_policy,
             name="ffw_gating",
         )
 
-        self.gating_ffw_2 = keras.layers.EinsumDense(
+        self.gating_ffw_2 = EinsumDense(
             equation="btd,df->btf",
             output_shape=(None, self.intermediate_dim // gate_dim_reduction),
             dtype=self.dtype_policy,
             name="ffw_gating_2",
         )
 
-        self.ffw_linear = keras.layers.EinsumDense(
+        self.ffw_linear = EinsumDense(
             equation="btf,fd->btd",
             output_shape=(None, self.hidden_dim),
             dtype=self.dtype_policy,

--- a/keras_hub/src/models/gemma4/gemma4_attention.py
+++ b/keras_hub/src/models/gemma4/gemma4_attention.py
@@ -3,6 +3,7 @@ import inspect
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.gemma4.gemma4_layers import Gemma4ClippableEinsumDense
 from keras_hub.src.models.gemma4.gemma4_layers import Gemma4VNorm
@@ -93,7 +94,7 @@ class Gemma4TextAttention(keras.layers.Layer):
     def build(self, inputs_shape):
         self.hidden_dim = inputs_shape[-1]
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             "btd,ndh->btnh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -105,7 +106,7 @@ class Gemma4TextAttention(keras.layers.Layer):
         # KV-shared layers borrow K/V from the source layer at runtime and do
         # not own their own projections.
         if not self.is_kv_shared_layer:
-            self.key_dense = keras.layers.EinsumDense(
+            self.key_dense = EinsumDense(
                 "bsd,kdh->bskh",
                 output_shape=(None, self.effective_num_kv_heads, self.head_dim),
                 kernel_initializer=self._kernel_initializer,
@@ -117,7 +118,7 @@ class Gemma4TextAttention(keras.layers.Layer):
             # When attention_k_eq_v, V reuses K's projection — no separate
             # weight.
             if not self.attention_k_eq_v:
-                self.value_dense = keras.layers.EinsumDense(
+                self.value_dense = EinsumDense(
                     "bsd,kdh->bskh",
                     output_shape=(
                         None,
@@ -175,7 +176,7 @@ class Gemma4TextAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=self._kernel_initializer,

--- a/keras_hub/src/models/gemma4/gemma4_decoder_block.py
+++ b/keras_hub/src/models/gemma4/gemma4_decoder_block.py
@@ -1,6 +1,7 @@
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.transformer_layer_utils import (
     compute_causal_mask,
 )
@@ -222,19 +223,19 @@ class Gemma4TextDecoderBlock(keras.layers.Layer):
         # Feed-forward network uses standard gated GELU activation.
         # `actual_intermediate_dim` may be 2x for KV-shared layers when
         # `use_double_wide_mlp=True` (E2B architecture).
-        self.gating_ffw = keras.layers.EinsumDense(
+        self.gating_ffw = EinsumDense(
             equation="btd,df->btf",
             output_shape=(None, self.actual_intermediate_dim),
             dtype=self.dtype_policy,
             name="ffw_gating",
         )
-        self.gating_ffw_2 = keras.layers.EinsumDense(
+        self.gating_ffw_2 = EinsumDense(
             equation="btd,df->btf",
             output_shape=(None, self.actual_intermediate_dim),
             dtype=self.dtype_policy,
             name="ffw_gating_2",
         )
-        self.ffw_linear = keras.layers.EinsumDense(
+        self.ffw_linear = EinsumDense(
             equation="btf,fd->btd",
             output_shape=(None, self.hidden_dim),
             dtype=self.dtype_policy,

--- a/keras_hub/src/models/gemma4/gemma4_layers.py
+++ b/keras_hub/src/models/gemma4/gemma4_layers.py
@@ -1,6 +1,7 @@
 import keras
-from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras import ops
+
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 
 
 class RMSNormalization(keras.layers.Layer):

--- a/keras_hub/src/models/gemma4/gemma4_layers.py
+++ b/keras_hub/src/models/gemma4/gemma4_layers.py
@@ -1,4 +1,5 @@
 import keras
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras import ops
 
 
@@ -310,7 +311,7 @@ class Gemma4ClippableEinsumDense(keras.layers.Layer):
         self.output_shape = output_shape
         self.use_clipped_linears = use_clipped_linears
         self.kernel_initializer = kernel_initializer
-        self.dense = keras.layers.EinsumDense(
+        self.dense = EinsumDense(
             equation,
             output_shape=output_shape,
             kernel_initializer=kernel_initializer,

--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
@@ -64,7 +65,7 @@ class GPTNeoXAttention(keras.layers.Layer):
         self._inv_norm_factor = 1.0 / math.sqrt(self.attn_head_size)
 
     def build(self, input_shape):
-        self._qkv_dense = keras.layers.EinsumDense(
+        self._qkv_dense = EinsumDense(
             equation="abc,cde->abde",
             output_shape=(None, self.num_heads, 3 * self.attn_head_size),
             bias_axes="de",
@@ -87,7 +88,7 @@ class GPTNeoXAttention(keras.layers.Layer):
         )
 
         # Output.
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="abc,cd->abd",
             output_shape=(None, self.hidden_dim),
             bias_axes="d",

--- a/keras_hub/src/models/gpt_oss/gpt_oss_attention.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 
@@ -76,7 +77,7 @@ class GptOssAttention(keras.layers.Layer):
 
         self._rotary_dim = (self._head_dim // 2) * 2
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, self._head_dim),
             bias_axes="uh",
@@ -87,7 +88,7 @@ class GptOssAttention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -102,7 +103,7 @@ class GptOssAttention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -122,7 +123,7 @@ class GptOssAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, self._hidden_dim),
             bias_axes="m",

--- a/keras_hub/src/models/llama/llama_attention.py
+++ b/keras_hub/src/models/llama/llama_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.models.llama.llama_rotary_embedding import (
     LlamaRotaryEmbedding,
 )
@@ -57,7 +58,7 @@ class LlamaAttention(keras.layers.Layer):
         head_dim = hidden_dim // self.num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(head_dim)
 
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, head_dim),
             kernel_initializer=self.kernel_initializer,
@@ -66,7 +67,7 @@ class LlamaAttention(keras.layers.Layer):
         )
         self._query_dense.build(inputs_shape)
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -79,7 +80,7 @@ class LlamaAttention(keras.layers.Layer):
         )
         self._key_dense.build(inputs_shape)
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -103,7 +104,7 @@ class LlamaAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
@@ -57,7 +58,7 @@ class CachedMistralAttention(keras.layers.Layer):
         self._head_dim = self._hidden_dim // self._num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(self._head_dim)
 
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self._num_query_heads, self._head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -66,7 +67,7 @@ class CachedMistralAttention(keras.layers.Layer):
         )
         self._query_dense.build(inputs_shape)
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -79,7 +80,7 @@ class CachedMistralAttention(keras.layers.Layer):
         )
         self._key_dense.build(inputs_shape)
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -103,7 +104,7 @@ class CachedMistralAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, self._hidden_dim),
             kernel_initializer=self._kernel_initializer,

--- a/keras_hub/src/models/mixtral/mixtral_attention.py
+++ b/keras_hub/src/models/mixtral/mixtral_attention.py
@@ -4,6 +4,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
@@ -54,7 +55,7 @@ class CachedMixtralAttention(keras.layers.Layer):
         self._head_dim = self._hidden_dim // self.num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(self._head_dim)
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, self._head_dim),
             kernel_initializer=self._kernel_initializer,
@@ -63,7 +64,7 @@ class CachedMixtralAttention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -76,7 +77,7 @@ class CachedMixtralAttention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -100,7 +101,7 @@ class CachedMixtralAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, self._hidden_dim),
             kernel_initializer=self._kernel_initializer,

--- a/keras_hub/src/models/moonshine/moonshine_multi_head_attention.py
+++ b/keras_hub/src/models/moonshine/moonshine_multi_head_attention.py
@@ -3,6 +3,7 @@ import keras
 from keras_hub.src.layers.modeling.cached_multi_head_attention import (
     CachedMultiHeadAttention,
 )
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.models.whisper.whisper_cached_multi_head_attention import (
     _build_proj_equation,
 )
@@ -140,7 +141,7 @@ class MoonshineMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             free_dims=query_rank - 1, bound_dims=1, output_dims=2
         )
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]
@@ -155,7 +156,7 @@ class MoonshineMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             free_dims=key_rank - 1, bound_dims=1, output_dims=2
         )
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]
@@ -170,7 +171,7 @@ class MoonshineMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             free_dims=value_rank - 1, bound_dims=1, output_dims=2
         )
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._value_dim]
@@ -198,7 +199,7 @@ class MoonshineMultiHeadAttention(CachedMultiHeadAttention):
             bound_dims=2,
             output_dims=len(output_shape),
         )
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(output_rank - 1, output_shape),
             bias_axes=bias_axes if self._use_bias else None,

--- a/keras_hub/src/models/phi3/phi3_attention.py
+++ b/keras_hub/src/models/phi3/phi3_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.phi3.phi3_rotary_embedding import (
     Phi3SuScaledRotaryEmbedding,
@@ -58,7 +59,7 @@ class Phi3Attention(keras.layers.Layer):
         head_dim = hidden_dim // self.num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(head_dim)
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, head_dim),
             kernel_initializer=self.kernel_initializer,
@@ -67,7 +68,7 @@ class Phi3Attention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -80,7 +81,7 @@ class Phi3Attention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -104,7 +105,7 @@ class Phi3Attention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/qwen/qwen_attention.py
+++ b/keras_hub/src/models/qwen/qwen_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
@@ -76,7 +77,7 @@ class QwenAttention(keras.layers.Layer):
         hidden_dim = inputs_shape[-1]
         head_dim = hidden_dim // self.num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(head_dim)
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, head_dim),
             kernel_initializer=self.kernel_initializer,
@@ -87,7 +88,7 @@ class QwenAttention(keras.layers.Layer):
         )
         self._query_dense.build(inputs_shape)
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -102,7 +103,7 @@ class QwenAttention(keras.layers.Layer):
         )
         self._key_dense.build(inputs_shape)
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -128,7 +129,7 @@ class QwenAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/qwen3/qwen3_attention.py
+++ b/keras_hub/src/models/qwen3/qwen3_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.qwen3.qwen3_layernorm import Qwen3LayerNorm
 from keras_hub.src.utils.keras_utils import clone_initializer
@@ -75,7 +76,7 @@ class Qwen3Attention(keras.layers.Layer):
             self.head_dim = hidden_dim // self.num_query_heads
 
         self._inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=self.kernel_initializer,
@@ -92,7 +93,7 @@ class Qwen3Attention(keras.layers.Layer):
         )
         self._query_dense_layer_norm.build(inputs_shape)
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -113,7 +114,7 @@ class Qwen3Attention(keras.layers.Layer):
         )
         self._key_dense_layer_norm.build(inputs_shape)
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -137,7 +138,7 @@ class Qwen3Attention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/qwen3_5/qwen3_5_attention.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.qwen3_5.qwen3_5_layers import Qwen3_5LayerNorm
 from keras_hub.src.utils.keras_utils import clone_initializer
@@ -147,7 +148,7 @@ class Qwen3_5Attention(keras.layers.Layer):
         hidden_dim = inputs_shape[-1]
         self._inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
 
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(
                 None,
@@ -170,7 +171,7 @@ class Qwen3_5Attention(keras.layers.Layer):
             (None, None, self.num_query_heads, self.head_dim)
         )
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -193,7 +194,7 @@ class Qwen3_5Attention(keras.layers.Layer):
             (None, None, self.num_key_value_heads, self.head_dim)
         )
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -212,7 +213,7 @@ class Qwen3_5Attention(keras.layers.Layer):
         self._dropout_layer = keras.layers.Dropout(
             rate=self.dropout, dtype=self.dtype_policy
         )
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_attention.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_attention.py
@@ -3,6 +3,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.qwen3_moe.qwen3_moe_layernorm import Qwen3MoeLayerNorm
 from keras_hub.src.utils.keras_utils import clone_initializer
@@ -76,7 +77,7 @@ class Qwen3MoeAttention(keras.layers.Layer):
             self.head_dim = hidden_dim // self.num_query_heads
 
         self._inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=self.kernel_initializer,
@@ -93,7 +94,7 @@ class Qwen3MoeAttention(keras.layers.Layer):
         )
         self._query_dense_layer_norm.build(inputs_shape)
 
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -114,7 +115,7 @@ class Qwen3MoeAttention(keras.layers.Layer):
         )
         self._key_dense_layer_norm.build(inputs_shape)
 
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -138,7 +139,7 @@ class Qwen3MoeAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/qwen_moe/qwen_moe_attention.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_attention.py
@@ -4,6 +4,7 @@ import math
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
@@ -81,7 +82,7 @@ class QwenMoeAttention(keras.layers.Layer):
         hidden_dim = inputs_shape[-1]
         head_dim = hidden_dim // self.num_query_heads
         self._inv_norm_factor = 1.0 / math.sqrt(head_dim)
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, head_dim),
             kernel_initializer=self.kernel_initializer,
@@ -92,7 +93,7 @@ class QwenMoeAttention(keras.layers.Layer):
         )
         self.query_dense.build(inputs_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -107,7 +108,7 @@ class QwenMoeAttention(keras.layers.Layer):
         )
         self.key_dense.build(inputs_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bkm,mvh->bkvh",
             output_shape=(
                 None,
@@ -133,7 +134,7 @@ class QwenMoeAttention(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
 
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, hidden_dim),
             kernel_initializer=self.kernel_initializer,

--- a/keras_hub/src/models/t5gemma/t5gemma_attention.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_attention.py
@@ -2,6 +2,7 @@ import inspect
 
 import keras
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.gemma.gemma_attention import CachedGemmaAttention
 from keras_hub.src.models.t5gemma.t5gemma_layers import (
@@ -141,7 +142,7 @@ class T5GemmaAttention(CachedGemmaAttention):
             kv_states_shape = input_shape
         # Query projection layer.
         self.hidden_dim = hidden_states_shape[-1]
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="btd,dnh->btnh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -152,7 +153,7 @@ class T5GemmaAttention(CachedGemmaAttention):
         self.query_dense.build(hidden_states_shape)
 
         # Key projection layer.
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bsd,dkh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -163,7 +164,7 @@ class T5GemmaAttention(CachedGemmaAttention):
         self.key_dense.build(kv_states_shape)
 
         # Value projection layer.
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bsd,dkh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -174,7 +175,7 @@ class T5GemmaAttention(CachedGemmaAttention):
         self.value_dense.build(kv_states_shape)
 
         # Output projection layer.
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),

--- a/keras_hub/src/models/t5gemma2/t5gemma2_attention.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_attention.py
@@ -2,6 +2,7 @@ import inspect
 
 import keras
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.gemma3.gemma3_attention import CachedGemma3Attention
 from keras_hub.src.models.gemma3.gemma3_layers import RMSNormalization
@@ -118,7 +119,7 @@ class T5Gemma2Attention(CachedGemma3Attention):
         hidden_states_shape = input_shape
         self.hidden_dim = hidden_states_shape[-1]
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="btd,dnh->btnh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -128,7 +129,7 @@ class T5Gemma2Attention(CachedGemma3Attention):
         )
         self.query_dense.build(hidden_states_shape)
 
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bsd,dkh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -138,7 +139,7 @@ class T5Gemma2Attention(CachedGemma3Attention):
         )
         self.key_dense.build(hidden_states_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bsd,dkh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -148,7 +149,7 @@ class T5Gemma2Attention(CachedGemma3Attention):
         )
         self.value_dense.build(hidden_states_shape)
 
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -440,7 +441,7 @@ class T5Gemma2MergedAttention(CachedGemma3Attention):
         self.hidden_dim = decoder_shape[-1]
 
         # Q projection from decoder hidden states.
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="btd,dnh->btnh",
             output_shape=(None, self.num_query_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -451,7 +452,7 @@ class T5Gemma2MergedAttention(CachedGemma3Attention):
         self.query_dense.build(decoder_shape)
 
         # K/V projections shared for self-attn and cross-attn.
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="bsd,dkh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -461,7 +462,7 @@ class T5Gemma2MergedAttention(CachedGemma3Attention):
         )
         self.key_dense.build(decoder_shape)
 
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="bsd,dkh->bskh",
             output_shape=(None, self.num_key_value_heads, self.head_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),
@@ -472,7 +473,7 @@ class T5Gemma2MergedAttention(CachedGemma3Attention):
         self.value_dense.build(decoder_shape)
 
         # Output projection.
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=clone_initializer(self._kernel_initializer),

--- a/keras_hub/src/models/video_prism/video_prism_layers.py
+++ b/keras_hub/src/models/video_prism/video_prism_layers.py
@@ -1,6 +1,7 @@
 import keras
 from keras import ops
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.layers.modeling.transformer_layer_utils import (
     compute_causal_mask,
 )
@@ -223,28 +224,28 @@ class VideoPrismAttention(keras.layers.Layer):
         self.attention_logit_soft_cap = attention_logit_soft_cap
         self.use_per_dim_scale = use_per_dim_scale
 
-        self.query_dense = keras.layers.EinsumDense(
+        self.query_dense = EinsumDense(
             equation="btd,dnh->btnh",
             output_shape=(None, self.num_heads, self.key_dim),
             bias_axes="nh",
             dtype=self.dtype_policy,
             name="query",
         )
-        self.key_dense = keras.layers.EinsumDense(
+        self.key_dense = EinsumDense(
             equation="btd,dnh->btnh",
             output_shape=(None, self.num_heads, self.key_dim),
             bias_axes="nh",
             dtype=self.dtype_policy,
             name="key",
         )
-        self.value_dense = keras.layers.EinsumDense(
+        self.value_dense = EinsumDense(
             equation="btd,dnh->btnh",
             output_shape=(None, self.num_heads, self.key_dim),
             bias_axes="nh",
             dtype=self.dtype_policy,
             name="value",
         )
-        self.output_dense = keras.layers.EinsumDense(
+        self.output_dense = EinsumDense(
             equation="btnh,nhd->btd",
             output_shape=(None, self.hidden_dim),
             bias_axes="d",

--- a/keras_hub/src/models/whisper/whisper_cached_multi_head_attention.py
+++ b/keras_hub/src/models/whisper/whisper_cached_multi_head_attention.py
@@ -8,6 +8,7 @@ import keras
 from keras_hub.src.layers.modeling.cached_multi_head_attention import (
     CachedMultiHeadAttention,
 )
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 
 
 def _index_to_einsum_variable(i):
@@ -73,7 +74,7 @@ class WhisperCachedMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             query_rank - 1, bound_dims=1, output_dims=2
         )
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]
@@ -86,7 +87,7 @@ class WhisperCachedMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             key_rank - 1, bound_dims=1, output_dims=2
         )
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]
@@ -99,7 +100,7 @@ class WhisperCachedMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             value_rank - 1, bound_dims=1, output_dims=2
         )
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._value_dim]
@@ -125,7 +126,7 @@ class WhisperCachedMultiHeadAttention(CachedMultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             query_rank - 1, bound_dims=2, output_dims=len(output_shape)
         )
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(output_rank - 1, output_shape),
             bias_axes=bias_axes if self._use_bias else None,

--- a/keras_hub/src/models/xlnet/relative_attention.py
+++ b/keras_hub/src/models/xlnet/relative_attention.py
@@ -2,6 +2,7 @@ import math
 import string
 
 import keras
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras import ops
 
 _CHR_IDX = string.ascii_lowercase
@@ -135,7 +136,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             free_dims, bound_dims=1, output_dims=2
         )
-        self._query_dense = keras.layers.EinsumDense(
+        self._query_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]
@@ -150,7 +151,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             len(self._key_shape) - 1, bound_dims=1, output_dims=2
         )
-        self._key_dense = keras.layers.EinsumDense(
+        self._key_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]
@@ -165,7 +166,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             len(self._value_shape) - 1, bound_dims=1, output_dims=2
         )
-        self._value_dense = keras.layers.EinsumDense(
+        self._value_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._value_dim]
@@ -181,7 +182,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
         _, _, output_rank = _build_proj_equation(
             free_dims, bound_dims=2, output_dims=1
         )
-        self._output_dense = keras.layers.EinsumDense(
+        self._output_dense = EinsumDense(
             "ibnd,hnd->ibh",
             output_shape=_get_output_shape(
                 output_rank - 1, [self._query_shape[-1]]
@@ -198,7 +199,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
         einsum_equation, _, output_rank = _build_proj_equation(
             len(self._key_shape) - 1, bound_dims=1, output_dims=2
         )
-        self._encoding_dense = keras.layers.EinsumDense(
+        self._encoding_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(
                 output_rank - 1, [self._num_heads, self._key_dim]

--- a/keras_hub/src/models/xlnet/relative_attention.py
+++ b/keras_hub/src/models/xlnet/relative_attention.py
@@ -2,8 +2,9 @@ import math
 import string
 
 import keras
-from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras import ops
+
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 
 _CHR_IDX = string.ascii_lowercase
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -366,7 +366,14 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             return
 
         def _get_supported_layers(mode):
-            supported_layers = [keras.layers.Dense, EinsumDense]
+            # Include both the stock `keras.layers.EinsumDense` (e.g. the dense
+            # sublayers created inside `keras.layers.MultiHeadAttention`) and
+            # the keras-hub `EinsumDense` subclass used by attention layers.
+            supported_layers = [
+                keras.layers.Dense,
+                keras.layers.EinsumDense,
+                EinsumDense,
+            ]
             if mode == "int8":
                 supported_layers.append(keras.layers.Embedding)
                 supported_layers.append(ReversibleEmbedding)

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -14,6 +14,7 @@ from keras import ops
 from keras import tree
 from keras.layers import ReversibleEmbedding
 
+from keras_hub.src.layers.modeling.einsum_dense import EinsumDense
 from keras_hub.src.models.retinanet.feature_pyramid import FeaturePyramid
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
 from keras_hub.src.utils.tensor_utils import is_float_dtype
@@ -365,7 +366,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             return
 
         def _get_supported_layers(mode):
-            supported_layers = [keras.layers.Dense, keras.layers.EinsumDense]
+            supported_layers = [keras.layers.Dense, EinsumDense]
             if mode == "int8":
                 supported_layers.append(keras.layers.Embedding)
                 supported_layers.append(ReversibleEmbedding)


### PR DESCRIPTION
 ## Summary

  This PR fixes a bug where the Adam/AdamW optimizer produces near-zero effective updates when fine-tuning Keras-Hub models with LoRA in `bfloat16` or `float16` precision (#2629). Under these conditions the training loss remains effectively unchanged across steps, even though the same configuration trains correctly with SGD.

  ## Root cause

  When LoRA is enabled, the adapter weights inherit the layer's compute dtype. Under a low-precision policy (`mixed_bfloat16` / `mixed_float16`) this means Adam accumulates its second-moment estimate `v_t` in `bfloat16`/`float16`. Because those formats have very limited mantissa precision, the small squared gradients underflow toward zero, the adaptive step size collapses, and the weights stop updating. SGD is unaffected because it maintains no second-moment term.
The same problem was addressed in core Keras via keras-team/keras#22559; this PR resolves it natively within Keras-Hub so existing models benefit without waiting on a Keras core release.

  ## Solution

  A Keras-Hub `EinsumDense` subclass (`keras_hub.src.layers.modeling.einsum_dense.EinsumDense`) is introduced to keep LoRA adapters in full precision:

  - **Float32 LoRA weights.** `enable_lora()` is overridden so that, under low-precision dtype policies, `lora_kernel_a` and
  `lora_kernel_b` are re-created and tracked in `float32`. This preserves the precision of the Adam accumulators and removes the underflow. Under a `float32` policy the override is a no-op, so default behavior is unchanged. Arguments are forwarded to the base `enable_lora()` by keyword to remain compatible with the Keras `EinsumDense.enable_lora` signature.
  - **Just-in-time compute casting.** `call()` casts the `float32` LoRA weights down to the layer's `compute_dtype` only for the duration of the forward pass. The computation is therefore numerically identical to the stock layer and raises no dtype-mismatch errors, while the stored adapters and their optimizer states remain `float32`.
  - **Serialization.** The layer is registered as a serializable Keras object so checkpoints and `save`/`load` round-trips resolve the class correctly. It is an internal implementation detail and is intentionally not exposed on the public API.

  The additional memory cost is negligible, since LoRA adapters are small relative to the frozen base weights.

  ## Scope

  All attention and decoder layers that previously used `keras.layers.EinsumDense` now use this implementation, covering Gemma, Gemma3, Gemma4, Qwen (and variants), Llama, Mistral, Mixtral, Phi-3, Falcon, Bloom, GPT-NeoX, GPT-OSS, T5Gemma, Whisper, Moonshine, DeBERTa-v3, Video-Prism, XLNet, and D-FINE.

  ## Testing

  - The Gemma, Gemma3, and Gemma4 LoRA fine-tuning and save/reload test suites pass.
  - The quantization test helper recognizes both the stock `keras.layers.EinsumDense` and this subclass, so quantization coverage including the dense layers inside `MultiHeadAttention` is preserved.
