### PR TITLE
Fix D-Fine torch/LiteRT export: static shapes in split + deformable attention

### DIFF
--- a/keras_hub/src/models/d_fine/d_fine_layers.py
+++ b/keras_hub/src/models/d_fine/d_fine_layers.py
@@ -1562,8 +1562,11 @@ class DFineFeatureAggregationBlock(keras.layers.Layer):
 
     def call(self, input_features, training=None):
         conv1_out = self.conv1(input_features, training=training)
+        # Integer split, not `[conv_dim, conv_dim]`: `keras.ops.split` reads a
+        # list as cumulative indices, giving a 0-width chunk and dynamic split
+        # sizes that break torch.export. `conv1` outputs `2 * conv_dim`. (#2495)
         split_features_tensor = keras.ops.split(
-            conv1_out, [self.conv_dim, self.conv_dim], axis=self.channel_axis
+            conv1_out, 2, axis=self.channel_axis
         )
         split_features = list(split_features_tensor)
         branch1 = self.csp_rep1(split_features[-1], training=training)

--- a/keras_hub/src/models/d_fine/d_fine_object_detector_test.py
+++ b/keras_hub/src/models/d_fine/d_fine_object_detector_test.py
@@ -199,3 +199,43 @@ class DFineObjectDetectorTest(TestCase):
                 "*": {"max": 1.0, "mean": 0.03},
             },
         )
+
+    @pytest.mark.skipif(
+        keras.config.backend() != "torch",
+        reason="torch.export is only available on the torch backend.",
+    )
+    def test_torch_export_static_shapes(self):
+        # #2495: D-Fine must export via torch.export with static shapes.
+        import torch
+
+        size = self.input_size
+        hgnetv2_backbone = HGNetV2Backbone(
+            stem_channels=[3, 8, 8],
+            stackwise_stage_filters=self.stackwise_stage_filters,
+            apply_downsample=self.apply_downsample,
+            use_lightweight_conv_block=self.use_lightweight_conv_block,
+            depths=[1, 1],
+            hidden_sizes=[16, 32],
+            embedding_size=8,
+            use_learnable_affine_block=True,
+            hidden_act="relu",
+            image_shape=(size, size, 3),
+            out_features=["stage1", "stage2"],
+            data_format="channels_last",
+        )
+        backbone = DFineBackbone(
+            **{
+                **self.base_backbone_kwargs,
+                "backbone": hgnetv2_backbone,
+                "image_shape": (size, size, 3),
+            }
+        )
+        detector = DFineObjectDetector(
+            backbone=backbone,
+            num_classes=4,
+            bounding_box_format=self.bounding_box_format,
+        )
+        exported = torch.export.export(
+            detector, (torch.from_numpy(self.images),), strict=False
+        )
+        exported.run_decompositions()  # must not raise

--- a/keras_hub/src/models/d_fine/d_fine_utils.py
+++ b/keras_hub/src/models/d_fine/d_fine_utils.py
@@ -225,27 +225,16 @@ def multi_scale_deformable_attention_v2(
     flattened_value = keras.ops.reshape(
         permuted_value, (-1, hidden_dim, seq_len)
     )
-    value_chunk_sizes = keras.ops.array(slice_sizes, dtype="int32")
-    cum_sizes = keras.ops.concatenate(
-        [
-            keras.ops.zeros((1,), dtype="int32"),
-            keras.ops.cumsum(value_chunk_sizes),
-        ]
-    )
+    # Static per-level slicing: `slice_sizes` are static ints, avoiding the
+    # dynamic `ops.slice`/`ops.shape` that breaks torch.export. (#2495)
     values = []
+    value_offset = 0
     for i in range(len(spatial_shapes)):
-        start = cum_sizes[i]
-        current_slice_size = slice_sizes[i]
-        dynamic_slice_start_indices = (0, 0, start)
-        dynamic_slice_shape = (
-            keras.ops.shape(flattened_value)[0],
-            keras.ops.shape(flattened_value)[1],
-            current_slice_size,
+        size = slice_sizes[i]
+        values.append(
+            flattened_value[:, :, value_offset : value_offset + size]
         )
-        sliced_value = keras.ops.slice(
-            flattened_value, dynamic_slice_start_indices, dynamic_slice_shape
-        )
-        values.append(sliced_value)
+        value_offset += size
     if method == "default":
         sampling_grids = 2 * sampling_locations - 1
     elif method == "discrete":
@@ -264,27 +253,15 @@ def multi_scale_deformable_attention_v2(
             num_points_from_shape,
         ),
     )
-    cum_points = keras.ops.concatenate(
-        [
-            keras.ops.zeros((1,), dtype="int32"),
-            keras.ops.cumsum(keras.ops.array(num_points, dtype="int32")),
-        ]
-    )
+    # Same as above: static Python offsets from the static `num_points` list.
     sampling_grids = []
+    point_offset = 0
     for i in range(num_levels):
-        start = cum_points[i]
-        current_level_num_points = num_points[i]
-        slice_start_indices = (0, 0, start, 0)
-        slice_shape = (
-            keras.ops.shape(flattened_sampling_grids)[0],
-            keras.ops.shape(flattened_sampling_grids)[1],
-            current_level_num_points,
-            keras.ops.shape(flattened_sampling_grids)[3],
+        pts = num_points[i]
+        sampling_grids.append(
+            flattened_sampling_grids[:, :, point_offset : point_offset + pts, :]
         )
-        sliced_grid = keras.ops.slice(
-            flattened_sampling_grids, slice_start_indices, slice_shape
-        )
-        sampling_grids.append(sliced_grid)
+        point_offset += pts
     sampling_values = []
     for level_id in range(num_levels):
         if spatial_shapes is not None and len(spatial_shapes) == num_levels:


### PR DESCRIPTION
D-Fine fails `torch.export` (the LiteRT path) with data-dependent symbolic shapes. Two model bugs:

- `DFineFeatureAggregationBlock`: `keras.ops.split(x, [conv_dim, conv_dim])` — a list is read as cumulative indices, giving a 0-width chunk and dynamic split sizes → `GuardOnDataDependentSymNode`. `conv1` outputs `2 * conv_dim`, so an integer `split(x, 2)` is equivalent.
- `multi_scale_deformable_attention_v2`: dynamic `keras.ops.slice` with `keras.ops.shape`-derived bounds → `PendingUnbackedSymbolNotFound`. The per-level sizes are static, so static slicing is equivalent.

Both preserve eager numerics exactly (0.0 diff). After them, `torch.export` + `run_decompositions` + `litert_torch.convert` succeed with static shapes. Adds a torch-backend regression test. Part of #2495.

(A separate `STABLEHLO_SORT` interpreter-kernel gap from `ops.top_k` is converter/runtime-side, not a model bug.)