### PR TITLE
[WIP] Serve KerasHub CausalLM models through vLLM on TPU

### DIFF
--- a/keras_hub/src/layers/modeling/cached_multi_head_attention.py
+++ b/keras_hub/src/layers/modeling/cached_multi_head_attention.py
@@ -79,6 +79,28 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
 
         query = self._query_dense(query)
 
+        # Dispatch to vLLM's native Pallas paged-attention when serving on TPU.
+        from keras_hub.src.vllm.context import get_vllm_context
+
+        vllm_ctx = get_vllm_context()
+        if vllm_ctx is not None and vllm_ctx.paged_attention_func is not None:
+            from keras_hub.src.vllm.attention import maybe_vllm_paged_attention
+
+            # `cache` carries vLLM's paged KV cache for this layer (set by the
+            # adapter from the vLLM model-wrapper context). Softmax scale defaults
+            # to 1/sqrt(head_dim), matching Keras MHA.
+            attention_output, new_kv_cache = maybe_vllm_paged_attention(
+                query,
+                self._key_dense(key),
+                self._value_dense(value),
+                cache,
+                float(self.key_dim) ** -0.5,
+            )
+            attention_output = self._output_dense(attention_output)
+            if cache is not None or new_kv_cache is not None:
+                return attention_output, new_kv_cache
+            return attention_output
+
         # If cache is not `None`, we will use the cache to compute the final key
         # and value tensors. If `cache_update_index` is not None, we will first
         # update the cache before use. To do this, we first call the

--- a/keras_hub/src/models/gemma/gemma_attention.py
+++ b/keras_hub/src/models/gemma/gemma_attention.py
@@ -97,9 +97,16 @@ class CachedGemmaAttention(keras.layers.Layer):
 
         self.built = True
 
-    def _apply_rope(self, x, start_index):
-        """Rope rotate q or k."""
-        x = self.rope_layer(x, start_index=start_index)
+    def _apply_rope(self, x, start_index, positions=None):
+        """Rope rotate q or k.
+
+        If ``positions`` is given (vLLM serving), rotate at those absolute
+        positions instead of a contiguous range from ``start_index``.
+        """
+        if positions is not None:
+            x = self.rope_layer(x, positions=positions)
+        else:
+            x = self.rope_layer(x, start_index=start_index)
         # Gemma uses a different layout for positional embeddings.
         # The transformation below ensures the embeddings are numerically
         # equivalent to the original gemma implementation.
@@ -236,6 +243,54 @@ class CachedGemmaAttention(keras.layers.Layer):
     ):
         query = self.query_dense(x)
         query = self._apply_rope(query, cache_update_index)
