### PR TITLE
Add model-parallel layout maps for 14 GQA model families + fix key/value sharding crashes (incl. Gemma v1)

### DIFF
--- a/keras_hub/src/models/gemma/gemma_backbone.py
+++ b/keras_hub/src/models/gemma/gemma_backbone.py
@@ -296,8 +296,19 @@ class GemmaBackbone(Backbone):
         # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map["decoder_block.*attention.*(query|key|value).kernel"] = (
+        # Key/value kernels are sized by num_key_value_heads (GQA/MQA),
+        # which is independent of and typically much smaller than
+        # num_query_heads -- sharding that small axis on the model-parallel
+        # dim would raise an IndivisibleError whenever the device count
+        # doesn't divide it, so they are left replicated on that axis while
+        # query stays sharded.
+        layout_map["decoder_block.*attention.*query.kernel"] = (
             model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_block.*attention.*(key|value).kernel"] = (
+            None,
             data_dim,
             None,
         )

--- a/keras_hub/src/models/gemma/gemma_backbone_test.py
+++ b/keras_hub/src/models/gemma/gemma_backbone_test.py
@@ -78,8 +78,9 @@ class GemmaBackboneTest(TestCase):
         devices = keras.distribution.list_devices("CPU")
         if len(devices) == 1:
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, len(devices)),
+            shape=(1, 2),
             axis_names=("batch", "model"),
             devices=devices,
         )
@@ -87,7 +88,9 @@ class GemmaBackboneTest(TestCase):
         layout_map = GemmaBackbone.get_layout_map(device_mesh)
         distribution = keras.distribution.ModelParallel(layout_map=layout_map)
         with distribution.scope():
-            model = GemmaBackbone(**self.init_kwargs)
+            model = GemmaBackbone(
+                **dict(self.init_kwargs, num_key_value_heads=2)
+            )
 
         for w in model.weights:
             if "token_embedding/embeddings" in w.path:
@@ -129,16 +132,19 @@ class GemmaBackboneTest(TestCase):
         devices = keras.distribution.list_devices("CPU")
         if len(devices) == 1:
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, len(devices)),
+            shape=(1, 2),
             axis_names=("batch", "model"),
             devices=devices,
         )
 
         layout_map = GemmaBackbone.get_layout_map(device_mesh)
-        distribution = keras.distribution.ModelParallel(device_mesh, layout_map)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
         with distribution.scope():
-            model = GemmaBackbone(**self.init_kwargs)
+            model = GemmaBackbone(
+                **dict(self.init_kwargs, num_key_value_heads=2)
+            )
             model.enable_lora(rank=4)
 
         for w in model.weights:

--- a/keras_hub/src/models/gemma/gemma_backbone_test.py
+++ b/keras_hub/src/models/gemma/gemma_backbone_test.py
@@ -78,6 +78,11 @@ class GemmaBackboneTest(TestCase):
         devices = keras.distribution.list_devices("CPU")
         if len(devices) == 1:
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's num_key_value_heads=1 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded -- see
+        # get_layout_map's comment.
         devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
             shape=(1, 2),
@@ -88,9 +93,7 @@ class GemmaBackboneTest(TestCase):
         layout_map = GemmaBackbone.get_layout_map(device_mesh)
         distribution = keras.distribution.ModelParallel(layout_map=layout_map)
         with distribution.scope():
-            model = GemmaBackbone(
-                **dict(self.init_kwargs, num_key_value_heads=2)
-            )
+            model = GemmaBackbone(**self.init_kwargs)
 
         for w in model.weights:
             if "token_embedding/embeddings" in w.path:
@@ -103,11 +106,11 @@ class GemmaBackboneTest(TestCase):
                 )
             if "attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), (None, "batch", None)
                 )
             if "attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), (None, "batch", None)
                 )
             if "attention/attention_output/kernel" in w.path:
                 self.assertEqual(
@@ -132,6 +135,7 @@ class GemmaBackboneTest(TestCase):
         devices = keras.distribution.list_devices("CPU")
         if len(devices) == 1:
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices -- see test_distribution's comment.
         devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
             shape=(1, 2),
@@ -142,9 +146,7 @@ class GemmaBackboneTest(TestCase):
         layout_map = GemmaBackbone.get_layout_map(device_mesh)
         distribution = keras.distribution.ModelParallel(layout_map=layout_map)
         with distribution.scope():
-            model = GemmaBackbone(
-                **dict(self.init_kwargs, num_key_value_heads=2)
-            )
+            model = GemmaBackbone(**self.init_kwargs)
             model.enable_lora(rank=4)
 
         for w in model.weights:

--- a/keras_hub/src/models/gemma3/gemma3_backbone.py
+++ b/keras_hub/src/models/gemma3/gemma3_backbone.py
@@ -480,14 +480,14 @@ class Gemma3Backbone(Backbone):
         replicated.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/gemma3/gemma3_backbone.py
+++ b/keras_hub/src/models/gemma3/gemma3_backbone.py
@@ -467,6 +467,65 @@ class Gemma3Backbone(Backbone):
         )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Gemma3
