### PR TITLE
Add ModelParallel layout map for Mistral, with a shared distribution-test helper

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -112,7 +112,20 @@ jobs:
           pip install --no-deps -e "." --progress-bar off
     - name: Run distribution tests
       run: |
-        pytest keras_hub/ -k "test_distribution or test_layout_map"
+        # -m (marker), not -k (name substring): a name match would also pick
+        # up any not-yet-refactored model's pre-existing test_distribution,
+        # which predates this effort's device-pinning discipline and isn't
+        # this job's responsibility to fix. Exit 5 ("no tests collected") is
+        # expected and tolerated on this branch alone, since the marker is
+        # only applied by the per-model layout-map PRs, not this one.
+        set +e
+        pytest keras_hub/ -m "multi_device and not kaggle_key_required and not extra_large"
+        code=$?
+        set -e
+        if [ "$code" -ne 0 ] && [ "$code" -ne 5 ]; then
+          exit "$code"
+        fi
+        echo "pytest exit code: $code (5 = no multi_device tests on this branch yet, expected)"
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,6 +75,44 @@ jobs:
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"
+  run_distribution_tests:
+    name: Test ModelParallel distribution (simulated multi-device)
+    runs-on: ubuntu-latest
+    env:
+      KERAS_BACKEND: jax
+      # Scoped to this job only -- exposes 8 simulated CPU devices so
+      # `keras.distribution` tests run instead of skipping (a real
+      # accelerator mesh isn't available in CI). Deliberately NOT set for
+      # the main `run_tests` job/conftest.py: changing the visible device
+      # count for the entire jax-backend test matrix risks affecting
+      # unrelated tests that assume a single device.
+      XLA_FLAGS: --xla_force_host_platform_device_count=8
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.11
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      with:
+        python-version: '3.11'
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        python -m pip install --upgrade pip setuptools
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: pip cache
+      # zizmor: ignore[cache-poisoning]
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-common.txt') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('pyproject.toml') }}
+    - name: Install dependencies
+      run: |
+          pip install -r requirements.txt --progress-bar off
+          pip install --no-deps -e "." --progress-bar off
+    - name: Run distribution tests
+      run: |
+        pytest keras_hub/ -k "test_distribution or test_layout_map"
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -80,7 +80,7 @@ jobs:
     container:
       image: python:3.11-slim
     runs-on: linux-x86-n2-16
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       KERAS_BACKEND: jax
       # Simulated devices: `keras.distribution` needs a multi-device mesh and
@@ -119,7 +119,7 @@ jobs:
         id: pip-cache
         run: |
           python -m pip install --upgrade pip setuptools
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: pip cache
         # zizmor: ignore[cache-poisoning]
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -66,13 +66,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest keras_hub/ -n auto --dist loadfile --durations=50
-    - name: Test ModelParallel distribution (simulated multi-device)
-      if: ${{ matrix.backend == 'jax' && matrix.version == 'keras-stable' }}
-      env:
-        # Scoped to this step: the rest of the suite keeps a single device.
-        XLA_FLAGS: --xla_force_host_platform_device_count=8
-      run: |
-        pytest keras_hub/ -m multi_device --durations=10
     - name: Run integration tests
       run: |
         python pip_build.py --install
@@ -82,6 +75,35 @@ jobs:
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"
+  run_distribution_tests:
+    name: Test ModelParallel distribution
+    container:
+      image: python:3.11-slim
+    runs-on: linux-x86-n2-16
+    timeout-minutes: 60
+    env:
+      KERAS_BACKEND: jax
+      # Simulated devices: `keras.distribution` needs a multi-device mesh and
+      # CI has no accelerator. Read by Jax at import, so it is set job-wide.
+      XLA_FLAGS: --xla_force_host_platform_device_count=8
+    steps:
+    - name: Install binary dependencies
+      # build-essential for C extensions (tokenizers, torch)
+      # curl, git, gnupg for checkout and other actions
+      run: |
+        apt-get update
+        apt-get -y install build-essential curl git gnupg
+        git config --global --add safe.directory '*'
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - name: Install dependencies
+      run: |
+          pip install -r requirements.txt --progress-bar off
+          pip install --no-deps -e "." --progress-bar off
+    - name: Test with pytest
+      run: |
+        pytest keras_hub/ -m multi_device --durations=10
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -66,6 +66,13 @@ jobs:
     - name: Test with pytest
       run: |
         pytest keras_hub/ -n auto --dist loadfile --durations=50
+    - name: Test ModelParallel distribution (simulated multi-device)
+      if: ${{ matrix.backend == 'jax' && matrix.version == 'keras-stable' }}
+      env:
+        # Scoped to this step: the rest of the suite keeps a single device.
+        XLA_FLAGS: --xla_force_host_platform_device_count=8
+      run: |
+        pytest keras_hub/ -m multi_device --durations=10
     - name: Run integration tests
       run: |
         python pip_build.py --install
@@ -75,57 +82,6 @@ jobs:
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"
-  run_distribution_tests:
-    name: Test ModelParallel distribution (simulated multi-device)
-    runs-on: ubuntu-latest
-    env:
-      KERAS_BACKEND: jax
-      # Scoped to this job only -- exposes 8 simulated CPU devices so
-      # `keras.distribution` tests run instead of skipping (a real
-      # accelerator mesh isn't available in CI). Deliberately NOT set for
-      # the main `run_tests` job/conftest.py: changing the visible device
-      # count for the entire jax-backend test matrix risks affecting
-      # unrelated tests that assume a single device.
-      XLA_FLAGS: --xla_force_host_platform_device_count=8
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      with:
-        persist-credentials: false
-    - name: Set up Python 3.11
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-      with:
-        python-version: '3.11'
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install --upgrade pip setuptools
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: pip cache
-      # zizmor: ignore[cache-poisoning]
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-common.txt') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('pyproject.toml') }}
-    - name: Install dependencies
-      run: |
-          pip install -r requirements.txt --progress-bar off
-          pip install --no-deps -e "." --progress-bar off
-    - name: Run distribution tests
-      run: |
-        # -m (marker), not -k (name substring): a name match would also pick
-        # up any not-yet-refactored model's pre-existing test_distribution,
-        # which predates this effort's device-pinning discipline and isn't
-        # this job's responsibility to fix. Exit 5 ("no tests collected") is
-        # expected and tolerated on this branch alone, since the marker is
-        # only applied by the per-model layout-map PRs, not this one.
-        set +e
-        pytest keras_hub/ -m "multi_device and not kaggle_key_required and not extra_large"
-        code=$?
-        set -e
-        if [ "$code" -ne 0 ] && [ "$code" -ne 5 ]; then
-          exit "$code"
-        fi
-        echo "pytest exit code: $code (5 = no multi_device tests on this branch yet, expected)"
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -95,6 +95,10 @@ def pytest_configure(config):
         "markers",
         "kaggle_key_required: mark test needing a kaggle key",
     )
+    config.addinivalue_line(
+        "markers",
+        "multi_device: mark test as needing multiple devices",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -244,18 +244,9 @@ class MistralBackbone(Backbone):
             data_dim,
             model_dim,
         )
-        # Query/key/value kernels have shape
-        # `(hidden_dim, num_heads, head_dim)`, so the contracting `hidden`
-        # dim is sharded on the data-parallel axis and the `num_heads` axis
-        # is sharded on the model-parallel axis (Megatron-style column
-        # parallelism), matching `attention_output`'s `(model, None, data)`
-        # row-parallel layout below. Key/value kernels use
-        # num_key_value_heads (GQA), which is independent of and typically
-        # much smaller than num_query_heads -- sharding that small axis on
-        # the model-parallel dim would raise an IndivisibleError whenever
-        # the model mesh dimension doesn't divide it, so key/value heads
-        # are left fully replicated on that axis while their hidden dim
-        # still shards on data for memory savings.
+        # Kernels are `(hidden_dim, num_heads, head_dim)`: `hidden` contracts
+        # so it shards on the data axis, `num_heads` on the model axis. Key
+        # and value heads are too few to divide the model axis, so stay whole.
         layout_map["transformer_layer.*self_attention.*query.kernel"] = (
             data_dim,
             model_dim,

--- a/keras_hub/src/models/mistral/mistral_backbone.py
+++ b/keras_hub/src/models/mistral/mistral_backbone.py
@@ -186,3 +186,90 @@ class MistralBackbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the Mistral
+        backbone weights.
+
+        Args:
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
+
+        Returns:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        layout_map["token_embedding/reverse_embeddings"] = (
+            data_dim,
+            model_dim,
+        )
+        # Query/key/value kernels have shape
+        # `(hidden_dim, num_heads, head_dim)`, so the contracting `hidden`
+        # dim is sharded on the data-parallel axis and the `num_heads` axis
+        # is sharded on the model-parallel axis (Megatron-style column
+        # parallelism), matching `attention_output`'s `(model, None, data)`
+        # row-parallel layout below. Key/value kernels use
+        # num_key_value_heads (GQA), which is independent of and typically
+        # much smaller than num_query_heads -- sharding that small axis on
+        # the model-parallel dim would raise an IndivisibleError whenever
+        # the model mesh dimension doesn't divide it, so key/value heads
+        # are left fully replicated on that axis while their hidden dim
+        # still shards on data for memory savings.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            data_dim,
+            model_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            data_dim,
+            None,
+            None,
+        )
+        layout_map["transformer_layer.*attention_output.kernel"] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        return layout_map

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -145,6 +145,7 @@ class MistralBackboneTest(TestCase):
         # Reference value calculated using the PyTorch model
         self.assertEqual(model.count_params(), 2704)
 
+    @pytest.mark.multi_device
     def test_distribution(self):
         # Note (preserved from the pre-refactor manual test): mesh is
         # pinned to exactly 2 devices (not len(devices), see the shared
@@ -190,6 +191,7 @@ class MistralBackboneTest(TestCase):
         for dims in (MISTRAL_7B_DIMS, MISTRAL_LARGE_DIMS)
         for shape in CAPPED_MESH_SHAPES
     )
+    @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -1,7 +1,3 @@
-import gc
-import os
-import re
-
 import keras
 import pytest
 from absl.testing import parameterized
@@ -9,75 +5,37 @@ from keras import ops
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.tests.test_case import TestCase
-from keras_hub.src.utils.preset_utils import load_json
 
-# Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
-# dimensions, frozen as literals and sourced once, offline -- do not add a
-# `get_file` call to the Tier-2 test body itself (that's what Tier 3,
-# `test_layout_map_live_presets` below, is for).
-#
-# MEMORY NOTE: memory-constrained local environments cannot load full-scale
-# model dims (see gemma_backbone_test.py's identical note for the OOM
-# history that motivated this rule). What matters for the divisibility/
-# sharding properties this tier tests is the RATIO of query heads to kv
-# heads and whether hidden/intermediate/vocab divide the mesh's model-axis
-# sizes -- not the absolute parameter count. So these dims are scaled down
-# ~16x from the real Mistral-7B preset config (`hidden_size=4096`,
-# `num_attention_heads=32`, `num_key_value_heads=8`,
-# `intermediate_size=14336`, `vocab_size=32000`, all five presets in
-# `mistral_presets.py` share this single architecture width class -- there
-# is no smaller/larger Mistral preset in the registry to source a second
-# class from) while preserving the real 4:1 query:kv GQA ratio and keeping
-# hidden/intermediate/vocab as clean values divisible by every mesh shape in
-# CAPPED_MESH_SHAPES. A second, larger synthetic class is included to
-# exercise an 8:1 GQA ratio and a bigger width tier (a plausible
-# larger-Mistral extrapolation, not a real preset -- documented as such).
-# Full-scale real dims are exercised by `test_layout_map_live_presets`
-# below, which has its own per-width-class memory-budget skip so it never
-# attempts a full-scale build in a memory-constrained environment either --
-# true full-scale verification happens on a dedicated or CI machine with
-# more memory.
+# Scaled ~16x down from the width class every Mistral preset shares
+# (vocab 32000, hidden 4096, intermediate 14336, 32 query / 8 kv heads).
+# The 4:1 query:kv ratio is kept, since divisibility depends on it.
 MISTRAL_7B_DIMS = {
-    "source_preset": "mistral_7b_en (real ratio, memory-scaled dims)",
-    "vocabulary_size": 2000,  # real: 32000, scaled /16.
-    "num_layers": 1,  # depth is irrelevant to spec matching/divisibility.
-    "num_query_heads": 8,  # real: 32, scaled /4 (keeps 4:1 GQA ratio).
-    "num_key_value_heads": 2,  # real: 8, scaled /4 -- 4:1 GQA ratio.
-    "hidden_dim": 256,  # real: 4096, scaled /16.
-    "intermediate_dim": 896,  # real: 14336, scaled /16.
+    "name": "mistral_7b",
+    "vocabulary_size": 2000,
+    "num_layers": 1,
+    "num_query_heads": 8,
+    "num_key_value_heads": 2,
+    "hidden_dim": 256,
+    "intermediate_dim": 896,
     "sliding_window": 128,
 }
+# Not a real preset: a wider extrapolation, to cover an 8:1 query:kv ratio.
 MISTRAL_LARGE_DIMS = {
-    # Not a real preset -- a plausible larger-Mistral extrapolation (doubled
-    # hidden/intermediate vs. MISTRAL_7B_DIMS) used to exercise an 8:1 GQA
-    # ratio and a bigger width tier under the mesh sweep.
-    "source_preset": "mistral_large (synthetic, larger width class)",
+    "name": "mistral_large",
     "vocabulary_size": 4000,
     "num_layers": 1,
     "num_query_heads": 16,
-    "num_key_value_heads": 2,  # 8:1 GQA ratio.
+    "num_key_value_heads": 2,
     "hidden_dim": 512,
     "intermediate_dim": 1792,
     "sliding_window": 128,
 }
 
-# Hard-capped mesh-shape list for memory-constrained local environments. See
-# gemma_backbone_test.py's identical constant for the full rationale (an
-# OOM kill history from an earlier run of this pipeline in a
-# memory-constrained environment) -- the dropped shapes (8x8, 16x16, 4x4x4,
-# 4x4x8) are never attempted here either.
-CAPPED_MESH_SHAPES = [
-    (2, 4),
-    (1, 8),
-    (4, 4),
-    (2, 2, 2),
-    (1, 1, 8),
-    (2, 2, 4),
-]
+# 3D shapes name their extra axis "seq"; no layout rule targets it, so it
+# leaves weights whole and only the "model" axis size affects divisibility.
+MESH_SHAPES = [(2, 4), (1, 8), (2, 2, 2)]
 
