### PR TITLE
Fix Gemma3/3n/4 preprocessor crashes with Python-only tokenizer

### DIFF
--- a/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
@@ -605,7 +605,7 @@ class Gemma3CausalLMPreprocessor(CausalLMPreprocessor):
 
         # === Vision processing ===
 
-        batch_size = tf.shape(prompts)[0]
+        batch_size = tf.shape(token_ids)[0]
         desired_height = self.image_converter.image_size[0]
         desired_width = self.image_converter.image_size[1]
         if images is None:
@@ -759,7 +759,7 @@ class Gemma3CausalLMPreprocessor(CausalLMPreprocessor):
 
         # === Vision processing ===
 
-        batch_size = tf.shape(prompts)[0]
+        batch_size = tf.shape(token_ids)[0]
         desired_height = self.image_converter.image_size[0]
         desired_width = self.image_converter.image_size[1]
         if images is None:

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor_test.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 
@@ -7,6 +9,7 @@ from keras_hub.src.models.gemma3.gemma3_causal_lm_preprocessor import (
 from keras_hub.src.models.gemma3.gemma3_image_converter import (
     Gemma3ImageConverter,
 )
+from keras_hub.src.models.gemma3.gemma3_tokenizer import Gemma3Tokenizer
 from keras_hub.src.tests.mocks.mock_gemma3_tokenizer import MockGemma3Tokenizer
 from keras_hub.src.tests.test_case import TestCase
 
@@ -180,6 +183,49 @@ class Gemma3CausalLMPreprocessorTest(TestCase):
                 "responses": ["hello", "", ""],
             }
             self.text_preprocessor(input_data)
+
+    def test_generate_preprocess_with_python_only_tokenizer(self):
+        # Regression test for the Python-only tokenizer workflow, which returns
+        # list[list[int]] with varying lengths and previously crashed in the
+        # vision branch on `tf.shape(prompts)[0]`.
+        proto_path = os.path.join(
+            self.get_test_data_dir(), "gemma3_test_vocab.spm"
+        )
+        tokenizer = Gemma3Tokenizer(proto=proto_path)
+        image_converter = Gemma3ImageConverter(image_size=(4, 4))
+        preprocessor = Gemma3CausalLMPreprocessor(
+            tokenizer=tokenizer,
+            image_converter=image_converter,
+            sequence_length=20,
+            max_images_per_prompt=2,
+            num_vision_tokens_per_image=5,
+        )
+        # Prompts tokenize to different lengths -> non-rectangular list.
+        prompts = ["the quick brown fox", "the quick"]
+        output = preprocessor.generate_preprocess(prompts, sequence_length=20)
+        self.assertEqual(output["token_ids"].shape[0], 2)
+        self.assertEqual(output["padding_mask"].shape[0], 2)
+
+    def test_call_with_python_only_tokenizer(self):
+        # Regression test for mixed rectangular/non-rectangular segments from
+        # the Python-only tokenizer workflow.
+        proto_path = os.path.join(
+            self.get_test_data_dir(), "gemma3_test_vocab.spm"
+        )
+        tokenizer = Gemma3Tokenizer(proto=proto_path)
+        preprocessor = Gemma3CausalLMPreprocessor(
+            tokenizer=tokenizer,
+            image_converter=None,
+            sequence_length=20,
+            max_images_per_prompt=0,
+            num_vision_tokens_per_image=0,
+        )
+        input_data = {
+            "prompts": ["the quick brown fox", "the quick"],
+            "responses": ["round", "round"],
+        }
+        output = preprocessor(input_data)
+        self.assertEqual(output[0]["token_ids"].shape[0], 2)
 
     @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor_test.py
@@ -185,9 +185,6 @@ class Gemma3CausalLMPreprocessorTest(TestCase):
             self.text_preprocessor(input_data)
 
     def test_generate_preprocess_with_python_only_tokenizer(self):
-        # Regression test for the Python-only tokenizer workflow, which returns
-        # list[list[int]] with varying lengths and previously crashed in the
-        # vision branch on `tf.shape(prompts)[0]`.
         proto_path = os.path.join(
             self.get_test_data_dir(), "gemma3_test_vocab.spm"
         )
@@ -207,19 +204,21 @@ class Gemma3CausalLMPreprocessorTest(TestCase):
         self.assertEqual(output["padding_mask"].shape[0], 2)
 
     def test_call_with_python_only_tokenizer(self):
