### PR TITLE
Fix for copybara sync failure

### DIFF
--- a/keras_hub/src/utils/transformers/convert_mixtral_test.py
+++ b/keras_hub/src/utils/transformers/convert_mixtral_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from keras_hub.src.models.backbone import Backbone
 from keras_hub.src.models.causal_lm import CausalLM
 from keras_hub.src.models.mixtral.mixtral_backbone import MixtralBackbone
@@ -7,6 +9,7 @@ from keras_hub.src.utils.transformers import convert_mixtral
 
 
 class TestMixtralConverter(TestCase):
+    @pytest.mark.extra_large
     def test_convert_tiny_preset(self):
         model = MixtralCausalLM.from_preset(
             "hf://hf-internal-testing/tiny-random-MixtralForCausalLM",
@@ -15,6 +18,7 @@ class TestMixtralConverter(TestCase):
         prompt = "What is your favorite condiment?"
         model.generate([prompt], max_length=15)
 
+    @pytest.mark.large
     def test_class_detection(self):
         model = CausalLM.from_preset(
             "hf://hf-internal-testing/tiny-random-MixtralForCausalLM",

--- a/keras_hub/src/utils/transformers/convert_t5gemma2.py
+++ b/keras_hub/src/utils/transformers/convert_t5gemma2.py
@@ -1,7 +1,6 @@
 import re
 
 import numpy as np
-from sentencepiece import sentencepiece_model_pb2 as sp_pb2
 
 from keras_hub.src.models.t5gemma2.t5gemma2_backbone import T5Gemma2Backbone
 from keras_hub.src.utils.preset_utils import check_file_exists
@@ -452,6 +451,8 @@ def _build_sentencepiece_proto(tokenizer_config):
     SentencePiece model that is byte-for-byte compatible with the
     Gemma-family tokenizer.
     """
+    from sentencepiece import sentencepiece_model_pb2 as sp_pb2
+
     vocab = dict(tokenizer_config["model"]["vocab"])
     merges = list(tokenizer_config["model"]["merges"])
 


### PR DESCRIPTION
- Add pytest markers to Mixtral converter tests.
- Move sentencepiece import inside function in T5Gemma2 converter.


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