+
+        # Dispatch to vLLM's native Pallas paged-attention when serving on TPU.
+        from keras_hub.src.vllm.context import get_vllm_context
+
+        vllm_ctx = get_vllm_context()
+        if vllm_ctx is not None and vllm_ctx.paged_attention_func is not None:
+            from keras_hub.src.vllm.attention import maybe_vllm_paged_attention
+
+            # Apply RoPE at vLLM's per-token absolute positions (not a scalar
+            # start_index) for correct paged / continuous-batched decode.
+            positions = getattr(vllm_ctx, "positions", None)
+            if positions is not None:
+                positions = ops.reshape(positions, (-1, 1))
+                query = self._apply_rope(
+                    self.query_dense(x), cache_update_index, positions=positions
+                )
+                key = self._apply_rope(
+                    self.key_dense(x), cache_update_index, positions=positions
+                )
+            else:
+                key = self._apply_rope(self.key_dense(x), cache_update_index)
+            value = self.value_dense(x)
+
+            # Match Gemma's own query normalization (the kernel applies `scale`,
+            # so we pass it raw rather than pre-scaling the query).
+            if self.query_head_dim_normalize:
+                scale = 1.0 / np.sqrt(self.head_dim)
+            else:
+                scale = 1.0 / np.sqrt(self.hidden_dim // self.num_query_heads)
+            sliding_window = (
+                self.sliding_window_size
+                if self.use_sliding_window_attention
+                else None
+            )
+
+            attention_vec, new_kv_cache = maybe_vllm_paged_attention(
+                query,
+                key,
+                value,
+                cache,
+                scale,
+                sliding_window=sliding_window,
+                soft_cap=getattr(self, "logit_soft_cap", None),
+            )
+            attention_output = self.output_dense(attention_vec)
+            if cache is not None or new_kv_cache is not None:
+                return attention_output, new_kv_cache
+            return attention_output
 
         if cache is not None:
             key_cache = cache[:, 0, ...]

--- a/keras_hub/src/models/llama/llama_attention.py
+++ b/keras_hub/src/models/llama/llama_attention.py
@@ -150,6 +150,39 @@ class LlamaAttention(keras.layers.Layer):
             key = self.rotary_embedding_layer(key, start_index=start_index)
             return key, value
 
+        # Dispatch to vLLM's native Pallas paged-attention when serving on TPU.
+        # Pass key/value before GQA expansion; the kernel handles grouped-query
+        # attention via the inferred num_kv_heads.
+        from keras_hub.src.vllm.context import get_vllm_context
+
+        vllm_ctx = get_vllm_context()
+        if vllm_ctx is not None and vllm_ctx.paged_attention_func is not None:
+            from keras_hub.src.vllm.attention import maybe_vllm_paged_attention
+
+            # Apply RoPE with vLLM's per-token absolute positions rather than a
+            # scalar start_index, so paged / continuous-batched decode rotates
+            # each token at its true position. Falls back to the start_index
+            # rope (computed above) if positions aren't available.
+            positions = getattr(vllm_ctx, "positions", None)
+            if positions is not None:
+                positions = ops.reshape(positions, (-1, 1))
+                query = self.rotary_embedding_layer(
+                    self._query_dense(hidden_states), positions=positions
+                )
+                key = self.rotary_embedding_layer(
+                    self._key_dense(hidden_states), positions=positions
+                )
+                value = self._value_dense(hidden_states)
+            else:
+                key, value = _compute_key_value(hidden_states)
+            attention_output, new_kv_cache = maybe_vllm_paged_attention(
+                query, key, value, cache, self._inv_norm_factor
+            )
+            attention_output = self._output_dense(attention_output)
+            if cache is not None or new_kv_cache is not None:
+                return attention_output, new_kv_cache
+            return attention_output
+
         if cache is not None:
             key_cache = cache[:, 0, ...]
             value_cache = cache[:, 1, ...]

--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -148,6 +148,39 @@ class CachedMistralAttention(keras.layers.Layer):
             key = self.rotary_embedding_layer(key, start_index=start_index)
             return key, value
 
+        # Dispatch to vLLM's native Pallas paged-attention when serving on TPU.
+        # Pass key/value before GQA expansion; the kernel handles grouped-query
+        # attention via the inferred num_kv_heads.
+        from keras_hub.src.vllm.context import get_vllm_context
+
+        vllm_ctx = get_vllm_context()
+        if vllm_ctx is not None and vllm_ctx.paged_attention_func is not None:
+            from keras_hub.src.vllm.attention import maybe_vllm_paged_attention
+
+            # Apply RoPE with vLLM's per-token absolute positions rather than a
+            # scalar start_index, so paged / continuous-batched decode rotates
+            # each token at its true position. Falls back to the start_index
+            # rope (computed above) if positions aren't available.
+            positions = getattr(vllm_ctx, "positions", None)
+            if positions is not None:
+                positions = ops.reshape(positions, (-1, 1))
+                query = self.rotary_embedding_layer(
+                    self._query_dense(hidden_states), positions=positions
+                )
+                key = self.rotary_embedding_layer(
+                    self._key_dense(hidden_states), positions=positions
+                )
+                value = self._value_dense(hidden_states)
+            else:
+                key, value = _compute_key_value(hidden_states)
+            attention_output, new_kv_cache = maybe_vllm_paged_attention(
+                query, key, value, cache, self._inv_norm_factor
+            )
+            attention_output = self._output_dense(attention_output)
+            if cache is not None or new_kv_cache is not None:
+                return attention_output, new_kv_cache
+            return attention_output
+
         if cache is not None:
             key_cache = cache[:, 0, ...]
             value_cache = cache[:, 1, ...]

--- a/keras_hub/src/vllm/__init__.py
+++ b/keras_hub/src/vllm/__init__.py
@@ -1,0 +1,20 @@
+"""
+Integration module for vLLM and Keras Hub.
+
+This module exposes the necessary adapters and hooks to allow vLLM to use Keras Hub
+models natively as the backend for LLM generation.
+"""
+
+from .adapter import KerasVLLMAdapter
+from .registry import KerasHubLLM
+from .registry import register_keras_hub_models
+from .registry import setup_vllm_model
+from .tokenizer import KerasVLLMTokenizerAdapter
+
+__all__ = [
+    "KerasHubLLM",
+    "KerasVLLMAdapter",
+    "KerasVLLMTokenizerAdapter",
+    "register_keras_hub_models",
+    "setup_vllm_model",
+]

--- a/keras_hub/src/vllm/adapter.py
+++ b/keras_hub/src/vllm/adapter.py
@@ -252,20 +252,17 @@ class KerasVLLMAdapter(torch.nn.Module):
     def _get_state_mapping(self) -> List[Tuple[Any, Any]]:
         """Builds the Keras StatelessScope state mapping from the patched buffers.
 
-        The weight buffers are immutable after load, so the (variable -> JAX
-        array) mapping is built once and cached. Without this, every decode step
-        re-ran a DLPack conversion over all of the model's weight buffers
-        (hundreds of tensors for a 2B model) on the host before any TPU compute
-        could start — a dominant per-token overhead.
+        Rebuilt on every call. Under vLLM's jitted step function the weight
+        buffers are JAX tracers, so caching the (variable -> JAX array) list on
+        the instance and reusing it across the prefill -> decode trace boundary
+        leaks a tracer (UnexpectedTracerError on the embedding). `forward()` runs
+        *inside* the jitted step function, so this conversion happens at trace
+        time only — rebuilding it has no per-token runtime cost.
         """
-        cached = getattr(self, "_state_mapping_cache", None)
-        if cached is None:
-            cached = [
-                (v, _to_jax(getattr(self, name)))
-                for v, name in self.keras_variable_mapping
-            ]
-            self._state_mapping_cache = cached
-        return cached
+        return [
+            (v, _to_jax(getattr(self, name)))
+            for v, name in self.keras_variable_mapping
+        ]
 
     def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         """Forward pass for vLLM.

--- a/keras_hub/src/vllm/adapter.py
+++ b/keras_hub/src/vllm/adapter.py
@@ -1,0 +1,548 @@
+"""
+Adapter module for bridging KerasHub models to vLLM's execution engine.
+
+This module provides the necessary wrappers to translate vLLM's internal state
+and PyTorch/XLA tensors into Keras backend-agnostic operations natively via JAX.
+"""
+
+import inspect
+from typing import Any, Dict, List, Optional, Tuple
+
+import jax
+import torch
+from keras import ops
+
+from keras_hub import models
+from keras_hub.src.vllm.context import clear_vllm_context
+from keras_hub.src.vllm.context import set_vllm_context
+
+
+def _to_jax(tensor: Any) -> Any:
+    """Converts a PyTorch tensor to a JAX array via DLPack.
+
+    Args:
+        tensor: The input tensor (PyTorch or other framework).
+
+    Returns:
+        The JAX array corresponding to the input tensor.
+
+    Raises:
+        ValueError: If unwrapping fails.
+    """
+    if not isinstance(tensor, torch.Tensor):
+        return tensor
+
+    try:
+        return jax.dlpack.from_dlpack(tensor.contiguous())
+    except Exception as e:
+        if "Unknown device type" in str(e):
+            for attr in ["jax_array", "_jax_array", "jax", "unwrap", "data"]:
+                if hasattr(tensor, attr):
+                    val = getattr(tensor, attr)
+                    if callable(val):
+                        try:
+                            val = val()
+                        except Exception:
+                            continue
+                    if val is not None and "torch.Tensor" not in str(type(val)):
+                        return val
+            if hasattr(tensor, "cpu") and hasattr(tensor, "numpy"):
+                import jax.numpy as jnp
+
+                return jnp.asarray(tensor.cpu().detach().numpy())
+            raise ValueError(
+                f"Failed to unwrap torchax tensor. dir: {dir(tensor)}. type: {type(tensor)}"
+            ) from e
+        raise
+
+
+def _to_torch(array: Any, reference_tensor: Optional[torch.Tensor] = None) -> Any:
+    """Converts a JAX array back to a PyTorch tensor via DLPack.
+
+    Args:
+        array: The JAX array to convert.
+        reference_tensor: An optional PyTorch tensor used to infer the target device.
+
+    Returns:
+        A PyTorch tensor sharing the same memory as the JAX array.
+    """
+    if isinstance(array, torch.Tensor):
+        return array
+
+    if hasattr(array, "aval"):
+        try:
+            import torchax
+
+            try:
+                import tpu_inference
+
+                if hasattr(tpu_inference, "utils") and hasattr(
+                    tpu_inference.utils, "to_torch"
+                ):
+                    return tpu_inference.utils.to_torch(array)
+            except ImportError:
+                pass
+
+            if hasattr(torchax, "interop") and hasattr(torchax.interop, "from_jax"):
+                return torchax.interop.from_jax(array)
+
+            env = torchax.default_env()
+            try:
+                return torchax.tensor.Tensor(array, env)
+            except Exception:
+                return torchax.tensor.Tensor(env, array)
+        except Exception:
+            return array
+
+    tensor = torch.from_dlpack(array)
+    if reference_tensor is not None:
+        tensor = tensor.to(reference_tensor.device)
+    return tensor
+
+
+class KerasVLLMAdapter(torch.nn.Module):
+    """Adapter that wraps a Keras Hub CausalLM for vLLM.
+
+    This class satisfies vLLM's internal model interface and is instantiated
+    when the model prefix is `keras_hub:`. It leverages JAX for execution
+    and maps vLLM's paged attention logic into the Keras ecosystem.
+    """
+
+    def __init__(
+        self,
+        vllm_config: Any = None,
+        rng: Any = None,
+        mesh: Any = None,
+        prefix: str = "",
+        **kwargs: Any,
+    ):
+        """Initializes the adapter and loads the underlying KerasHub model.
+
+        ``prefix`` is required for vLLM to recognize this as a "new-style"
+        model class (it checks for both ``vllm_config`` and ``prefix`` in the
+        signature); otherwise vLLM falls back to old-style arg-guessing and
+        fails to pass ``vllm_config``.
+
+        Args:
+            vllm_config: Configuration from vLLM including the huggingface config.
+            rng: Random number generator context (JAX).
+            mesh: Device mesh context for sharding (JAX).
+            **kwargs: Additional parameters.
+
+        Raises:
+            ValueError: If the `keras_hub_preset` is not specified.
+        """
+        super().__init__()
+        # Extract the underlying huggingface config which we mapped in config.py
+        if hasattr(vllm_config, "model_config") and hasattr(
+            vllm_config.model_config, "hf_config"
+        ):
+            self.config = vllm_config.model_config.hf_config
+        else:
+            self.config = vllm_config
+
+        self.preset_name = getattr(self.config, "keras_hub_preset", None)
+        if self.preset_name is None:
+            raise ValueError(
+                "The vLLM config must specify keras_hub_preset to load the correct model."
+            )
+
+        self._resolve_vllm_architecture()
+
+        dtype = getattr(self.config, "torch_dtype", None)
+        if dtype == "bfloat16":
+            import keras
+
+            keras.config.set_floatx("bfloat16")
+
+        self.model = models.CausalLM.from_preset(
+            self.preset_name, preprocessor=None, dtype=dtype
+        )
+
+        self.keras_variable_mapping = []
+        for i, v in enumerate(self.model.variables):
+            name = f"keras_var_{i}"
+            self.register_buffer(name, _to_torch(v.value))
+            self.keras_variable_mapping.append((v, name))
+
+    def _resolve_vllm_architecture(self) -> None:
+        """Resolves and sets the corresponding vLLM architecture based on the preset."""
+        if hasattr(self.config, "architectures"):
+            preset_name = self.preset_name.lower()
+            if "gemma" in preset_name:
+                self.config.architectures = ["GemmaForCausalLM"]
+            elif "llama" in preset_name:
+                self.config.architectures = ["LlamaForCausalLM"]
+            elif "mistral" in preset_name:
+                self.config.architectures = ["MistralForCausalLM"]
+            elif "qwen" in preset_name:
+                self.config.architectures = ["Qwen2ForCausalLM"]
+            else:
+                self.config.architectures = ["LlamaForCausalLM"]
+
+    def get_vllm_model(self, vllm_config: Any, rng: Any, mesh: Any) -> Tuple:
+        """Object-oriented hook for vLLM's TPU runner.
+
+        Args:
+            vllm_config: The vLLM configuration object.
+            rng: Random number generator key.
+            mesh: Device mesh.
+
+        Returns:
+            A tuple of functions and configurations expected by vLLM.
+        """
+        model_params = {"keras_variables": [v.value for v in self.model.variables]}
+        return (
+            self._vllm_jit_model,
+            self._vllm_compute_logits_fn,
+            model_params,
+            None,
+            {},
+            None,
+            self,
+        )
+
+    def _vllm_jit_model(
+        self,
+        params: Dict[str, Any],
+        vllm_config: Any,
+        kv_caches: List[torch.Tensor],
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        attention_metadata: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Tuple[List[torch.Tensor], torch.Tensor, Any]:
+        """Wrapper to evaluate the model step under JIT mapping.
+
+        Returns:
+            A tuple containing the updated KV caches, hidden states, and auxiliary output.
+        """
+        import keras
+
+        state_mapping = zip(self.model.variables, params["keras_variables"])
+        with keras.StatelessScope(state_mapping=state_mapping):
+            hidden_states, updated_kv_caches = self.forward_step(
+                input_ids,
+                positions=positions,
+                kv_caches=kv_caches,
+                attention_metadata=attention_metadata,
+            )
+        return updated_kv_caches, hidden_states, None
+
+    def _vllm_compute_logits_fn(
+        self, params: Dict[str, Any], hidden_states: torch.Tensor, *args: Any, **kwargs: Any
+    ) -> torch.Tensor:
+        """Bound logits computation function for vLLM's execution engine."""
+        import keras
+
+        state_mapping = zip(self.model.variables, params["keras_variables"])
+        with keras.StatelessScope(state_mapping=state_mapping):
+            return self.compute_logits(hidden_states)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Embeds input IDs.
+
+        Required by vLLM interface but handled natively within the Keras Hub
+        backbone. We return the input_ids as-is or raise NotImplementedError
+        if explicitly invoked, to prevent silent failures.
+        """
+        raise NotImplementedError("Embedding is handled internally by Keras Hub backbone.")
+
+    def _get_state_mapping(self) -> List[Tuple[Any, Any]]:
+        """Builds the Keras StatelessScope state mapping from the patched buffers.
+
+        The weight buffers are immutable after load, so the (variable -> JAX
+        array) mapping is built once and cached. Without this, every decode step
+        re-ran a DLPack conversion over all of the model's weight buffers
+        (hundreds of tensors for a 2B model) on the host before any TPU compute
+        could start — a dominant per-token overhead.
+        """
+        cached = getattr(self, "_state_mapping_cache", None)
+        if cached is None:
+            cached = [
+                (v, _to_jax(getattr(self, name)))
+                for v, name in self.keras_variable_mapping
+            ]
+            self._state_mapping_cache = cached
+        return cached
+
+    def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        """Forward pass for vLLM.
+
+        Supports both GPU and TPU signature structures dynamically.
+        """
+        is_tpu = False
+        try:
+            from tpu_inference.models.vllm.vllm_model_wrapper_context import (
+                get_vllm_model_wrapper_context,
+            )
+
+            vllm_ctx = get_vllm_model_wrapper_context()
+            is_tpu = vllm_ctx is not None
+        except (ImportError, AssertionError):
+            pass
+
+        # VllmModelWrapper invokes the model as `model(**kwargs)`, so inputs
+        # arrive as keyword args; fall back to positional for other callers.
+        def _arg(idx, name):
+            if len(args) > idx:
+                return args[idx]
+            return kwargs.get(name)
+
+        if is_tpu:
+            input_ids = _arg(0, "input_ids")
+            positions = _arg(1, "positions")
+            try:
+                from vllm.forward_context import (
+                    get_forward_context,
+                    is_forward_context_available,
+                )
+
+                if is_forward_context_available():
+                    fc = get_forward_context()
+                    attn_metadata = fc.attn_metadata
+                else:
+                    attn_metadata = _arg(3, "attn_metadata")
+            except ImportError:
+                attn_metadata = _arg(3, "attn_metadata")
+            kv_caches = vllm_ctx.kv_caches if vllm_ctx is not None else None
+        else:
+            input_ids = _arg(0, "input_ids")
+            positions = _arg(1, "positions")
+            kv_caches = _arg(2, "kv_caches")
+            attn_metadata = _arg(3, "attn_metadata")
+
+        import keras
+
+        with keras.StatelessScope(state_mapping=self._get_state_mapping()):
+            hidden_states, updated_kv_caches = self.forward_step(
+                input_ids, positions, kv_caches, attn_metadata
+            )
+
+        # On the TPU path vLLM harvests the new KV caches from the model-wrapper
+        # context, so we must write the kernel-updated caches back into it.
+        # Otherwise every decode step reuses the original (stale) cache.
+        if is_tpu and updated_kv_caches is not None and vllm_ctx is not None:
+            wrapper_caches = getattr(vllm_ctx, "kv_caches", None)
+            if wrapper_caches is not None:
+                for i, updated in enumerate(updated_kv_caches):
+                    if updated is not None and i < len(wrapper_caches):
+                        wrapper_caches[i] = updated
+        return hidden_states
+
+    def _get_wrapper_mesh(self) -> Any:
+        """Returns the JAX device mesh from vLLM's TPU model-wrapper context.
+
+        The Pallas paged-attention kernel shards across this mesh. Returns
+        ``None`` when not running under the tpu-inference wrapper (e.g. on the
+        GPU path or in unit tests), in which case the kernel is not invoked.
+        """
+        try:
+            from tpu_inference.models.vllm.vllm_model_wrapper_context import (
+                get_vllm_model_wrapper_context,
+            )
+
+            wrapper_ctx = get_vllm_model_wrapper_context()
+            return getattr(wrapper_ctx, "mesh", None) if wrapper_ctx else None
+        except (ImportError, AssertionError):
+            return None
+
+    @staticmethod
+    def _resolve_backbone_component(backbone: Any, names: List[str], what: str) -> Any:
+        """Returns the first attribute in ``names`` present on ``backbone``.
+
+        Raises a clear error if none are found, so an unsupported backbone fails
+        loudly rather than with a cryptic AttributeError mid-forward.
+        """
+        for name in names:
+            component = getattr(backbone, name, None)
+            if component is not None:
+                return component
+        raise AttributeError(
+            f"KerasVLLMAdapter could not find the {what} on backbone "
+            f"{type(backbone).__name__} (tried {names}). The vLLM forward "
+            f"re-implements the backbone and expects a standard KerasHub "
+            f"decoder layout (token_embedding, transformer_layers, final norm)."
+        )
+
+    def forward_step(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[torch.Tensor],
+        attention_metadata: Any,
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        """Triggers a single autoregressive step."""
+        is_prompt = getattr(attention_metadata, "is_prompt", False)
+
+        jax_input_ids = _to_jax(input_ids)
+        jax_positions = _to_jax(positions)
+
+        if len(jax_input_ids.shape) == 1:
+            jax_input_ids = ops.expand_dims(jax_input_ids, axis=-1)
+
+        # This method re-implements the backbone forward so per-layer paged KV
+        # caches can be threaded into each attention layer. It assumes a standard
+        # KerasHub decoder layout: a `token_embedding`, an iterable of
+        # `transformer_layers`, and a final norm; optionally a learned
+        # `position_embedding`. Components are resolved defensively so an
+        # unsupported backbone fails with a clear message instead of an
+        # AttributeError deep in the loop.
+        backbone = self.model.backbone
+        token_embedding = self._resolve_backbone_component(
+            backbone, ["token_embedding"], "token embedding"
+        )
+        x = token_embedding(jax_input_ids)
+
+        hidden_dim = backbone.hidden_dim
+        is_gemma = (
+            getattr(self, "preset_name", "") and "gemma" in self.preset_name.lower()
+        )
+        if is_gemma:
+            x = x * ops.sqrt(ops.cast(hidden_dim, x.dtype))
+
+        # Add learned position embeddings for backbones that use them (GPT-2,
+        # OPT, ...). RoPE-based backbones (Gemma, Llama, Mistral) have no
+        # `position_embedding` layer and apply rotary positions inside attention,
+        # so this is skipped for them. We index by vLLM's `positions` tensor
+        # (not 0..T-1) so decode steps use the correct absolute position.
+        position_embedding = getattr(backbone, "position_embedding", None)
+        if position_embedding is not None and jax_positions is not None:
+            pos_weight = position_embedding.position_embeddings
+            pos_ids = ops.cast(ops.reshape(jax_positions, (-1,)), "int32")
+            pos_emb = ops.take(pos_weight, pos_ids, axis=0)
+            pos_emb = ops.reshape(pos_emb, ops.shape(x))
+            x = x + ops.cast(pos_emb, x.dtype)
+
+        block_tables = None
+        if (
+            hasattr(attention_metadata, "block_tables")
+            and attention_metadata.block_tables is not None
+        ):
+            block_tables = _to_jax(attention_metadata.block_tables)
+
+        slot_mapping = None
+        if hasattr(attention_metadata, "slot_mapping_tensor"):
+            slot_mapping = _to_jax(attention_metadata.slot_mapping_tensor)
+        elif (
+            hasattr(attention_metadata, "slot_mapping")
+            and attention_metadata.slot_mapping is not None
+        ):
+            slot_mapping = _to_jax(attention_metadata.slot_mapping)
+
+        # Retrieve the vLLM native paged attention function if injected from TPU inference.
+        # This prevents Keras from maintaining complex hardware-specific kernels.
+        paged_attn_func = getattr(attention_metadata, "paged_attention_func", None)
+        # The Pallas kernel needs the JAX device mesh, which lives on the vLLM
+        # model-wrapper context on the TPU path.
+        mesh = self._get_wrapper_mesh()
+        set_vllm_context(
+            block_tables,
+            slot_mapping,
+            attention_metadata,
+            paged_attn_func,
+            mesh,
+            positions=jax_positions,
+        )
+
+        try:
+            kwargs_base = {}
+            if jax_positions is not None:
+                kwargs_base["positions"] = jax_positions
+
+            if hasattr(attention_metadata, "seq_lens_tensor"):
+                kwargs_base["seq_lens"] = _to_jax(attention_metadata.seq_lens_tensor)
+            elif (
+                hasattr(attention_metadata, "seq_lens")
+                and attention_metadata.seq_lens is not None
+            ):
+                kwargs_base["seq_lens"] = ops.convert_to_tensor(
+                    attention_metadata.seq_lens, dtype="int32"
+                )
+
+            if is_prompt and hasattr(attention_metadata, "seq_lens"):
+                padding_mask = ops.ones(ops.shape(jax_input_ids), dtype="bool")
+            else:
+                padding_mask = ops.ones(ops.shape(jax_input_ids), dtype="bool")
+
+            kwargs_base["padding_mask"] = padding_mask
+
+            jax_kv_caches = None
+            if kv_caches is not None:
+                jax_kv_caches = [_to_jax(cache) for cache in kv_caches]
+
+            transformer_layers = self._resolve_backbone_component(
+                backbone, ["transformer_layers"], "transformer layers"
+            )
+            # All decoder layers share a class/signature, so inspect once and
+            # cache on the instance — the layout is fixed for the model's
+            # lifetime, so this need not run per layer or per forward step.
+            layer_params = getattr(self, "_layer_params_cache", None)
+            if layer_params is None:
+                layer_params = (
+                    set(inspect.signature(transformer_layers[0].call).parameters)
+                    if len(transformer_layers)
+                    else set()
+                )
+                self._layer_params_cache = layer_params
+            for i, layer in enumerate(transformer_layers):
+                kwargs = kwargs_base.copy()
+
+                cache_tensor = (
+                    jax_kv_caches[i]
+                    if jax_kv_caches is not None and len(jax_kv_caches) > i
+                    else None
+                )
+
+                if "self_attention_cache" in layer_params:
+                    kwargs["self_attention_cache"] = cache_tensor
+                elif "cache" in layer_params:
+                    if hasattr(layer, "decoder_sequence_length"):
+                        kwargs["cache_update_index"] = 0
+                    else:
+                        kwargs["cache"] = cache_tensor
+
+                if "kv_cache" in layer_params:
+                    kwargs["kv_cache"] = cache_tensor
+
+                supported_kwargs = {
+                    k: v for k, v in kwargs.items() if k in layer_params
+                }
+
+                out = layer(x, **supported_kwargs)
+
+                if isinstance(out, tuple):
+                    x = out[0]
+                    if len(out) > 1 and jax_kv_caches is not None:
+                        jax_kv_caches[i] = out[1]
+                else:
+                    x = out
+
+            final_norm = self._resolve_backbone_component(
+                backbone,
+                ["layer_norm", "final_layer_norm", "norm"],
+                "final norm",
+            )
+            hidden_states = final_norm(x)
+
+            if len(hidden_states.shape) == 3 and hidden_states.shape[1] == 1:
+                hidden_states = ops.squeeze(hidden_states, axis=1)
+
+            return _to_torch(hidden_states, input_ids), jax_kv_caches
+        finally:
+            clear_vllm_context()
+
+    def load_weights(self, weights: Any = None) -> None:
+        """Loads weights. Pre-loaded by Keras Hub natively."""
+        pass
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, *args: Any, **kwargs: Any
+    ) -> torch.Tensor:
+        """Computes logits for the LM head."""
+        jax_hidden_states = _to_jax(hidden_states)
+        logits = self.model.backbone.token_embedding(
+            jax_hidden_states, reverse=True
+        )
+        return _to_torch(logits, hidden_states)

--- a/keras_hub/src/vllm/attention.py
+++ b/keras_hub/src/vllm/attention.py
@@ -1,0 +1,99 @@
+"""Shared dispatch from KerasHub attention layers to vLLM's paged-attention.
+
+KerasHub has several bespoke attention layers (the generic
+``CachedMultiHeadAttention`` used by GPT-2 and friends, plus per-model layers
+for Gemma, Llama, Mistral, ...). Rather than duplicate the (fragile) call into
+``tpu_inference``'s native Pallas kernel in each one, every layer routes through
+``maybe_vllm_paged_attention`` so the bridge lives in exactly one place.
+"""
+
+from typing import Any, Optional, Tuple
+
+from keras import ops
+
+from keras_hub.src.vllm.context import get_vllm_context
+
+
+def maybe_vllm_paged_attention(
+    query: Any,
+    key: Any,
+    value: Any,
+    cache: Any,
+    scale: float,
+    sliding_window: Optional[int] = None,
+    soft_cap: Optional[float] = None,
+) -> Optional[Tuple[Any, Any]]:
+    """Run vLLM's injected Pallas paged-attention kernel, if active.
+
+    Returns ``(attention_output, new_kv_cache)`` when running under vLLM's TPU
+    engine (i.e. a paged-attention function has been injected into the active
+    ``vllm_context``), or ``None`` otherwise so the caller falls back to its
+    standard Keras attention path.
+
+    Args:
+        query: Post-projection (and, where applicable, post-RoPE) query tensor.
+        key: Post-projection/post-RoPE key tensor. Must NOT be GQA-expanded —
+            the kernel handles grouped-query attention via ``num_kv_heads``,
+            which is inferred from this tensor's head dimension.
+        value: Post-projection value tensor (also not GQA-expanded).
+        cache: This layer's paged KV cache (vLLM layout), or ``None``.
+        scale: Softmax scale to apply inside the kernel (e.g. ``1/sqrt(head_dim)``).
+            Pass the model's own convention; do not pre-scale ``query``.
+        sliding_window: Optional sliding-window size for local attention.
+
+    Returns:
+        ``(attention_output, new_kv_cache)`` or ``None``. ``attention_output``
+        is returned in KerasHub's ``(batch, seq, num_heads, head_dim)`` layout,
+        ready for the caller's output projection.
+
+    Note:
+        KerasHub emits ``(batch, seq, num_heads, head_dim)`` tensors, whereas
+        ``tpu_inference``'s ``_jax_attn_func`` expects flattened
+        ``(num_tokens, num_heads * head_dim)`` inputs and returns the same flat
+        layout. We flatten the leading (batch, seq) dims into a single token
+        dim before the call and restore them afterwards. This conversion is a
+        best-effort match to the kernel's contract and is the primary thing to
+        confirm on real TPU hardware (see the Colab parity test).
+    """
+    ctx = get_vllm_context()
+    if ctx is None or ctx.paged_attention_func is None:
+        return None
+
+    num_heads = query.shape[-2]
+    head_dim = query.shape[-1]
+    num_kv_heads = key.shape[-2]
+    # Leading dims (e.g. (batch, seq)) to restore on the output.
+    lead_shape = tuple(query.shape[:-2])
+
+    # vLLM convention: a single flattened token dim, channels = heads * head_dim.
+    query = ops.reshape(query, (-1, num_heads * head_dim))
+    key = ops.reshape(key, (-1, num_kv_heads * head_dim))
+    value = ops.reshape(value, (-1, num_kv_heads * head_dim))
+
+    # `soft_cap` is only forwarded when set (Gemma 2/3); omitting it keeps this
+    # call compatible with tpu-inference builds whose kernel dispatch predates
+    # soft-cap plumbing.
+    extra = {"sliding_window": sliding_window}
+    if soft_cap is not None:
+        extra["soft_cap"] = soft_cap
+
+    new_kv_cache, attention_output = ctx.paged_attention_func(
+        cache,
+        query,
+        key,
+        value,
+        None,  # sinks: KerasHub attention layers have no attention sinks
+        ctx.attention_metadata,
+        ctx.mesh,
+        scale,
+        head_dim,
+        num_heads,
+        num_kv_heads,
+        **extra,
+    )
+
+    # Kernel returns (num_tokens, num_heads * head_dim); restore KerasHub layout.
+    attention_output = ops.reshape(
+        attention_output, (*lead_shape, num_heads, head_dim)
+    )
+    return attention_output, new_kv_cache

--- a/keras_hub/src/vllm/context.py
+++ b/keras_hub/src/vllm/context.py
@@ -1,0 +1,83 @@
+"""
+Thread-local context management for passing vLLM metadata to Keras layers.
+"""
+
+import threading
+from typing import Any, Optional
+
+
+class VLLMContext(threading.local):
+    """Thread-local context for passing serving metadata to Keras layers.
+
+    Attributes:
+        block_tables: The block tables tensor for paged attention.
+        slot_mapping: The slot mapping tensor for paged attention.
+        attention_metadata: The full attention metadata object from vLLM.
+        paged_attention_func: The compiled hardware-specific paged attention kernel.
+        mesh: The JAX device mesh required by the paged attention kernel.
+        positions: vLLM's per-token absolute position ids (for RoPE models).
+        active: Boolean indicating if the context is currently active.
+    """
+
+    def __init__(self) -> None:
+        """Initializes an empty inactive context."""
+        super().__init__()
+        self.block_tables: Optional[Any] = None
+        self.slot_mapping: Optional[Any] = None
+        self.attention_metadata: Optional[Any] = None
+        self.paged_attention_func: Optional[Any] = None
+        self.mesh: Optional[Any] = None
+        self.positions: Optional[Any] = None
+        self.active: bool = False
+
+
+_vllm_context = VLLMContext()
+
+
+def set_vllm_context(
+    block_tables: Any,
+    slot_mapping: Any,
+    attention_metadata: Optional[Any] = None,
+    paged_attention_func: Optional[Any] = None,
+    mesh: Optional[Any] = None,
+    positions: Optional[Any] = None,
+) -> None:
+    """Sets the thread-local vLLM context parameters.
+
+    Args:
+        block_tables: Array representing memory blocks for key/value caching.
+        slot_mapping: Array mapping sequence tokens to cache slots.
+        attention_metadata: Additional hardware/framework specific metadata.
+        paged_attention_func: The function to use for paged attention.
+        mesh: The JAX device mesh the paged attention kernel shards across.
+        positions: vLLM's per-token absolute position ids (used by RoPE models
+            to apply rotary embeddings at the correct positions under paged /
+            continuous-batched decode).
+    """
+    _vllm_context.block_tables = block_tables
+    _vllm_context.slot_mapping = slot_mapping
+    _vllm_context.attention_metadata = attention_metadata
+    _vllm_context.paged_attention_func = paged_attention_func
+    _vllm_context.mesh = mesh
+    _vllm_context.positions = positions
+    _vllm_context.active = True
+
+
+def clear_vllm_context() -> None:
+    """Clears the thread-local vLLM context."""
+    _vllm_context.block_tables = None
+    _vllm_context.slot_mapping = None
+    _vllm_context.attention_metadata = None
+    _vllm_context.paged_attention_func = None
+    _vllm_context.mesh = None
+    _vllm_context.positions = None
+    _vllm_context.active = False
+
+
+def get_vllm_context() -> Optional[VLLMContext]:
+    """Retrieves the active thread-local vLLM context.
+
+    Returns:
+        The `VLLMContext` instance if active, otherwise `None`.
+    """
+    return _vllm_context if getattr(_vllm_context, "active", False) else None

--- a/keras_hub/src/vllm/registry.py
+++ b/keras_hub/src/vllm/registry.py
@@ -1,0 +1,368 @@
+"""
+Registry module for Keras Hub to vLLM Integration.
+
+Hooks into vLLM's model loading mechanism so that `LLM(model="keras_hub:preset_name")`
+is recognized and routed to the `KerasVLLMAdapter`.
+"""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+
+from keras_hub.src.vllm.adapter import KerasVLLMAdapter
+
+
+def _verify_tokenizer_dir(temp_dir: str) -> bool:
+    """Loads the exported tokenizer back and checks it tokenizes to non-empty.
+
+    Guards against transformers/tokenizers versions that build an empty
+    tokenizer from the exported assets (which is worse than no tokenizer).
+    """
+    from transformers import AutoTokenizer
+
+    rt = AutoTokenizer.from_pretrained(temp_dir)
+    return len(rt("hello world").get("input_ids", [])) > 0
+
+
+def _export_sentencepiece(tokenizer, temp_dir: str, proto: bytes) -> bool:
+    """Exports a KerasHub SentencePiece tokenizer (Gemma/Llama/Mistral) for HF.
+
+    Writes the raw SP proto as `tokenizer.model` plus a tokenizer_config naming
+    the matching HF class, then verifies it round-trips. On failure, removes the
+    files so the caller falls back to skip_tokenizer_init + pre-tokenization.
+    """
+    try:
+        with open(os.path.join(temp_dir, "tokenizer.model"), "wb") as f:
+            f.write(proto)
+    except Exception as e:  # noqa: BLE001
+        logging.warning("Could not write SentencePiece tokenizer.model: %s", e)
+        return False
+
+    cls_name = type(tokenizer).__name__.lower()
+    hf_class = "GemmaTokenizer" if "gemma" in cls_name else "LlamaTokenizer"
+    with open(
+        os.path.join(temp_dir, "tokenizer_config.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump(
+            {
+                "tokenizer_class": hf_class,
+                "legacy": False,
+                "add_bos_token": True,
+                "add_eos_token": False,
+            },
+            f,
+        )
+
+    try:
+        if _verify_tokenizer_dir(temp_dir):
+            return True
+        raise ValueError("exported SentencePiece tokenizer produced empty output")
+    except Exception as e:  # noqa: BLE001
+        logging.warning(
+            "SentencePiece tokenizer unusable (%s); use skip_tokenizer_init=True "
+            "+ pre-tokenized input for this preset.",
+            e,
+        )
+        for fn in ("tokenizer.model", "tokenizer.json", "tokenizer_config.json"):
+            p = os.path.join(temp_dir, fn)
+            if os.path.exists(p):
+                os.remove(p)
+        return False
+
+
+def _export_hf_tokenizer(tokenizer, temp_dir: str) -> bool:
+    """Writes HF-compatible tokenizer files so vLLM can tokenize raw text.
+
+    Handles KerasHub's byte-level BPE tokenizers (GPT-2, OPT, ... -> stock
+    `GPT2Tokenizer`) and SentencePiece tokenizers (Gemma, Llama, Mistral ->
+    `tokenizer.model` + Llama/Gemma tokenizer). Returns True on success; on
+    failure the caller should use ``skip_tokenizer_init=True`` + pre-tokenized
+    input.
+    """
+    # SentencePiece family: KerasHub stores the serialized proto on `.proto`.
+    proto = getattr(tokenizer, "proto", None)
+    if proto:
+        return _export_sentencepiece(tokenizer, temp_dir, proto)
+
+    # Byte-level BPE family.
+    if not (hasattr(tokenizer, "merges") and hasattr(tokenizer, "save_assets")):
+        return False
+    try:
+        # Writes vocabulary.json + merges.txt into temp_dir.
+        tokenizer.save_assets(temp_dir)
+    except Exception as e:  # noqa: BLE001
+        logging.warning("Tokenizer save_assets failed: %s", e)
+        return False
+
+    vocab_src = os.path.join(temp_dir, "vocabulary.json")
+    vocab_dst = os.path.join(temp_dir, "vocab.json")  # HF expects this name
+    if os.path.exists(vocab_src) and not os.path.exists(vocab_dst):
+        shutil.copyfile(vocab_src, vocab_dst)
+    merges_path = os.path.join(temp_dir, "merges.txt")
+    if not (os.path.exists(vocab_dst) and os.path.exists(merges_path)):
+        return False
+
+    # HF's GPT2Tokenizer drops the first line of merges.txt (expects a version
+    # header). KerasHub writes no header, so prepend one or the first real merge
+    # rule would be silently lost.
+    with open(merges_path, "r", encoding="utf-8") as f:
+        merges_content = f.read()
+    if not merges_content.startswith("#version"):
+        with open(merges_path, "w", encoding="utf-8") as f:
+            f.write("#version: 0.2\n" + merges_content)
+
+    eos = "<|endoftext|>"
+
+    # Prefer emitting a fast tokenizer (tokenizer.json), which vLLM v1's
+    # incremental detokenizer favors. Building GPT2TokenizerFast from the
+    # vocab/merges and calling save_pretrained writes tokenizer.json plus
+    # consistent tokenizer_config.json / special_tokens_map.json.
+    try:
+        from transformers import AutoTokenizer, GPT2TokenizerFast
+
+        fast = GPT2TokenizerFast(
+            vocab_file=vocab_dst,
+            merges_file=merges_path,
+            unk_token=eos,
+            bos_token=eos,
+            eos_token=eos,
+            add_prefix_space=False,
+        )
+        fast.save_pretrained(temp_dir)
+        # Verify the emitted tokenizer.json actually round-trips (some
+        # transformers/tokenizers versions build an empty byte-level BPE from
+        # vocab+merges). If it tokenizes to nothing, it's worse than the slow
+        # tokenizer — remove it and fall back.
+        reloaded = AutoTokenizer.from_pretrained(temp_dir)
+        if len(reloaded("hello world").get("input_ids", [])) > 0:
+            return True
+        raise ValueError("emitted fast tokenizer produced empty output")
+    except Exception as e:  # noqa: BLE001 - fall back to the slow tokenizer
+        logging.warning(
+            "Fast tokenizer.json unusable (%s); using slow GPT2Tokenizer.", e
+        )
+        # Remove a possibly-broken tokenizer.json so vLLM loads the slow files
+        # (vocab.json + merges.txt) instead of the bad fast tokenizer.
+        broken = os.path.join(temp_dir, "tokenizer.json")
+        if os.path.exists(broken):
+            os.remove(broken)
+
+    # Slow-tokenizer fallback: minimal config over vocab.json + merges.txt.
+    with open(
+        os.path.join(temp_dir, "tokenizer_config.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump(
+            {
+                "tokenizer_class": "GPT2Tokenizer",
+                "bos_token": eos,
+                "eos_token": eos,
+                "unk_token": eos,
+                "add_prefix_space": False,
+                "clean_up_tokenization_spaces": False,
+            },
+            f,
+        )
+    with open(
+        os.path.join(temp_dir, "special_tokens_map.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump({"bos_token": eos, "eos_token": eos, "unk_token": eos}, f)
+    return True
+
+
+def _register_model_architecture() -> None:
+    """Registers KerasVLLMAdapter with vLLM's internal model registry."""
+    try:
+        from vllm.model_executor.models import ModelRegistry
+
+        ModelRegistry.register_model("KerasVLLMAdapter", KerasVLLMAdapter)
+    except ImportError:
+        logging.warning(
+            "Skipping KerasVLLMAdapter registration. vLLM is not installed "
+            "or the ModelRegistry module could not be imported."
+        )
+
+
+def register_keras_hub_models() -> None:
+    """Registers KerasVLLMAdapter with vLLM via its sanctioned ModelRegistry.
+
+    No monkeypatching: architecture recognition goes through vLLM's public
+    `ModelRegistry.register_model` here, and through tpu-inference's native
+    `_get_model_architecture` hook on the serving side. When `setup_vllm_model`
+    materializes a model directory, vLLM loads the `KerasVLLMAdapter`.
+    """
+    _register_model_architecture()
+
+
+def setup_vllm_model(preset: str, dtype: str = "float16") -> str:
+    """Creates a configuration directory for vLLM to load a Keras Hub preset.
+
+    Args:
+        preset: The Keras Hub preset name (e.g., "gemma_2b_en").
+        dtype: The torch dtype to run inference with.
+
+    Returns:
+        The path to the temporary configuration directory to pass to `vllm.LLM`.
+    """
+    temp_dir = tempfile.mkdtemp(prefix="keras_hub_vllm_")
+
+    preset_lower = preset.lower()
+    if "opt" in preset_lower:
+        model_type = "opt"
+    elif "gpt2" in preset_lower or "gpt_2" in preset_lower:
+        model_type = "gpt2"
+    elif "gemma" in preset_lower:
+        model_type = "gemma2"
+    else:
+        model_type = "gemma2"
+
+    # Derive the true vocabulary size from the preset's tokenizer. vLLM relies
+    # on vocab_size for KV-cache memory profiling, so a hardcoded value
+    # silently mis-profiles any model other than the one it was tuned for
+    # (e.g. GPT-2's 50257 vs. Gemma's 256000).
+    vocab_size = None
+    eos_token_id = None
+    try:
+        from keras_hub import models
+
+        tokenizer = models.Tokenizer.from_preset(preset)
+        vocab_size = int(tokenizer.vocabulary_size())
+        eos_token_id = getattr(tokenizer, "end_token_id", None)
+        # Export HF-format tokenizer files so vLLM can accept raw-text prompts.
+        # If unsupported (e.g. SentencePiece), pass skip_tokenizer_init=True to
+        # LLM(...) and feed token IDs tokenized with the KerasHub tokenizer.
+        if _export_hf_tokenizer(tokenizer, temp_dir):
+            logging.info("Exported HF tokenizer assets for preset %r.", preset)
+        else:
+            logging.warning(
+                "Could not export an HF tokenizer for preset %r; use "
+                "skip_tokenizer_init=True + pre-tokenized input.",
+                preset,
+            )
+    except Exception as e:  # noqa: BLE001 - fall back to a sane default
+        logging.warning(
+            "Could not infer vocab_size for preset %r (%s); falling back to a "
+            "default. Set it explicitly if memory profiling looks wrong.",
+            preset,
+            e,
+        )
+        vocab_size = 50272 if "opt" in preset_lower else 256000
+
+    config_dict = {
+        "architectures": ["KerasVLLMAdapter"],
+        "_name_or_path": f"keras_hub:{preset}",
+        "keras_hub_preset": preset,
+        "torch_dtype": dtype,
+        "model_type": model_type,
+        "vocab_size": vocab_size,
+    }
+    if eos_token_id is not None:
+        config_dict["eos_token_id"] = int(eos_token_id)
+        config_dict["bos_token_id"] = int(
+            getattr(tokenizer, "start_token_id", None) or eos_token_id
+        )
+
+    # Write the REAL architecture dims so vLLM allocates a matching KV cache.
+    # Without these, vLLM guesses from `model_type` (e.g. "gemma2" -> HF
+    # Gemma-2 defaults), which mismatches the actual KerasHub backbone and fails
+    # the kernel's kv_cache-shape check (num_kv_heads / num_layers / head_dim).
+    config_dict.update(_derive_arch_config(preset))
+
+    with open(os.path.join(temp_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config_dict, f)
+
+    return temp_dir
+
+
+def _derive_arch_config(preset: str) -> dict:
+    """Reads the KerasHub backbone config and maps it to HF/vLLM config keys.
+
+    Reads the preset's serialized ``config.json`` directly (no model build, no
+    TPU allocation) and translates its backbone args to the fields vLLM uses for
+    KV-cache allocation. Works across families: GPT-2 uses ``num_heads`` (no
+    GQA); Gemma/Llama/Mistral use ``num_query_heads`` / ``num_key_value_heads``
+    / ``head_dim``.
+    """
+    try:
+        from keras_hub.src.utils import preset_utils
+
+        cfg = preset_utils.load_json(preset).get("config", {})
+    except Exception as e:  # noqa: BLE001
+        logging.warning(
+            "Could not derive architecture for %r (%s); vLLM will guess from "
+            "model_type, which may mismatch the KV cache.",
+            preset,
+            e,
+        )
+        return {}
+
+    hidden = cfg.get("hidden_dim")
+    n_heads = cfg.get("num_query_heads") or cfg.get("num_heads")
+    n_kv = cfg.get("num_key_value_heads") or n_heads
+    head_dim = cfg.get("head_dim")
+    if head_dim is None and hidden and n_heads:
+        head_dim = hidden // n_heads
+
+    arch = {}
+    if cfg.get("num_layers"):
+        arch["num_hidden_layers"] = int(cfg["num_layers"])
+    if n_heads:
+        arch["num_attention_heads"] = int(n_heads)
+    if n_kv:
+        arch["num_key_value_heads"] = int(n_kv)
+    if head_dim:
+        arch["head_dim"] = int(head_dim)
+    if hidden:
+        arch["hidden_size"] = int(hidden)
+    if cfg.get("intermediate_dim"):
+        arch["intermediate_size"] = int(cfg["intermediate_dim"])
+    return arch
+
+
+# vLLM is optional at import time, so the subclass is defined only when present.
+try:
+    from vllm import LLM as _BaseLLM
+except Exception:  # noqa: BLE001 - vllm not installed / import failure
+    _BaseLLM = None
+
+
+if _BaseLLM is not None:
+
+    class KerasHubLLM(_BaseLLM):
+        """A `vllm.LLM` that accepts the ``keras_hub:<preset>`` model scheme.
+
+        This is plain subclassing (no monkeypatching): a ``keras_hub:`` model
+        string is normalized into a materialized model directory (config +
+        tokenizer) before delegating to ``vllm.LLM``. Any other model string is
+        passed straight through, so the class behaves exactly like ``vllm.LLM``
+        for non-KerasHub models.
+
+        Example::
+
+            from keras_hub.src.vllm import KerasHubLLM
+            llm = KerasHubLLM("keras_hub:gpt2_base_en")
+            llm.generate(["The future of AI is"], sampling_params)
+        """
+
+        def __init__(self, model, **kwargs):
+            if isinstance(model, str) and model.startswith("keras_hub:"):
+                preset = model.split("keras_hub:", 1)[1]
+                # dtype defaults to bf16 (TPU paged KV cache); consumed here, not
+                # forwarded — the exported config.json carries torch_dtype.
+                dtype = kwargs.pop("dtype", "bfloat16")
+                os.environ.setdefault("MODEL_IMPL_TYPE", "vllm")
+                register_keras_hub_models()
+                model = setup_vllm_model(preset, dtype=dtype)
+                kwargs.setdefault("tokenizer", model)
+            super().__init__(model=model, **kwargs)
+
+else:
+
+    class KerasHubLLM:  # pragma: no cover - exercised only without vLLM
+        """Placeholder when vLLM is unavailable; raises on use."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "KerasHubLLM requires vLLM. Install vllm (or vllm-tpu) first."
+            )

--- a/keras_hub/src/vllm/registry.py
+++ b/keras_hub/src/vllm/registry.py
@@ -171,6 +171,47 @@ def _export_hf_tokenizer(tokenizer, temp_dir: str) -> bool:
     return True
 
 
+def _copy_preset_tokenizer_json(preset: str, temp_dir: str) -> bool:
+    """Fallback: copy the preset's own HF ``tokenizer.json`` into ``temp_dir``.
+
+    Some presets (e.g. ``gpt2_large_en``) ship a ready-made fast-tokenizer
+    ``tokenizer.json`` but omit the ``vocabulary.json`` that KerasHub's
+    ``Tokenizer.from_preset`` needs, so the normal export path can't run. vLLM
+    loads ``tokenizer.json`` directly, so this keeps raw-text prompts working.
+    Returns True only if the copied tokenizer round-trips.
+    """
+    try:
+        from keras_hub.src.utils import preset_utils
+
+        src = preset_utils.get_file(preset, "tokenizer.json")
+    except Exception as e:  # noqa: BLE001
+        logging.warning("No preset tokenizer.json for %r: %s", preset, e)
+        return False
+    if not src or not os.path.exists(src):
+        return False
+    shutil.copyfile(src, os.path.join(temp_dir, "tokenizer.json"))
+    cfg_path = os.path.join(temp_dir, "tokenizer_config.json")
+    if not os.path.exists(cfg_path):
+        with open(cfg_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "tokenizer_class": "PreTrainedTokenizerFast",
+                    "clean_up_tokenization_spaces": False,
+                },
+                f,
+            )
+    try:
+        from transformers import AutoTokenizer
+
+        reloaded = AutoTokenizer.from_pretrained(temp_dir)
+        if len(reloaded("hello world").get("input_ids", [])) > 0:
+            return True
+        logging.warning("Preset tokenizer.json for %r produced empty output.", preset)
+    except Exception as e:  # noqa: BLE001
+        logging.warning("Preset tokenizer.json unusable for %r: %s", preset, e)
+    return False
+
+
 def _register_model_architecture() -> None:
     """Registers KerasVLLMAdapter with vLLM's internal model registry."""
     try:
@@ -223,31 +264,52 @@ def setup_vllm_model(preset: str, dtype: str = "float16") -> str:
     # (e.g. GPT-2's 50257 vs. Gemma's 256000).
     vocab_size = None
     eos_token_id = None
+    tokenizer = None
+    # Load the KerasHub tokenizer (best effort) for vocab_size / eos and as the
+    # primary HF-export source.
     try:
         from keras_hub import models
 
         tokenizer = models.Tokenizer.from_preset(preset)
         vocab_size = int(tokenizer.vocabulary_size())
         eos_token_id = getattr(tokenizer, "end_token_id", None)
-        # Export HF-format tokenizer files so vLLM can accept raw-text prompts.
-        # If unsupported (e.g. SentencePiece), pass skip_tokenizer_init=True to
-        # LLM(...) and feed token IDs tokenized with the KerasHub tokenizer.
-        if _export_hf_tokenizer(tokenizer, temp_dir):
-            logging.info("Exported HF tokenizer assets for preset %r.", preset)
-        else:
-            logging.warning(
-                "Could not export an HF tokenizer for preset %r; use "
-                "skip_tokenizer_init=True + pre-tokenized input.",
-                preset,
-            )
-    except Exception as e:  # noqa: BLE001 - fall back to a sane default
+    except Exception as e:  # noqa: BLE001
         logging.warning(
-            "Could not infer vocab_size for preset %r (%s); falling back to a "
-            "default. Set it explicitly if memory profiling looks wrong.",
-            preset,
-            e,
+            "Could not load KerasHub tokenizer for preset %r (%s).", preset, e
         )
-        vocab_size = 50272 if "opt" in preset_lower else 256000
+
+    # Export an HF tokenizer so vLLM accepts raw text. Prefer the KerasHub
+    # tokenizer; if that's unavailable/fails, fall back to the preset's own
+    # tokenizer.json (some presets ship it without vocabulary.json).
+    exported = False
+    if tokenizer is not None:
+        try:
+            exported = _export_hf_tokenizer(tokenizer, temp_dir)
+        except Exception as e:  # noqa: BLE001
+            logging.warning("HF tokenizer export failed for %r: %s", preset, e)
+    if not exported:
+        exported = _copy_preset_tokenizer_json(preset, temp_dir)
+    if exported:
+        logging.info("Exported HF tokenizer assets for preset %r.", preset)
+    else:
+        logging.warning(
+            "Could not export an HF tokenizer for preset %r; use "
+            "skip_tokenizer_init=True + pre-tokenized input.",
+            preset,
+        )
+
+    # Sane vocab_size default by family when it couldn't be inferred (vLLM uses
+    # it for KV-cache memory profiling, so the gemma default mis-sizes GPT-2/OPT).
+    if vocab_size is None:
+        if "gpt2" in preset_lower or "gpt_2" in preset_lower:
+            vocab_size = 50257
+        elif "opt" in preset_lower:
+            vocab_size = 50272
+        else:
+            vocab_size = 256000
+        logging.warning(
+            "vocab_size not inferred for %r; defaulting to %d.", preset, vocab_size
+        )
 
     config_dict = {
         "architectures": ["KerasVLLMAdapter"],

--- a/keras_hub/src/vllm/tests/__init__.py
+++ b/keras_hub/src/vllm/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for vLLM integration.
+"""

--- a/keras_hub/src/vllm/tests/attention_test.py
+++ b/keras_hub/src/vllm/tests/attention_test.py
@@ -1,0 +1,106 @@
+"""CPU unit tests for the paged-attention bridge shape/argument handling.
+
+These exercise `maybe_vllm_paged_attention` with a recording stand-in for the
+injected kernel, so no TPU/vLLM/tpu-inference is required — only keras (any
+backend) + numpy.
+"""
+
+from keras import ops
+
+from keras_hub.src.vllm import context as vllm_context
+from keras_hub.src.vllm.attention import maybe_vllm_paged_attention
+
+
+class _RecordingKernel:
+    """Stands in for tpu-inference's _jax_attn_func.
+
+    Records the call and echoes back (new_kv_cache, outputs) where outputs has
+    the same flat (num_tokens, num_heads*head_dim) shape as the query input,
+    matching the real kernel's output convention.
+    """
+
+    def __init__(self):
+        self.args = None
+        self.kwargs = None
+
+    def __call__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        kv_cache, q = args[0], args[1]
+        return kv_cache, q
+
+
+def teardown_function(_):
+    vllm_context.clear_vllm_context()
+
+
+def test_returns_none_when_context_inactive():
+    vllm_context.clear_vllm_context()
+    z = ops.zeros((1, 2, 4, 8))
+    assert maybe_vllm_paged_attention(z, z, z, None, 0.125) is None
+
+
+def test_shape_conversion_and_argument_order():
+    kernel = _RecordingKernel()
+    cache = ops.zeros((3, 4))
+    vllm_context.set_vllm_context(
+        block_tables=None,
+        slot_mapping=None,
+        attention_metadata="META",
+        paged_attention_func=kernel,
+        mesh="MESH",
+    )
+    B, T, H, D = 1, 2, 4, 8
+    q = ops.reshape(ops.arange(B * T * H * D, dtype="float32"), (B, T, H, D))
+    k = ops.ones((B, T, H, D))
+    v = ops.ones((B, T, H, D))
+
+    out, new_cache = maybe_vllm_paged_attention(q, k, v, cache, scale=0.125)
+
+    # Output is restored to KerasHub's (B, T, H, D) layout.
+    assert tuple(out.shape) == (B, T, H, D)
+
+    args, kwargs = kernel.args, kernel.kwargs
+    # Order mirrors _jax_attn_func:
+    # (kv_cache, q, k, v, sinks, attn_meta, mesh, scale, head_size,
+    #  num_heads, num_kv_heads)
+    assert args[0] is cache
+    assert tuple(args[1].shape) == (B * T, H * D)  # flattened query
+    assert tuple(args[2].shape) == (B * T, H * D)  # flattened key
+    assert tuple(args[3].shape) == (B * T, H * D)  # flattened value
+    assert args[4] is None  # sinks
+    assert args[5] == "META"
+    assert args[6] == "MESH"
+    assert args[7] == 0.125  # scale
+    assert args[8] == D  # head_size
+    assert args[9] == H  # num_heads
+    assert args[10] == H  # num_kv_heads
+    assert kwargs.get("sliding_window") is None
+    assert "soft_cap" not in kwargs  # omitted when not provided
+
+
+def test_num_kv_heads_inferred_for_gqa():
+    kernel = _RecordingKernel()
+    vllm_context.set_vllm_context(None, None, "META", kernel, "MESH")
+    q = ops.ones((1, 1, 8, 4))  # 8 query heads
+    k = ops.ones((1, 1, 2, 4))  # 2 kv heads (grouped-query attention)
+    v = ops.ones((1, 1, 2, 4))
+
+    maybe_vllm_paged_attention(q, k, v, ops.zeros((1, 1)), scale=0.5)
+
+    assert kernel.args[9] == 8  # num_heads from query
+    assert kernel.args[10] == 2  # num_kv_heads from key
+
+
+def test_soft_cap_forwarded_only_when_set():
+    kernel = _RecordingKernel()
+    vllm_context.set_vllm_context(None, None, "META", kernel, "MESH")
+    q = ops.ones((1, 1, 2, 4))
+    k = ops.ones((1, 1, 2, 4))
+    v = ops.ones((1, 1, 2, 4))
+
+    maybe_vllm_paged_attention(
+        q, k, v, ops.zeros((1, 1)), scale=0.5, soft_cap=50.0, sliding_window=64
+    )
+    assert kernel.kwargs["soft_cap"] == 50.0
+    assert kernel.kwargs["sliding_window"] == 64

--- a/keras_hub/src/vllm/tests/context_test.py
+++ b/keras_hub/src/vllm/tests/context_test.py
@@ -1,0 +1,41 @@
+"""CPU unit tests for the thread-local vLLM context (no TPU/keras needed)."""
+
+from keras_hub.src.vllm import context as vllm_context
+
+
+def teardown_function(_):
+    vllm_context.clear_vllm_context()
+
+
+def test_inactive_by_default():
+    vllm_context.clear_vllm_context()
+    assert vllm_context.get_vllm_context() is None
+
+
+def test_set_get_roundtrip():
+    vllm_context.set_vllm_context(
+        block_tables="BT",
+        slot_mapping="SM",
+        attention_metadata="META",
+        paged_attention_func="FUNC",
+        mesh="MESH",
+    )
+    ctx = vllm_context.get_vllm_context()
+    assert ctx is not None
+    assert ctx.block_tables == "BT"
+    assert ctx.slot_mapping == "SM"
+    assert ctx.attention_metadata == "META"
+    assert ctx.paged_attention_func == "FUNC"
+    assert ctx.mesh == "MESH"
+    assert ctx.active is True
+
+
+def test_clear_resets_everything():
+    vllm_context.set_vllm_context("BT", "SM", "META", "FUNC", "MESH")
+    vllm_context.clear_vllm_context()
+    assert vllm_context.get_vllm_context() is None
+    # The singleton's fields are reset too.
+    from keras_hub.src.vllm.context import _vllm_context
+
+    assert _vllm_context.mesh is None
+    assert _vllm_context.paged_attention_func is None

--- a/keras_hub/src/vllm/tests/tokenizer_export_test.py
+++ b/keras_hub/src/vllm/tests/tokenizer_export_test.py
@@ -1,0 +1,78 @@
+"""CPU unit tests for HF tokenizer export in setup_vllm_model.
+
+Uses a tiny fake KerasHub byte-level BPE tokenizer so no preset download is
+needed. Importing registry pulls the adapter (torch/jax), so we skip cleanly if
+those aren't installed.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+# registry imports the adapter, which needs torch + jax.
+pytest.importorskip("torch")
+pytest.importorskip("jax")
+
+from keras_hub.src.vllm.registry import _export_hf_tokenizer  # noqa: E402
+
+
+class _FakeBPETokenizer:
+    """Minimal stand-in for a KerasHub BytePairTokenizer (GPT-2 style)."""
+
+    proto = None  # marks this as NOT SentencePiece
+
+    def __init__(self):
+        # A tiny but valid byte-level vocab + merges.
+        self.vocabulary = {
+            "<|endoftext|>": 0,
+            "Ġ": 1,
+            "t": 2,
+            "h": 3,
+            "e": 4,
+            "Ġt": 5,
+            "Ġth": 6,
+            "Ġthe": 7,
+        }
+        self.merges = ["Ġ t", "Ġt h", "Ġth e"]
+
+    def save_assets(self, dir_path):
+        with open(os.path.join(dir_path, "vocabulary.json"), "w") as f:
+            json.dump(self.vocabulary, f)
+        with open(os.path.join(dir_path, "merges.txt"), "w") as f:
+            for merge in self.merges:
+                f.write(merge + "\n")
+
+
+def test_bpe_export_writes_hf_files():
+    tmp = tempfile.mkdtemp()
+    ok = _export_hf_tokenizer(_FakeBPETokenizer(), tmp)
+
+    assert ok is True
+    # HF byte-level BPE needs vocab.json + merges.txt.
+    assert os.path.exists(os.path.join(tmp, "vocab.json"))
+    assert os.path.exists(os.path.join(tmp, "merges.txt"))
+    # A usable tokenizer config is present (fast tokenizer.json, or the slow
+    # GPT2Tokenizer fallback config).
+    assert os.path.exists(os.path.join(tmp, "tokenizer.json")) or os.path.exists(
+        os.path.join(tmp, "tokenizer_config.json")
+    )
+
+
+def test_merges_txt_has_version_header():
+    # HF's BPE parser drops the first merges line; the export must prepend a
+    # header so no real merge rule is lost.
+    tmp = tempfile.mkdtemp()
+    _export_hf_tokenizer(_FakeBPETokenizer(), tmp)
+    with open(os.path.join(tmp, "merges.txt")) as f:
+        first = f.readline()
+    assert first.startswith("#version")
+
+
+def test_non_bpe_non_sp_returns_false():
+    # An object that is neither BPE (no merges) nor SentencePiece (no proto).
+    class _Other:
+        proto = None
+
+    assert _export_hf_tokenizer(_Other(), tempfile.mkdtemp()) is False

--- a/keras_hub/src/vllm/tokenizer.py
+++ b/keras_hub/src/vllm/tokenizer.py
@@ -1,0 +1,128 @@
+"""
+Tokenizer adapter for bridging KerasHub Tokenizers to vLLM.
+
+This module provides the necessary wrappers to ensure vLLM processes tokens
+identically to the native KerasHub environment.
+"""
+
+from typing import Any, Dict, List, Union
+
+from keras import ops
+from keras_hub import models
+
+
+class KerasVLLMTokenizerAdapter:
+    """Adapts a Keras Hub Tokenizer to the interface expected by vLLM.
+
+    To ensure complete numerical and logical consistency, the vLLM runner
+    uses the exact tokenizer assets provided by the KerasHub preset.
+    """
+
+    def __init__(self, preset_or_tokenizer: Union[str, Any]):
+        """Initializes the tokenizer wrapper for vLLM.
+
+        Args:
+            preset_or_tokenizer: The name of the KerasHub preset to load or
+                a loaded Tokenizer.
+        """
+        if isinstance(preset_or_tokenizer, str):
+            self.preset_name = preset_or_tokenizer
+            self.tokenizer = models.Tokenizer.from_preset(preset_or_tokenizer)
+        else:
+            self.preset_name = getattr(preset_or_tokenizer, "name", "unknown")
+            self.tokenizer = preset_or_tokenizer
+
+    @property
+    def is_fast(self) -> bool:
+        """Returns whether this is a fast tokenizer."""
+        return False
+
+    @property
+    def vocab_size(self) -> int:
+        """Returns the size of the vocabulary."""
+        return self.tokenizer.vocabulary_size()
+
+    def __len__(self) -> int:
+        """Returns the vocabulary size when length is requested."""
+        return self.vocab_size
+
+    @property
+    def bos_token_id(self) -> int:
+        """Returns the ID of the beginning-of-sequence token."""
+        return getattr(self.tokenizer, "start_token_id", 2)
+
+    @property
+    def eos_token_id(self) -> int:
+        """Returns the ID of the end-of-sequence token."""
+        return getattr(self.tokenizer, "end_token_id", 1)
+
+    @property
+    def pad_token_id(self) -> int:
+        """Returns the ID of the padding token."""
+        return getattr(self.tokenizer, "pad_token_id", 0)
+
+    @property
+    def all_special_ids(self) -> List[int]:
+        """Returns a list of all special token IDs."""
+        special_ids = [self.bos_token_id, self.eos_token_id, self.pad_token_id]
+        return [token_id for token_id in special_ids if token_id is not None]
+
+    @property
+    def all_special_tokens(self) -> List[str]:
+        """Returns a list of all special tokens."""
+        return ["<bos>", "<eos>", "<pad>"]
+
+    def get_vocab(self) -> Dict[str, int]:
+        """Returns a dictionary mapping tokens to integer IDs.
+
+        vLLM expects this to construct its tokenizer cache keys.
+
+        Returns:
+            A dictionary mapping strings to their token IDs.
+        """
+        if hasattr(self.tokenizer, "get_vocabulary"):
+            vocab_list = self.tokenizer.get_vocabulary()
+            return {token: idx for idx, token in enumerate(vocab_list)}
+
+        # Fallback if get_vocabulary is not exposed
+        vocab = {}
+        for i in range(self.vocab_size):
+            try:
+                vocab[self.tokenizer.id_to_token(i)] = i
+            except Exception:
+                vocab[str(i)] = i
+        return vocab
+
+    def encode(self, text: str, **kwargs: Any) -> List[int]:
+        """Converts text to token IDs using the native Keras Hub tokenizer.
+
+        Args:
+            text: The text to encode.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A list of token IDs.
+        """
+        token_ids = self.tokenizer(text)
+        return ops.convert_to_numpy(token_ids).tolist()
+
+    def decode(self, token_ids: List[int], **kwargs: Any) -> str:
+        """Converts token IDs back to text using the native Keras Hub tokenizer.
+
+        Args:
+            token_ids: A list of token IDs.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The decoded string.
+        """
+        text = self.tokenizer.detokenize(token_ids)
+        try:
+            np_text = ops.convert_to_numpy(text)
+            if hasattr(np_text, "item"):
+                np_text = np_text.item()
+            if isinstance(np_text, bytes):
+                return np_text.decode("utf-8")
+            return str(np_text)
+        except Exception:
+            return str(text)


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
Adds a self-contained `keras_hub/src/vllm/` module that lets any supported KerasHub `CausalLM` be served through vLLM's TPU backend (`tpu-inference`) using its native Pallas **paged-attention** kernel, reusing backbones, `from_preset()` weights, presets, and tokenizers, via a one-line API:

```python
from keras_hub.src.vllm import KerasHubLLM
llm = KerasHubLLM("keras_hub:gemma_2b_en")
print(llm.generate(["The future of AI is"])[0].outputs[0].text)
```
No core Keras layer gains a hard dependency on vLLM; the only touch points in core layers are cheap, guarded conditionals that are inert outside vLLM serving. The existing `generate()` path is unchanged.

**Why:** KerasHub generation today uses a static, dense, per-request KV cache with no continuous batching, paged attention, prefix sharing, or scheduler. This wires KerasHub into vLLM's runtime to get those, while staying on the JAX/TPU stack where Keras/JAX are the natural toolchain. The existing `generate()` path is unchanged.

**Design: contained module and guarded hooks.** No core Keras layer gains a hard dependency on vLLM; the only touch points in core layers are cheap, guarded conditionals that are inert outside vLLM serving. No hardware kernel is duplicated in KerasHub (it borrows `tpu-inference`'s RPA kernel).

New module `keras_hub/src/vllm/`:

| File | Role |
|---|---|
| `adapter.py` | `KerasVLLMAdapter`, vLLM model interface; runs the backbone so per-layer paged caches thread through; PyTorch↔JAX bridge; tied-embedding logits |
| `attention.py` | `maybe_vllm_paged_attention()`, single bridge into the RPA kernel (shape conversion, GQA inference, scale/sliding_window/soft_cap) |
| `context.py` | thread-local `vllm_context` (block tables, slot mapping, attn metadata, injected kernel fn, mesh, positions) |
| `registry.py` | `register_keras_hub_models()`, `setup_vllm_model()` (config.json and HF tokenizer export with `tokenizer.json` fallback), `KerasHubLLM` |
| `tokenizer.py` | HF tokenizer export (byte-level BPE and SentencePiece) with round-trip verification |
| `tests/` | CPU unit tests (context, bridge, tokenizer export) |

Guarded hooks in existing attention layers (no-ops outside vLLM serving): `cached_multi_head_attention.py` (GPT-2) and the `gemma`/`llama`/`mistral` attention layers gain a branch that delegates to the bridge only when a serving context is active.

**Roadmap:**
- [x] vLLM serving scaffold — thread-local serving context
- [x] Paged-attention bridge (`maybe_vllm_paged_attention`)
- [x] `KerasVLLMAdapter` (torch.nn.Module wrapping a Keras `CausalLM`)
- [x] HF tokenizer export (byte-level BPE + SentencePiece)
- [x] Registry , `setup_vllm_model` , `KerasHubLLM` one-line API
- [x] GPT-2 attention hook
- [x] Gemma / Llama / Mistral attention hooks (RoPE at vLLM positions, GQA, soft-cap)
- [x] CPU unit tests (context, bridge, tokenizer export)
- [x] Correctness: next-token-exact vs native KerasHub (bf16)
- [x] Benchmarks: pure Keras vs vLLM-native vs this integration (TTFT / throughput / latency)

**Notes / limitations:** TPU/JAX path only (`MODEL_IMPL_TYPE=vllm`); serving runs in bf16 to match the TPU paged KV cache. **Follow-up (deferred):** `gemma3`/ `gemma4` attention hooks; Gemma 2/3 soft-cap end-to-end validation; multi-chip sharding (TP>1)

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->
- Companion serving-side hooks: `vllm-project/tpu-inference` PR (registry recognition, Pallas-kernel injection, `soft_cap` forwarding). <!-- link once opened -->
- vLLM PagedAttention / continuous batching; `tpu-inference` Ragged Paged Attention (RPA) kernel.

## Colab Notebook

**Usage:** `colab_test.ipynb` — `KerasHubLLM("keras_hub:<preset>")` end-to-end on TPU (GPT-2, Gemma 2B, Llama 3.2 1B).

**Correctness:** the integration's next token matches native KerasHub greedy generation (bf16) **exactly** for the test prompts. (Full-text greedy parity isn't the bar: bf16-on-TPU paged attention vs bf16-on-CPU dense attention diverges after the first precision-driven argmax flip — so we compare the next-token distribution in matched dtype.) CPU unit tests cover the dependency-light logic.

**Benchmarks** (`colab_benchmark.ipynb`): `gpt2_large_en` (774M) on TPU v6e, bf16, 128 output tokens, warm, best-of-3. **A** = pure KerasHub `generate()` (floor), **B** = vLLM-native (ceiling), **C** = this integration.

Throughput (output tok/s) and speedups:

| prompt (tok) | conc | A | B | C | **C/A** | **C/B** |
|---:|---:|---:|---:|---:|:---:|:---:|
| 37 | 1 | 536.9 | 359.1 | 322.7 | 0.60× | 0.90× |
| 37 | 32 | 2329 | 5642 | 5517 | **2.37×** | 0.98× |
| 37 | 64 | 2475 | 6175 | 6174 | **2.49×** | 1.00× |
| 37 | 128 | 4751 | 6589 | 6559 | 1.38× | 1.00× |
| 602 | 1 | 442.1 | 330.4 | 327.8 | 0.74× | 0.99× |
| 602 | 32 | 583.0 | 5329 | 5246 | **9.00×** | 0.98× |
| 602 | 64 | **OOM** | 5923 | 5888 | **A-OOM** | 0.99× |
| 602 | 128 | **OOM** | 6341 | 6294 | **A-OOM** | 0.99× |

Time-to-first-token (p50, s):

| prompt (tok) | conc | A | B | C |
|---:|---:|---:|---:|---:|
| 37 | 1 | 0.0045 | 0.0095 | 0.012 |
| 37 | 128 | 0.041 | 0.134 | 0.130 |
| 602 | 1 | 0.0085 | 0.011 | 0.011 |
| 602 | 32 | 0.150 | 0.062 | 0.064 |
| 602 | 64 | OOM | 0.113 | 0.118 |
| 602 | 128 | OOM | 0.225 | 0.229 |

**Takeaways:** C ≈ B on every metric (C/B ≈ 0.98–1.00× past c=1) → the adapter adds no measurable overhead vs native vLLM. C beats pure Keras under load (2.4× at moderate concurrency, **9× at long-context c=32**, serves loads where pure Keras **OOMs**; TTFT ~2.4× lower at 602/c=32). Pure Keras wins only at c=1 (single-request) — the regime paged serving isn't built to optimize.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