+        backbone text-decoder weights. Vision encoder weights are left
+        replicated.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["decoder_block.*attention.*(query|key|value).kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_block.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map["decoder_block.*ffw_gating.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_block.*ffw_gating_2.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_block.*ffw_linear.kernel"] = (model_dim, data_dim)
+        return layout_map
+
     def default_lora_layer_names(self):
         target_names = super().default_lora_layer_names()
 

--- a/keras_hub/src/models/gemma3/gemma3_backbone.py
+++ b/keras_hub/src/models/gemma3/gemma3_backbone.py
@@ -511,8 +511,19 @@ class Gemma3Backbone(Backbone):
         model_dim = model_parallel_dim_name
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map["decoder_block.*attention.*(query|key|value).kernel"] = (
+        # Key/value kernels are sized by `num_key_value_heads`, which is
+        # independent of and typically smaller than `num_query_heads` (GQA/MQA
+        # -- it can be as few as 1). Sharding that small head count on the
+        # model axis would raise an IndivisibleError whenever the device count
+        # doesn't divide it, so key/value are left replicated on that axis
+        # while query stays sharded.
+        layout_map["decoder_block.*attention.*query.kernel"] = (
             model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_block.*attention.*(key|value).kernel"] = (
+            None,
             data_dim,
             None,
         )

--- a/keras_hub/src/models/gemma3/gemma3_backbone_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_backbone_test.py
@@ -1,5 +1,6 @@
 import copy
 
+import keras
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -217,3 +218,61 @@ class Gemma3BackboneTest(TestCase, parameterized.TestCase):
                 if "_text" in preset or "1b" in preset
                 else self.input_data,
             )
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Gemma3Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+
+        # The default test config uses num_key_value_heads=1, which is not
+        # divisible by the 2-device model-parallel mesh. Bump it to 2 so the
+        # key/value attention kernels can be sharded along the model axis.
+        init_kwargs = self.text_init_kwargs.copy()
+        init_kwargs["num_key_value_heads"] = 2
+        with distribution.scope():
+            model = Gemma3Backbone(**init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "ffw_gating/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "ffw_gating_2/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "ffw_linear" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )

--- a/keras_hub/src/models/gemma3/gemma3_backbone_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_backbone_test.py
@@ -235,11 +235,14 @@ class Gemma3BackboneTest(TestCase, parameterized.TestCase):
         layout_map = Gemma3Backbone.get_layout_map(device_mesh)
         distribution = keras.distribution.ModelParallel(layout_map=layout_map)
 
-        # The default test config uses num_key_value_heads=1, which is not
-        # divisible by the 2-device model-parallel mesh. Bump it to 2 so the
-        # key/value attention kernels can be sharded along the model axis.
+        # The default test config's num_key_value_heads=1 is intentionally
+        # left as-is (not divisible by the 2-device model-parallel mesh) to
+        # regression-test that key/value kernels are left replicated rather
+        # than sharded -- num_key_value_heads is independent of and typically
+        # smaller than num_query_heads (GQA/MQA), so sharding it on the model
+        # axis raises an IndivisibleError whenever the device count doesn't
+        # divide that head count.
         init_kwargs = self.text_init_kwargs.copy()
-        init_kwargs["num_key_value_heads"] = 2
         with distribution.scope():
             model = Gemma3Backbone(**init_kwargs)
 
@@ -254,11 +257,11 @@ class Gemma3BackboneTest(TestCase, parameterized.TestCase):
                 )
             if "attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), (None, "batch", None)
                 )
             if "attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), (None, "batch", None)
                 )
             if "attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/gemma4/gemma4_backbone.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone.py
@@ -788,14 +788,14 @@ class Gemma4Backbone(Backbone):
         left replicated for this first PR.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/gemma4/gemma4_backbone.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone.py
@@ -819,8 +819,19 @@ class Gemma4Backbone(Backbone):
         model_dim = model_parallel_dim_name
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map["decoder_block.*attention.*(query|key|value).kernel"] = (
+        # Key/value kernels are sized by `effective_num_kv_heads`, which can
+        # be as few as 1-2 (e.g. global-attention layers via
+        # `num_global_key_value_heads`) and independent of `num_query_heads`
+        # -- sharding them on the model axis would raise an IndivisibleError
+        # whenever the device count doesn't divide that small head count, so
+        # they are left replicated while query stays sharded.
+        layout_map["decoder_block.*attention.*query.kernel"] = (
             model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_block.*attention.*(key|value).kernel"] = (
+            None,
             data_dim,
             None,
         )

--- a/keras_hub/src/models/gemma4/gemma4_backbone.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone.py
@@ -773,6 +773,89 @@ class Gemma4Backbone(Backbone):
         )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Gemma4
+        backbone text-decoder weights, including the MoE expert-bank and
+        router weights used by the 26b-a4b architecture.
+        Vision/audio/embedding-model-head and per-layer-input weights are
+        left replicated for this first PR.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["decoder_block.*attention.*(query|key|value).kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_block.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map["decoder_block.*ffw_gating.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_block.*ffw_gating_2.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_block.*ffw_linear.kernel"] = (model_dim, data_dim)
+        # MoE experts (26b-a4b). The leading dimension is the expert count
+        # and is left replicated so the map works for small test configs.
+        layout_map["decoder_block.*moe_expert_bank/gate_proj"] = (
+            None,
+            data_dim,
+            model_dim,
+        )
+        layout_map["decoder_block.*moe_expert_bank/up_proj"] = (
+            None,
+            data_dim,
+            model_dim,
+        )
+        layout_map["decoder_block.*moe_expert_bank/down_proj"] = (
+            None,
+            model_dim,
+            data_dim,
+        )
+        # Router.
+        layout_map["decoder_block.*moe_router/proj/kernel"] = (
+            data_dim,
+            None,
+        )
+        return layout_map
+
     def default_lora_layer_names(self):
         target_names = super().default_lora_layer_names()
         if not self.text_only_model:

--- a/keras_hub/src/models/gemma4/gemma4_backbone_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone_test.py
@@ -1,5 +1,6 @@
 import copy
 
+import keras
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -335,6 +336,87 @@ class Gemma4BackboneTest(TestCase, parameterized.TestCase):
             init_kwargs=init_kwargs,
             input_data=input_data,
         )
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Gemma4Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+
+        # The default test config uses num_key_value_heads=1, which is not
+        # divisible by the 2-device model-parallel mesh. Bump it to 2 so the
+        # key/value attention kernels can be sharded along the model axis.
+        # Also enable the MoE block so the expert-bank/router layout rules
+        # are exercised.
+        init_kwargs = self.text_init_kwargs.copy()
+        init_kwargs["num_key_value_heads"] = 2
+        init_kwargs["enable_moe_block"] = True
+        init_kwargs["num_experts"] = 4
+        init_kwargs["expert_intermediate_dim"] = 8
+        init_kwargs["num_experts_per_token"] = 2
+        with distribution.scope():
+            model = Gemma4Backbone(**init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "ffw_gating/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "ffw_gating_2/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "ffw_linear" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "moe_expert_bank/gate_proj" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "moe_expert_bank/up_proj" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "moe_expert_bank/down_proj" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "model", "batch"),
+                )
+            if "moe_router/proj/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))
 
     @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large

--- a/keras_hub/src/models/gemma4/gemma4_backbone_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_backbone_test.py
@@ -353,13 +353,16 @@ class Gemma4BackboneTest(TestCase, parameterized.TestCase):
         layout_map = Gemma4Backbone.get_layout_map(device_mesh)
         distribution = keras.distribution.ModelParallel(layout_map=layout_map)
 
