### PR TITLE
Security: Tar archive extraction vulnerable to symlink-based path traversal

### DIFF
--- a/tools/checkpoint_conversion/checkpoint_conversion_utils.py
+++ b/tools/checkpoint_conversion/checkpoint_conversion_utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import sys
 import tarfile
 import zipfile
 
@@ -29,6 +30,13 @@ def extract_files_from_archive(archive_file_path):
                     raise Exception(
                         f"Attempted Path Traversal in Tar File: {member.name}"
                     )
+                if member.islnk() or member.issym():
+                    if not _is_within_directory(".", member.linkname):
+                        raise Exception(
+                            f"Attempted Path Traversal via Symlink in Tar File: {member.name}"
+                        )
+            if sys.version_info >= (3, 12):
+                return tar.extractall(filter="data")
             return tar.extractall()
     elif archive_file_path.endswith(".zip"):
         with zipfile.ZipFile(archive_file_path, "r") as zip_ref:


### PR DESCRIPTION
## 🔒 Security Fix

### Problem
The `extract_files_from_archive` function validates member names with `_is_within_directory` to prevent path traversal, but does NOT protect against symlink-based attacks. A malicious tar.gz archive can contain: (1) a symlink member named "evil_link" pointing to "/etc" (passes the name check since it's within "."), then (2) a regular file member named "evil_link/shadow" (also passes the name check). During extraction, Python's `tarfile.extractall()` follows symlinks, so the second member writes to "/etc/shadow" instead of "./evil_link/shadow". This is a well-documented attack pattern (CVE-2007-4559 family). Since this library downloads and extracts model checkpoints from the internet (GCS, HuggingFace, Kaggle), a poisoned checkpoint archive could achieve arbitrary file write on the user's machine.


**Severity**: `high`
**File**: `tools/checkpoint_conversion/checkpoint_conversion_utils.py`

### Solution
Add symlink/link target validation and use the `filter` parameter on
Python 3.12+, or block symlinks entirely:


### Changes
- `tools/checkpoint_conversion/checkpoint_conversion_utils.py` (modified)

## Description of the change



## Reference


## Colab Notebook


## Checklist


- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2783