-        # Regression test for mixed rectangular/non-rectangular segments from
-        # the Python-only tokenizer workflow.
         proto_path = os.path.join(
             self.get_test_data_dir(), "gemma3_test_vocab.spm"
         )
         tokenizer = Gemma3Tokenizer(proto=proto_path)
+        # image_converter must be set: the text-only branch of `call()`
+        # returns before `token_ids` is used to compute `batch_size`.
+        image_converter = Gemma3ImageConverter(image_size=(4, 4))
         preprocessor = Gemma3CausalLMPreprocessor(
             tokenizer=tokenizer,
-            image_converter=None,
+            image_converter=image_converter,
             sequence_length=20,
-            max_images_per_prompt=0,
-            num_vision_tokens_per_image=0,
+            max_images_per_prompt=2,
+            num_vision_tokens_per_image=5,
         )
+        # Prompts tokenize to different lengths -> non-rectangular list.
         input_data = {
             "prompts": ["the quick brown fox", "the quick"],
             "responses": ["round", "round"],

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
@@ -656,7 +656,7 @@ class Gemma3nCausalLMPreprocessor(CausalLMPreprocessor):
             return keras.utils.pack_x_y_sample_weight(x, y, sample_weight)
 
         # === Multimodal processing ===
-        batch_size = tf.shape(prompts)[0]
+        batch_size = tf.shape(token_ids)[0]
         desired_height = (
             self.image_converter.image_size[0] if self.image_converter else 0
         )
@@ -846,7 +846,7 @@ class Gemma3nCausalLMPreprocessor(CausalLMPreprocessor):
             }
 
         # === Multimodal processing ===
-        batch_size = tf.shape(prompts)[0]
+        batch_size = tf.shape(token_ids)[0]
         desired_height = (
             self.image_converter.image_size[0] if self.image_converter else 0
         )

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor_test.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 from keras_hub.src.models.gemma3n.gemma3n_audio_converter import (
@@ -9,6 +11,7 @@ from keras_hub.src.models.gemma3n.gemma3n_causal_lm_preprocessor import (
 from keras_hub.src.models.gemma3n.gemma3n_image_converter import (
     Gemma3nImageConverter,
 )
+from keras_hub.src.models.gemma3n.gemma3n_tokenizer import Gemma3nTokenizer
 from keras_hub.src.tests.mocks.mock_gemma3n_tokenizer import (
     MockGemma3nTokenizer,
 )
@@ -325,3 +328,50 @@ class Gemma3nCausalLMPreprocessorTest(TestCase):
                 "audios": [np.ones((16000,))],
             }
             self.text_preprocessor(input_data)
+
+    def test_generate_preprocess_with_python_only_tokenizer(self):
+        # Regression test for the Python-only tokenizer workflow, which returns
+        # list[list[int]] with varying lengths and previously crashed in the
+        # multimodal branch on `tf.shape(prompts)[0]`.
+        proto_path = os.path.join(
+            self.get_test_data_dir(), "gemma3n_test_vocab.spm"
+        )
+        tokenizer = Gemma3nTokenizer(proto=proto_path)
+        image_converter = Gemma3nImageConverter(image_size=(4, 4))
+        preprocessor = Gemma3nCausalLMPreprocessor(
+            tokenizer=tokenizer,
+            image_converter=image_converter,
+            audio_converter=None,
+            sequence_length=20,
+            max_images_per_prompt=2,
+            num_vision_tokens_per_image=5,
+            max_audios_per_prompt=0,
+            num_audio_tokens_per_audio=0,
+        )
+        # Prompts tokenize to different lengths -> non-rectangular list.
+        prompts = ["the quick brown fox", "the quick"]
+        output = preprocessor.generate_preprocess(prompts, sequence_length=20)
+        self.assertEqual(output["token_ids"].shape[0], 2)
+        self.assertEqual(output["padding_mask"].shape[0], 2)
+
+    def test_call_with_python_only_tokenizer(self):
+        # Regression test for mixed rectangular/non-rectangular segments from
+        # the Python-only tokenizer workflow.
+        proto_path = os.path.join(
+            self.get_test_data_dir(), "gemma3n_test_vocab.spm"
+        )
+        tokenizer = Gemma3nTokenizer(proto=proto_path)
+        preprocessor = Gemma3nCausalLMPreprocessor(
+            tokenizer=tokenizer,
+            image_converter=None,
+            audio_converter=None,
+            sequence_length=20,
+            max_images_per_prompt=0,
+            num_vision_tokens_per_image=0,
+        )
+        input_data = {
+            "prompts": ["the quick brown fox", "the quick"],
+            "responses": ["round", "round"],
+        }
+        output = preprocessor(input_data)
+        self.assertEqual(output[0]["token_ids"].shape[0], 2)

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor_test.py
@@ -330,9 +330,6 @@ class Gemma3nCausalLMPreprocessorTest(TestCase):
             self.text_preprocessor(input_data)
 
     def test_generate_preprocess_with_python_only_tokenizer(self):
-        # Regression test for the Python-only tokenizer workflow, which returns
-        # list[list[int]] with varying lengths and previously crashed in the
-        # multimodal branch on `tf.shape(prompts)[0]`.
         proto_path = os.path.join(
             self.get_test_data_dir(), "gemma3n_test_vocab.spm"
         )
@@ -355,20 +352,24 @@ class Gemma3nCausalLMPreprocessorTest(TestCase):
         self.assertEqual(output["padding_mask"].shape[0], 2)
 
     def test_call_with_python_only_tokenizer(self):
-        # Regression test for mixed rectangular/non-rectangular segments from
-        # the Python-only tokenizer workflow.
         proto_path = os.path.join(
             self.get_test_data_dir(), "gemma3n_test_vocab.spm"
         )
         tokenizer = Gemma3nTokenizer(proto=proto_path)
+        # image_converter must be set: the text-only branch of `call()`
+        # returns before `token_ids` is used to compute `batch_size`.
+        image_converter = Gemma3nImageConverter(image_size=(4, 4))
         preprocessor = Gemma3nCausalLMPreprocessor(
             tokenizer=tokenizer,
-            image_converter=None,
+            image_converter=image_converter,
             audio_converter=None,
             sequence_length=20,
-            max_images_per_prompt=0,
-            num_vision_tokens_per_image=0,
+            max_images_per_prompt=2,
+            num_vision_tokens_per_image=5,
+            max_audios_per_prompt=0,
+            num_audio_tokens_per_audio=0,
         )
+        # Prompts tokenize to different lengths -> non-rectangular list.
         input_data = {
             "prompts": ["the quick brown fox", "the quick"],
             "responses": ["round", "round"],

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
@@ -966,7 +966,7 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
 
             return keras.utils.pack_x_y_sample_weight(x, y, sample_weight)
 
-        batch_size = tf.shape(prompts)[0]
+        batch_size = tf.shape(token_ids)[0]
 
         # === Vision & Audio processing ===
         if images is not None and self.image_converter is not None:
@@ -1149,7 +1149,7 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
                 ),
             }
 