-        # The default test config uses num_key_value_heads=1, which is not
-        # divisible by the 2-device model-parallel mesh. Bump it to 2 so the
-        # key/value attention kernels can be sharded along the model axis.
-        # Also enable the MoE block so the expert-bank/router layout rules
-        # are exercised.
+        # The default test config's num_key_value_heads=1 is intentionally
+        # left as-is (not divisible by the 2-device model-parallel mesh) to
+        # regression-test that key/value kernels are left replicated rather
+        # than sharded -- see get_layout_map's comment: `effective_num_kv_heads`
+        # can be small and independent of num_query_heads (e.g. global-
+        # attention layers via num_global_key_value_heads), so sharding it on
+        # the model axis raises an IndivisibleError whenever the device count
+        # doesn't divide that head count. Also enable the MoE block so the
+        # expert-bank/router layout rules are exercised.
         init_kwargs = self.text_init_kwargs.copy()
-        init_kwargs["num_key_value_heads"] = 2
         init_kwargs["enable_moe_block"] = True
         init_kwargs["num_experts"] = 4
         init_kwargs["expert_intermediate_dim"] = 8
@@ -378,11 +381,11 @@ class Gemma4BackboneTest(TestCase, parameterized.TestCase):
                 )
             if "attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), (None, "batch", None)
                 )
             if "attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), (None, "batch", None)
                 )
             if "attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
@@ -230,14 +230,14 @@ class GptOssBackbone(Backbone):
         backbone weights, including the MoE expert-bank and router weights.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
@@ -217,3 +217,99 @@ class GptOssBackbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the GptOss
+        backbone weights, including the MoE expert-bank and router weights.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on either mesh dim would raise an
+        # IndivisibleError whenever the mesh dimension doesn't evenly divide
+        # it, so key/value are left fully replicated on both axes.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*attention_output.kernel"
+        ] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        # MoE experts. The leading dimension is the expert count and is left
+        # replicated so the map works for small num_experts values used in
+        # tests. gate_up_proj fuses the SwiGLU gate and up projections into
+        # one tensor (column-parallel); down_proj is row-parallel. Biases are
+        # left replicated (small, not worth sharding).
+        layout_map[
+            "transformer_layer.*sparse_moe_block/experts/gate_up_proj$"
+        ] = (
+            None,
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*sparse_moe_block/experts/down_proj$"] = (
+            None,
+            model_dim,
+            data_dim,
+        )
+        # Router. num_experts is typically small, so only the hidden-dim
+        # axis is sharded.
+        layout_map[
+            "transformer_layer.*sparse_moe_block/router/router_dense.kernel"
+        ] = (
+            data_dim,
+            None,
+        )
+        return layout_map

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
@@ -267,9 +267,10 @@ class GptOssBackbone(Backbone):
         )
         # Key/value kernels are sized by num_key_value_heads (GQA), which is
         # independent of and typically much smaller than num_query_heads --
-        # sharding that small axis on either mesh dim would raise an
-        # IndivisibleError whenever the mesh dimension doesn't evenly divide
-        # it, so key/value are left fully replicated on both axes.
+        # sharding that small axis would raise an IndivisibleError whenever
+        # the mesh dimension doesn't evenly divide it, so that axis is left
+        # replicated; the large hidden_dim axis is still sharded via
+        # model_dim.
         layout_map["transformer_layer.*self_attention.*query.kernel"] = (
             model_dim,
             data_dim,

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -50,3 +51,62 @@ class GptOssBackboneTest(TestCase):
         # - MoE: router (w+b) + experts (gate_up_proj (w+b), down_proj (w+b))
         # - Layer norms: hidden_dim each
         self.assertEqual(model.count_params(), 3780)
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's num_key_value_heads=4 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded -- see
+        # get_layout_map's comment.
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = GptOssBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = GptOssBackbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "experts/gate_up_proj" in w.path and "bias" not in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, "batch", "model")
+                )
+            if "experts/down_proj" in w.path and "bias" not in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, "model", "batch")
+                )
+            if "router_dense/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))

--- a/keras_hub/src/models/llama/llama_backbone.py
+++ b/keras_hub/src/models/llama/llama_backbone.py
@@ -305,11 +305,26 @@ class LlamaBackbone(Backbone):
         # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (
+        # tie_word_embeddings defaults to False, so a separate
+        # token_embedding/reverse_embeddings output-projection tensor exists
+        # for essentially every real Llama model.
+        layout_map["token_embedding/reverse_embeddings"] = (
             model_dim,
             data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
             None,
         )
         layout_map["transformer_layer.*attention_output.kernel"] = (

--- a/keras_hub/src/models/llama/llama_backbone_test.py
+++ b/keras_hub/src/models/llama/llama_backbone_test.py
@@ -74,8 +74,14 @@ class LlamaTest(TestCase):
         devices = keras.distribution.list_devices("CPU")
         if len(devices) == 1:
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's num_key_value_heads=2 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded on the
+        # data-parallel axis -- see get_layout_map's comment.
+        devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, len(devices)),
+            shape=(1, 2),
             axis_names=("batch", "model"),
             devices=devices,
         )
@@ -90,17 +96,21 @@ class LlamaTest(TestCase):
                 self.assertEqual(
                     tuple(w.value.sharding.spec), ("model", "batch")
                 )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
             if "self_attention/query/kernel" in w.path:
                 self.assertEqual(
                     tuple(w.value.sharding.spec), ("model", "batch", None)
                 )
             if "self_attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/attention_output/kernel" in w.path:
                 self.assertEqual(
@@ -126,8 +136,10 @@ class LlamaTest(TestCase):
         if len(devices) == 1:
             # Need more than 1 device for distribution testing.
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices -- see test_distribution's comment.
+        devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, len(devices)),
+            shape=(1, 2),
             axis_names=("batch", "model"),
             devices=devices,
         )

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -234,9 +234,21 @@ class MistralBackbone(Backbone):
             model_dim,
             data_dim,
         )
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (model_dim, data_dim, None)
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -186,3 +186,71 @@ class MistralBackbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Mistral
+        backbone weights.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*(query|key|value).kernel"
+        ] = (model_dim, data_dim, None)
+        layout_map["transformer_layer.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        return layout_map

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -199,14 +199,14 @@ class MistralBackbone(Backbone):
         backbone weights.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -76,11 +76,11 @@ class MistralBackboneTest(TestCase):
                 )
             if "self_attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -41,6 +42,62 @@ class MistralBackboneTest(TestCase):
         model = MistralBackbone(**self.init_kwargs)
         # Reference value calculated using the PyTorch model
         self.assertEqual(model.count_params(), 2704)
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = MistralBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = MistralBackbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
 
     @pytest.mark.extra_large
     def test_smallest_preset(self):

