### PR TITLE
FIX:  Pin SentencePiece<0.2.2 to unblock CI test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "rich",
     "kagglehub!=1.0.1",
     "kagglesdk==0.1.28",
-    "sentencepiece",
+    "sentencepiece<0.2.2",
     "tokenizers",
     "tensorflow-text;platform_system != 'Windows'",
 ]

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@ rich
 kagglehub!=1.0.1
 kagglesdk==0.1.28
 tokenizers
-sentencepiece
+sentencepiece<0.2.2
 # Tooling deps.
 pre-commit
 astor


### PR DESCRIPTION
## Description of the change

**Context:** Currently, all PRs are hitting deterministic CI failures (AttributeError: 'SentencePieceProcessor' object has no attribute 'Init') during the instantiation of SentencePiece-based tokenizers.

**Root Cause:** The sentencepiece Python package released version 0.2.2 (July 12, 2026), which migrated their Python wrapper from SWIG to pybind11. This migration completely removed the internal C++ bridge method .Init() which keras_hub/src/tokenizers/sentence_piece_tokenizer.py relies on to dynamically load models from protocol buffers in memory.

**Changes in this PR:** This PR provides a hotfix to unblock development by pinning the dependency:

**Future Work:** Once CI is unblocked, a follow-up PR will be opened to fully support **sentencepiece>=0.2.2.** That PR will refactor **_set_proto_spm** to drop the deprecated .Init() API in favor of the new pybind11 supported methods, enabling KerasHub to take advantage of the new version's performance improvements.


- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
