### PR TITLE
[Gemma3] Reduce concatenate and copy in KV cache update to improve perf

### DIFF
--- a/keras_hub/src/models/gemma3/gemma3_attention.py
+++ b/keras_hub/src/models/gemma3/gemma3_attention.py
@@ -331,8 +331,7 @@ class CachedGemma3Attention(keras.layers.Layer):
         query = self._apply_rope(query, cache_update_index)
 
         if cache is not None:
-            key_cache = cache[:, 0, ...]
-            value_cache = cache[:, 1, ...]
+            key_cache, value_cache = cache
             key_update = self.key_dense(x)
 
             if self.use_query_key_norm:
@@ -379,7 +378,7 @@ class CachedGemma3Attention(keras.layers.Layer):
 
             key = ops.slice_update(key_cache, start, key_update)
             value = ops.slice_update(value_cache, start, value_update)
-            cache = ops.stack((key, value), axis=1)
+            cache = (key, value)
         else:
             key = self.key_dense(x)
 

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm.py
@@ -145,7 +145,10 @@ class Gemma3CausalLM(CausalLM):
 
         Args:
             token_ids: a dense int Tensor with shape `(batch_size, max_length)`.
-            cache: a dense float Tensor, the cache of key and value.
+            cache: a tuple of per-layer caches, one entry per transformer
+                layer. Each entry is a `(key, value)` tuple, where `key` and
+                `value` are dense float Tensors with shape
+                `(batch_size, max_length, num_key_value_heads, head_dim)`.
             cache_update_index: int, or int Tensor. The index of current inputs
                 in the whole sequence.
             img_embeddings: a dense float Tensor with shape
@@ -157,7 +160,8 @@ class Gemma3CausalLM(CausalLM):
             A (logits, hidden_states, cache) tuple. Where `logits` is the
             language model logits for the input token_ids, `hidden_states` is
             the final hidden representation of the input tokens, and `cache` is