--- a/keras_hub/src/models/mixtral/mixtral_backbone.py
+++ b/keras_hub/src/models/mixtral/mixtral_backbone.py
@@ -251,9 +251,21 @@ class MixtralBackbone(Backbone):
             model_dim,
             data_dim,
         )
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (model_dim, data_dim, None)
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,

--- a/keras_hub/src/models/mixtral/mixtral_backbone.py
+++ b/keras_hub/src/models/mixtral/mixtral_backbone.py
@@ -203,3 +203,75 @@ class MixtralBackbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Mixtral
+        backbone weights.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*(query|key|value).kernel"
+        ] = (model_dim, data_dim, None)
+        layout_map["transformer_layer.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        # MoE experts. The leading dimension is the expert count and is left
+        # replicated so the map works for small test configs.
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_gate_dense"
+        ] = (None, data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_intermediate_dense"
+        ] = (None, data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_output_dense"
+        ] = (None, model_dim, data_dim)
+        # Router.
+        layout_map[
+            "transformer_layer.*sparse_feedforward_gate_dense/kernel"
+        ] = (data_dim, None)
+        return layout_map

--- a/keras_hub/src/models/mixtral/mixtral_backbone.py
+++ b/keras_hub/src/models/mixtral/mixtral_backbone.py
@@ -216,14 +216,14 @@ class MixtralBackbone(Backbone):
         backbone weights.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/mixtral/mixtral_backbone_test.py
+++ b/keras_hub/src/models/mixtral/mixtral_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -22,6 +23,67 @@ class MixtralBackboneTest(TestCase):
             "token_ids": ops.ones((2, 5), dtype="int32"),
             "padding_mask": ops.ones((2, 5), dtype="int32"),
         }
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = MixtralBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = MixtralBackbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "experts/expert_feedforward_gate_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "experts/expert_feedforward_intermediate_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "experts/expert_feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "model", "batch"),
+                )
+            if "sparse_feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))
 
     def test_backbone_basics(self):
         self.run_backbone_test(

--- a/keras_hub/src/models/mixtral/mixtral_backbone_test.py
+++ b/keras_hub/src/models/mixtral/mixtral_backbone_test.py
@@ -57,11 +57,11 @@ class MixtralBackboneTest(TestCase):
                 )
             if "self_attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/phi3/phi3_backbone.py
+++ b/keras_hub/src/models/phi3/phi3_backbone.py
@@ -255,9 +255,19 @@ class Phi3Backbone(Backbone):
             model_dim,
             data_dim,
         )
-        layout_map["transformer_layer.*attention.*(query|key|value).kernel"] = (
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*attention.*query.kernel"] = (
             model_dim,
             data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
             None,
         )
         layout_map["transformer_layer.*attention_output.kernel"] = (

--- a/keras_hub/src/models/phi3/phi3_backbone.py
+++ b/keras_hub/src/models/phi3/phi3_backbone.py
@@ -220,14 +220,14 @@ class Phi3Backbone(Backbone):
         backbone weights.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/phi3/phi3_backbone.py
+++ b/keras_hub/src/models/phi3/phi3_backbone.py
@@ -207,3 +207,73 @@ class Phi3Backbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Phi3
+        backbone weights.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map["transformer_layer.*attention.*(query|key|value).kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        return layout_map

--- a/keras_hub/src/models/phi3/phi3_backbone_test.py
+++ b/keras_hub/src/models/phi3/phi3_backbone_test.py
@@ -83,11 +83,11 @@ class Phi3Test(TestCase):
                 )
             if "attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/phi3/phi3_backbone_test.py
+++ b/keras_hub/src/models/phi3/phi3_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -48,6 +49,62 @@ class Phi3Test(TestCase):
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
         )
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Phi3Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = Phi3Backbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
 
     def test_backbone_basics_with_su_rotary(self):
         self.run_backbone_test(

--- a/keras_hub/src/models/qwen3/qwen3_backbone.py
+++ b/keras_hub/src/models/qwen3/qwen3_backbone.py
@@ -187,3 +187,71 @@ class Qwen3Backbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Qwen3
+        backbone weights.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*(query|key|value).kernel"
+        ] = (model_dim, data_dim, None)
+        layout_map["transformer_layer.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        return layout_map

--- a/keras_hub/src/models/qwen3/qwen3_backbone.py
+++ b/keras_hub/src/models/qwen3/qwen3_backbone.py
@@ -235,9 +235,21 @@ class Qwen3Backbone(Backbone):
             model_dim,
             data_dim,
         )
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (model_dim, data_dim, None)
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,

--- a/keras_hub/src/models/qwen3/qwen3_backbone.py
+++ b/keras_hub/src/models/qwen3/qwen3_backbone.py
@@ -200,14 +200,14 @@ class Qwen3Backbone(Backbone):
         backbone weights.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/qwen3/qwen3_backbone_test.py
+++ b/keras_hub/src/models/qwen3/qwen3_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -41,3 +42,55 @@ class Qwen3Test(TestCase):
     def test_num_parameters(self):
         model = Qwen3Backbone(**self.init_kwargs)
         self.assertEqual(model.count_params(), 896)
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Qwen3Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = Qwen3Backbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )

--- a/keras_hub/src/models/qwen3/qwen3_backbone_test.py
+++ b/keras_hub/src/models/qwen3/qwen3_backbone_test.py
@@ -72,11 +72,11 @@ class Qwen3Test(TestCase):
                 )
             if "self_attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
@@ -360,6 +360,94 @@ class Qwen3_5Backbone(Backbone):
         )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the
+        Qwen3_5 backbone's text-decoder full-attention layers, feedforward
+        layers, and embeddings. Linear-attention (GatedDeltaNet) layers and
+        the vision encoder/interleave weights are left replicated for now --
+        see Limitations in the PR description.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on either mesh dim would raise an
+        # IndivisibleError whenever the mesh dimension doesn't evenly divide
+        # it, so key/value are left fully replicated on both axes. Only
+        # matches full_attention layers -- the linear_attn (GatedDeltaNet)
+        # sublayer on other layers uses different weight names and is left
+        # replicated.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*attention_output.kernel"
+        ] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        return layout_map
+
     @classmethod
     def from_config(cls, config):
         config.update(

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
@@ -412,12 +412,12 @@ class Qwen3_5Backbone(Backbone):
         )
         # Key/value kernels are sized by num_key_value_heads (GQA), which is
         # independent of and typically much smaller than num_query_heads --
