### PR TITLE
Fix RetinaNet LiteRT export test: assert on real output keys

### DIFF
--- a/keras_hub/src/models/retinanet/retinanet_object_detector_test.py
+++ b/keras_hub/src/models/retinanet/retinanet_object_detector_test.py
@@ -117,9 +117,12 @@ class RetinaNetObjectDetectorTest(TestCase):
             init_kwargs=self.init_kwargs,
             input_data=input_data,
             comparison_mode="statistical",
+            # The model outputs `bbox_regression`/`cls_logits`; the previous
+            # `enc_topk_logits`/`logits` keys were copy-pasted from D-FINE and
+            # never matched. Conversion is accurate, so assert tightly. (#2495)
             output_thresholds={
-                "enc_topk_logits": {"max": 5.0, "mean": 0.05},
-                "logits": {"max": 2.0, "mean": 0.05},
-                "*": {"max": 1.5, "mean": 0.05},
+                "bbox_regression": {"max": 0.05, "mean": 0.005},
+                "cls_logits": {"max": 0.05, "mean": 0.005},
+                "*": {"max": 0.05, "mean": 0.005},
             },
         )


### PR DESCRIPTION
RetinaNet has no conversion bug — under litert-torch it converts with ~5e-3 max diff vs Keras inference, and it has no BatchNorm-training leak.

The "~500%" in #2495 is a test artifact: `test_litert_export` keyed `output_thresholds` on `enc_topk_logits`/`logits` (copy-pasted from D-FINE). RetinaNet emits `bbox_regression`/`cls_logits`, so those never matched and only a loose wildcard applied.

Test-only fix: assert on the real keys with tight thresholds. Part of #2495.