### PR TITLE
 Pin kagglesdk==0.1.30 and surface kagglehub import errors

### DIFF
--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -18,8 +18,15 @@ from keras_hub.src.utils.tensor_utils import get_tensor_size_in_bits
 try:
     import kagglehub
     from kagglehub.exceptions import KaggleApiHTTPError
-except ImportError:
+except ModuleNotFoundError:
     kagglehub = None
+except ImportError as e:
+    raise ImportError(
+        f"The `kagglehub` package is installed but failed to import "
+        f"due to a dependency error: {e}. This is likely caused by an "
+        f"incompatible version of `kagglesdk`. Please try: "
+        f"`pip install --upgrade kagglehub kagglesdk`."
+    ) from e
 
 try:
     import huggingface_hub

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -18,15 +18,16 @@ from keras_hub.src.utils.tensor_utils import get_tensor_size_in_bits
 try:
     import kagglehub
     from kagglehub.exceptions import KaggleApiHTTPError
-except ModuleNotFoundError:
-    kagglehub = None
 except ImportError as e:
-    raise ImportError(
-        f"The `kagglehub` package is installed but failed to import "
-        f"due to a dependency error: {e}. This is likely caused by an "
-        f"incompatible version of `kagglesdk`. Please try: "
-        f"`pip install --upgrade kagglehub kagglesdk`."
-    ) from e
+    if getattr(e, "name", None) == "kagglehub":
+        kagglehub = None
+    else:
+        raise ImportError(
+            f"The `kagglehub` package is installed but failed to import "
+            f"due to a dependency error: {e}. This is likely caused by "
+            f"an incompatible version of `kagglesdk`. Please try: "
+            f"`pip install --upgrade kagglehub kagglesdk`."
+        ) from e
 
 try:
     import huggingface_hub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "regex",
     "rich",
     "kagglehub!=1.0.1",
+    "kagglesdk==0.1.30",
     "sentencepiece",
     "tokenizers",
     "tensorflow-text;platform_system != 'Windows'",

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -3,6 +3,7 @@ dm-tree
 regex
 rich
 kagglehub!=1.0.1
+kagglesdk==0.1.30
 tokenizers
 sentencepiece
 # Tooling deps.


### PR DESCRIPTION
## Description of the change



Pin kagglesdk to the stable Jun 11 release (0.1.30) to prevent
broken transitive dependency versions (e.g., 0.1.31, 0.1.32) from
silently breaking CI.

Also update the kagglehub import in `preset_utils.py`  to distinguish
between ModuleNotFoundError (package not installed) and ImportError
(broken dependency), so future issues surface immediately with a
clear error message instead of the misleading "please install
kagglehub" error.


- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