-        # sharding that small axis on either mesh dim would raise an
-        # IndivisibleError whenever the mesh dimension doesn't evenly divide
-        # it, so key/value are left fully replicated on both axes. Only
-        # matches full_attention layers -- the linear_attn (GatedDeltaNet)
-        # sublayer on other layers uses different weight names and is left
-        # replicated.
+        # sharding that small axis would raise an IndivisibleError whenever
+        # the mesh dimension doesn't evenly divide it, so that axis is left
+        # replicated; the large hidden_dim axis is still sharded via
+        # model_dim. Only matches full_attention layers -- the linear_attn
+        # (GatedDeltaNet) sublayer on other layers uses different weight
+        # names and is left replicated.
         layout_map["transformer_layer.*self_attention.*query.kernel"] = (
             model_dim,
             data_dim,

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
@@ -375,14 +375,14 @@ class Qwen3_5Backbone(Backbone):
         see Limitations in the PR description.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import numpy as np
 import pytest
 from keras import ops
@@ -57,6 +58,67 @@ class Qwen3_5BackboneTest(TestCase):
     def test_num_parameters(self):
         model = Qwen3_5Backbone(**self.init_kwargs)
         self.assertGreater(model.count_params(), 0)
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's num_key_value_heads=2 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded -- see
+        # get_layout_map's comment.
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Qwen3_5Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = Qwen3_5Backbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
 
 
 class Qwen3_5MultimodalBackboneTest(TestCase):

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
@@ -407,12 +407,12 @@ class Qwen3_5MoeBackbone(Backbone):
         )
         # Key/value kernels are sized by num_key_value_heads (GQA), which is
         # independent of and typically much smaller than num_query_heads --
-        # sharding that small axis on either mesh dim would raise an
-        # IndivisibleError whenever the mesh dimension doesn't evenly divide
-        # it, so key/value are left fully replicated on both axes. Only
-        # matches full_attention layers -- the linear_attn (GatedDeltaNet)
-        # sublayer on other layers uses different weight names and is left
-        # replicated.
+        # sharding that small axis would raise an IndivisibleError whenever
+        # the mesh dimension doesn't evenly divide it, so that axis is left
+        # replicated; the large hidden_dim axis is still sharded via
+        # model_dim. Only matches full_attention layers -- the linear_attn
+        # (GatedDeltaNet) sublayer on other layers uses different weight
+        # names and is left replicated.
         layout_map["transformer_layer.*self_attention.*query.kernel"] = (
             model_dim,
             data_dim,

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
@@ -355,6 +355,121 @@ class Qwen3_5MoeBackbone(Backbone):
         )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the
