### PR TITLE
Fix LoRA save/load to use stable layer paths (#2701)

### DIFF
--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -238,16 +238,20 @@ class Backbone(keras.Model):
         store = keras.src.saving.saving_lib.H5IOStore(filepath, mode="w")
         lora_store = store.make("lora")
         lora_store["rank"] = self._lora_rank
-        # We cannot identify layers by name since names are non-unique,
-        # so we identify them by index in the topologically sorted list
-        # of layers that have weights.
+        # We identify each layer by its `path` rather than by its position in
+        # the flattened layer list. Layer names are non-unique, and integer
+        # positions are not stable: the topologically sorted list of layers
+        # that have weights can be ordered differently when a model is rebuilt,
+        # which previously caused LoRA weights to be restored into the wrong
+        # layers (see #2701). A layer's `path` is both unique and stable across
+        # reconstructions of the same architecture.
         all_layers = self._flatten_layers(include_self=False)
         all_layers = [lyr for lyr in all_layers if lyr.weights]
         for layer_index in self._lora_enabled_layers:
             # We only lora the einsumdense layers,
             # so the factored weights are always named `kernel`
             layer = all_layers[layer_index]
-            inner_store = store.make(f"lora/{layer_index}")
+            inner_store = store.make(f"lora/{layer.path}")
             inner_store["lora_kernel_a"] = layer.lora_kernel_a
             inner_store["lora_kernel_b"] = layer.lora_kernel_b
         store.close()
@@ -271,10 +275,15 @@ class Backbone(keras.Model):
         all_layers = [lyr for lyr in all_layers if lyr.weights]
         for layer_index in self._lora_enabled_layers:
             layer = all_layers[layer_index]
-            lora_kernel_a = store.get(f"lora/{layer_index}")["lora_kernel_a"]
-            lora_kernel_b = store.get(f"lora/{layer_index}")["lora_kernel_b"]
-            layer.lora_kernel_a.assign(lora_kernel_a)
-            layer.lora_kernel_b.assign(lora_kernel_b)
+            # Prefer the stable, path-based key. Fall back to the legacy
+            # integer-index key so `.lora.h5` files saved by older versions
+            # still load.
+            if f"lora/{layer.path}" in store.h5_file:
+                inner_store = store.get(f"lora/{layer.path}")
+            else:
+                inner_store = store.get(f"lora/{layer_index}")
+            layer.lora_kernel_a.assign(inner_store["lora_kernel_a"])
+            layer.lora_kernel_b.assign(inner_store["lora_kernel_b"])
         store.close()
 
     def export_to_transformers(self, path):

--- a/keras_hub/src/models/backbone_test.py
+++ b/keras_hub/src/models/backbone_test.py
@@ -1,5 +1,7 @@
 import os
 
+import h5py
+import keras
 import numpy as np
 import pytest
 
@@ -28,6 +30,97 @@ class TestBackbone(TestCase):
         self.assertNotIn("gpt2_base_en", bert_presets)
         self.assertIn("bert_tiny_en_uncased", all_presets)
         self.assertIn("gpt2_base_en", all_presets)
+
+    def test_lora_save_and_reload(self):
+        # Regression test for #2701: saving LoRA weights and reloading them
+        # into a freshly constructed model must reproduce the same outputs.
+        init_kwargs = {
+            "vocabulary_size": 10,
+            "num_layers": 2,
+            "num_heads": 2,
+            "hidden_dim": 2,
+            "intermediate_dim": 4,
+            "max_sequence_length": 5,
+        }
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "segment_ids": np.zeros((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+        backbone = BertBackbone(**init_kwargs)
+        # Snapshot the base weights so the reloaded model starts from an
+        # identical state; only the LoRA adapters travel through `.lora.h5`.
+        base_path = os.path.join(self.get_temp_dir(), "base.weights.h5")
+        backbone.save_weights(base_path)
+
+        backbone.enable_lora(4)
+        # Simulate fine-tuning: give the (initially zero) `lora_kernel_b`
+        # adapters non-zero values so the LoRA branch changes the output.
+        rng = np.random.RandomState(42)
+        for layer in backbone._flatten_layers():
+            if getattr(layer, "lora_kernel_a", None) is not None:
+                layer.lora_kernel_a.assign(
+                    rng.normal(size=layer.lora_kernel_a.shape).astype("float32")
+                )
+                layer.lora_kernel_b.assign(
+                    rng.normal(size=layer.lora_kernel_b.shape).astype("float32")
+                )
+        lora_path = os.path.join(self.get_temp_dir(), "model.lora.h5")
+        backbone.save_lora_weights(lora_path)
+        ref_out = backbone(input_data)
+
+        # Reload into a freshly constructed backbone. It is auto-named
+        # differently, which exercises the stable path-based identification.
+        reloaded = BertBackbone(**init_kwargs)
+        reloaded.load_weights(base_path)
+        reloaded.enable_lora(4)
+        reloaded.load_lora_weights(lora_path)
+        new_out = reloaded(input_data)
+
+        self.assertAllClose(ref_out, new_out, rtol=1e-5, atol=1e-5)
+
+    def test_lora_weights_use_stable_path_keys(self):
+        init_kwargs = {
+            "vocabulary_size": 10,
+            "num_layers": 2,
+            "num_heads": 2,
+            "hidden_dim": 2,
+            "intermediate_dim": 4,
+            "max_sequence_length": 5,
+        }
+        backbone = BertBackbone(**init_kwargs)
+        backbone.enable_lora(4)
+        lora_path = os.path.join(self.get_temp_dir(), "model.lora.h5")
+        backbone.save_lora_weights(lora_path)
+
+        # LoRA weights are keyed by the (stable, unique) layer path rather
+        # than by an unstable integer index.
+        with h5py.File(lora_path, "r") as f:
+            top_level = set(f["lora"].keys())
+        self.assertIn("transformer_layer_0", top_level)
+        self.assertNotIn("0", top_level)
+
+        # Backward compatibility: a file written with the legacy integer-index
+        # keys must still load without error.
+        legacy_path = os.path.join(self.get_temp_dir(), "legacy.lora.h5")
+        store = keras.src.saving.saving_lib.H5IOStore(legacy_path, mode="w")
+        lora_store = store.make("lora")
+        lora_store["rank"] = backbone._lora_rank
+        all_layers = [
+            lyr
+            for lyr in backbone._flatten_layers(include_self=False)
+            if lyr.weights
+        ]
+        for layer_index in backbone._lora_enabled_layers:
+            layer = all_layers[layer_index]
+            inner_store = store.make(f"lora/{layer_index}")
+            inner_store["lora_kernel_a"] = layer.lora_kernel_a
+            inner_store["lora_kernel_b"] = layer.lora_kernel_b
+        store.close()
+
+        reloaded = BertBackbone(**init_kwargs)
+        reloaded.enable_lora(4)
+        reloaded.load_lora_weights(legacy_path)  # must not raise
 
     @pytest.mark.large
     def test_from_preset(self):


### PR DESCRIPTION
## Summary

Fixes #2701. `Backbone.save_lora_weights` / `load_lora_weights` could restore LoRA adapters into the wrong layers when reloading into a freshly constructed model, which changed the model's outputs. The problem is reproducible on `bert_base_en` and is not model-specific.

## Root cause

The save/load logic identified each LoRA-enabled layer by its integer position in the weight-filtered flattened layer list (`[l for l in self._flatten_layers() if l.weights]`). Layer names are non-unique, so indices were used as a workaround, but that position is not stable across model reconstructions: the ordering of layers-with-weights can differ between the model that saved the adapters and a freshly built model that loads them. When the ordering shifts, `lora_kernel_a` / `lora_kernel_b` are assigned to the wrong layers, and the reloaded model no longer matches the original (the `rtol=1e-5, atol=1e-5` comparison fails).

## Fix

Identify each layer by its `layer.path`, which is unique and stable across reconstructions of the same architecture:

- `save_lora_weights` stores each adapter under `lora/{layer.path}`.
- `load_lora_weights` looks each adapter up by `layer.path`, and falls back to the legacy integer-index key so `.lora.h5` files written by earlier versions continue to load.

## Tests

Added to `keras_hub/src/models/backbone_test.py`:

- `test_lora_save_and_reload`: enables LoRA on a BERT backbone, assigns non-zero adapters, saves the LoRA weights, reloads them into a separately constructed backbone (different auto-generated name), and asserts the outputs match at `rtol=1e-5, atol=1e-5`, the exact scenario from the issue.
- `test_lora_weights_use_stable_path_keys`: asserts the saved file is keyed by layer path rather than integer index, and that a legacy index-keyed file still loads.

All existing Gemma/Gemma3/Gemma4 LoRA fine-tuning and save/reload tests continue to pass.