-        batch_size = tf.shape(prompts)[0]
+        batch_size = tf.shape(token_ids)[0]
 
         # === Vision & Audio processing ===
         if images is not None and self.image_converter is not None:

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor_test.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -8,6 +10,7 @@ from keras_hub.src.models.gemma4.gemma4_causal_lm_preprocessor import (
 from keras_hub.src.models.gemma4.gemma4_image_converter import (
     Gemma4ImageConverter,
 )
+from keras_hub.src.models.gemma4.gemma4_tokenizer import Gemma4Tokenizer
 from keras_hub.src.models.gemma4.gemma4_video_converter import (
     Gemma4VideoConverter,
 )
@@ -312,6 +315,49 @@ class Gemma4CausalLMPreprocessorTest(TestCase):
         self.assertEqual(
             expanded_cleared.numpy()[0], expanded_default.numpy()[0]
         )
+
+    def test_generate_preprocess_with_python_only_tokenizer(self):
+        # Regression test for the Python-only tokenizer workflow, which returns
+        # list[list[int]] with varying lengths and previously crashed in the
+        # multimodal branch on `tf.shape(prompts)[0]`.
+        proto_path = os.path.join(
+            self.get_test_data_dir(), "gemma4_test_vocab.spm"
+        )
+        tokenizer = Gemma4Tokenizer(proto=proto_path)
+        image_converter = Gemma4ImageConverter(image_size=(4, 4), patch_size=4)
+        preprocessor = Gemma4CausalLMPreprocessor(
+            tokenizer=tokenizer,
+            image_converter=image_converter,
+            sequence_length=20,
+            max_images_per_prompt=2,
+            num_vision_tokens_per_image=5,
+        )
+        # Prompts tokenize to different lengths -> non-rectangular list.
+        prompts = ["the quick brown fox", "the quick"]
+        output = preprocessor.generate_preprocess(prompts, sequence_length=20)
+        self.assertEqual(output["token_ids"].shape[0], 2)
+        self.assertEqual(output["padding_mask"].shape[0], 2)
+
+    def test_call_with_python_only_tokenizer(self):
+        # Regression test for mixed rectangular/non-rectangular segments from
+        # the Python-only tokenizer workflow.
+        proto_path = os.path.join(
+            self.get_test_data_dir(), "gemma4_test_vocab.spm"
+        )
+        tokenizer = Gemma4Tokenizer(proto=proto_path)
+        preprocessor = Gemma4CausalLMPreprocessor(
+            tokenizer=tokenizer,
+            image_converter=None,
+            sequence_length=20,
+            max_images_per_prompt=0,
+            num_vision_tokens_per_image=0,
+        )
+        input_data = {
+            "prompts": ["the quick brown fox", "the quick"],
+            "responses": ["round", "round"],
+        }
+        output = preprocessor(input_data)
+        self.assertEqual(output[0]["token_ids"].shape[0], 2)
 
     @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor_test.py
@@ -317,9 +317,6 @@ class Gemma4CausalLMPreprocessorTest(TestCase):
         )
 
     def test_generate_preprocess_with_python_only_tokenizer(self):