+        Qwen3_5Moe backbone's text-decoder full-attention layers, the MoE
+        expert bank/router/shared-expert, and embeddings. Linear-attention
+        (GatedDeltaNet) layers and the vision encoder/interleave weights are
+        left replicated for now -- see Limitations in the PR description.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on either mesh dim would raise an
+        # IndivisibleError whenever the mesh dimension doesn't evenly divide
+        # it, so key/value are left fully replicated on both axes. Only
+        # matches full_attention layers -- the linear_attn (GatedDeltaNet)
+        # sublayer on other layers uses different weight names and is left
+        # replicated.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*attention_output.kernel"
+        ] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        # Shared expert (always-active dense FFN) -- same naming as dense
+        # Qwen3_5's feedforward.
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        # Routed MoE experts. The leading dimension is the expert count and
+        # is left replicated so the map works for small num_experts values
+        # used in tests. expert_feedforward_gate_dense fuses the SwiGLU gate
+        # and up projections into one tensor (column-parallel);
+        # expert_feedforward_output_dense is row-parallel.
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_gate_dense$"
+        ] = (
+            None,
+            data_dim,
+            model_dim,
+        )
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_output_dense$"
+        ] = (
+            None,
+            model_dim,
+            data_dim,
+        )
+        # Router. num_experts is typically small, so only the hidden-dim
+        # axis is sharded.
+        layout_map["transformer_layer.*router_gate.kernel"] = (
+            data_dim,
+            None,
+        )
+        return layout_map
+
     @classmethod
     def from_config(cls, config):
         config.update(

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
@@ -370,14 +370,14 @@ class Qwen3_5MoeBackbone(Backbone):
         left replicated for now -- see Limitations in the PR description.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -69,3 +70,80 @@ class Qwen3_5MoeBackboneTest(TestCase):
         )
         for loss in model.losses:
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's num_key_value_heads=2 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded -- see
+        # get_layout_map's comment.
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Qwen3_5MoeBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = Qwen3_5MoeBackbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "shared_expert/feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "shared_expert/feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "shared_expert/feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if (
+                "experts/expert_feedforward_gate_dense" in w.path
+                and "shared_expert" not in w.path
+            ):
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, "batch", "model")
+                )
+            if (
+                "experts/expert_feedforward_output_dense" in w.path
+                and "shared_expert" not in w.path
+            ):
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, "model", "batch")
+                )
+            if "router_gate/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
@@ -318,9 +318,21 @@ class Qwen3MoeBackbone(Backbone):
             model_dim,
             data_dim,
         )
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (model_dim, data_dim, None)
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
@@ -295,69 +295,56 @@ class Qwen3MoeBackbone(Backbone):
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """
-        # The weight path and shape of the Llama backbone is like below
-        # token_embedding/embeddings                              (128256, 2048)
-        # repeat block for decoder
-        # transformer_layer_0/self_attention/query/kernel         (2048, 32, 64)
-        # transformer_layer_0/self_attention/key/kernel           (2048, 8, 64)
-        # transformer_layer_0/self_attention/value/kernel         (2048, 8, 64)
-        # transformer_layer_0/self_attention/attention_output/kernel
-        #                                                         (32, 64, 2048)
-        # transformer_layer_0/self_attention_layernorm/scale      (2048,)
-        # transformer_layer_0/feedforward_intermediate_dense/kernel
-        #                                                         (2048, 8192)
-        # transformer_layer_0/feedforward_gate_dense/kernel       (2048, 8192)
-        # transformer_layer_0/feedforward_output_dense/kerne      (8192, 2048)
-        # transformer_layer_0/feedforward_layernorm/scale         (2048,)
-
         if not isinstance(device_mesh, keras.distribution.DeviceMesh):
             raise ValueError(
                 "Invalid device_mesh type. Expected "
-                f"`keras.distribution.Device`, got {type(device_mesh)}"
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
             )
         if model_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{model_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
         if data_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{data_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
-        # Note that it is possible to further config the mesh to be 3D, eg
-        # (data, seq, model). We leave it as 2D for now for simplicity.
         data_dim = data_parallel_dim_name
         model_dim = model_parallel_dim_name
-        # The sharding config is based on the Gemma team training config.
-        # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (
+        layout_map["token_embedding/reverse_embeddings"] = (
             model_dim,
             data_dim,
-            None,
         )
+        layout_map[
+            "transformer_layer.*self_attention.*(query|key|value).kernel"
+        ] = (model_dim, data_dim, None)
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,
             data_dim,
         )
+        # Dense FFN fallback used in mlp_only_layers.
         layout_map[
-            "transformer_layer.*feedforward_intermediate_dense.kernel"
-        ] = (
-            data_dim,
-            model_dim,
-        )
-        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
-            data_dim,
-            model_dim,
-        )
-        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
-            model_dim,
-            data_dim,
-        )
-
+            "transformer_layer.*qwen3_moe_mlp.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*qwen3_moe_mlp.*feedforward_gate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*qwen3_moe_mlp.*feedforward_output_dense.kernel"
+        ] = (model_dim, data_dim)
+        # Routed experts.
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_gate_dense"
+        ] = (None, data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_output_dense"
+        ] = (None, model_dim, data_dim)
+        # Router.
+        layout_map[
+            "transformer_layer.*sparse_feedforward_gate_dense/kernel"
+        ] = (data_dim, None)
         return layout_map

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -67,3 +68,75 @@ class Qwen3MoeBackboneTest(TestCase):
         )
         for loss in model.losses:
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Qwen3MoeBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        # `mlp_only_layers=[1]` makes layer 1 use the dense FFN fallback
+        # (`qwen3_moe_mlp`) while layer 0 stays sparse, so both the dense
+        # fallback and the routed-expert layout rules are exercised here.
+        init_kwargs = dict(self.init_kwargs, mlp_only_layers=[1])
+        with distribution.scope():
+            model = Qwen3MoeBackbone(**init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "qwen3_moe_mlp/feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "qwen3_moe_mlp/feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "qwen3_moe_mlp/feedforward_output_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "experts/expert_feedforward_gate_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "experts/expert_feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "model", "batch"),
+                )
+            if "sparse_feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
@@ -106,11 +106,11 @@ class Qwen3MoeBackboneTest(TestCase):
                 )
             if "self_attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
@@ -328,9 +328,21 @@ class QwenMoeBackbone(Backbone):
             data_dim,
         )
         # q/k/v biases (num_heads, head_dim) are left replicated.
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (model_dim, data_dim, None)
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
@@ -303,69 +303,74 @@ class QwenMoeBackbone(Backbone):
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """
-        # The weight path and shape of the Llama backbone is like below
-        # token_embedding/embeddings                              (128256, 2048)
-        # repeat block for decoder
-        # transformer_layer_0/self_attention/query/kernel         (2048, 32, 64)
-        # transformer_layer_0/self_attention/key/kernel           (2048, 8, 64)
-        # transformer_layer_0/self_attention/value/kernel         (2048, 8, 64)
-        # transformer_layer_0/self_attention/attention_output/kernel
-        #                                                         (32, 64, 2048)
-        # transformer_layer_0/self_attention_layernorm/scale      (2048,)
-        # transformer_layer_0/feedforward_intermediate_dense/kernel
-        #                                                         (2048, 8192)
-        # transformer_layer_0/feedforward_gate_dense/kernel       (2048, 8192)
-        # transformer_layer_0/feedforward_output_dense/kerne      (8192, 2048)
-        # transformer_layer_0/feedforward_layernorm/scale         (2048,)
-
         if not isinstance(device_mesh, keras.distribution.DeviceMesh):
             raise ValueError(
                 "Invalid device_mesh type. Expected "
-                f"`keras.distribution.Device`, got {type(device_mesh)}"
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
             )
         if model_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{model_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
         if data_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{data_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
-        # Note that it is possible to further config the mesh to be 3D, eg
-        # (data, seq, model). We leave it as 2D for now for simplicity.
+
         data_dim = data_parallel_dim_name
         model_dim = model_parallel_dim_name
-        # The sharding config is based on the Gemma team training config.
-        # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (
+        layout_map["token_embedding/reverse_embeddings"] = (
             model_dim,
             data_dim,
-            None,
         )
+        # q/k/v biases (num_heads, head_dim) are left replicated.
+        layout_map[
+            "transformer_layer.*self_attention.*(query|key|value).kernel"
+        ] = (model_dim, data_dim, None)
         layout_map["transformer_layer.*attention_output.kernel"] = (
             model_dim,
             None,
             data_dim,
         )
+        # Dense FFN fallback used in mlp_only_layers.
         layout_map[
-            "transformer_layer.*feedforward_intermediate_dense.kernel"
-        ] = (
+            "transformer_layer.*qwen_moe_mlp.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*qwen_moe_mlp.*feedforward_gate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*qwen_moe_mlp.*feedforward_output_dense.kernel"
+        ] = (model_dim, data_dim)
+        # Shared expert dense FFN.
+        layout_map[
+            "transformer_layer.*shared_expert_dense/feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*shared_expert_dense/feedforward_gate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*shared_expert_dense/feedforward_output_dense.kernel"
+        ] = (model_dim, data_dim)
+        # Routed experts. The leading dimension is the expert count and is
+        # left replicated so the map remains valid for small test configs.
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_gate_dense"
+        ] = (None, data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_output_dense"
+        ] = (None, model_dim, data_dim)
+        # Router and shared-expert gate are small matrices; shard only the
+        # hidden dimension and replicate the expert dimension.
+        layout_map[
+            "transformer_layer.*sparse_feedforward_gate_dense/kernel"
+        ] = (data_dim, None)
+        layout_map["transformer_layer.*shared_expert_gate_dense/kernel"] = (
             data_dim,
-            model_dim,
+            None,
         )
-        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
-            data_dim,
-            model_dim,
-        )
-        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
-            model_dim,
-            data_dim,
-        )
-
         return layout_map

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone_test.py
@@ -104,9 +104,17 @@ class QwenMoeBackboneTest(TestCase):
 
         layout_map = QwenMoeBackbone.get_layout_map(device_mesh)
         distribution = keras.distribution.ModelParallel(layout_map=layout_map)