-# Same 8 expected_shardings patterns as MistralBackboneTest.test_distribution
-# (post-QKV-axis-fix), reused by the Tier-2 and Tier-3 mesh sweeps below.
-_EXPECTED_SHARDINGS = {
+EXPECTED_SHARDINGS = {
     "token_embedding/embeddings": ("model", "batch"),
     "token_embedding/reverse_embeddings": ("batch", "model"),
     "self_attention.*query.kernel": ("batch", "model", None),
@@ -87,25 +45,6 @@ _EXPECTED_SHARDINGS = {
     "feedforward_gate_dense.kernel": ("batch", "model"),
     "feedforward_output_dense.kernel": ("model", "batch"),
 }
-
-
-def _assert_mistral_shardings_and_coverage(test_case, model, layout_map):
-    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
-    for pattern, expected in _EXPECTED_SHARDINGS.items():
-        matches = [w for w in model.weights if re.search(pattern, w.path)]
-        test_case.assertGreater(len(matches), 0)
-        for w in matches:
-            test_case.assertEqual(tuple(w.value.sharding.spec), expected)
-    offending = [
-        w.path
-        for w in model.weights
-        if len(w.shape) >= 2 and layout_map[w.path] is None
-    ]
-    test_case.assertEqual(
-        offending,
-        [],
-        f"The following rank>=2 weights are unmapped: {offending}",
-    )
 
 
 class MistralBackboneTest(TestCase):
@@ -167,346 +106,56 @@ class MistralBackboneTest(TestCase):
 
     @pytest.mark.multi_device
     def test_distribution(self):
-        # Note (preserved from the pre-refactor manual test): mesh is
-        # pinned to exactly 2 devices (not len(devices), see the shared
-        # helper) so that the default test config's num_key_value_heads=4
-        # -- intentionally not divisible by every host's device count --
-        # regression-tests that key/value kernels are left replicated on
-        # the model axis rather than sharded. See get_layout_map's comment.
         self.run_distribution_test(
             cls=MistralBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
-            expected_shardings={
-                "token_embedding/embeddings": ("model", "batch"),
-                "token_embedding/reverse_embeddings": ("batch", "model"),
-                "self_attention.*query.kernel": ("batch", "model", None),
-                "self_attention.*(key|value).kernel": (
-                    "batch",
-                    None,
-                    None,
-                ),
-                "self_attention.*attention_output.kernel": (
-                    "model",
-                    None,
-                    "batch",
-                ),
-                "feedforward_intermediate_dense.kernel": (
-                    "batch",
-                    "model",
-                ),
-                "feedforward_gate_dense.kernel": ("batch", "model"),
-                "feedforward_output_dense.kernel": ("model", "batch"),
-            },
-            allow_replicated=(),
+            expected_shardings=EXPECTED_SHARDINGS,
+        )
+
+    @pytest.mark.multi_device
+    def test_distribution_parity(self):
+        self.run_distribution_parity_test(
+            cls=MistralBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
         )
 
     @parameterized.named_parameters(
-        (
-            f"{dims['source_preset'].split(' ')[0]}_mesh"
-            f"_{'x'.join(str(s) for s in shape)}",
-            dims,
-            shape,
-        )
+        (f"{dims['name']}_mesh_{'x'.join(str(s) for s in shape)}", dims, shape)
         for dims in (MISTRAL_7B_DIMS, MISTRAL_LARGE_DIMS)
-        for shape in CAPPED_MESH_SHAPES
+        for shape in MESH_SHAPES
     )
     @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
-        if keras.backend.backend() != "jax":
-            self.skipTest("`ModelParallel` testing requires the Jax backend.")
-        devices = keras.distribution.list_devices("CPU")
-        n_needed = 1
-        for s in mesh_shape:
-            n_needed *= s
-        if n_needed > len(devices):
-            self.skipTest(
-                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
-                f"{len(devices)} available. Run with "
-                f"XLA_FLAGS=--xla_force_host_platform_device_count="
-                f"{n_needed} to exercise this shape locally."
-            )
-
-        # Query-head-divisibility skip rule: an inherent tensor-parallelism
-        # ceiling, not a bug. model_axis_size is the mesh's last axis,
-        # matching this repo's axis_names=(..., "model") convention.
         model_axis_size = mesh_shape[-1]
-        num_query_heads = dims["num_query_heads"]
-        if num_query_heads % model_axis_size != 0:
+        num_devices = 1
+        for size in mesh_shape:
+            num_devices *= size
+        devices = self._skip_unless_distribution(num_devices)[:num_devices]
+        if dims["num_query_heads"] % model_axis_size:
+            # An inherent tensor-parallelism ceiling, not a defect: the model
+            # axis cannot exceed the query heads it splits.
             self.skipTest(
-                f"num_query_heads={num_query_heads} not divisible by "
-                f"model-axis={model_axis_size}: inherent "
-                "tensor-parallelism limit, not a bug"
+                f"num_query_heads={dims['num_query_heads']} is not divisible "
+                f"by model-axis size {model_axis_size}."
             )
 
-        devices = devices[:n_needed]
-        if len(mesh_shape) == 2:
-            axis_names = ("batch", "model")
-        else:
-            # 3D shape: the extra axis is named "seq" per the plan/
-            # testing-strategy convention, but get_layout_map only names
-            # "batch"/"model" -- the "seq" axis simply replicates weights
-            # (no rule targets it), matching every other 3D-mesh test in
-            # this PR series.
-            axis_names = ("batch", "seq", "model")
+        axis_names = (
+            ("batch", "model")
+            if len(mesh_shape) == 2
+            else ("batch", "seq", "model")
+        )
         device_mesh = keras.distribution.DeviceMesh(
-            shape=mesh_shape,
-            axis_names=axis_names,
-            devices=devices,
+            shape=mesh_shape, axis_names=axis_names, devices=devices
         )
         layout_map = MistralBackbone.get_layout_map(device_mesh)
-        distribution = keras.distribution.ModelParallel(
-            layout_map=layout_map, batch_dim_name="batch"
-        )
-        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        init_kwargs = {k: v for k, v in dims.items() if k != "name"}
         with distribution.scope():
-            # bfloat16: a memory mitigation for memory-constrained
-            # environments -- spec assertions are dtype-independent.
             model = MistralBackbone(dtype="bfloat16", **init_kwargs)
-            _assert_mistral_shardings_and_coverage(self, model, layout_map)
-        del model
-        gc.collect()
-
-    @pytest.mark.multi_device
-    def test_query_head_divisibility_skip_triggers(self):
-        """Regression test: the skip rule in `test_layout_map_mesh_shapes`
-        is not dead code -- it must actually trigger for a config where
-        `num_query_heads` does not divide the mesh's model-axis size, and
-        that indivisibility must be real (i.e. building without the skip
-        would raise, proving the guard is load-bearing rather than
-        decorative).
-        """
-        if keras.backend.backend() != "jax":
-            self.skipTest("`ModelParallel` testing requires the Jax backend.")
-        devices = keras.distribution.list_devices("CPU")
-        # Pinned to exactly 2 devices, matching run_distribution_test's
-        # convention -- deterministic regardless of how many virtual
-        # devices the test environment exposes.
-        if len(devices) < 2:
-            self.skipTest("`ModelParallel` testing requires multiple devices.")
-        devices = devices[:2]
-        mesh_shape = (1, 2)
-        model_axis_size = mesh_shape[-1]
-
-        # num_query_heads=3 does not divide model_axis_size=2 -- this is
-        # the condition the skip rule in test_layout_map_mesh_shapes
-        # guards against.
-        num_query_heads = 3
-        self.assertNotEqual(num_query_heads % model_axis_size, 0)
-
-        device_mesh = keras.distribution.DeviceMesh(
-            shape=mesh_shape,
-            axis_names=("batch", "model"),
-            devices=devices,
-        )
-        layout_map = MistralBackbone.get_layout_map(device_mesh)
-        distribution = keras.distribution.ModelParallel(
-            layout_map=layout_map, batch_dim_name="batch"
-        )
-        # Proves the skip rule is necessary: building this genuinely
-        # indivisible config under the same layout map that
-        # test_layout_map_mesh_shapes would have used (had it not skipped)
-        # actually raises, rather than silently succeeding.
-        with self.assertRaises(Exception):
-            with distribution.scope():
-                MistralBackbone(
-                    vocabulary_size=40,
-                    num_layers=1,
-                    num_query_heads=num_query_heads,
-                    num_key_value_heads=1,
-                    hidden_dim=24,
-                    intermediate_dim=16,
-                    sliding_window=4,
-                    dtype="bfloat16",
-                )
-        gc.collect()
-
-    @pytest.mark.kaggle_key_required
-    @pytest.mark.multi_device
-    @pytest.mark.extra_large
-    def test_layout_map_live_presets(self):
-        if keras.backend.backend() != "jax":
-            self.skipTest("`ModelParallel` testing requires the Jax backend.")
-
-        # Fetch every preset's config only (no weights), then dedupe by the
-        # divisibility-relevant dims so width-classes that share a config
-        # (e.g. base vs instruct variants of the same size) are only built
-        # once per mesh shape -- a memory/time necessity on this machine,
-        # while every preset in the registry is still fetched and
-        # evaluated, preserving full registry coverage.
-        dim_keys = (
-            "vocabulary_size",
-            "num_query_heads",
-            "num_key_value_heads",
-            "hidden_dim",
-            "intermediate_dim",
-            "sliding_window",
-        )
-        width_classes = {}  # dedupe key -> (config dict, [preset names])
-        fetch_failures = []
-        for preset in MistralBackbone.presets:
-            try:
-                cfg = load_json(preset)["config"]
-            except Exception as e:
-                # A preset this account can't reach (e.g. an unaccepted
-                # Kaggle license consent click-through) is logged, not
-                # fatal -- the rest of the registry still gets exercised.
-                fetch_failures.append((preset, str(e)))
-                continue
-            # num_layers is forced to 1 below regardless of the real
-            # value -- layout rules are per-decoder-block regexes, so
-            # depth is irrelevant to spec matching/divisibility, and 1
-            # layer keeps build memory bounded in memory-constrained
-            # environments.
-            cfg = dict(cfg)
-            cfg["num_layers"] = 1
-            key = tuple(cfg.get(k) for k in dim_keys)
-            if key not in width_classes:
-                width_classes[key] = (cfg, [])
-            width_classes[key][1].append(preset)
-
-        if fetch_failures:
-            print(
-                f"test_layout_map_live_presets: {len(fetch_failures)} "
-                f"preset config fetches failed (logged, non-fatal): "
-                f"{fetch_failures}"
-            )
-        if not width_classes:
-            self.skipTest(
-                "No preset configs were reachable "
-                f"({len(fetch_failures)} fetch failures) -- likely a "
-                "Kaggle license-consent gate on this account for the "
-                "mistral family. See the module comment above "
-                "CAPPED_MESH_SHAPES."
-            )
-        print(
-            f"test_layout_map_live_presets: {len(width_classes)} unique "
-            f"width-classes across {len(MistralBackbone.presets)} registry "
-            "presets:"
-        )
-        for cfg, presets in width_classes.values():
-            print(f"  {presets}")
-
-        devices = keras.distribution.list_devices("CPU")
-        skip_reasons = []
-        ran_any = False
-        for cfg, presets in width_classes.values():
-            num_query_heads = cfg["num_query_heads"]
-            for mesh_shape in CAPPED_MESH_SHAPES:
-                combo_label = f"{presets[0]}@{mesh_shape}"
-                with self.subTest(combo=combo_label):
-                    n_needed = 1
-                    for s in mesh_shape:
-                        n_needed *= s
-                    if n_needed > len(devices):
-                        reason = (
-                            f"{combo_label}: needs {n_needed} devices, "
-                            f"only {len(devices)} available"
-                        )
-                        skip_reasons.append(reason)
-                        continue
-                    model_axis_size = mesh_shape[-1]
-                    if num_query_heads % model_axis_size != 0:
-                        reason = (
-                            f"{combo_label}: num_query_heads="
-                            f"{num_query_heads} not divisible by "
-                            f"model-axis={model_axis_size}: inherent "
-                            "tensor-parallelism limit, not a bug"
-                        )
-                        skip_reasons.append(reason)
-                        continue
-
-                    # Memory-budget guard: memory-constrained local
-                    # environments cannot build full-scale presets (see
-                    # CAPPED_MESH_SHAPES' comment for the OOM history).
-                    # Estimate this width-class's single-decoder-block bf16
-                    # footprint and skip the actual build if it exceeds a
-                    # conservative local threshold. Mistral has UNTIED
-                    # embeddings (`tie_weights=False` in MistralBackbone),
-                    # so the embedding term is counted twice (forward +
-                    # reverse output projection). Attention projections map
-                    # hidden<->hidden for query/output and hidden<->(hidden
-                    # scaled by the kv/query head ratio) for GQA's key/value.
-                    # The FFN is SwiGLU (gate + intermediate + output, 3
-                    # hidden*intermediate matrices), matching this model's
-                    # dense (non-MoE) feedforward block. Times a 3x safety
-                    # margin for JAX/XLA transient copies during
-                    # construction/resharding. The config-fetch, dedup, and
-                    # divisibility-skip logic above still exercises every
-                    # registry preset either way; only the expensive
-                    # build+assert step is capped.
-                    hidden = cfg["hidden_dim"]
-                    num_kv_heads = cfg["num_key_value_heads"]
-                    kv_ratio = num_kv_heads / num_query_heads
-                    est_params = (
-                        2 * cfg["vocabulary_size"] * hidden  # untied embed
-                        + 2 * hidden * hidden  # attention q/o
-                        + 2 * hidden * hidden * kv_ratio  # attention k/v
-                        + 3 * hidden * cfg["intermediate_dim"]  # SwiGLU FFN
-                    )
-                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
-                    max_local_bytes = int(
-                        os.environ.get(
-                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
-                            300 * 1024 * 1024,
-                        )
-                    )
-                    if est_bytes > max_local_bytes:
-                        reason = (
-                            f"{combo_label}: estimated build memory "
-                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
-                            f"{max_local_bytes / 1e6:.0f}MB local safety "
-                            "threshold for memory-constrained environments "
-                            "-- verify this width-class on a machine with "
-                            "more memory or in CI (raise the budget via the "
-                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET env var)"
-                        )
-                        skip_reasons.append(reason)
-                        continue
-
-                    combo_devices = devices[:n_needed]
-                    if len(mesh_shape) == 2:
-                        axis_names = ("batch", "model")
-                    else:
-                        axis_names = ("batch", "seq", "model")
-                    device_mesh = keras.distribution.DeviceMesh(
-                        shape=mesh_shape,
-                        axis_names=axis_names,
-                        devices=combo_devices,
-                    )
-                    layout_map = MistralBackbone.get_layout_map(device_mesh)
-                    distribution = keras.distribution.ModelParallel(
-                        layout_map=layout_map, batch_dim_name="batch"
-                    )
-                    # `cfg` is the preset's full serialized `get_config()`
-                    # dict; pass all of it (real architecture flags such as
-                    # rope scaling, tie-embeddings, etc. must survive to
-                    # actually exercise the live preset's real architecture)
-                    # and only drop `"dtype"` so the explicit
-                    # `dtype="bfloat16"` override below doesn't collide with
-                    # a duplicate keyword argument. `num_layers` is forced to
-                    # 1 (layout rules are per-decoder-block, so depth is
-                    # irrelevant and 1 layer keeps build memory bounded).
-                    init_kwargs = {k: v for k, v in cfg.items() if k != "dtype"}
-                    init_kwargs["num_layers"] = 1
-                    with distribution.scope():
-                        model = MistralBackbone(dtype="bfloat16", **init_kwargs)
-                        _assert_mistral_shardings_and_coverage(
-                            self, model, layout_map
-                        )
-                    del model
-                    gc.collect()
-                    ran_any = True
-
-        print(
-            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
-            f"skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
-        )
-        if not ran_any:
-            self.skipTest(
-                "All (width-class, mesh-shape) combos were skipped: "
-                f"{skip_reasons}"
-            )
+            self.assert_sharding_specs(model, EXPECTED_SHARDINGS)
+            self.assert_sharding_coverage(model, layout_map)
 
     @pytest.mark.extra_large
     def test_smallest_preset(self):

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -1,5 +1,4 @@
 import gc
-import json
 import os
 import re
 
@@ -10,8 +9,7 @@ from keras import ops
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.tests.test_case import TestCase
-from keras_hub.src.utils.preset_utils import CONFIG_FILE
-from keras_hub.src.utils.preset_utils import get_file
+from keras_hub.src.utils.preset_utils import load_json
 
 # Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
 # dimensions, frozen as literals and sourced once, offline -- do not add a
@@ -272,9 +270,7 @@ class MistralBackboneTest(TestCase):
         fetch_failures = []
         for preset in MistralBackbone.presets:
             try:
-                path = get_file(preset, CONFIG_FILE)
-                with open(path) as f:
-                    cfg = json.load(f)["config"]
+                cfg = load_json(preset)["config"]
             except Exception as e:
                 # A preset this account can't reach (e.g. an unaccepted
                 # Kaggle license consent click-through) is logged, not

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -247,6 +247,60 @@ class MistralBackboneTest(TestCase):
         del model
         gc.collect()
 
+    @pytest.mark.multi_device
+    def test_query_head_divisibility_skip_triggers(self):
+        """Regression test: the skip rule in `test_layout_map_mesh_shapes`
+        is not dead code -- it must actually trigger for a config where
+        `num_query_heads` does not divide the mesh's model-axis size, and
+        that indivisibility must be real (i.e. building without the skip
+        would raise, proving the guard is load-bearing rather than
+        decorative).
+        """
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        # Pinned to exactly 2 devices, matching run_distribution_test's
+        # convention -- deterministic regardless of how many virtual
+        # devices the test environment exposes.
+        if len(devices) < 2:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        mesh_shape = (1, 2)
+        model_axis_size = mesh_shape[-1]
+
+        # num_query_heads=3 does not divide model_axis_size=2 -- this is
+        # the condition the skip rule in test_layout_map_mesh_shapes
+        # guards against.
+        num_query_heads = 3
+        self.assertNotEqual(num_query_heads % model_axis_size, 0)
+
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape,
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+        layout_map = MistralBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        # Proves the skip rule is necessary: building this genuinely
+        # indivisible config under the same layout map that
+        # test_layout_map_mesh_shapes would have used (had it not skipped)
+        # actually raises, rather than silently succeeding.
+        with self.assertRaises(Exception):
+            with distribution.scope():
+                MistralBackbone(
+                    vocabulary_size=40,
+                    num_layers=1,
+                    num_query_heads=num_query_heads,
+                    num_key_value_heads=1,
+                    hidden_dim=24,
+                    intermediate_dim=16,
+                    sliding_window=4,
+                    dtype="bfloat16",
+                )
+        gc.collect()
+
     @pytest.mark.kaggle_key_required
     @pytest.mark.multi_device
     @pytest.mark.extra_large

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -6,9 +6,9 @@ from keras import ops
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.tests.test_case import TestCase
 
-# Scaled ~16x down from the width class every Mistral preset shares
-# (vocab 32000, hidden 4096, intermediate 14336, 32 query / 8 kv heads).
-# The 4:1 query:kv ratio is kept, since divisibility depends on it.
+# Scaled ~16x down from the 7B presets (hidden 4096, intermediate 14336,
+# 32 query / 8 kv heads). The 4:1 query:kv ratio is kept, since that is what
+# divisibility depends on; the magistral presets are a different width class.
 MISTRAL_7B_DIMS = {
     "name": "mistral_7b",
     "vocabulary_size": 2000,

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -270,7 +270,8 @@ class MistralBackboneTest(TestCase):
         for preset in MistralBackbone.presets:
             try:
                 path = get_file(preset, CONFIG_FILE)
-                cfg = json.load(open(path))["config"]
+                with open(path) as f:
+                    cfg = json.load(f)["config"]
             except Exception as e:
                 # A preset this account can't reach (e.g. an unaccepted
                 # Kaggle license consent click-through) is logged, not

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -1,8 +1,110 @@
+import gc
+import json
+import re
+
+import keras
 import pytest
+from absl.testing import parameterized
 from keras import ops
 
 from keras_hub.src.models.mistral.mistral_backbone import MistralBackbone
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
+
+# Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
+# dimensions, frozen as literals and sourced once, offline -- do not add a
+# `get_file` call to the Tier-2 test body itself (that's what Tier 3,
+# `test_layout_map_live_presets` below, is for).
+#
+# MEMORY NOTE: this local dev machine cannot load full-scale model dims (see
+# gemma_backbone_test.py's identical note for the OOM history that motivated
+# this rule). What matters for the divisibility/sharding properties this
+# tier tests is the RATIO of query heads to kv heads and whether
+# hidden/intermediate/vocab divide the mesh's model-axis sizes -- not the
+# absolute parameter count. So these dims are scaled down ~16x from the real
+# Mistral-7B preset config (`hidden_size=4096`, `num_attention_heads=32`,
+# `num_key_value_heads=8`, `intermediate_size=14336`, `vocab_size=32000`,
+# all five presets in `mistral_presets.py` share this single architecture
+# width class -- there is no smaller/larger Mistral preset in the registry
+# to source a second class from) while preserving the real 4:1 query:kv
+# GQA ratio and keeping hidden/intermediate/vocab as clean values divisible
+# by every mesh shape in CAPPED_MESH_SHAPES. A second, larger synthetic
+# class is included to exercise an 8:1 GQA ratio and a bigger width tier
+# (a plausible larger-Mistral extrapolation, not a real preset -- documented
+# as such). Full-scale real dims are exercised by
+# `test_layout_map_live_presets` below, which has its own per-width-class
+# memory-budget skip so it never attempts a full-scale build locally either
+# -- true full-scale verification happens offline on a machine with more
+# RAM, not on this box.
+MISTRAL_7B_DIMS = {
+    "source_preset": "mistral_7b_en (real ratio, memory-scaled dims)",
+    "vocabulary_size": 2000,  # real: 32000, scaled /16.
+    "num_layers": 1,  # depth is irrelevant to spec matching/divisibility.
+    "num_query_heads": 8,  # real: 32, scaled /4 (keeps 4:1 GQA ratio).
+    "num_key_value_heads": 2,  # real: 8, scaled /4 -- 4:1 GQA ratio.
+    "hidden_dim": 256,  # real: 4096, scaled /16.
+    "intermediate_dim": 896,  # real: 14336, scaled /16.
+    "sliding_window": 128,
+}
+MISTRAL_LARGE_DIMS = {
+    # Not a real preset -- a plausible larger-Mistral extrapolation (doubled
+    # hidden/intermediate vs. MISTRAL_7B_DIMS) used to exercise an 8:1 GQA
+    # ratio and a bigger width tier under the mesh sweep.
+    "source_preset": "mistral_large (synthetic, larger width class)",
+    "vocabulary_size": 4000,
+    "num_layers": 1,
+    "num_query_heads": 16,
+    "num_key_value_heads": 2,  # 8:1 GQA ratio.
+    "hidden_dim": 512,
+    "intermediate_dim": 1792,
+    "sliding_window": 128,
+}
+
+# Hard-capped mesh-shape list for this shared 37GB dev machine. See
+# gemma_backbone_test.py's identical constant for the full rationale
+# (systemd-oomd OOM kill history on this box) -- the dropped shapes
+# (8x8, 16x16, 4x4x4, 4x4x8) are never attempted here either.
+CAPPED_MESH_SHAPES = [
+    (2, 4),
+    (1, 8),
+    (4, 4),
+    (2, 2, 2),
+    (1, 1, 8),
+    (2, 2, 4),
+]
+
+# Same 8 expected_shardings patterns as MistralBackboneTest.test_distribution
+# (post-QKV-axis-fix), reused by the Tier-2 and Tier-3 mesh sweeps below.
+_EXPECTED_SHARDINGS = {
+    "token_embedding/embeddings": ("model", "batch"),
+    "token_embedding/reverse_embeddings": ("batch", "model"),
+    "self_attention.*query.kernel": ("batch", "model", None),
+    "self_attention.*(key|value).kernel": ("batch", None, None),
+    "self_attention.*attention_output.kernel": ("model", None, "batch"),
+    "feedforward_intermediate_dense.kernel": ("batch", "model"),
+    "feedforward_gate_dense.kernel": ("batch", "model"),
+    "feedforward_output_dense.kernel": ("model", "batch"),
+}
+
+
+def _assert_mistral_shardings_and_coverage(test_case, model, layout_map):
+    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
+    for pattern, expected in _EXPECTED_SHARDINGS.items():
+        matches = [w for w in model.weights if re.search(pattern, w.path)]
+        test_case.assertGreater(len(matches), 0)
+        for w in matches:
+            test_case.assertEqual(tuple(w.value.sharding.spec), expected)
+    offending = [
+        w.path
+        for w in model.weights
+        if len(w.shape) >= 2 and layout_map[w.path] is None
+    ]
+    test_case.assertEqual(
+        offending,
+        [],
+        f"The following rank>=2 weights are unmapped: {offending}",
+    )
 
 
 class MistralBackboneTest(TestCase):
@@ -41,6 +143,268 @@ class MistralBackboneTest(TestCase):
         model = MistralBackbone(**self.init_kwargs)
         # Reference value calculated using the PyTorch model
         self.assertEqual(model.count_params(), 2704)
+
+    def test_distribution(self):
+        # Note (preserved from the pre-refactor manual test): mesh is
+        # pinned to exactly 2 devices (not len(devices), see the shared
+        # helper) so that the default test config's num_key_value_heads=4
+        # -- intentionally not divisible by every host's device count --
+        # regression-tests that key/value kernels are left replicated on
+        # the model axis rather than sharded. See get_layout_map's comment.
+        self.run_distribution_test(
+            cls=MistralBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_shardings={
+                "token_embedding/embeddings": ("model", "batch"),
+                "token_embedding/reverse_embeddings": ("batch", "model"),
+                "self_attention.*query.kernel": ("batch", "model", None),
+                "self_attention.*(key|value).kernel": (
+                    "batch",
+                    None,
+                    None,
+                ),
+                "self_attention.*attention_output.kernel": (
+                    "model",
+                    None,
+                    "batch",
+                ),
+                "feedforward_intermediate_dense.kernel": (
+                    "batch",
+                    "model",
+                ),
+                "feedforward_gate_dense.kernel": ("batch", "model"),
+                "feedforward_output_dense.kernel": ("model", "batch"),
+            },
+            allow_replicated=(),
+        )
+
+    @parameterized.named_parameters(
+        (
+            f"{dims['source_preset'].split(' ')[0]}_mesh"
+            f"_{'x'.join(str(s) for s in shape)}",
+            dims,
+            shape,
+        )
+        for dims in (MISTRAL_7B_DIMS, MISTRAL_LARGE_DIMS)
+        for shape in CAPPED_MESH_SHAPES
+    )
+    def test_layout_map_mesh_shapes(self, dims, mesh_shape):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        n_needed = 1
+        for s in mesh_shape:
+            n_needed *= s
+        if n_needed > len(devices):
+            self.skipTest(
+                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
+                f"{len(devices)} available. Run with "
+                f"XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{n_needed} to exercise this shape locally."
+            )
+
+        # Query-head-divisibility skip rule: an inherent tensor-parallelism
+        # ceiling, not a bug. model_axis_size is the mesh's last axis,
+        # matching this repo's axis_names=(..., "model") convention.
+        model_axis_size = mesh_shape[-1]
+        num_query_heads = dims["num_query_heads"]
+        if num_query_heads % model_axis_size != 0:
+            self.skipTest(
+                f"num_query_heads={num_query_heads} not divisible by "
+                f"model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
+        devices = devices[:n_needed]
+        if len(mesh_shape) == 2:
+            axis_names = ("batch", "model")
+        else:
+            # 3D shape: the extra axis is named "seq" per the plan/
+            # testing-strategy convention, but get_layout_map only names
+            # "batch"/"model" -- the "seq" axis simply replicates weights
+            # (no rule targets it), matching every other 3D-mesh test in
+            # this PR series.
+            axis_names = ("batch", "seq", "model")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape,
+            axis_names=axis_names,
+            devices=devices,
+        )
+        layout_map = MistralBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
+        with distribution.scope():
+            # bfloat16: a memory mitigation for this shared dev machine --
+            # spec assertions are dtype-independent.
+            model = MistralBackbone(dtype="bfloat16", **init_kwargs)
+            _assert_mistral_shardings_and_coverage(self, model, layout_map)
+        del model
+        gc.collect()
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.multi_device
+    @pytest.mark.extra_large
+    def test_layout_map_live_presets(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+
+        # Fetch every preset's config only (no weights), then dedupe by the
+        # divisibility-relevant dims so width-classes that share a config
+        # (e.g. base vs instruct variants of the same size) are only built
+        # once per mesh shape -- a memory/time necessity on this machine,
+        # while every preset in the registry is still fetched and
+        # evaluated, preserving full registry coverage.
+        dim_keys = (
+            "vocabulary_size",
+            "num_query_heads",
+            "num_key_value_heads",
+            "hidden_dim",
+            "intermediate_dim",
+            "sliding_window",
+        )
+        width_classes = {}  # dedupe key -> (config dict, [preset names])
+        fetch_failures = []
+        for preset in MistralBackbone.presets:
+            try:
+                path = get_file(preset, CONFIG_FILE)
+                cfg = json.load(open(path))["config"]
+            except Exception as e:
+                # A preset this account can't reach (e.g. an unaccepted
+                # Kaggle license consent click-through) is logged, not
+                # fatal -- the rest of the registry still gets exercised.
+                fetch_failures.append((preset, str(e)))
+                continue
+            # num_layers is forced to 1 below regardless of the real
+            # value -- layout rules are per-decoder-block regexes, so
+            # depth is irrelevant to spec matching/divisibility, and 1
+            # layer keeps build memory bounded on this shared machine.
+            cfg = dict(cfg)
+            cfg["num_layers"] = 1
+            key = tuple(cfg.get(k) for k in dim_keys)
+            if key not in width_classes:
+                width_classes[key] = (cfg, [])
+            width_classes[key][1].append(preset)
+
+        if fetch_failures:
+            print(
+                f"test_layout_map_live_presets: {len(fetch_failures)} "
+                f"preset config fetches failed (logged, non-fatal): "
+                f"{fetch_failures}"
+            )
+        if not width_classes:
+            self.skipTest(
+                "No preset configs were reachable "
+                f"({len(fetch_failures)} fetch failures) -- likely a "
+                "Kaggle license-consent gate on this account for the "
+                "mistral family. See the module comment above "
+                "CAPPED_MESH_SHAPES."
+            )
+        print(
+            f"test_layout_map_live_presets: {len(width_classes)} unique "
+            f"width-classes across {len(MistralBackbone.presets)} registry "
+            "presets:"
+        )
+        for cfg, presets in width_classes.values():
+            print(f"  {presets}")
+
+        devices = keras.distribution.list_devices("CPU")
+        skip_reasons = []
+        ran_any = False
+        for cfg, presets in width_classes.values():
+            num_query_heads = cfg["num_query_heads"]
+            for mesh_shape in CAPPED_MESH_SHAPES:
+                combo_label = f"{presets[0]}@{mesh_shape}"
+                with self.subTest(combo=combo_label):
+                    n_needed = 1
+                    for s in mesh_shape:
+                        n_needed *= s
+                    if n_needed > len(devices):
+                        reason = (
+                            f"{combo_label}: needs {n_needed} devices, "
+                            f"only {len(devices)} available"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+                    model_axis_size = mesh_shape[-1]
+                    if num_query_heads % model_axis_size != 0:
+                        reason = (
+                            f"{combo_label}: num_query_heads="
+                            f"{num_query_heads} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    # Memory-budget guard: this shared dev machine cannot
+                    # locally build full-scale presets (see
+                    # CAPPED_MESH_SHAPES' comment for the OOM history).
+                    # Estimate this width-class's single-decoder-block
+                    # bf16 footprint (embedding table + one FFN block's 3
+                    # matrices, times a 3x safety margin for JAX/XLA
+                    # transient copies during construction/resharding) and
+                    # skip the actual build if it exceeds a conservative
+                    # local threshold. The config-fetch, dedup, and
+                    # divisibility-skip logic above still exercises every
+                    # registry preset either way; only the expensive
+                    # build+assert step is capped.
+                    est_params = (
+                        cfg["vocabulary_size"] * cfg["hidden_dim"]
+                        + 3 * cfg["hidden_dim"] * cfg["intermediate_dim"]
+                    )
+                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
+                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    if est_bytes > max_local_bytes:
+                        reason = (
+                            f"{combo_label}: estimated build memory "
+                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
+                            f"{max_local_bytes / 1e6:.0f}MB local safety "
+                            "threshold on this shared, RAM-constrained "
+                            "dev machine -- verify this width-class on a "
+                            "machine with more RAM or in CI"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    combo_devices = devices[:n_needed]
+                    if len(mesh_shape) == 2:
+                        axis_names = ("batch", "model")
+                    else:
+                        axis_names = ("batch", "seq", "model")
+                    device_mesh = keras.distribution.DeviceMesh(
+                        shape=mesh_shape,
+                        axis_names=axis_names,
+                        devices=combo_devices,
+                    )
+                    layout_map = MistralBackbone.get_layout_map(device_mesh)
+                    distribution = keras.distribution.ModelParallel(
+                        layout_map=layout_map, batch_dim_name="batch"
+                    )
+                    init_kwargs = {
+                        k: v for k, v in cfg.items() if k in dim_keys
+                    }
+                    init_kwargs["num_layers"] = 1
+                    with distribution.scope():
+                        model = MistralBackbone(dtype="bfloat16", **init_kwargs)
+                        _assert_mistral_shardings_and_coverage(
+                            self, model, layout_map
+                        )
+                    del model
+                    gc.collect()
+                    ran_any = True
+
+        print(
+            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
+            f"skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
+        )
+        if not ran_any:
+            self.skipTest(
+                "All (width-class, mesh-shape) combos were skipped: "
+                f"{skip_reasons}"
+            )
 
     @pytest.mark.extra_large
     def test_smallest_preset(self):

--- a/keras_hub/src/models/mistral/mistral_backbone_test.py
+++ b/keras_hub/src/models/mistral/mistral_backbone_test.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import os
 import re
 
 import keras
@@ -17,26 +18,27 @@ from keras_hub.src.utils.preset_utils import get_file
 # `get_file` call to the Tier-2 test body itself (that's what Tier 3,
 # `test_layout_map_live_presets` below, is for).
 #
-# MEMORY NOTE: this local dev machine cannot load full-scale model dims (see
-# gemma_backbone_test.py's identical note for the OOM history that motivated
-# this rule). What matters for the divisibility/sharding properties this
-# tier tests is the RATIO of query heads to kv heads and whether
-# hidden/intermediate/vocab divide the mesh's model-axis sizes -- not the
-# absolute parameter count. So these dims are scaled down ~16x from the real
-# Mistral-7B preset config (`hidden_size=4096`, `num_attention_heads=32`,
-# `num_key_value_heads=8`, `intermediate_size=14336`, `vocab_size=32000`,
-# all five presets in `mistral_presets.py` share this single architecture
-# width class -- there is no smaller/larger Mistral preset in the registry
-# to source a second class from) while preserving the real 4:1 query:kv
-# GQA ratio and keeping hidden/intermediate/vocab as clean values divisible
-# by every mesh shape in CAPPED_MESH_SHAPES. A second, larger synthetic
-# class is included to exercise an 8:1 GQA ratio and a bigger width tier
-# (a plausible larger-Mistral extrapolation, not a real preset -- documented
-# as such). Full-scale real dims are exercised by
-# `test_layout_map_live_presets` below, which has its own per-width-class
-# memory-budget skip so it never attempts a full-scale build locally either
-# -- true full-scale verification happens offline on a machine with more
-# RAM, not on this box.
+# MEMORY NOTE: memory-constrained local environments cannot load full-scale
+# model dims (see gemma_backbone_test.py's identical note for the OOM
+# history that motivated this rule). What matters for the divisibility/
+# sharding properties this tier tests is the RATIO of query heads to kv
+# heads and whether hidden/intermediate/vocab divide the mesh's model-axis
+# sizes -- not the absolute parameter count. So these dims are scaled down
+# ~16x from the real Mistral-7B preset config (`hidden_size=4096`,
+# `num_attention_heads=32`, `num_key_value_heads=8`,
+# `intermediate_size=14336`, `vocab_size=32000`, all five presets in
+# `mistral_presets.py` share this single architecture width class -- there
+# is no smaller/larger Mistral preset in the registry to source a second
+# class from) while preserving the real 4:1 query:kv GQA ratio and keeping
+# hidden/intermediate/vocab as clean values divisible by every mesh shape in
+# CAPPED_MESH_SHAPES. A second, larger synthetic class is included to
+# exercise an 8:1 GQA ratio and a bigger width tier (a plausible
+# larger-Mistral extrapolation, not a real preset -- documented as such).
+# Full-scale real dims are exercised by `test_layout_map_live_presets`
+# below, which has its own per-width-class memory-budget skip so it never
+# attempts a full-scale build in a memory-constrained environment either --
+# true full-scale verification happens on a dedicated or CI machine with
+# more memory.
 MISTRAL_7B_DIMS = {
     "source_preset": "mistral_7b_en (real ratio, memory-scaled dims)",
     "vocabulary_size": 2000,  # real: 32000, scaled /16.
@@ -61,10 +63,11 @@ MISTRAL_LARGE_DIMS = {
     "sliding_window": 128,
 }
 
-# Hard-capped mesh-shape list for this shared 37GB dev machine. See
-# gemma_backbone_test.py's identical constant for the full rationale
-# (systemd-oomd OOM kill history on this box) -- the dropped shapes
-# (8x8, 16x16, 4x4x4, 4x4x8) are never attempted here either.
+# Hard-capped mesh-shape list for memory-constrained local environments. See
+# gemma_backbone_test.py's identical constant for the full rationale (an
+# OOM kill history from an earlier run of this pipeline in a
+# memory-constrained environment) -- the dropped shapes (8x8, 16x16, 4x4x4,
+# 4x4x8) are never attempted here either.
 CAPPED_MESH_SHAPES = [
     (2, 4),
     (1, 8),
@@ -237,8 +240,8 @@ class MistralBackboneTest(TestCase):
         )
         init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
         with distribution.scope():
-            # bfloat16: a memory mitigation for this shared dev machine --
-            # spec assertions are dtype-independent.
+            # bfloat16: a memory mitigation for memory-constrained
+            # environments -- spec assertions are dtype-independent.
             model = MistralBackbone(dtype="bfloat16", **init_kwargs)
             _assert_mistral_shardings_and_coverage(self, model, layout_map)
         del model
@@ -281,7 +284,8 @@ class MistralBackboneTest(TestCase):
             # num_layers is forced to 1 below regardless of the real
             # value -- layout rules are per-decoder-block regexes, so
             # depth is irrelevant to spec matching/divisibility, and 1
-            # layer keeps build memory bounded on this shared machine.
+            # layer keeps build memory bounded in memory-constrained
+            # environments.
             cfg = dict(cfg)
             cfg["num_layers"] = 1
             key = tuple(cfg.get(k) for k in dim_keys)
@@ -340,32 +344,50 @@ class MistralBackboneTest(TestCase):
                         skip_reasons.append(reason)
                         continue
 
-                    # Memory-budget guard: this shared dev machine cannot
-                    # locally build full-scale presets (see
+                    # Memory-budget guard: memory-constrained local
+                    # environments cannot build full-scale presets (see
                     # CAPPED_MESH_SHAPES' comment for the OOM history).
-                    # Estimate this width-class's single-decoder-block
-                    # bf16 footprint (embedding table + one FFN block's 3
-                    # matrices, times a 3x safety margin for JAX/XLA
-                    # transient copies during construction/resharding) and
-                    # skip the actual build if it exceeds a conservative
-                    # local threshold. The config-fetch, dedup, and
+                    # Estimate this width-class's single-decoder-block bf16
+                    # footprint and skip the actual build if it exceeds a
+                    # conservative local threshold. Mistral has UNTIED
+                    # embeddings (`tie_weights=False` in MistralBackbone),
+                    # so the embedding term is counted twice (forward +
+                    # reverse output projection). Attention projections map
+                    # hidden<->hidden for query/output and hidden<->(hidden
+                    # scaled by the kv/query head ratio) for GQA's key/value.
+                    # The FFN is SwiGLU (gate + intermediate + output, 3
+                    # hidden*intermediate matrices), matching this model's
+                    # dense (non-MoE) feedforward block. Times a 3x safety
+                    # margin for JAX/XLA transient copies during
+                    # construction/resharding. The config-fetch, dedup, and
                     # divisibility-skip logic above still exercises every
                     # registry preset either way; only the expensive
                     # build+assert step is capped.
+                    hidden = cfg["hidden_dim"]
+                    num_kv_heads = cfg["num_key_value_heads"]
+                    kv_ratio = num_kv_heads / num_query_heads
                     est_params = (
-                        cfg["vocabulary_size"] * cfg["hidden_dim"]
-                        + 3 * cfg["hidden_dim"] * cfg["intermediate_dim"]
+                        2 * cfg["vocabulary_size"] * hidden  # untied embed
+                        + 2 * hidden * hidden  # attention q/o
+                        + 2 * hidden * hidden * kv_ratio  # attention k/v
+                        + 3 * hidden * cfg["intermediate_dim"]  # SwiGLU FFN
                     )
                     est_bytes = est_params * 2 * 3  # bf16 * safety margin
-                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    max_local_bytes = int(
+                        os.environ.get(
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
+                            300 * 1024 * 1024,
+                        )
+                    )
                     if est_bytes > max_local_bytes:
                         reason = (
                             f"{combo_label}: estimated build memory "
                             f"~{est_bytes / 1e9:.2f}GB exceeds the "
                             f"{max_local_bytes / 1e6:.0f}MB local safety "
-                            "threshold on this shared, RAM-constrained "
-                            "dev machine -- verify this width-class on a "
-                            "machine with more RAM or in CI"
+                            "threshold for memory-constrained environments "
+                            "-- verify this width-class on a machine with "
+                            "more memory or in CI (raise the budget via the "
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET env var)"
                         )
                         skip_reasons.append(reason)
                         continue
@@ -384,9 +406,16 @@ class MistralBackboneTest(TestCase):
                     distribution = keras.distribution.ModelParallel(
                         layout_map=layout_map, batch_dim_name="batch"
                     )
-                    init_kwargs = {
-                        k: v for k, v in cfg.items() if k in dim_keys
-                    }
+                    # `cfg` is the preset's full serialized `get_config()`
+                    # dict; pass all of it (real architecture flags such as
+                    # rope scaling, tie-embeddings, etc. must survive to
+                    # actually exercise the live preset's real architecture)
+                    # and only drop `"dtype"` so the explicit
+                    # `dtype="bfloat16"` override below doesn't collide with
+                    # a duplicate keyword argument. `num_layers` is forced to
+                    # 1 (layout rules are per-decoder-block, so depth is
+                    # irrelevant and 1 layer keeps build memory bounded).
+                    init_kwargs = {k: v for k, v in cfg.items() if k != "dtype"}
                     init_kwargs["num_layers"] = 1
                     with distribution.scope():
                         model = MistralBackbone(dtype="bfloat16", **init_kwargs)

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1179,13 +1179,19 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
                 # Distributed twin.
                 parity_devices = all_devices[:n_needed]
+                # axis_names length must equal the mesh rank or DeviceMesh
+                # raises -- pick the naming that matches len(mesh_shape) so a
+                # 1D (pure batch- or model-parallel) shape works too, not just
+                # the 2D/3D defaults.
+                if len(mesh_shape) == 1:
+                    axis_names = ("batch",)
+                elif len(mesh_shape) == 2:
+                    axis_names = ("batch", "model")
+                else:
+                    axis_names = ("batch", "seq", "model")
                 parity_mesh = keras.distribution.DeviceMesh(
                     shape=mesh_shape,
-                    axis_names=(
-                        ("batch", "model")
-                        if len(mesh_shape) == 2
-                        else ("batch", "seq", "model")
-                    ),
+                    axis_names=axis_names,
                     devices=parity_devices,
                 )
                 parity_layout_map = cls.get_layout_map(
@@ -1202,14 +1208,21 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     distributed_model = cls(**get_kwargs())
                     distributed_out = distributed_model(input_data)
 
-                # Forward parity. `assertAllClose` already recurses through
-                # nested structures (see the class override above) -- a
-                # manual tree.flatten()+zip() here would silently truncate
-                # on a structure-length mismatch instead of failing loudly,
-                # so compare the structures directly.
-                self.assertAllClose(
-                    undistributed_out, distributed_out, rtol=rtol, atol=atol
-                )
+                # Forward parity. Assert the two output structures match
+                # first -- this fails loudly on a structure mismatch, unlike a
+                # bare tree.flatten()+zip() which would silently truncate to
+                # the shorter one. Then compare leaf-by-leaf, skipping paired
+                # None leaves (an unset optional output on both twins):
+                # `assertAllClose` on a raw None pair raises TypeError rather
+                # than treating them as equal.
+                tree.assert_same_structure(undistributed_out, distributed_out)
+                for u_leaf, d_leaf in zip(
+                    tree.flatten(undistributed_out),
+                    tree.flatten(distributed_out),
+                ):
+                    if u_leaf is None and d_leaf is None:
+                        continue
+                    self.assertAllClose(u_leaf, d_leaf, rtol=rtol, atol=atol)
 
                 # 5-step training-convergence parity. Fixed SGD+mse
                 # choice -- do not substitute Adam without re-verifying,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1092,6 +1092,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             # Forward.
             out = model(input_data)
             for leaf in tree.flatten(out):
+                # Some backbones can return an optional None leaf (e.g. an
+                # unset auxiliary output) -- skip rather than fail on it.
+                if leaf is None:
+                    continue
                 self.assertTrue(
                     np.isfinite(ops.convert_to_numpy(leaf)).all(),
                     "Forward output contains non-finite values.",
@@ -1100,7 +1104,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             # Backward + optimizer step.
             if run_training:
                 y = tree.map_structure(
-                    lambda o: np.zeros(o.shape, "float32"), out
+                    lambda o: (
+                        None if o is None else np.zeros(o.shape, "float32")
+                    ),
+                    out,
                 )
                 batch_size = tree.flatten(input_data)[0].shape[0]
                 model.compile(optimizer="sgd", loss="mse")
@@ -1152,7 +1159,11 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 ]
                 parity_mesh = keras.distribution.DeviceMesh(
                     shape=mesh_shape,
-                    axis_names=("batch", "model"),
+                    axis_names=(
+                        ("batch", "model")
+                        if len(mesh_shape) == 2
+                        else ("batch", "seq", "model")
+                    ),
                     devices=parity_devices,
                 )
                 parity_layout_map = cls.get_layout_map(
@@ -1172,21 +1183,14 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     distributed_model = cls(**kwargs)
                     distributed_out = distributed_model(input_data)
 
-                # Forward parity. Both calls happen outside any
-                # distribution scope so neither model's ops pick up a
-                # scope they weren't built under -- `distributed_out` was
-                # already computed above, inside the scope where
-                # `distributed_model` lives; only comparing here.
-                for u_leaf, d_leaf in zip(
-                    tree.flatten(undistributed_out),
-                    tree.flatten(distributed_out),
-                ):
-                    self.assertAllClose(
-                        ops.convert_to_numpy(u_leaf),
-                        ops.convert_to_numpy(d_leaf),
-                        rtol=rtol,
-                        atol=atol,
-                    )
+                # Forward parity. `assertAllClose` already recurses through
+                # nested structures (see the class override above) -- a
+                # manual tree.flatten()+zip() here would silently truncate
+                # on a structure-length mismatch instead of failing loudly,
+                # so compare the structures directly.
+                self.assertAllClose(
+                    undistributed_out, distributed_out, rtol=rtol, atol=atol
+                )
 
                 # 5-step training-convergence parity. Fixed SGD+mse
                 # choice -- do not substitute Adam without re-verifying,
@@ -1197,7 +1201,9 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 # single shared `with` block mixes local and distributed
                 # device placement and raises a JAX device-mismatch error.
                 y = tree.map_structure(
-                    lambda o: np.zeros(o.shape, "float32"),
+                    lambda o: (
+                        None if o is None else np.zeros(o.shape, "float32")
+                    ),
                     undistributed_out,
                 )
                 batch_size = tree.flatten(input_data)[0].shape[0]
@@ -1208,28 +1214,31 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     distributed_model.compile(
                         optimizer=keras.optimizers.SGD(0.01), loss="mse"
                     )
-                for _ in range(5):
-                    u_history = undistributed_model.fit(
+                # A single fit(epochs=5) call over one batch runs exactly 5
+                # train steps and returns all 5 losses in history.history
+                # ["loss"] -- equivalent to looping fit(epochs=1) 5 times,
+                # but avoids 5x the per-call Keras/JAX setup overhead.
+                u_history = undistributed_model.fit(
+                    input_data,
+                    y,
+                    batch_size=batch_size,
+                    epochs=5,
+                    verbose=0,
+                )
+                with parity_distribution.scope():
+                    d_history = distributed_model.fit(
                         input_data,
                         y,
                         batch_size=batch_size,
-                        epochs=1,
+                        epochs=5,
                         verbose=0,
                     )
-                    with parity_distribution.scope():
-                        d_history = distributed_model.fit(
-                            input_data,
-                            y,
-                            batch_size=batch_size,
-                            epochs=1,
-                            verbose=0,
-                        )
-                    self.assertAllClose(
-                        u_history.history["loss"][0],
-                        d_history.history["loss"][0],
-                        rtol=rtol,
-                        atol=atol,
-                    )
+                self.assertAllClose(
+                    u_history.history["loss"],
+                    d_history.history["loss"],
+                    rtol=rtol,
+                    atol=atol,
+                )
                 del undistributed_model, distributed_model
                 gc.collect()
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1101,7 +1101,9 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
             output = model(input_data)
             for leaf in tree.flatten(output):
-                if leaf is None or not is_float_dtype(leaf.dtype):
+                if leaf is None or not is_float_dtype(
+                    getattr(leaf, "dtype", None)
+                ):
                     continue
                 self.assertTrue(
                     np.isfinite(ops.convert_to_numpy(leaf)).all(),
@@ -1145,9 +1147,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             cls: The backbone class to build.
             init_kwargs: See `run_distribution_test`.
             input_data: A dict of input arrays, batch dimension first.
-            mesh_shape: The mesh to shard the twin on. The default is the
-                smallest shape with more than one device on both axes, so it
-                exercises data- and model-parallel sharding together.
+            mesh_shape: A `("batch", "model")` mesh to shard the twin on. The
+                default is the smallest shape with more than one device on
+                both axes, so it exercises data- and model-parallel sharding
+                together.
             forward_rtol: Relative tolerance for the forward comparison. Tight
                 is safe here -- a single forward pass does not accumulate
                 reduction-order error.
@@ -1160,10 +1163,6 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         """
         num_devices = int(np.prod(mesh_shape))
         devices = self._skip_unless_distribution(num_devices)[:num_devices]
-        # DeviceMesh requires exactly one axis name per mesh dimension.
-        axis_names = {1: ("batch",), 2: ("batch", "model")}.get(
-            len(mesh_shape), ("batch", "seq", "model")
-        )
 
         seed = 42
         keras.utils.set_random_seed(seed)
@@ -1171,7 +1170,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         undistributed_output = undistributed(input_data)
 
         device_mesh = keras.distribution.DeviceMesh(
-            shape=mesh_shape, axis_names=axis_names, devices=devices
+            shape=mesh_shape, axis_names=("batch", "model"), devices=devices
         )
         distribution = keras.distribution.ModelParallel(
             layout_map=cls.get_layout_map(device_mesh)

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1024,13 +1024,28 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         """
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")
-        devices = keras.distribution.list_devices("CPU")
-        if len(devices) < 2:
+        # A bare string is iterable character-by-character, silently turning
+        # `allow_replicated="foo"` into per-character regexes instead of one
+        # pattern -- guard against that footgun explicitly.
+        assert not isinstance(allow_replicated, str), (
+            "allow_replicated must be a tuple/list of patterns, not a bare "
+            "string"
+        )
+        all_devices = keras.distribution.list_devices("CPU")
+        if len(all_devices) < 2:
             self.skipTest("`ModelParallel` testing requires multiple devices.")
-        # Pinned to exactly 2 devices (not len(devices)): preserves
+
+        def get_kwargs():
+            # A fresh copy each call -- a dict init_kwargs must not be
+            # mutated in place by one construction and leak into the next
+            # (e.g. Backbone.__init__ popping/normalizing a kwarg).
+            kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
+            return dict(kwargs) if isinstance(kwargs, dict) else kwargs
+
+        # Pinned to exactly 2 devices (not len(all_devices)): preserves
         # indivisibility regression semantics (e.g. a GQA model's
         # num_key_value_heads=1) deterministically across environments.
-        devices = devices[:2]
+        devices = all_devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
             shape=(1, 2),
             axis_names=("batch", "model"),
@@ -1082,8 +1097,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             layout_map=layout_map, batch_dim_name="batch"
         )
         with distribution.scope():
-            kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
-            model = cls(**kwargs)
+            model = cls(**get_kwargs())
 
             # Spec + coverage assertions.
             assert_shardings(model)
@@ -1094,7 +1108,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             for leaf in tree.flatten(out):
                 # Some backbones can return an optional None leaf (e.g. an
                 # unset auxiliary output) -- skip rather than fail on it.
-                if leaf is None:
+                # Also skip non-float leaves (e.g. integer token-id or bool
+                # mask outputs) -- np.isfinite on them is meaningless and
+                # can warn/error depending on backend and numpy version.
+                if leaf is None or not is_float_dtype(leaf.dtype):
                     continue
                 self.assertTrue(
                     np.isfinite(ops.convert_to_numpy(leaf)).all(),
@@ -1110,7 +1127,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     out,
                 )
                 batch_size = tree.flatten(input_data)[0].shape[0]
-                model.compile(optimizer="sgd", loss="mse")
+                # Loss structure must match the output structure -- a bare
+                # "mse" broadcasts to every leaf, which breaks if any leaf
+                # is None (an unset optional output).
+                loss = tree.map_structure(
+                    lambda o: None if o is None else "mse", out
+                )
+                model.compile(optimizer="sgd", loss=loss)
                 history = model.fit(
                     input_data,
                     y,
@@ -1143,20 +1166,19 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             for mesh_shape in parity_mesh_shapes:
                 n_needed = int(np.prod(mesh_shape))
                 # Defensive guard for externally-constrained environments;
-                # the conftest change guarantees 8 devices in CI.
-                if len(keras.distribution.list_devices("CPU")) < n_needed:
+                # the conftest change guarantees 8 devices in CI. Reuses
+                # all_devices fetched once above rather than re-querying
+                # list_devices() on every mesh-shape iteration.
+                if len(all_devices) < n_needed:
                     continue
 
                 # Undistributed twin.
                 keras.utils.set_random_seed(seed)
-                kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
-                undistributed_model = cls(**kwargs)
+                undistributed_model = cls(**get_kwargs())
                 undistributed_out = undistributed_model(input_data)
 
                 # Distributed twin.
-                parity_devices = keras.distribution.list_devices("CPU")[
-                    :n_needed
-                ]
+                parity_devices = all_devices[:n_needed]
                 parity_mesh = keras.distribution.DeviceMesh(
                     shape=mesh_shape,
                     axis_names=(
@@ -1177,10 +1199,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     # construction reproduces identical initial weights on
                     # both twins -- verified in the design doc.
                     keras.utils.set_random_seed(seed)
-                    kwargs = (
-                        init_kwargs() if callable(init_kwargs) else init_kwargs
-                    )
-                    distributed_model = cls(**kwargs)
+                    distributed_model = cls(**get_kwargs())
                     distributed_out = distributed_model(input_data)
 
                 # Forward parity. `assertAllClose` already recurses through
@@ -1207,12 +1226,15 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     undistributed_out,
                 )
                 batch_size = tree.flatten(input_data)[0].shape[0]
+                parity_loss = tree.map_structure(
+                    lambda o: None if o is None else "mse", undistributed_out
+                )
                 undistributed_model.compile(
-                    optimizer=keras.optimizers.SGD(0.01), loss="mse"
+                    optimizer=keras.optimizers.SGD(0.01), loss=parity_loss
                 )
                 with parity_distribution.scope():
                     distributed_model.compile(
-                        optimizer=keras.optimizers.SGD(0.01), loss="mse"
+                        optimizer=keras.optimizers.SGD(0.01), loss=parity_loss
                     )
                 # A single fit(epochs=5) call over one batch runs exactly 5
                 # train steps and returns all 5 losses in history.history

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1153,7 +1153,9 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         Args:
             cls: The backbone class to build.
             init_kwargs: See `run_distribution_test`.
-            input_data: A dict of input arrays, batch dimension first.
+            input_data: A dict of input arrays, batch dimension first. The
+                batch size must be divisible by `mesh_shape[0]`, or Jax raises
+                an indivisibility error when sharding the input.
             mesh_shape: A `("batch", "model")` mesh to shard the twin on. The
                 default is the smallest shape with more than one device on
                 both axes, so it exercises data- and model-parallel sharding

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -947,6 +947,294 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         if run_quantization_check:
             self.run_quantization_test(backbone, cls, init_kwargs, input_data)
 
+    def run_distribution_test(
+        self,
+        cls,
+        init_kwargs,
+        input_data,
+        expected_shardings,
+        allow_replicated=(),
+        layout_map_kwargs=None,
+        run_training=True,
+        assert_parity_vs_undistributed=True,
+        parity_mesh_shapes=((1, 2), (2, 2)),
+        parity_rtol=1e-5,
+        parity_atol=1e-6,
+        parity_moe_rtol=1e-4,
+        parity_moe_atol=1e-5,
+        is_moe=False,
+    ):
+        """Run shared `ModelParallel` layout-map tests for a backbone.
+
+        This is the shared structural/coverage/training test used by every
+        model's `test_distribution`. It builds `cls` under
+        a fixed `(1, 2)` `("batch", "model")` mesh (pinned to exactly 2
+        devices via `devices[:2]`, not `len(devices)`, so indivisibility
+        regressions -- e.g. a GQA model with `num_key_value_heads=1` -- are
+        exercised deterministically regardless of how many virtual devices
+        the test environment exposes), asserts every expected sharding spec,
+        asserts every rank>=2 weight is either mapped or explicitly allowed
+        to stay replicated, runs a real forward + backward + optimizer step,
+        re-asserts specs post-step, and (by default) checks numerical parity
+        and short-training-convergence against an undistributed twin.
+
+        Args:
+            cls: The backbone class to build.
+            init_kwargs: A dict of constructor kwargs, or a zero-arg callable
+                returning such a dict. The callable form is invoked *inside*
+                the distribution scope -- required for models that take a
+                prebuilt sub-encoder (e.g. a vision tower) as a constructor
+                argument, since that sub-encoder must itself be constructed
+                inside the scope or `fit()` raises a mixed local/distributed
+                device error.
+            input_data: A dict of input arrays, batch dimension first.
+            expected_shardings: A dict mapping a weight-path regex to the
+                expected sharding spec tuple for every weight whose path
+                matches (via `re.search`), e.g.
+                `{r"attention.*query.kernel": ("model", "batch", None)}`.
+            allow_replicated: An iterable of weight-path regexes for weights
+                that are intentionally left fully replicated. Must be
+                exhaustive: every rank>=2 weight not covered by the layout
+                map must match one of these patterns or the test fails.
+            layout_map_kwargs: Extra kwargs forwarded to `cls.get_layout_map`.
+            run_training: If True, run one `fit()` step and assert the loss
+                is finite and that specs survive the optimizer step.
+            assert_parity_vs_undistributed: If True (default), also assert
+                that this model's forward output and 5-step training-loss
+                trajectory numerically match an undistributed twin built
+                from identical seeded weights, at each shape in
+                `parity_mesh_shapes`. Note this does *not* validate that a
+                layout map chose the communication-efficient axis
+                convention -- GSPMD reshards transparently under either a
+                correct or an inefficient-but-valid axis choice, so parity
+                is blind to that class of bug. That is answered by separate
+                HLO/communication-volume analysis, not by this check.
+            parity_mesh_shapes: Mesh shapes to check parity at.
+            parity_rtol: Relative tolerance for dense-model parity checks.
+            parity_atol: Absolute tolerance for dense-model parity checks.
+            parity_moe_rtol: Relative tolerance for MoE-model parity checks
+                (looser -- sharded-reduction float noise is larger for MoE).
+            parity_moe_atol: Absolute tolerance for MoE-model parity checks.
+            is_moe: If True, use the `parity_moe_rtol`/`parity_moe_atol` pair
+                instead of `parity_rtol`/`parity_atol`.
+
+        Returns:
+            The distributed model built in this call, for any additional
+            model-specific assertions the caller wants to run.
+        """
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) < 2:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices (not len(devices)): preserves
+        # indivisibility regression semantics (e.g. a GQA model's
+        # num_key_value_heads=1) deterministically across environments.
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        def assert_shardings(model):
+            for pattern, expected in expected_shardings.items():
+                matches = [
+                    w for w in model.weights if re.search(pattern, w.path)
+                ]
+                self.assertGreater(
+                    len(matches),
+                    0,
+                    f"Expected sharding pattern {pattern!r} matched no "
+                    "weights -- dead assertion.",
+                )
+                for w in matches:
+                    self.assertEqual(
+                        tuple(w.value.sharding.spec),
+                        expected,
+                        f"Weight {w.path} has sharding "
+                        f"{tuple(w.value.sharding.spec)}, expected "
+                        f"{expected}.",
+                    )
+
+        def assert_coverage(model, layout_map):
+            offending = []
+            for w in model.weights:
+                if len(w.shape) < 2:
+                    continue
+                if layout_map[w.path] is not None:
+                    continue
+                if any(re.search(p, w.path) for p in allow_replicated):
+                    continue
+                offending.append(w.path)
+            self.assertEqual(
+                offending,
+                [],
+                "The following rank>=2 weights are neither mapped by the "
+                "layout map nor explicitly allow-replicated: "
+                f"{offending}",
+            )
+
+        layout_map = cls.get_layout_map(
+            device_mesh, **(layout_map_kwargs or {})
+        )
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        with distribution.scope():
+            kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
+            model = cls(**kwargs)
+
+            # Spec + coverage assertions.
+            assert_shardings(model)
+            assert_coverage(model, layout_map)
+
+            # Forward.
+            out = model(input_data)
+            for leaf in tree.flatten(out):
+                self.assertTrue(
+                    np.isfinite(ops.convert_to_numpy(leaf)).all(),
+                    "Forward output contains non-finite values.",
+                )
+
+            # Backward + optimizer step.
+            if run_training:
+                y = tree.map_structure(
+                    lambda o: np.zeros(o.shape, "float32"), out
+                )
+                batch_size = tree.flatten(input_data)[0].shape[0]
+                model.compile(optimizer="sgd", loss="mse")
+                history = model.fit(
+                    input_data,
+                    y,
+                    batch_size=batch_size,
+                    epochs=1,
+                    verbose=0,
+                )
+                loss = history.history["loss"][0]
+                self.assertTrue(
+                    np.isfinite(loss), "Training loss is not finite."
+                )
+                # Re-assert specs: catches optimizer-state resharding
+                # regressions. Deliberately does NOT assert output
+                # activation shardings -- those are GSPMD-chosen and
+                # brittle to assert on.
+                assert_shardings(model)
+
+        # Numerical parity + convergence vs. an undistributed twin. Does not
+        # and cannot detect axis-convention efficiency bugs (GSPMD reshards
+        # transparently either way, see the docstring above) -- this only
+        # catches numerically-wrong GSPMD lowering, a distinct bug class
+        # from axis inefficiency.
+        if assert_parity_vs_undistributed:
+            rtol, atol = (
+                (parity_moe_rtol, parity_moe_atol)
+                if is_moe
+                else (parity_rtol, parity_atol)
+            )
+            seed = 42
+            for mesh_shape in parity_mesh_shapes:
+                n_needed = int(np.prod(mesh_shape))
+                # Defensive guard for externally-constrained environments;
+                # the conftest change guarantees 8 devices in CI.
+                if len(keras.distribution.list_devices("CPU")) < n_needed:
+                    continue
+
+                # Undistributed twin.
+                keras.utils.set_random_seed(seed)
+                kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
+                undistributed_model = cls(**kwargs)
+                undistributed_out = undistributed_model(input_data)
+
+                # Distributed twin.
+                parity_devices = keras.distribution.list_devices("CPU")[
+                    :n_needed
+                ]
+                parity_mesh = keras.distribution.DeviceMesh(
+                    shape=mesh_shape,
+                    axis_names=("batch", "model"),
+                    devices=parity_devices,
+                )
+                parity_layout_map = cls.get_layout_map(
+                    parity_mesh, **(layout_map_kwargs or {})
+                )
+                parity_distribution = keras.distribution.ModelParallel(
+                    layout_map=parity_layout_map, batch_dim_name="batch"
+                )
+                with parity_distribution.scope():
+                    # Seed-reset (not weight-copy) immediately before
+                    # construction reproduces identical initial weights on
+                    # both twins -- verified in the design doc.
+                    keras.utils.set_random_seed(seed)
+                    kwargs = (
+                        init_kwargs() if callable(init_kwargs) else init_kwargs
+                    )
+                    distributed_model = cls(**kwargs)
+                    distributed_out = distributed_model(input_data)
+
+                # Forward parity. Both calls happen outside any
+                # distribution scope so neither model's ops pick up a
+                # scope they weren't built under -- `distributed_out` was
+                # already computed above, inside the scope where
+                # `distributed_model` lives; only comparing here.
+                for u_leaf, d_leaf in zip(
+                    tree.flatten(undistributed_out),
+                    tree.flatten(distributed_out),
+                ):
+                    self.assertAllClose(
+                        ops.convert_to_numpy(u_leaf),
+                        ops.convert_to_numpy(d_leaf),
+                        rtol=rtol,
+                        atol=atol,
+                    )
+
+                # 5-step training-convergence parity. Fixed SGD+mse
+                # choice -- do not substitute Adam without re-verifying,
+                # see the helper's docstring/plan. Each twin's compile()
+                # and fit() calls run under their own construction
+                # context (undistributed: no scope; distributed: its own
+                # ModelParallel scope) -- interleaving fit() calls under a
+                # single shared `with` block mixes local and distributed
+                # device placement and raises a JAX device-mismatch error.
+                y = tree.map_structure(
+                    lambda o: np.zeros(o.shape, "float32"),
+                    undistributed_out,
+                )
+                batch_size = tree.flatten(input_data)[0].shape[0]
+                undistributed_model.compile(
+                    optimizer=keras.optimizers.SGD(0.01), loss="mse"
+                )
+                with parity_distribution.scope():
+                    distributed_model.compile(
+                        optimizer=keras.optimizers.SGD(0.01), loss="mse"
+                    )
+                for _ in range(5):
+                    u_history = undistributed_model.fit(
+                        input_data,
+                        y,
+                        batch_size=batch_size,
+                        epochs=1,
+                        verbose=0,
+                    )
+                    with parity_distribution.scope():
+                        d_history = distributed_model.fit(
+                            input_data,
+                            y,
+                            batch_size=batch_size,
+                            epochs=1,
+                            verbose=0,
+                        )
+                    self.assertAllClose(
+                        u_history.history["loss"][0],
+                        d_history.history["loss"][0],
+                        rtol=rtol,
+                        atol=atol,
+                    )
+                del undistributed_model, distributed_model
+                gc.collect()
+
+        return model
+
     def run_vision_backbone_test(
         self,
         cls,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -947,6 +947,106 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         if run_quantization_check:
             self.run_quantization_test(backbone, cls, init_kwargs, input_data)
 
+    def _skip_unless_distribution(self, min_devices):
+        """Skip unless the Jax backend and `min_devices` CPU devices exist."""
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) < min_devices:
+            self.skipTest(
+                f"Needs {min_devices} devices, found {len(devices)}. Rerun "
+                "with XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{min_devices} to exercise this test."
+            )
+        return devices
+
+    def _distribution_init_kwargs(self, init_kwargs):
+        """Return fresh constructor kwargs for one model construction.
+
+        A callable `init_kwargs` is invoked here, inside whatever
+        distribution scope the caller has entered.
+        """
+        kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
+        return dict(kwargs) if isinstance(kwargs, dict) else kwargs
+
+    def _fit_distribution_model(
+        self, model, input_data, reference_output, epochs
+    ):
+        """Compile with SGD/mse against zeros and return the loss history."""
+        loss_spec = tree.map_structure(
+            lambda o: None if o is None else "mse", reference_output
+        )
+        y = tree.map_structure(
+            lambda o: None if o is None else np.zeros(o.shape, "float32"),
+            reference_output,
+        )
+        model.compile(optimizer=keras.optimizers.SGD(0.01), loss=loss_spec)
+        history = model.fit(
+            input_data,
+            y,
+            batch_size=tree.flatten(input_data)[0].shape[0],
+            epochs=epochs,
+            verbose=0,
+        )
+        return history.history["loss"]
+
+    def assert_sharding_specs(self, model, expected_shardings):
+        """Assert every weight matching each regex has the expected spec.
+
+        Args:
+            model: A built model.
+            expected_shardings: A dict mapping a weight-path regex to the
+                sharding spec tuple expected of every weight it matches (via
+                `re.search`), e.g.
+                `{r"attention.*query.kernel": ("batch", "model", None)}`.
+        """
+        for pattern, expected in expected_shardings.items():
+            matches = [w for w in model.weights if re.search(pattern, w.path)]
+            self.assertGreater(
+                len(matches),
+                0,
+                f"Sharding pattern {pattern!r} matched no weights.",
+            )
+            for w in matches:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    expected,
+                    f"Weight {w.path} has sharding "
+                    f"{tuple(w.value.sharding.spec)}, expected {expected}.",
+                )
+
+    def assert_sharding_coverage(self, model, layout_map, allow_replicated=()):
+        """Assert no rank>=2 weight is left unsharded by accident.
+
+        An unmatched weight is not an error to `LayoutMap` -- it is simply
+        kept whole on every device. This turns that silence into a failure
+        unless the weight is explicitly declared.
+
+        Args:
+            model: A built model.
+            layout_map: The `keras.distribution.LayoutMap` used to build it.
+            allow_replicated: An iterable of weight-path regexes for weights
+                intentionally kept whole. Must be exhaustive.
+        """
+        self.assertNotIsInstance(
+            allow_replicated,
+            str,
+            "allow_replicated must be an iterable of patterns, not a string.",
+        )
+        offending = [
+            w.path
+            for w in model.weights
+            if len(w.shape) >= 2
+            and layout_map[w.path] is None
+            and not any(re.search(p, w.path) for p in allow_replicated)
+        ]
+        self.assertEqual(
+            offending,
+            [],
+            "These rank>=2 weights are neither mapped by the layout map nor "
+            f"listed in allow_replicated: {offending}",
+        )
+
     def run_distribution_test(
         self,
         cls,
@@ -954,163 +1054,53 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         input_data,
         expected_shardings,
         allow_replicated=(),
-        layout_map_kwargs=None,
         run_training=True,
-        assert_parity_vs_undistributed=True,
-        parity_mesh_shapes=((1, 2), (2, 2)),
-        parity_rtol=1e-5,
-        parity_atol=1e-6,
-        parity_moe_rtol=1e-4,
-        parity_moe_atol=1e-5,
-        is_moe=False,
     ):
-        """Run shared `ModelParallel` layout-map tests for a backbone.
+        """Test that a backbone's `get_layout_map` shards every weight.
 
-        This is the shared structural/coverage/training test used by every
-        model's `test_distribution`. It builds `cls` under
-        a fixed `(1, 2)` `("batch", "model")` mesh (pinned to exactly 2
-        devices via `devices[:2]`, not `len(devices)`, so indivisibility
-        regressions -- e.g. a GQA model with `num_key_value_heads=1` -- are
-        exercised deterministically regardless of how many virtual devices
-        the test environment exposes), asserts every expected sharding spec,
-        asserts every rank>=2 weight is either mapped or explicitly allowed
-        to stay replicated, runs a real forward + backward + optimizer step,
-        re-asserts specs post-step, and (by default) checks numerical parity
-        and short-training-convergence against an undistributed twin.
+        Builds `cls` under a two-device `("batch", "model")` mesh, asserts
+        every expected sharding spec, asserts no rank>=2 weight is left
+        unsharded by accident, then runs a forward pass, a backward pass and
+        an optimizer step and re-asserts that the specs survived.
+
+        The mesh is pinned to two devices rather than every visible device so
+        that a config whose head counts do not divide the host's device count
+        still exercises the same path everywhere.
+
+        Numerical parity against an unsharded model is a separate, more
+        expensive check -- see `run_distribution_parity_test`.
 
         Args:
             cls: The backbone class to build.
             init_kwargs: A dict of constructor kwargs, or a zero-arg callable
-                returning such a dict. The callable form is invoked *inside*
-                the distribution scope -- required for models that take a
-                prebuilt sub-encoder (e.g. a vision tower) as a constructor
-                argument, since that sub-encoder must itself be constructed
-                inside the scope or `fit()` raises a mixed local/distributed
-                device error.
+                returning one. Models that take a prebuilt sub-encoder (e.g.
+                a vision tower) need the callable form, because that
+                sub-encoder must also be built inside the distribution scope
+                or `fit()` raises a mixed device-placement error.
             input_data: A dict of input arrays, batch dimension first.
-            expected_shardings: A dict mapping a weight-path regex to the
-                expected sharding spec tuple for every weight whose path
-                matches (via `re.search`), e.g.
-                `{r"attention.*query.kernel": ("model", "batch", None)}`.
-            allow_replicated: An iterable of weight-path regexes for weights
-                that are intentionally left fully replicated. Must be
-                exhaustive: every rank>=2 weight not covered by the layout
-                map must match one of these patterns or the test fails.
-            layout_map_kwargs: Extra kwargs forwarded to `cls.get_layout_map`.
-            run_training: If True, run one `fit()` step and assert the loss
-                is finite and that specs survive the optimizer step.
-            assert_parity_vs_undistributed: If True (default), also assert
-                that this model's forward output and 5-step training-loss
-                trajectory numerically match an undistributed twin built
-                from identical seeded weights, at each shape in
-                `parity_mesh_shapes`. Note this does *not* validate that a
-                layout map chose the communication-efficient axis
-                convention -- GSPMD reshards transparently under either a
-                correct or an inefficient-but-valid axis choice, so parity
-                is blind to that class of bug. That is answered by separate
-                HLO/communication-volume analysis, not by this check.
-            parity_mesh_shapes: Mesh shapes to check parity at.
-            parity_rtol: Relative tolerance for dense-model parity checks.
-            parity_atol: Absolute tolerance for dense-model parity checks.
-            parity_moe_rtol: Relative tolerance for MoE-model parity checks
-                (looser -- sharded-reduction float noise is larger for MoE).
-            parity_moe_atol: Absolute tolerance for MoE-model parity checks.
-            is_moe: If True, use the `parity_moe_rtol`/`parity_moe_atol` pair
-                instead of `parity_rtol`/`parity_atol`.
+            expected_shardings: See `assert_sharding_specs`.
+            allow_replicated: See `assert_sharding_coverage`.
+            run_training: If True, run one `fit()` step and assert the loss is
+                finite and the specs survive the optimizer step.
 
         Returns:
-            The distributed model built in this call, for any additional
-            model-specific assertions the caller wants to run.
+            The distributed model, for any model-specific assertions the
+            caller wants to add.
         """
-        if keras.backend.backend() != "jax":
-            self.skipTest("`ModelParallel` testing requires the Jax backend.")
-        # A bare string is iterable character-by-character, silently turning
-        # `allow_replicated="foo"` into per-character regexes instead of one
-        # pattern -- guard against that footgun explicitly.
-        assert not isinstance(allow_replicated, str), (
-            "allow_replicated must be a tuple/list of patterns, not a bare "
-            "string"
-        )
-        all_devices = keras.distribution.list_devices("CPU")
-        if len(all_devices) < 2:
-            self.skipTest("`ModelParallel` testing requires multiple devices.")
-
-        def get_kwargs():
-            # A fresh copy each call -- a dict init_kwargs must not be
-            # mutated in place by one construction and leak into the next
-            # (e.g. Backbone.__init__ popping/normalizing a kwarg).
-            kwargs = init_kwargs() if callable(init_kwargs) else init_kwargs
-            return dict(kwargs) if isinstance(kwargs, dict) else kwargs
-
-        # Pinned to exactly 2 devices (not len(all_devices)): preserves
-        # indivisibility regression semantics (e.g. a GQA model's
-        # num_key_value_heads=1) deterministically across environments.
-        devices = all_devices[:2]
+        devices = self._skip_unless_distribution(2)[:2]
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, 2),
-            axis_names=("batch", "model"),
-            devices=devices,
+            shape=(1, 2), axis_names=("batch", "model"), devices=devices
         )
+        layout_map = cls.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
 
-        def assert_shardings(model):
-            for pattern, expected in expected_shardings.items():
-                matches = [
-                    w for w in model.weights if re.search(pattern, w.path)
-                ]
-                self.assertGreater(
-                    len(matches),
-                    0,
-                    f"Expected sharding pattern {pattern!r} matched no "
-                    "weights -- dead assertion.",
-                )
-                for w in matches:
-                    self.assertEqual(
-                        tuple(w.value.sharding.spec),
-                        expected,
-                        f"Weight {w.path} has sharding "
-                        f"{tuple(w.value.sharding.spec)}, expected "
-                        f"{expected}.",
-                    )
-
-        def assert_coverage(model, layout_map):
-            offending = []
-            for w in model.weights:
-                if len(w.shape) < 2:
-                    continue
-                if layout_map[w.path] is not None:
-                    continue
-                if any(re.search(p, w.path) for p in allow_replicated):
-                    continue
-                offending.append(w.path)
-            self.assertEqual(
-                offending,
-                [],
-                "The following rank>=2 weights are neither mapped by the "
-                "layout map nor explicitly allow-replicated: "
-                f"{offending}",
-            )
-
-        layout_map = cls.get_layout_map(
-            device_mesh, **(layout_map_kwargs or {})
-        )
-        distribution = keras.distribution.ModelParallel(
-            layout_map=layout_map, batch_dim_name="batch"
-        )
         with distribution.scope():
-            model = cls(**get_kwargs())
+            model = cls(**self._distribution_init_kwargs(init_kwargs))
+            self.assert_sharding_specs(model, expected_shardings)
+            self.assert_sharding_coverage(model, layout_map, allow_replicated)
 
-            # Spec + coverage assertions.
-            assert_shardings(model)
-            assert_coverage(model, layout_map)
-
-            # Forward.
-            out = model(input_data)
-            for leaf in tree.flatten(out):
-                # Some backbones can return an optional None leaf (e.g. an
-                # unset auxiliary output) -- skip rather than fail on it.
-                # Also skip non-float leaves (e.g. integer token-id or bool
-                # mask outputs) -- np.isfinite on them is meaningless and
-                # can warn/error depending on backend and numpy version.
+            output = model(input_data)
+            for leaf in tree.flatten(output):
                 if leaf is None or not is_float_dtype(leaf.dtype):
                     continue
                 self.assertTrue(
@@ -1118,166 +1108,123 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     "Forward output contains non-finite values.",
                 )
 
-            # Backward + optimizer step.
             if run_training:
-                y = tree.map_structure(
-                    lambda o: (
-                        None if o is None else np.zeros(o.shape, "float32")
-                    ),
-                    out,
+                losses = self._fit_distribution_model(
+                    model, input_data, output, epochs=1
                 )
-                batch_size = tree.flatten(input_data)[0].shape[0]
-                # Loss structure must match the output structure -- a bare
-                # "mse" broadcasts to every leaf, which breaks if any leaf
-                # is None (an unset optional output).
-                loss = tree.map_structure(
-                    lambda o: None if o is None else "mse", out
-                )
-                model.compile(optimizer="sgd", loss=loss)
-                history = model.fit(
-                    input_data,
-                    y,
-                    batch_size=batch_size,
-                    epochs=1,
-                    verbose=0,
-                )
-                loss = history.history["loss"][0]
                 self.assertTrue(
-                    np.isfinite(loss), "Training loss is not finite."
+                    np.isfinite(losses[0]), "Training loss is not finite."
                 )
-                # Re-assert specs: catches optimizer-state resharding
-                # regressions. Deliberately does NOT assert output
-                # activation shardings -- those are GSPMD-chosen and
-                # brittle to assert on.
-                assert_shardings(model)
-
-        # Numerical parity + convergence vs. an undistributed twin. Does not
-        # and cannot detect axis-convention efficiency bugs (GSPMD reshards
-        # transparently either way, see the docstring above) -- this only
-        # catches numerically-wrong GSPMD lowering, a distinct bug class
-        # from axis inefficiency.
-        if assert_parity_vs_undistributed:
-            rtol, atol = (
-                (parity_moe_rtol, parity_moe_atol)
-                if is_moe
-                else (parity_rtol, parity_atol)
-            )
-            seed = 42
-            for mesh_shape in parity_mesh_shapes:
-                n_needed = int(np.prod(mesh_shape))
-                # Defensive guard for externally-constrained environments;
-                # the conftest change guarantees 8 devices in CI. Reuses
-                # all_devices fetched once above rather than re-querying
-                # list_devices() on every mesh-shape iteration.
-                if len(all_devices) < n_needed:
-                    continue
-
-                # Undistributed twin.
-                keras.utils.set_random_seed(seed)
-                undistributed_model = cls(**get_kwargs())
-                undistributed_out = undistributed_model(input_data)
-
-                # Distributed twin.
-                parity_devices = all_devices[:n_needed]
-                # axis_names length must equal the mesh rank or DeviceMesh
-                # raises -- pick the naming that matches len(mesh_shape) so a
-                # 1D (pure batch- or model-parallel) shape works too, not just
-                # the 2D/3D defaults.
-                if len(mesh_shape) == 1:
-                    axis_names = ("batch",)
-                elif len(mesh_shape) == 2:
-                    axis_names = ("batch", "model")
-                else:
-                    axis_names = ("batch", "seq", "model")
-                parity_mesh = keras.distribution.DeviceMesh(
-                    shape=mesh_shape,
-                    axis_names=axis_names,
-                    devices=parity_devices,
-                )
-                parity_layout_map = cls.get_layout_map(
-                    parity_mesh, **(layout_map_kwargs or {})
-                )
-                parity_distribution = keras.distribution.ModelParallel(
-                    layout_map=parity_layout_map, batch_dim_name="batch"
-                )
-                with parity_distribution.scope():
-                    # Seed-reset (not weight-copy) immediately before
-                    # construction reproduces identical initial weights on
-                    # both twins -- verified in the design doc.
-                    keras.utils.set_random_seed(seed)
-                    distributed_model = cls(**get_kwargs())
-                    distributed_out = distributed_model(input_data)
-
-                # Forward parity. Assert the two output structures match
-                # first -- this fails loudly on a structure mismatch, unlike a
-                # bare tree.flatten()+zip() which would silently truncate to
-                # the shorter one. Then compare leaf-by-leaf, skipping paired
-                # None leaves (an unset optional output on both twins):
-                # `assertAllClose` on a raw None pair raises TypeError rather
-                # than treating them as equal.
-                tree.assert_same_structure(undistributed_out, distributed_out)
-                for u_leaf, d_leaf in zip(
-                    tree.flatten(undistributed_out),
-                    tree.flatten(distributed_out),
-                ):
-                    if u_leaf is None and d_leaf is None:
-                        continue
-                    self.assertAllClose(u_leaf, d_leaf, rtol=rtol, atol=atol)
-
-                # 5-step training-convergence parity. Fixed SGD+mse
-                # choice -- do not substitute Adam without re-verifying,
-                # see the helper's docstring/plan. Each twin's compile()
-                # and fit() calls run under their own construction
-                # context (undistributed: no scope; distributed: its own
-                # ModelParallel scope) -- interleaving fit() calls under a
-                # single shared `with` block mixes local and distributed
-                # device placement and raises a JAX device-mismatch error.
-                y = tree.map_structure(
-                    lambda o: (
-                        None if o is None else np.zeros(o.shape, "float32")
-                    ),
-                    undistributed_out,
-                )
-                batch_size = tree.flatten(input_data)[0].shape[0]
-                parity_loss = tree.map_structure(
-                    lambda o: None if o is None else "mse", undistributed_out
-                )
-                undistributed_model.compile(
-                    optimizer=keras.optimizers.SGD(0.01), loss=parity_loss
-                )
-                with parity_distribution.scope():
-                    distributed_model.compile(
-                        optimizer=keras.optimizers.SGD(0.01), loss=parity_loss
-                    )
-                # A single fit(epochs=5) call over one batch runs exactly 5
-                # train steps and returns all 5 losses in history.history
-                # ["loss"] -- equivalent to looping fit(epochs=1) 5 times,
-                # but avoids 5x the per-call Keras/JAX setup overhead.
-                u_history = undistributed_model.fit(
-                    input_data,
-                    y,
-                    batch_size=batch_size,
-                    epochs=5,
-                    verbose=0,
-                )
-                with parity_distribution.scope():
-                    d_history = distributed_model.fit(
-                        input_data,
-                        y,
-                        batch_size=batch_size,
-                        epochs=5,
-                        verbose=0,
-                    )
-                self.assertAllClose(
-                    u_history.history["loss"],
-                    d_history.history["loss"],
-                    rtol=rtol,
-                    atol=atol,
-                )
-                del undistributed_model, distributed_model
-                gc.collect()
-
+                # Catches optimizer state resharding a weight off-spec.
+                self.assert_sharding_specs(model, expected_shardings)
         return model
+
+    def run_distribution_parity_test(
+        self,
+        cls,
+        init_kwargs,
+        input_data,
+        mesh_shape=(2, 2),
+        forward_rtol=1e-5,
+        forward_atol=1e-6,
+        train_rtol=1e-3,
+        train_atol=1e-4,
+    ):
+        """Test that a sharded backbone matches an unsharded twin.
+
+        Builds two models from the same seed -- one under `mesh_shape`, one
+        undistributed -- and asserts their forward outputs match, that both
+        actually train, and that their final training losses agree.
+
+        This cannot detect a layout map that shards a valid but
+        communication-inefficient axis. GSPMD reshards transparently, so both
+        conventions produce identical numbers; only collective-volume
+        analysis tells them apart.
+
+        Args:
+            cls: The backbone class to build.
+            init_kwargs: See `run_distribution_test`.
+            input_data: A dict of input arrays, batch dimension first.
+            mesh_shape: The mesh to shard the twin on. The default is the
+                smallest shape with more than one device on both axes, so it
+                exercises data- and model-parallel sharding together.
+            forward_rtol: Relative tolerance for the forward comparison. Tight
+                is safe here -- a single forward pass does not accumulate
+                reduction-order error.
+            forward_atol: Absolute tolerance for the forward comparison.
+            train_rtol: Relative tolerance for the final-loss comparison. Much
+                looser than the forward pair on purpose: sharded reductions
+                reorder float accumulation and that divergence compounds with
+                every step.
+            train_atol: Absolute tolerance for the final-loss comparison.
+        """
+        num_devices = int(np.prod(mesh_shape))
+        devices = self._skip_unless_distribution(num_devices)[:num_devices]
+        # DeviceMesh requires exactly one axis name per mesh dimension.
+        axis_names = {1: ("batch",), 2: ("batch", "model")}.get(
+            len(mesh_shape), ("batch", "seq", "model")
+        )
+
+        seed = 42
+        keras.utils.set_random_seed(seed)
+        undistributed = cls(**self._distribution_init_kwargs(init_kwargs))
+        undistributed_output = undistributed(input_data)
+
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape, axis_names=axis_names, devices=devices
+        )
+        distribution = keras.distribution.ModelParallel(
+            layout_map=cls.get_layout_map(device_mesh)
+        )
+        with distribution.scope():
+            keras.utils.set_random_seed(seed)
+            distributed = cls(**self._distribution_init_kwargs(init_kwargs))
+            distributed_output = distributed(input_data)
+
+        # Compare structures first: a bare flatten+zip would silently
+        # truncate to the shorter one.
+        tree.assert_same_structure(undistributed_output, distributed_output)
+        for undistributed_leaf, distributed_leaf in zip(
+            tree.flatten(undistributed_output),
+            tree.flatten(distributed_output),
+        ):
+            if undistributed_leaf is None and distributed_leaf is None:
+                continue
+            self.assertAllClose(
+                undistributed_leaf,
+                distributed_leaf,
+                rtol=forward_rtol,
+                atol=forward_atol,
+            )
+
+        # Each twin trains under the context it was built in; interleaving
+        # them raises a Jax device-placement error.
+        undistributed_losses = self._fit_distribution_model(
+            undistributed, input_data, undistributed_output, epochs=5
+        )
+        with distribution.scope():
+            distributed_losses = self._fit_distribution_model(
+                distributed, input_data, undistributed_output, epochs=5
+            )
+
+        for name, losses in (
+            ("Undistributed", undistributed_losses),
+            ("Distributed", distributed_losses),
+        ):
+            self.assertTrue(
+                np.isfinite(losses).all(), f"{name} loss is not finite."
+            )
+            self.assertLess(
+                losses[-1], losses[0], f"{name} model did not train."
+            )
+        # Final loss only. Comparing every step would track reduction-order
+        # divergence, which grows with step count and is not a defect.
+        self.assertAllClose(
+            undistributed_losses[-1],
+            distributed_losses[-1],
+            rtol=train_rtol,
+            atol=train_atol,
+        )
 
     def run_vision_backbone_test(
         self,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1018,9 +1018,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
     def assert_sharding_coverage(self, model, layout_map, allow_replicated=()):
         """Assert no rank>=2 weight is left unsharded by accident.
 
-        An unmatched weight is not an error to `LayoutMap` -- it is simply
-        kept whole on every device. This turns that silence into a failure
-        unless the weight is explicitly declared.
+        A weight that no rule matches is not an error to `LayoutMap` -- it is
+        simply kept whole on every device. Neither is a rule whose spec names
+        no mesh axis. This turns both silences into a failure unless the
+        weight is explicitly declared.
 
         Args:
             model: A built model.
@@ -1033,13 +1034,19 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             str,
             "allow_replicated must be an iterable of patterns, not a string.",
         )
-        offending = [
-            w.path
-            for w in model.weights
-            if len(w.shape) >= 2
-            and layout_map[w.path] is None
-            and not any(re.search(p, w.path) for p in allow_replicated)
-        ]
+        # Materialized so a one-shot iterable is not consumed by the first
+        # weight, silently un-exempting every weight after it.
+        allow_replicated = tuple(allow_replicated)
+        offending = []
+        for w in model.weights:
+            if len(w.shape) < 2:
+                continue
+            layout = layout_map[w.path]
+            if layout is not None and any(a is not None for a in layout.axes):
+                continue
+            if any(re.search(p, w.path) for p in allow_replicated):
+                continue
+            offending.append(w.path)
         self.assertEqual(
             offending,
             [],
@@ -1127,8 +1134,8 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         init_kwargs,
         input_data,
         mesh_shape=(2, 2),
-        forward_rtol=1e-5,
-        forward_atol=1e-6,
+        forward_rtol=1e-4,
+        forward_atol=1e-5,
         train_rtol=1e-3,
         train_atol=1e-4,
     ):
@@ -1151,10 +1158,12 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 default is the smallest shape with more than one device on
                 both axes, so it exercises data- and model-parallel sharding
                 together.
-            forward_rtol: Relative tolerance for the forward comparison. Tight
-                is safe here -- a single forward pass does not accumulate
-                reduction-order error.
-            forward_atol: Absolute tolerance for the forward comparison.
+            forward_rtol: Relative tolerance for the forward comparison.
+            forward_atol: Absolute tolerance for the forward comparison. This
+                pair is what decides the check: sharded and unsharded outputs
+                differ by a roughly fixed ~2e-6 of float noise regardless of
+                element magnitude, so for the many near-zero elements the
+                relative term contributes nothing.
             train_rtol: Relative tolerance for the final-loss comparison. Much
                 looser than the forward pair on purpose: sharded reductions
                 reorder float accumulation and that divergence compounds with


### PR DESCRIPTION
Closes #2825
Closes #2829

Part of #2807.

Adds `MistralBackbone.get_layout_map` together with the shared
`ModelParallel` distribution-test helper it uses. These were originally two
PRs; they are merged here because the helper had no caller on its own, which
made it both unreviewable and unexercised. #2813 is closed in favour of this.

## Summary

**`MistralBackbone.get_layout_map`** — a Megatron-style layout map. Query
kernels shard their head axis on the model axis and their contracting hidden
axis on the data axis; attention output is the row-parallel mirror. Key and
value heads are kept whole, because `num_key_value_heads` is small under
grouped-query attention and frequently does not divide the model axis.

**`TestCase.run_distribution_test`** — builds a backbone under a two-device
mesh, asserts every expected sharding spec, asserts that no rank>=2 weight
was left whole by accident, then runs a forward pass, a backward pass and an
optimizer step and re-asserts the specs survived.

**`TestCase.run_distribution_parity_test`** — builds a sharded model and an
unsharded twin from the same seed and asserts they agree numerically.

**`TestCase.assert_sharding_specs` / `assert_sharding_coverage`** — exposed so
per-model tests can use them directly rather than reimplementing them.

**CI** — a `run_distribution_tests` job runs the multi-device tests with eight
simulated CPU devices.

## Changes since the last review

Thanks for the review — it found real problems. What changed:

### Landing the helper with a consumer

The helper and the CI job now arrive with Mistral, so the helper is exercised
by a real caller and the job has tests to collect. The `set +e` block that
tolerated pytest's exit code 5 is gone: an empty marker selector now fails
the job, which is the behaviour that was wanted.

### The CI job

Kept as its own job, rebuilt against `run_tests` rather than `check_format`:
same `python:3.11-slim` container, same `linux-x86-n2-16` runner, same
`timeout-minutes`, same binary dependencies and install steps. It carries no
pip-cache step, so our own `::set-output` went with it and nothing needs a
`zizmor: ignore[cache-poisoning]` exemption.

The reason for a separate job rather than folding the tests into `run_tests`
is feedback latency. Inside `run_tests` the result lands behind the ~22 minute
main suite; as its own job it reports in about 4 minutes and runs in parallel,
so someone iterating on sharding sees a red check quickly instead of waiting
out a full matrix. It also re-runs alone.

`XLA_FLAGS` is job-wide here, which it could not be inside `run_tests`: this
job runs nothing but distribution tests, so there is no single-device step for
it to affect.

The `set +e` / exit-code-5 tolerance is gone and nothing replaced it. It turns
out none was needed: `pytest -m multi_device` returns 5 when the marker matches
nothing, even where files were collected and then deselected. So if a later
refactor drops every `multi_device` marker, this job goes red rather than
green — which was the property the tolerance block was destroying.

Test selection stays `pytest keras_hub/ -m multi_device` rather than a
hardcoded path list. Narrowing the path would shave a few seconds of collection
and reintroduce the risk of silently under-collecting as further models land;
full-tree collection picks up new tests automatically, as it already does for
the pre-existing `gpt2_causal_lm_test.py` distribution tests.

For context on how the original went wrong: this branch's merge base predated
f0006d85 (#2856), so the `run_tests` shape being compared against did not
exist in the tree the job was written in. The branch is now rebased onto
current master.

`check_format`'s own `::set-output` is replaced with `$GITHUB_OUTPUT` as you
suggested. `nightly.yml` and `publish-to-pypi.yml` still have theirs, but those
are separate workflows and seemed out of scope for this change.

### Cost

The duplicate `(1, 2)` parity mesh is gone; it rebuilt the mesh the structural
phase had already built. Per call:

| | Constructions | Forwards | Gradient steps | Device configs |
|---|---|---|---|---|
| Before | 5 | 5 | 21 | 4 |
| After | 3 | 3 | 11 | 3 |

The alternative of reusing the structural model as the parity twin was not
taken: that model is built without the seed reset that makes a twin
comparable, so reusing it would couple the two phases for the same saving.

### Tolerances

You were right that reduction-order divergence compounds, so this was
measured — Mistral on jax, eight simulated devices, three model shapes, three
repeats (results were identical across repeats). Tolerances shown are the
smallest `(rtol, atol)` for which `assertAllClose` passes:

| Config | Forward | 5-step trajectory | 20-step trajectory | Monotonic? |
|---|---|---|---|---|
| repo's Mistral test config | `1e-6/1e-7` | `1e-6/1e-7` | `1e-3/1e-4` | No |
| 8 layers, hidden 64 | `1e-5/1e-6` | `1e-6/1e-7` | `1e-2/1e-3` | No |
| 4 layers, hidden 128 | `1e-5/1e-6` | `1e-6/1e-7` | `1e-6/1e-7` | Yes |

Three things follow.

The compounding is real and steep — up to 10,000x between step 5 and step 20,
driven by depth. At the five steps actually run the current `1e-5` holds with
about 10x margin, so it is not flaky today, but it is a fuse: any increase in
step count, or a model deeper than these small configs, walks into it. Since
this helper is about to be applied to models with 8 to 40 real layers, it is
worth fixing now.

Forward parity needed correcting too, and my first pass got it wrong. The
three shapes above suggested `1e-5/1e-6` was safe, but that only held for
those three. The sharded and unsharded outputs differ by a roughly fixed
~2e-6 of float noise regardless of element magnitude, so for the many
near-zero elements the relative term contributes nothing and `atol` alone
decides. Three of five shapes one step away from the sampled ones fail at
`atol=1e-6` — 4 layers/hidden 128, 8 layers/hidden 64 and 12 layers/hidden 64
all land at 1.4-2.0e-6. So the forward pair is now `1e-4/1e-5`, which passes
every shape measured with about 5x margin.

That does cost detection, and it is worth being plain about: injecting a 1e-5
relative divergence between the twins is no longer caught, where 1e-4 and
above still is. That band contains only float noise — a numerically wrong
lowering produces O(1) error, not 1e-5 — so it seemed better than shipping a
check that fails on the next model.

Asserting a monotonically decreasing trajectory would not work. It fails on
two of the three shapes, including the repo's own default Mistral config,
whose loss goes `0.99465, 0.98428, 0.98294, 0.98415, 0.97570` — step four
rises. So the training assertion is instead: every loss finite, final loss
below first on both twins (it holds everywhere, with the smallest margin
0.32%, about three orders of magnitude above the noise floor), and the two
final losses compared at `rtol=1e-3/atol=1e-4` — a 1000x margin over the
measured requirement.

`is_moe`, `parity_moe_rtol` and `parity_moe_atol` are gone. The measurement
removed the last argument for them: forward parity needs the same tolerance
across every shape tested, so a separate MoE pair was a guess. An MoE model
that needs looser numbers passes `forward_rtol` at its own call site.
`layout_map_kwargs` is gone too; it had no caller. `parity_mesh_shapes` became
a singular `mesh_shape`: you asked to drop `(1, 2)` from the default, and once
the default is one shape the loop over it is dead weight. It had no caller
either. Callers can still pick the mesh, and anyone wanting parity at a second
shape can call the method twice or parameterize it, which is what
`test_layout_map_mesh_shapes` already does. `(1, 2)` itself is still exercised
— by the structural test, which is what made the parity iteration a duplicate.

### Making reduced coverage visible

Splitting the helper in two turned out to be the cleanest fix. On a machine
with two devices:

```
test_distribution         PASSED
test_distribution_parity  SKIPPED (Needs 4 devices, found 2. Rerun with
                          XLA_FLAGS=--xla_force_host_platform_device_count=4)
```

`warnings.warn` would not have worked here: `pyproject.toml` sets
`filterwarnings = ["error", ..., "ignore::UserWarning"]`, so a `UserWarning`
is filtered out before it reaches pytest's summary — invisible, which is the
problem it was meant to solve. `skipTest` is reported under the existing
`addopts = "-vv"`.

The split also cut the signature from 15 parameters to 7 and 9, which seemed
a better answer to the parameter complaint than removing three and leaving
twelve.

### Comments

Removed. The change now runs 4.4% comment lines, which is `keras_hub/src`'s own
baseline, with no block over three lines. Everything referring to
documents outside this repository is gone, including one comment that was
simply wrong — it claimed the `conftest.py` change guaranteed eight devices
in CI, which it never did; that comes from `XLA_FLAGS`.

Also applied: `self.assertNotIsInstance` instead of the bare `assert`;
`loss_spec`/`losses` instead of rebinding `loss`; both no-op `batch_dim_name`
arguments dropped. On the shallow copy — the comment was wrong, so it is
deleted rather than the copy deepened: `init_kwargs` may contain a prebuilt
sub-encoder (a vision tower), and deep-copying a Keras layer there would
clone its variables.

### Mistral's own tests

`test_layout_map_live_presets` is dropped. Its memory guard admits about 52M
parameters, while the embedding table alone is 98M-580M for every real preset
— checked against all 91 cached preset configs, none could pass — so it could
never execute an assertion, and its `extra_large` marker excluded it from CI
anyway. Real-preset divisibility is verified offline instead, and the results
are in the limitation tables on the per-model PRs.

The mesh sweep drops `(1, 1, 8)` and `(2, 2, 4)`, which impose the same axis
sizes as `(1, 8)` and `(2, 4)` — the extra `seq` axis is targeted by no layout
rule, so they asserted nothing new.

## Verification

All on CPU with simulated devices; no full-scale preset is loaded.

- `pytest keras_hub/src/models/mistral/mistral_backbone_test.py -m multi_device`
  with 8 devices: 8 passed.
- With 2 devices: 1 passed, 7 skipped, each naming the device count it needs.
- The parity test run 5 times consecutively: 5/5 passed, no flake.
- Full Mistral file and `gemma_backbone_test.py` (nearest existing consumer of
  `test_case.py`): no regressions.
- An empty selector fails: `pytest -m <marker-that-matches-nothing>` exits 5,
  so a future refactor dropping every `multi_device` marker turns the job red.
- `ruff check` and `ruff format --check`: clean. Workflow YAML validated.
- In CI, the distribution job collects 11 tests and passes in ~40s; the two
  pre-existing `gpt2_causal_lm_test.py` distribution tests are picked up too.
  They had been carrying an unregistered `multi_device` marker, so this is the
  first time they run against more than one device.

## Follow-ups, not in this PR

The remaining 15 model PRs in #2807 carry the same patterns this review
found — the dead live-presets test, the no-op `batch_dim_name`, comment
density, and 16 near-identical copies of the mesh-sweep scaffold. They will be
brought to the shape settled here rather than fixed piecemeal now, so the
shape only has to be agreed once.
