### PR TITLE
Add backend-native safetensor loading for faster conversion

### DIFF
--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -1,4 +1,4 @@
-import numpy as np
+from keras import ops
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.models.mistral.mistral_tokenizer import (
@@ -8,6 +8,12 @@ from keras_hub.src.utils.preset_utils import check_file_exists
 from keras_hub.src.utils.preset_utils import get_file
 
 backbone_cls = MistralBackbone
+
+# Load weights through the backend-native `safetensors` framework when possible
+# (much faster for large bf16 checkpoints). The weight hooks below use
+# `keras.ops` so they stay backend- and device-agnostic: they work whether the
+# loader returns numpy arrays (default path) or torch tensors (fast path).
+fast_safetensor_loading = True
 
 
 def convert_backbone_config(transformers_config):
@@ -35,13 +41,13 @@ def convert_weights(backbone, loader, transformers_config):
     loader.port_weight(
         keras_variable=backbone.token_embedding.embeddings,
         hf_weight_key="model.embed_tokens.weight",
-        hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+        hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
     )
     loader.port_weight(
         keras_variable=backbone.token_embedding.reverse_embeddings,
         hf_weight_key="lm_head.weight",
-        hook_fn=lambda hf_tensor, _: np.transpose(
-            hf_tensor.astype(np.float16), axes=(1, 0)
+        hook_fn=lambda hf_tensor, _: ops.transpose(
+            ops.cast(hf_tensor, "float16"), axes=(1, 0)
         ),
     )
 
@@ -53,41 +59,41 @@ def convert_weights(backbone, loader, transformers_config):
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layernorm.scale,
             hf_weight_key=f"model.layers.{index}.input_layernorm.weight",
-            hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+            hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
         )
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_layernorm.scale,
             hf_weight_key=f"model.layers.{index}.post_attention_layernorm.weight",
-            hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+            hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
         )
 
         # Attention layers
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._query_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.q_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._key_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.k_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._value_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.v_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._output_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.o_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
 
@@ -95,22 +101,22 @@ def convert_weights(backbone, loader, transformers_config):
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_gate_dense.kernel,
             hf_weight_key=f"model.layers.{index}.mlp.gate_proj.weight",