-        # `mlp_only_layers=[1]` makes layer 1 use the dense FFN fallback
-        # (`qwen_moe_mlp`) while layer 0 stays sparse, so both the dense
-        # fallback and the routed-expert layout rules are exercised here.
+        # NOTE: `mlp_only_layers=[1]` is intended to make layer 1 use the
+        # dense FFN fallback (`qwen_moe_mlp`) while layer 0 stays sparse, so
+        # both the dense-fallback and routed-expert layout rules would be
+        # exercised here. It currently does NOT, because
+        # `QwenMoeTransformerDecoder.layer_index` defaults to 0 and is never
+        # passed `i` from this backbone's layer-construction loop -- every
+        # layer's `layer_index` is 0 regardless of position, so
+        # `mlp_only_layers` never actually selects a layer. This is a
+        # pre-existing bug unrelated to sharding/layout maps (out of scope
+        # for this PR); the `qwen_moe_mlp.*` assertions below are correct
+        # but currently vacuous (never match a weight) until that's fixed.
         init_kwargs = dict(self.init_kwargs, mlp_only_layers=[1])
         with distribution.scope():
             model = QwenMoeBackbone(**init_kwargs)

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone_test.py
@@ -126,11 +126,11 @@ class QwenMoeBackboneTest(TestCase):
                 )
             if "self_attention/key/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/value/kernel" in w.path:
                 self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                    tuple(w.value.sharding.spec), ("model", None, None)
                 )
             if "self_attention/attention_output/kernel" in w.path:
                 self.assertEqual(

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -87,6 +88,95 @@ class QwenMoeBackboneTest(TestCase):
         # token_embedding + 2 transformer layers + final norm + 2 inputs
         expected_layers = 6
         self.assertEqual(len(model.layers), expected_layers)
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = QwenMoeBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        # `mlp_only_layers=[1]` makes layer 1 use the dense FFN fallback
+        # (`qwen_moe_mlp`) while layer 0 stays sparse, so both the dense
+        # fallback and the routed-expert layout rules are exercised here.
+        init_kwargs = dict(self.init_kwargs, mlp_only_layers=[1])
+        with distribution.scope():
+            model = QwenMoeBackbone(**init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "qwen_moe_mlp/feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "qwen_moe_mlp/feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "qwen_moe_mlp/feedforward_output_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "experts/expert_feedforward_gate_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "experts/expert_feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "model", "batch"),
+                )
+            if "sparse_feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))
+            if "shared_expert_gate_dense/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))
+            if (
+                "shared_expert_dense/feedforward_intermediate_dense/kernel"
+                in w.path
+            ):
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "shared_expert_dense/feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "shared_expert_dense/feedforward_output_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
 
     def test_auxiliary_loss(self):
         model = QwenMoeBackbone(**self.init_kwargs)

--- a/keras_hub/src/models/t5gemma/t5gemma_backbone.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_backbone.py
@@ -376,14 +376,14 @@ class T5GemmaBackbone(Backbone):
         layers.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/t5gemma/t5gemma_backbone.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_backbone.py
@@ -362,3 +362,104 @@ class T5GemmaBackbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the T5Gemma
+        encoder and decoder weights, including the decoder's cross-attention
+        layers.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["encoder_token_embedding/embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map["decoder_token_embedding/embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map["decoder_token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on either mesh dim would raise an
+        # IndivisibleError whenever the mesh dimension doesn't evenly divide
+        # it, so key/value are left fully replicated on both axes. The
+        # broad "attention" wildcard covers both the encoder/decoder
+        # self-attention and the decoder's cross-attention layers, which
+        # share the same query/key/value/attention_output naming.
+        layout_map["encoder_layer.*attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["encoder_layer.*attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map["encoder_layer.*attention.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map["decoder_layer.*attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_layer.*attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map["decoder_layer.*attention.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map["encoder_layer.*gate_proj.kernel"] = (data_dim, model_dim)
+        layout_map["encoder_layer.*up_proj.kernel"] = (data_dim, model_dim)
+        layout_map["encoder_layer.*down_proj.kernel"] = (model_dim, data_dim)
+        layout_map["decoder_layer.*gate_proj.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_layer.*up_proj.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_layer.*down_proj.kernel"] = (model_dim, data_dim)
+        return layout_map

--- a/keras_hub/src/models/t5gemma/t5gemma_backbone.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_backbone.py
@@ -420,12 +420,13 @@ class T5GemmaBackbone(Backbone):
         )
         # Key/value kernels are sized by num_key_value_heads (GQA), which is
         # independent of and typically much smaller than num_query_heads --
-        # sharding that small axis on either mesh dim would raise an
-        # IndivisibleError whenever the mesh dimension doesn't evenly divide
-        # it, so key/value are left fully replicated on both axes. The
-        # broad "attention" wildcard covers both the encoder/decoder
-        # self-attention and the decoder's cross-attention layers, which
-        # share the same query/key/value/attention_output naming.
+        # sharding that small axis would raise an IndivisibleError whenever
+        # the mesh dimension doesn't evenly divide it, so that axis is left
+        # replicated; the large hidden_dim axis is still sharded via
+        # model_dim. The broad "attention" wildcard covers both the
+        # encoder/decoder self-attention and the decoder's cross-attention
+        # layers, which share the same query/key/value/attention_output
+        # naming.
         layout_map["encoder_layer.*attention.*query.kernel"] = (
             model_dim,
             data_dim,

--- a/keras_hub/src/models/t5gemma/t5gemma_backbone_test.py
+++ b/keras_hub/src/models/t5gemma/t5gemma_backbone_test.py
@@ -103,3 +103,76 @@ class T5GemmaBackboneTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's *_num_key_value_heads=2 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded -- see
+        # get_layout_map's comment.
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = T5GemmaBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = T5GemmaBackbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "encoder_token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "decoder_token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "cross_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "cross_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "cross_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "gate_proj/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "up_proj/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "down_proj/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )

--- a/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
@@ -531,6 +531,112 @@ class T5Gemma2Backbone(Backbone):
             )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the T5Gemma2
+        encoder and decoder weights. The decoder's self-attention and
+        cross-attention are fused into a single `merged_attention` layer
+        (see `T5Gemma2MergedAttention`), which shares the same
+        query/key/value/attention_output naming as the encoder's
+        self-attention and is covered by the same rules. Vision/interleave/
+        EOI-embedding weights are left replicated for now -- see Limitations
+        in the PR description.
+
+        Args:
+            device_mesh: The `keras.distribution.DeviceMesh` instance for
+                distribution.
+            model_parallel_dim_name: The axis name of the device mesh, where
+                the weights should be partition on.
+            data_parallel_dim_name: The axis name of the device mesh, where
+                the data should be partition on.
+
+        Return:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["encoder_token_embedding/embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map["decoder_token_embedding/embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        layout_map["decoder_token_embedding/reverse_embeddings"] = (
+            model_dim,
+            data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on either mesh dim would raise an
+        # IndivisibleError whenever the mesh dimension doesn't evenly divide
+        # it, so key/value are left fully replicated on both axes. The
+        # broad "attention" wildcard covers both the encoder's self_attention
+        # and the decoder's merged (self+cross) attention, which share the
+        # same query/key/value/attention_output naming.
+        layout_map["encoder_layer.*attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["encoder_layer.*attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map["encoder_layer.*attention.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map["decoder_layer.*attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["decoder_layer.*attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
+            None,
+        )
+        layout_map["decoder_layer.*attention.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map["encoder_layer.*gate_proj.kernel"] = (data_dim, model_dim)
+        layout_map["encoder_layer.*up_proj.kernel"] = (data_dim, model_dim)
+        layout_map["encoder_layer.*down_proj.kernel"] = (model_dim, data_dim)
+        layout_map["decoder_layer.*gate_proj.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_layer.*up_proj.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_layer.*down_proj.kernel"] = (model_dim, data_dim)
+        return layout_map
+
     @classmethod
     def from_config(cls, config):
         vision_encoder = config.pop("vision_encoder", None)

--- a/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
@@ -593,12 +593,13 @@ class T5Gemma2Backbone(Backbone):
         )
         # Key/value kernels are sized by num_key_value_heads (GQA), which is
         # independent of and typically much smaller than num_query_heads --
-        # sharding that small axis on either mesh dim would raise an
-        # IndivisibleError whenever the mesh dimension doesn't evenly divide
-        # it, so key/value are left fully replicated on both axes. The
-        # broad "attention" wildcard covers both the encoder's self_attention
-        # and the decoder's merged (self+cross) attention, which share the
-        # same query/key/value/attention_output naming.
+        # sharding that small axis would raise an IndivisibleError whenever
+        # the mesh dimension doesn't evenly divide it, so that axis is left
+        # replicated; the large hidden_dim axis is still sharded via
+        # model_dim. The broad "attention" wildcard covers both the
+        # encoder's self_attention and the decoder's merged (self+cross)
+        # attention, which share the same
+        # query/key/value/attention_output naming.
         layout_map["encoder_layer.*attention.*query.kernel"] = (
             model_dim,
             data_dim,

--- a/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_backbone.py
@@ -549,14 +549,14 @@ class T5Gemma2Backbone(Backbone):
         in the PR description.
 
         Args:
-            device_mesh: The `keras.distribution.DeviceMesh` instance for
-                distribution.
-            model_parallel_dim_name: The axis name of the device mesh, where
-                the weights should be partition on.
-            data_parallel_dim_name: The axis name of the device mesh, where
-                the data should be partition on.
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
 
-        Return:
+        Returns:
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """

--- a/keras_hub/src/models/t5gemma2/t5gemma2_backbone_test.py
+++ b/keras_hub/src/models/t5gemma2/t5gemma2_backbone_test.py
@@ -114,3 +114,76 @@ class T5Gemma2BackboneTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): the default test
+        # config's *_num_key_value_heads=2 is intentionally left as-is (not
+        # divisible by every host's device count) to regression-test that
+        # key/value kernels are left replicated rather than sharded -- see
+        # get_layout_map's comment.
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = T5Gemma2Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = T5Gemma2Backbone(**self.init_kwargs)
+
+        for w in model.weights:
+            if "encoder_token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "decoder_token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "merged_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "merged_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "merged_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "gate_proj/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "up_proj/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "down_proj/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )


### PR DESCRIPTION
## Summary

Adds `get_layout_map` + `test_distribution` for model-parallel (`ModelParallel`) sharding to 14 GQA model
families: Gemma (v1 fix), Gemma3, Gemma4, Qwen3, QwenMoe, Qwen3Moe, Qwen3_5, Qwen3_5Moe, Mistral, Mixtral, Phi3,
GptOss, T5Gemma, T5Gemma2, and Llama (fix). Regex-based `LayoutMap` rules over a `(batch, model)` mesh, following
the existing `LlamaBackbone`/`GemmaBackbone` pattern.

## Bugs fixed

- **GQA key/value kernels sharded on an axis too small to divide the mesh.** `num_key_value_heads` is
  independent of and often much smaller than `num_query_heads` (down to 1 for MQA) — sharding it crashes with
  `IndivisibleError` whenever a mesh dim doesn't evenly divide it. Fix: query stays sharded; key/value's
  kv-heads axis is left replicated (hidden_dim axis still shards via `model_dim`). Found in two einsum
  conventions (Gemma-style heads-on-axis-0, Mistral-style heads-on-axis-1) across all 14 models, including
  **Gemma v1** — missed in an earlier pass, found by an independent review, whose test had also been edited to
  mask the crash rather than catch it (both fixed).
- **Missing `token_embedding/reverse_embeddings`** for models with untied embeddings (Mistral, Phi3, Qwen3,
  Llama, GptOss, Qwen3_5, Qwen3_5Moe, T5Gemma/T5Gemma2).

## Verification

- `test_distribution` passes for all 14 models at 2- and 4-device CPU mesh.
- Mesh-shape sweep across 2D (`2×4` .. `16×16`) and 3D (`2×2×2` .. `4×4×8`) topologies matching real TPU
  generations: **140/140** pass, verified per-weight.
- Cross-checked against **34 real production presets** (config-only, via Kaggle/HF) — zero regressions, since
  the fix only ever replicates (never adds a divisibility requirement).
- Independently verified on a real 8-device TPU mesh (Gemma4 26B MoE) — no compile-time errors or OOMs.
- `pre-commit run --all-files` clean.

## Known limitations (not addressed here)

- Query-head sharding still requires exact divisibility by the mesh width — pre-existing, inherent to tensor
  parallelism, affects several small real presets at 16-way sharding.
- Key/value are always replicated on the kv-heads axis, never conditionally sharded even when divisible (keeps
  the map static/mesh-agnostic; costs some unused parallelism headroom).
- Vision/audio/per-layer-input weights (Gemma3/4, Qwen3_5) and MoE expert-count axis (6 MoE models) are left
  replicated — separate scope.
- `QwenMoe`'s dense-FFN fallback layout is correct but untestable due to a pre-existing, unrelated `layer_index`
  bug (documented in-code, not fixed here).
- `QwenBackbone` (v1, non-MoE) likely has the same bug and wasn't audited; `Gemma3n`/`SmolLM3` use a
  structurally different (Dense-fused) attention kernel and aren't covered.
- JAX-only, matching the rest of keras-hub's distribution support.