-        # Regression test for the Python-only tokenizer workflow, which returns
-        # list[list[int]] with varying lengths and previously crashed in the
-        # multimodal branch on `tf.shape(prompts)[0]`.
         proto_path = os.path.join(
             self.get_test_data_dir(), "gemma4_test_vocab.spm"
         )
@@ -339,19 +336,21 @@ class Gemma4CausalLMPreprocessorTest(TestCase):
         self.assertEqual(output["padding_mask"].shape[0], 2)
 
     def test_call_with_python_only_tokenizer(self):
-        # Regression test for mixed rectangular/non-rectangular segments from
-        # the Python-only tokenizer workflow.
         proto_path = os.path.join(
             self.get_test_data_dir(), "gemma4_test_vocab.spm"
         )
         tokenizer = Gemma4Tokenizer(proto=proto_path)
+        # image_converter must be set: the text-only branch of `call()`
+        # returns before `token_ids` is used to compute `batch_size`.
+        image_converter = Gemma4ImageConverter(image_size=(4, 4), patch_size=4)
         preprocessor = Gemma4CausalLMPreprocessor(
             tokenizer=tokenizer,
-            image_converter=None,
+            image_converter=image_converter,
             sequence_length=20,
-            max_images_per_prompt=0,
-            num_vision_tokens_per_image=0,
+            max_images_per_prompt=2,
+            num_vision_tokens_per_image=5,
         )
+        # Prompts tokenize to different lengths -> non-rectangular list.
         input_data = {
             "prompts": ["the quick brown fox", "the quick"],
             "responses": ["round", "round"],


### PR DESCRIPTION
Fix Gemma3/3n/4 preprocessor crashes with Python-only tokenizer

Fixes crashes in `Gemma3CausalLMPreprocessor`, `Gemma3nCausalLMPreprocessor`,
and `Gemma4CausalLMPreprocessor` when the Python-only tokenizer workflow
returns `list[list[int]]` with varying sequence lengths.

### Background
PR #2769 is adding `_call_python` paths that bypass `convert_to_ragged_batch`
for the Python-only workflow, so the `tensor_utils.py` ragged-batch fallback is
not needed here. The preprocessor-only fixes below remain valuable regardless
of #2769.

### Problem
`Gemma3CausalLMPreprocessor`, `Gemma3nCausalLMPreprocessor`, and
`Gemma4CausalLMPreprocessor` used `tf.shape(prompts)[0]` after tokenization.
When `prompts` is a non-rectangular Python list, `tf.shape()` fails.

### Fix
In `gemma{3,3n,4}_causal_lm_preprocessor.py`, use `tf.shape(token_ids)[0]`
instead of `tf.shape(prompts)[0]` after tokenization.

### Tests
Added regression tests in:
- `keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor_test.py`
- `keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor_test.py`
- `keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor_test.py`

These tests exercise `generate_preprocess()` and `__call__()` with the real
Python tokenizer and prompts that tokenize to different lengths.