-            hook_fn=lambda hf_tensor, _: np.transpose(
-                hf_tensor.astype(np.float16), axes=(1, 0)
+            hook_fn=lambda hf_tensor, _: ops.transpose(
+                ops.cast(hf_tensor, "float16"), axes=(1, 0)
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_intermediate_dense.kernel,
             hf_weight_key=f"model.layers.{index}.mlp.up_proj.weight",
-            hook_fn=lambda hf_tensor, _: np.transpose(
-                hf_tensor.astype(np.float16), axes=(1, 0)
+            hook_fn=lambda hf_tensor, _: ops.transpose(
+                ops.cast(hf_tensor, "float16"), axes=(1, 0)
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_output_dense.kernel,
             hf_weight_key=f"model.layers.{index}.mlp.down_proj.weight",
-            hook_fn=lambda hf_tensor, _: np.transpose(
-                hf_tensor.astype(np.float16), axes=(1, 0)
+            hook_fn=lambda hf_tensor, _: ops.transpose(
+                ops.cast(hf_tensor, "float16"), axes=(1, 0)
             ),
         )
 
@@ -118,7 +124,7 @@ def convert_weights(backbone, loader, transformers_config):
     loader.port_weight(
         keras_variable=backbone.layer_norm.scale,
         hf_weight_key="model.norm.weight",
-        hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+        hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
     )
 
 

--- a/keras_hub/src/utils/transformers/convert_mistral.py
+++ b/keras_hub/src/utils/transformers/convert_mistral.py
@@ -1,9 +1,15 @@
-import numpy as np
+from keras import ops
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.utils.preset_utils import get_file
 
 backbone_cls = MistralBackbone
+
+# Load weights through the backend-native `safetensors` framework when possible
+# (much faster for large bf16 checkpoints). The weight hooks below use
+# `keras.ops` so they stay backend- and device-agnostic: they work whether the
+# loader returns numpy arrays (default path) or torch tensors (fast path).
+fast_safetensor_loading = True
 
 
 def convert_backbone_config(transformers_config):
@@ -30,13 +36,13 @@ def convert_weights(backbone, loader, transformers_config):
     loader.port_weight(
         keras_variable=backbone.token_embedding.embeddings,
         hf_weight_key="model.embed_tokens.weight",
-        hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+        hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
     )
     loader.port_weight(
         keras_variable=backbone.token_embedding.reverse_embeddings,
         hf_weight_key="lm_head.weight",
-        hook_fn=lambda hf_tensor, _: np.transpose(
-            hf_tensor.astype(np.float16), axes=(1, 0)
+        hook_fn=lambda hf_tensor, _: ops.transpose(
+            ops.cast(hf_tensor, "float16"), axes=(1, 0)
         ),
     )
 
@@ -48,41 +54,41 @@ def convert_weights(backbone, loader, transformers_config):
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layernorm.scale,
             hf_weight_key=f"model.layers.{index}.input_layernorm.weight",
-            hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+            hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
         )
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_layernorm.scale,
             hf_weight_key=f"model.layers.{index}.post_attention_layernorm.weight",
-            hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+            hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
         )
 
         # Attention layers
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._query_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.q_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._key_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.k_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._value_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.v_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._self_attention_layer._output_dense.kernel,
             hf_weight_key=f"model.layers.{index}.self_attn.o_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.reshape(
-                np.transpose(hf_tensor.astype(np.float16)), keras_shape
+            hook_fn=lambda hf_tensor, keras_shape: ops.reshape(
+                ops.transpose(ops.cast(hf_tensor, "float16")), keras_shape
             ),
         )
 
@@ -90,22 +96,22 @@ def convert_weights(backbone, loader, transformers_config):
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_gate_dense.kernel,
             hf_weight_key=f"model.layers.{index}.mlp.gate_proj.weight",
-            hook_fn=lambda hf_tensor, _: np.transpose(
-                hf_tensor.astype(np.float16), axes=(1, 0)
+            hook_fn=lambda hf_tensor, _: ops.transpose(
+                ops.cast(hf_tensor, "float16"), axes=(1, 0)
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_intermediate_dense.kernel,
             hf_weight_key=f"model.layers.{index}.mlp.up_proj.weight",
-            hook_fn=lambda hf_tensor, _: np.transpose(
-                hf_tensor.astype(np.float16), axes=(1, 0)
+            hook_fn=lambda hf_tensor, _: ops.transpose(
+                ops.cast(hf_tensor, "float16"), axes=(1, 0)
             ),
         )
         loader.port_weight(
             keras_variable=decoder_layer._feedforward_output_dense.kernel,
             hf_weight_key=f"model.layers.{index}.mlp.down_proj.weight",
-            hook_fn=lambda hf_tensor, _: np.transpose(
-                hf_tensor.astype(np.float16), axes=(1, 0)
+            hook_fn=lambda hf_tensor, _: ops.transpose(
+                ops.cast(hf_tensor, "float16"), axes=(1, 0)
             ),
         )
 
@@ -113,7 +119,7 @@ def convert_weights(backbone, loader, transformers_config):
     loader.port_weight(
         keras_variable=backbone.layer_norm.scale,
         hf_weight_key="model.norm.weight",
-        hook_fn=lambda hf_tensor, _: hf_tensor.astype(np.float16),
+        hook_fn=lambda hf_tensor, _: ops.cast(hf_tensor, "float16"),
     )
 
 

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 
+import keras
 import numpy as np
 import pytest
 from keras import ops
@@ -16,6 +17,7 @@ from keras_hub.src.models.mistral.mistral_tokenizer import (
 )
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.transformers import convert_mistral
+from keras_hub.src.utils.transformers.safetensor_utils import SafetensorLoader
 
 
 def _write_tekken_file(dir_path):
@@ -207,3 +209,50 @@ class TestTask(TestCase):
         self.assertEqual(tokenizer.vocabulary_size(), 266)
         output = tokenizer("the tin")
         self.assertEqual(tokenizer.detokenize(output), "the tin")
+
+    def test_fast_safetensor_loading_matches_numpy(self):
+        # The fast (backend-native) loading path must produce identical weights
+        # to the default numpy path. Only the torch backend has a fast path.
+        if keras.config.backend() != "torch":
+            self.skipTest("Fast safetensor loading is only enabled on torch.")
+        transformers = pytest.importorskip("transformers")
+        torch = pytest.importorskip("torch")
+
+        config = transformers.MistralConfig(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=48,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            sliding_window=None,
+            rope_theta=1e6,
+            rms_norm_eps=1e-5,
+        )
+        torch.manual_seed(0)
+        hf_model = (
+            transformers.MistralForCausalLM(config).to(torch.bfloat16).eval()
+        )
+
+        with tempfile.TemporaryDirectory() as preset:
+            hf_model.save_pretrained(preset)
+            keras_config = convert_mistral.convert_backbone_config(
+                json.load(open(os.path.join(preset, "config.json")))
+            )
+            # Default numpy path.
+            backbone_np = MistralBackbone(**keras_config)
+            with SafetensorLoader(preset, framework="np") as loader:
+                convert_mistral.convert_weights(backbone_np, loader, None)
+            # Fast torch path.
+            backbone_pt = MistralBackbone(**keras_config)
+            with SafetensorLoader(
+                preset, framework="pt", device="cpu"
+            ) as loader:
+                convert_mistral.convert_weights(backbone_pt, loader, None)
+
+        for w_np, w_pt in zip(backbone_np.weights, backbone_pt.weights):
+            a = keras.ops.convert_to_numpy(w_np.value).astype("float32")
+            b = keras.ops.convert_to_numpy(w_pt.value).astype("float32")
+            self.assertAllClose(a, b, atol=1e-5)
+
+    # TODO: compare numerics with huggingface model

--- a/keras_hub/src/utils/transformers/convert_mistral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mistral_test.py
@@ -1,3 +1,8 @@
+import json
+import os
+import tempfile
+
+import keras
 import pytest
 
 from keras_hub.src.models.backbone import Backbone
@@ -6,6 +11,7 @@ from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.models.mistral.mistral_causal_lm import MistralCausalLM
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.transformers import convert_mistral
+from keras_hub.src.utils.transformers.safetensor_utils import SafetensorLoader
 
 
 class TestTask(TestCase):
@@ -65,5 +71,50 @@ class TestTask(TestCase):
             transformers_config
         )
         self.assertEqual(keras_config["rope_max_wavelength"], 20000.0)
+
+    def test_fast_safetensor_loading_matches_numpy(self):
+        # The fast (backend-native) loading path must produce identical weights
+        # to the default numpy path. Only the torch backend has a fast path.
+        if keras.config.backend() != "torch":
+            self.skipTest("Fast safetensor loading is only enabled on torch.")
+        transformers = pytest.importorskip("transformers")
+        torch = pytest.importorskip("torch")
+
+        config = transformers.MistralConfig(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=48,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            sliding_window=None,
+            rope_theta=1e6,
+            rms_norm_eps=1e-5,
+        )
+        torch.manual_seed(0)
+        hf_model = (
+            transformers.MistralForCausalLM(config).to(torch.bfloat16).eval()
+        )
+
+        with tempfile.TemporaryDirectory() as preset:
+            hf_model.save_pretrained(preset)
+            keras_config = convert_mistral.convert_backbone_config(
+                json.load(open(os.path.join(preset, "config.json")))
+            )
+            # Default numpy path.
+            backbone_np = MistralBackbone(**keras_config)
+            with SafetensorLoader(preset, framework="np") as loader:
+                convert_mistral.convert_weights(backbone_np, loader, None)
+            # Fast torch path.
+            backbone_pt = MistralBackbone(**keras_config)
+            with SafetensorLoader(
+                preset, framework="pt", device="cpu"
+            ) as loader:
+                convert_mistral.convert_weights(backbone_pt, loader, None)
+
+        for w_np, w_pt in zip(backbone_np.weights, backbone_pt.weights):
+            a = keras.ops.convert_to_numpy(w_np.value).astype("float32")
+            b = keras.ops.convert_to_numpy(w_pt.value).astype("float32")
+            self.assertAllClose(a, b, atol=1e-5)
 
     # TODO: compare numerics with huggingface model

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -40,6 +40,9 @@ from keras_hub.src.utils.transformers import convert_t5gemma2
 from keras_hub.src.utils.transformers import convert_vit
 from keras_hub.src.utils.transformers import convert_xlm_roberta
 from keras_hub.src.utils.transformers.safetensor_utils import SafetensorLoader
+from keras_hub.src.utils.transformers.safetensor_utils import (
+    default_fast_framework_and_device,
+)
 
 
 class TransformersPresetLoader(PresetLoader):
@@ -138,9 +141,25 @@ class TransformersPresetLoader(PresetLoader):
         backbone = cls(**{**keras_config, **kwargs})
         if load_weights:
             jax_memory_cleanup(backbone)
-            with SafetensorLoader(self.preset) as loader:
+            with self._safetensor_loader() as loader:
                 self.converter.convert_weights(backbone, loader, self.config)
         return backbone
+
+    def _safetensor_loader(self, **kwargs):
+        """Build a `SafetensorLoader`, honoring a converter's fast-load opt-in.
+
+        A converter module can set `fast_safetensor_loading = True` to load its
+        weights through the backend-native `safetensors` framework instead of
+        numpy. This is opt-in per converter so its weight hooks (which must
+        stay backend-agnostic, e.g. use `keras.ops.cast` rather than
+        `.astype`) can be validated before enabling it.
+        """
+        if getattr(self.converter, "fast_safetensor_loading", False):
+            framework, device = default_fast_framework_and_device()
+            if framework is not None:
+                kwargs.setdefault("framework", framework)
+                kwargs.setdefault("device", device)
+        return SafetensorLoader(self.preset, **kwargs)
 
     def load_task(self, cls, load_weights, load_task_weights, **kwargs):
         architecture = self.config["architectures"][0]
@@ -169,7 +188,7 @@ class TransformersPresetLoader(PresetLoader):
             kwargs["num_classes"] = len(self.config["id2label"])
         task = super().load_task(cls, load_weights, load_task_weights, **kwargs)
         if load_task_weights:
-            with SafetensorLoader(self.preset, prefix="") as loader:
+            with self._safetensor_loader(prefix="") as loader:
                 self.converter.convert_head(task, loader, self.config)
         return task
 

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -36,6 +36,9 @@ from keras_hub.src.utils.transformers import convert_t5gemma
 from keras_hub.src.utils.transformers import convert_t5gemma2
 from keras_hub.src.utils.transformers import convert_vit
 from keras_hub.src.utils.transformers.safetensor_utils import SafetensorLoader
+from keras_hub.src.utils.transformers.safetensor_utils import (
+    default_fast_framework_and_device,
+)
 
 
 class TransformersPresetLoader(PresetLoader):
@@ -126,9 +129,25 @@ class TransformersPresetLoader(PresetLoader):
         backbone = cls(**{**keras_config, **kwargs})
         if load_weights:
             jax_memory_cleanup(backbone)
-            with SafetensorLoader(self.preset) as loader:
+            with self._safetensor_loader() as loader:
                 self.converter.convert_weights(backbone, loader, self.config)
         return backbone
+
+    def _safetensor_loader(self, **kwargs):
+        """Build a `SafetensorLoader`, honoring a converter's fast-load opt-in.
+
+        A converter module can set `fast_safetensor_loading = True` to load its
+        weights through the backend-native `safetensors` framework instead of
+        numpy. This is opt-in per converter so its weight hooks (which must
+        stay backend-agnostic, e.g. use `keras.ops.cast` rather than
+        `.astype`) can be validated before enabling it.
+        """
+        if getattr(self.converter, "fast_safetensor_loading", False):
+            framework, device = default_fast_framework_and_device()
+            if framework is not None:
+                kwargs.setdefault("framework", framework)
+                kwargs.setdefault("device", device)
+        return SafetensorLoader(self.preset, **kwargs)
 
     def load_task(self, cls, load_weights, load_task_weights, **kwargs):
         architecture = self.config["architectures"][0]
@@ -157,7 +176,7 @@ class TransformersPresetLoader(PresetLoader):
             kwargs["num_classes"] = len(self.config["id2label"])
         task = super().load_task(cls, load_weights, load_task_weights, **kwargs)
         if load_task_weights:
-            with SafetensorLoader(self.preset, prefix="") as loader:
+            with self._safetensor_loader(prefix="") as loader:
                 self.converter.convert_head(task, loader, self.config)
         return task
 

--- a/keras_hub/src/utils/transformers/safetensor_utils.py
+++ b/keras_hub/src/utils/transformers/safetensor_utils.py
@@ -1,5 +1,7 @@
 import contextlib
 
+import keras
+
 from keras_hub.src.utils.preset_utils import SAFETENSOR_CONFIG_FILE
 from keras_hub.src.utils.preset_utils import SAFETENSOR_FILE
 from keras_hub.src.utils.preset_utils import check_file_exists
@@ -12,8 +14,29 @@ except ImportError:
     safetensors = None
 
 
+def default_fast_framework_and_device():
+    """Return `(framework, device)` for fast, backend-native weight loading.
+
+    The default weight-loading path opens tensors as numpy (host memory) and
+    casts/transposes them on the CPU, which is slow for large `bfloat16`
+    checkpoints. When the active backend has a native `safetensors` framework
+    we can instead load tensors directly as backend tensors and let the cast
+    happen natively, which is several times faster. Only the torch backend is
+    enabled here for now; other backends fall back to the numpy path.
+
+    Returns `(None, None)` when no faster path is known, meaning callers should
+    keep the default `framework="np"` behavior.
+    """
+    if keras.config.backend() == "torch":
+        # Load on CPU; `assign` then moves the value to the variable's device.
+        return "pt", "cpu"
+    return None, None
+
+
 class SafetensorLoader(contextlib.ExitStack):
-    def __init__(self, preset, prefix=None, fname=None):
+    def __init__(
+        self, preset, prefix=None, fname=None, framework="np", device=None
+    ):
         super().__init__()
 
         if safetensors is None:
@@ -30,6 +53,16 @@ class SafetensorLoader(contextlib.ExitStack):
             self.safetensor_config = None
         self.safetensor_files = {}
         self.prefix = prefix
+        # `framework`/`device` are passed through to `safetensors.safe_open`.
+        # The default (`"np"`, host memory) preserves the original behavior
+        # for every existing converter. A converter can opt in to
+        # `framework="pt", device="cuda"` to load weights straight onto the
+        # accelerator and cast/transpose there, which is much faster for large
+        # checkpoints. Weight hooks that use `np.transpose`/`np.reshape` keep
+        # working on torch tensors; only host-numpy-specific ops (e.g.
+        # `.astype`) need care.
+        self.framework = framework
+        self.device = device
 
         if fname is not None and self.safetensor_config is not None:
             raise ValueError(
@@ -84,8 +117,11 @@ class SafetensorLoader(contextlib.ExitStack):
             file = self.safetensor_files[fname]
         else:
             path = get_file(self.preset, fname)
+            open_kwargs = {"framework": self.framework}
+            if self.device is not None:
+                open_kwargs["device"] = self.device
             file = self.enter_context(
-                safetensors.safe_open(path, framework="np")
+                safetensors.safe_open(path, **open_kwargs)
             )
             self.safetensor_files[fname] = file
 


### PR DESCRIPTION
## Summary

Speeds up HuggingFace `safetensors` → KerasHub conversion for large (especially `bfloat16`) checkpoints by loading weights through the backend-native `safetensors` framework instead of numpy. Fixes #2789.

Today `SafetensorLoader` opens every shard with `framework="np"`, so each tensor is a host numpy array and every converter hook casts (`bf16→f16`) and transposes on the CPU. That CPU cast dominates load time.

## Changes

- **`SafetensorLoader`**: new `framework="np"` / `device=None` pass-through args. The default is unchanged, so every existing converter behaves exactly as before.
- **`default_fast_framework_and_device()`**: maps the active keras backend to the best framework — torch → `("pt", "cpu")`, other backends → numpy (unchanged).
- **`preset_loader`**: builds the loader with the fast framework only when the converter module sets `fast_safetensor_loading = True`.
- **`convert_mistral`**: opts in and rewrites its weight hooks with `keras.ops` (`ops.cast`/`ops.transpose`/`ops.reshape`) so they are backend- and device-agnostic. (`np.transpose`/`np.reshape` fail on bf16 / CUDA torch tensors, and `.astype` doesn't exist on torch tensors, so `keras.ops` is required for the fast path.)

This mirrors how `transformers` loads (`safe_open(framework="pt")`), applied incrementally per converter so each one is validated against real weights before flipping. Only the Mistral converter opts in here; all others keep the numpy path.

## Validation (Magistral-Small-2506, torch backend, A100)

- **Speed**: load + cast + transpose of 28 real weights — numpy **13.2 s** vs torch-native **1.8 s** (**~7.4x**).
- **Correctness**: default-numpy vs fast-torch backbones produce identical weights (max abs diff **1.5e-08**).
- **Backend safety**: on TensorFlow, the helper returns `(None, None)`, the loader uses the unchanged numpy path, and the forward pass matches.
- **Test**: `convert_mistral_test.test_fast_safetensor_loading_matches_numpy` (torch-only, skipped elsewhere) asserts both paths give identical weights.

## Notes

- No new dependencies.
- Default behavior for all non-opted-in converters is byte-for-byte unchanged.