-            the decoding cache.
+            the updated decoding cache, in the same tuple-of-tuples format as
+            the `cache` argument.
         """
 
         text_embeddings = self.backbone.token_embedding(token_ids)

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm.py
@@ -178,9 +178,10 @@ class Gemma3CausalLM(CausalLM):
             x = text_embeddings
 
         # Each decoder layer has a cache; we update them separately.
+        # Cache is a tuple of per-layer (key, value) pairs — no stacking.
         caches = []
         for i, transformer_layer in enumerate(self.backbone.transformer_layers):
-            current_cache = cache[:, i, ...]
+            current_cache = cache[i]
             x, next_cache = transformer_layer(
                 x,
                 cache=current_cache,
@@ -190,7 +191,7 @@ class Gemma3CausalLM(CausalLM):
                 cache_update_mask=cache_update_mask,
             )
             caches.append(next_cache)
-        cache = ops.stack(caches, axis=1)
+        cache = tuple(caches)
         hidden_states = x = self.backbone.layer_norm(x)
         logits = self.backbone.token_embedding(x, reverse=True)
         return logits, hidden_states, cache
@@ -212,8 +213,15 @@ class Gemma3CausalLM(CausalLM):
         num_layers = self.backbone.num_layers
         num_heads = self.backbone.num_key_value_heads
         head_dim = self.backbone.head_dim
-        shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        cache = ops.zeros(shape, dtype=self.compute_dtype)
+        # Allocate per-layer (key, value) caches as a tuple.
+        layer_shape = [batch_size, max_length, num_heads, head_dim]
+        cache = tuple(
+            (
+                ops.zeros(layer_shape, dtype=self.compute_dtype),
+                ops.zeros(layer_shape, dtype=self.compute_dtype),
+            )
+            for _ in range(num_layers)
+        )
         # Seed the cache.
         logits, hidden_states, cache = self.call_with_cache(
             token_ids=token_ids,

--- a/keras_hub/src/models/gemma3/gemma3_decoder_block.py
+++ b/keras_hub/src/models/gemma3/gemma3_decoder_block.py
@@ -210,7 +210,7 @@ class Gemma3DecoderBlock(keras.layers.Layer):
         batch_size = ops.shape(x)[0]
         input_length = output_length = ops.shape(x)[1]
         if cache is not None:
-            input_length = ops.shape(cache)[2]
+            input_length = ops.shape(cache[0])[1]
 
         if self.use_bidirectional_attention:
             # `output_length` and `input_length` will be the same in this case


### PR DESCRIPTION
## Description of the change
-----------------------------------------------------
This PR fixes issue https://github.com/keras-team/keras-hub/issues/2780
When running Gemma3 on CPU, we observe significant % of time is spent on concatenate when doing KV cache update. This PR helps reduce time for KV Cache update and thus improve tokens/sec performance.

## More details for the code change
The original code -- what it does and why it's slow

The cache is one big 6D tensor: [B, num_layers, 2, max_length, num_heads, head_dim]

    cache shape: [1, 34, 2, 2048, 4, 256] in BF16 = ~136 MB
                  B  layers K/V  seq  heads dim
During each token generation step, the flow is:

    # 1. Slice out per-layer cache (cheap -- just a view)
    current_cache = cache[:, i, ...]  # shape: [B, 2, S, H, D]

    # 2. Inside attention: unstack K and V (cheap -- views)
    key_cache = cache[:, 0, ...]    # [B, S, H, D]
    value_cache = cache[:, 1, ...]  # [B, S, H, D]

    # 3. Update single token position (DUS on 4MB tensor -- acceptable)
    key = ops.slice_update(key_cache, start, key_update)
    value = ops.slice_update(value_cache, start, value_update)

    # 4. BOTTLENECK: stack K+V back together (copies ~4 MB per layer)
    cache = ops.stack((key, value), axis=1)  # new [B, 2, S, H, D] tensor
    #   This happens 34 times (once per layer) = 34 x 4 MB = ~136 MB

    # 5. BIGGEST BOTTLENECK: stack all 34 layers together
    cache = ops.stack(caches, axis=1)  # new [B, 34, 2, S, H, D] tensor
    #   This copies all 34 layer caches into one new 136 MB tensor
Steps 4 and 5 together account for the ~18% concatenate + ~10% copy_bitcast seen in the profile.


This solution -- what changes
----------------------------
The key idea: if the cache is never a single tensor, it never needs to be assembled into one.

Instead of one [B, 34, 2, S, H, D] tensor, the cache becomes:

    cache = (
        (key_layer0, value_layer0),   # each is [B, S, H, D] = ~2 MB
        (key_layer1, value_layer1),
        ...
        (key_layer33, value_layer33),
    )
    # A Python tuple of 34 tuples -- 68 separate tensors, each ~2 MB

The generation flow becomes:

    # 1. Get per-layer cache (Python tuple indexing -- zero cost)
    current_cache = cache[i]  # returns (key_cache, value_cache) tuple

    # 2. Inside attention: unpack tuple (zero cost)
    key_cache, value_cache = cache  # just Python variable binding

    # 3. Update single token position (DUS on 2MB tensor -- same as before)
    key = ops.slice_update(key_cache, start, key_update)     # [B, S, H, D]
    value = ops.slice_update(value_cache, start, value_update) # [B, S, H, D]

    # 4. Return as tuple (ZERO COST -- no data copy)
    cache = (key, value)   # Python tuple, no ops.stack

    # 5. Collect all layers (ZERO COST -- no data copy)
    cache = tuple(caches)  # Python tuple, no ops.stack
Steps 4 and 5 are now free. Creating a Python tuple doesn't copy any tensor data -- it just creates a container holding references to the existing tensors.


Why does this work with JAX's while_loop?
-------------------------------------------
JAX's while_loop (which the sampler uses) requires that loop-carried variables have the same "pytree structure" across iterations. A pytree is JAX's term for nested containers of tensors -- tuples, lists, dicts are all valid.

Our tuple of tuples:

    ((tensor, tensor), (tensor, tensor), ..., (tensor, tensor))

is a valid pytree. Each individual tensor [B, S, H, D] maintains the same shape across iterations (only the content at position cache_update_index changes). So JAX is happy.

Summary of data movement per token
------------------------------------

    Operation                          Original        V3
    -------------------------------------------------------
    Per-layer slice_update on key      2 MB            2 MB (same)
    Per-layer slice_update on value    2 MB            2 MB (same)
    Per-layer K/V reassembly           4 MB (stack)    0 (tuple)
    Cross-layer reassembly             136 MB (stack)  0 (tuple)
    -------------------------------------------------------
    Total per token                    ~272 MB         ~136 MB

The slice_update copies remain (unavoidable -- attention needs the full K/V with the new token inserted), but the stacking copies are completely eliminated.


## Colab Notebook
There is no change in API or model, the change is in implementation.

## Checklist

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [Y] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [Y] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [Y] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [Y] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
