### PR TITLE
Add/fix ModelParallel layout map for gpt_oss

### DIFF
--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone.py
@@ -217,3 +217,116 @@ class GptOssBackbone(Backbone):
             }
         )
         return config
+
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the GptOss
+        backbone weights, including the MoE expert-bank and router weights.
+
+        Args:
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
+
+        Returns:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        # `reverse_embeddings` is `(hidden_dim, vocabulary_size)` -- the
+        # transpose of `embeddings` -- so the vocab-parallel output
+        # projection wants vocab-on-model, hidden-on-data, matching
+        # `embeddings` above.
+        layout_map["token_embedding/reverse_embeddings"] = (
+            data_dim,
+            model_dim,
+        )
+        # Query/key/value kernels are `(hidden_dim, num_heads, head_dim)`
+        # (einsum `bqm,muh->bquh` / `bkm,mvh->bkvh`), i.e. the contracting
+        # hidden_dim axis comes first, not the heads axis -- unlike Gemma's
+        # `(num_heads, hidden_dim, head_dim)` kernels. So the hidden_dim
+        # axis (data_dim) is sharded for column-parallelism, matching
+        # Megatron-style tensor parallelism and this layer's own
+        # `attention_output` rule below. Key/value are additionally sized by
+        # num_key_value_heads (GQA), which is independent of and typically
+        # much smaller than num_query_heads; both the heads and head_dim
+        # axes are left replicated for key/value (as for query) since only
+        # the large hidden_dim contracting axis is sharded.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            data_dim,
+            model_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            data_dim,
+            None,
+            None,
+        )
+        # Query/key/value biases are `(num_heads, head_dim)` -- 2-D, but
+        # tiny relative to the kernels, and sharding either axis adds
+        # divisibility risk (num_key_value_heads is often small, e.g. GQA)
+        # for negligible memory savings. Left fully replicated; covered via
+        # the test's `allow_replicated` list, not a layout_map rule.
+        layout_map[
+            "transformer_layer.*self_attention.*attention_output.kernel"
+        ] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        # MoE experts. The leading dimension is the expert count and is left
+        # replicated so the map works for small num_experts values used in
+        # tests. gate_up_proj fuses the SwiGLU gate and up projections into
+        # one tensor (column-parallel); down_proj is row-parallel. Expert
+        # biases (`(num_experts, ...)`, 2-D) are left fully replicated, same
+        # rationale as the attention biases above -- negligible size, not
+        # worth the divisibility risk; covered via `allow_replicated`.
+        layout_map[
+            "transformer_layer.*sparse_moe_block/experts/gate_up_proj$"
+        ] = (
+            None,
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*sparse_moe_block/experts/down_proj$"] = (
+            None,
+            model_dim,
+            data_dim,
+        )
+        # Router. num_experts is typically small, so only the hidden-dim
+        # axis is sharded.
+        layout_map[
+            "transformer_layer.*sparse_moe_block/router/router_dense.kernel"
+        ] = (
+            data_dim,
+            None,
+        )
+        return layout_map

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import os
 import re
 
 import keras
@@ -17,9 +18,9 @@ from keras_hub.src.utils.preset_utils import get_file
 # `get_file` call to the Tier-2 test body itself (that's what Tier 3,
 # `test_layout_map_live_presets` below, is for).
 #
-# MEMORY NOTE: this local dev machine cannot load full-scale model dims (see
-# `gemma_backbone_test.py`'s identical note for the OOM history that
-# established this rule). GPT-OSS real presets (`gpt_oss_20b_en`,
+# MEMORY NOTE: memory-constrained local environments cannot load full-scale
+# model dims (see `gemma_backbone_test.py`'s identical note for the OOM
+# history that established this rule). GPT-OSS real presets (`gpt_oss_20b_en`,
 # `gpt_oss_120b_en`) share `num_attention_heads=64`, `num_key_value_heads=8`
 # (an 8:1 GQA ratio), `hidden_size=2880`, `head_dim=64`, and differ mainly in
 # `num_local_experts` (32 vs 128) and `num_hidden_layers` (24 vs 36). What
@@ -37,7 +38,7 @@ from keras_hub.src.utils.preset_utils import get_file
 # per-width-class memory-budget skip (accounting for the MoE expert banks,
 # the real parameter bulk) so it never attempts a full-scale build locally
 # either -- true full-scale verification happens offline on a machine with
-# more RAM (Tier 4 in the design doc), not on this box.
+# more RAM (Tier 4 in the design doc), not in this environment.
 GPT_OSS_20B_DIMS = {
     "source_preset": "gpt_oss_20b_en (real ratio, memory-scaled dims)",
     "vocabulary_size": 2000,
@@ -63,16 +64,15 @@ GPT_OSS_120B_DIMS = {
     "top_k": 4,  # matches real top_k=4.
 }
 
-# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
-# 10-shape matrix from the testing-strategy doc is
+# Hard-capped mesh-shape list for memory-constrained local environments. The
+# full 10-shape matrix from the testing-strategy doc is
 # 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
 # 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
-# DROPPED here due to a demonstrated systemd-oomd OOM kill of the entire
-# desktop app on this shared machine during an earlier attempt at this same
-# pipeline (confirmed via journalctl; see `gemma_backbone_test.py`'s
-# identical constant/comment). Do not attempt the dropped shapes even
-# experimentally on this box -- revisiting them requires a dedicated or CI
-# machine, not this one.
+# DROPPED here due to a demonstrated OOM kill of the entire desktop
+# environment during an earlier attempt at this same pipeline (confirmed via
+# journalctl; see `gemma_backbone_test.py`'s identical constant/comment). Do
+# not attempt the dropped shapes even experimentally in these environments --
+# revisiting them requires a dedicated or CI machine with more memory.
 CAPPED_MESH_SHAPES = [
     (2, 4),
     (1, 8),
@@ -136,7 +136,7 @@ class GptOssBackboneTest(TestCase):
             "num_key_value_heads": 4,
             "hidden_dim": 16,
             "intermediate_dim": 8,
-            "num_experts": 2,
+            "num_experts": 4,
             "top_k": 2,
             "sliding_window": 2,
         }
@@ -171,7 +171,7 @@ class GptOssBackboneTest(TestCase):
         # - Attention: q, k, v, o projections + sinks
         # - MoE: router (w+b) + experts (gate_up_proj (w+b), down_proj (w+b))
         # - Layer norms: hidden_dim each
-        self.assertEqual(model.count_params(), 3780)
+        self.assertEqual(model.count_params(), 5512)
 
     def test_distribution(self):
         # Note (preserved from the pre-refactor manual test): mesh is
@@ -254,8 +254,8 @@ class GptOssBackboneTest(TestCase):
         )
         init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
         with distribution.scope():
-            # bfloat16: a memory mitigation for this shared dev machine --
-            # spec assertions are dtype-independent.
+            # bfloat16: a memory mitigation for memory-constrained local
+            # environments -- spec assertions are dtype-independent.
             model = GptOssBackbone(dtype="bfloat16", **init_kwargs)
             _assert_gpt_oss_shardings_and_coverage(self, model, layout_map)
         del model
@@ -270,9 +270,10 @@ class GptOssBackboneTest(TestCase):
 
         # Fetch every preset's config only (no weights), then dedupe by the
         # divisibility-relevant dims so width-classes that share a config
-        # are only built once per mesh shape -- a memory/time necessity on
-        # this machine, while every preset in the registry is still fetched
-        # and evaluated, preserving full registry coverage.
+        # are only built once per mesh shape -- a memory/time necessity in
+        # memory-constrained local environments, while every preset in the
+        # registry is still fetched and evaluated, preserving full registry
+        # coverage.
         dim_keys = (
             "vocabulary_size",
             "num_query_heads",
@@ -299,7 +300,8 @@ class GptOssBackboneTest(TestCase):
             # num_layers is forced to 1 below regardless of the real
             # value -- layout rules are per-decoder-block regexes, so
             # depth is irrelevant to spec matching/divisibility, and 1
-            # layer keeps build memory bounded on this shared machine.
+            # layer keeps build memory bounded in memory-constrained local
+            # environments.
             cfg = dict(cfg)
             cfg["num_layers"] = 1
             key = tuple(cfg.get(k) for k in dim_keys)
@@ -358,10 +360,10 @@ class GptOssBackboneTest(TestCase):
                         skip_reasons.append(reason)
                         continue
 
-                    # Memory-budget guard: this shared dev machine cannot
-                    # locally build full-scale presets (see
-                    # CAPPED_MESH_SHAPES' comment for the OOM history that
-                    # established this rule). Estimate this width-class's
+                    # Memory-budget guard: memory-constrained local
+                    # environments cannot locally build full-scale presets
+                    # (see CAPPED_MESH_SHAPES' comment for the OOM history
+                    # that established this rule). Estimate this width-class's
                     # single-decoder-block bf16 footprint. Unlike a dense
                     # model, GPT-OSS's parameter bulk is its MoE expert
                     # banks (gate_up_proj + down_proj, per expert), so the
@@ -395,14 +397,19 @@ class GptOssBackboneTest(TestCase):
                         + num_experts * (hidden * 2 * inter + inter * hidden)
                     )
                     est_bytes = est_params * 2 * 3  # bf16 * safety margin
-                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    max_local_bytes = int(
+                        os.environ.get(
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
+                            300 * 1024 * 1024,
+                        )
+                    )
                     if est_bytes > max_local_bytes:
                         reason = (
                             f"{combo_label}: estimated build memory "
                             f"~{est_bytes / 1e9:.2f}GB exceeds the "
                             f"{max_local_bytes / 1e6:.0f}MB local safety "
-                            "threshold on this shared, RAM-constrained "
-                            "dev machine -- verify this width-class on a "
+                            "threshold for memory-constrained local "
+                            "environments -- verify this width-class on a "
                             "machine with more RAM or in CI"
                         )
                         skip_reasons.append(reason)
@@ -422,9 +429,7 @@ class GptOssBackboneTest(TestCase):
                     distribution = keras.distribution.ModelParallel(
                         layout_map=layout_map, batch_dim_name="batch"
                     )
-                    init_kwargs = {
-                        k: v for k, v in cfg.items() if k in dim_keys
-                    }
+                    init_kwargs = {k: v for k, v in cfg.items() if k != "dtype"}
                     init_kwargs["num_layers"] = 1
                     with distribution.scope():
                         model = GptOssBackbone(dtype="bfloat16", **init_kwargs)

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
@@ -1,8 +1,130 @@
+import gc
+import json
+import re
+
+import keras
 import pytest
+from absl.testing import parameterized
 from keras import ops
 
 from keras_hub.src.models.gpt_oss.gpt_oss_backbone import GptOssBackbone
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
+
+# Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
+# dimensions, frozen as literals and sourced once, offline -- do not add a
+# `get_file` call to the Tier-2 test body itself (that's what Tier 3,
+# `test_layout_map_live_presets` below, is for).
+#
+# MEMORY NOTE: this local dev machine cannot load full-scale model dims (see
+# `gemma_backbone_test.py`'s identical note for the OOM history that
+# established this rule). GPT-OSS real presets (`gpt_oss_20b_en`,
+# `gpt_oss_120b_en`) share `num_attention_heads=64`, `num_key_value_heads=8`
+# (an 8:1 GQA ratio), `hidden_size=2880`, `head_dim=64`, and differ mainly in
+# `num_local_experts` (32 vs 128) and `num_hidden_layers` (24 vs 36). What
+# matters for the divisibility/sharding properties this tier tests is the
+# RATIO of query heads to kv heads and whether hidden/intermediate/vocab
+# divide the mesh's model-axis sizes -- not the absolute parameter count or
+# expert count. So these dims are scaled down by roughly 20-30x from the
+# real presets while preserving the exact 8:1 query:kv head ratio and
+# keeping hidden/intermediate/vocab as clean values divisible by every mesh
+# shape in CAPPED_MESH_SHAPES. `num_experts`/`top_k` are also scaled down
+# (real 32/128 experts, top_k=4) since expert count only affects the
+# leading (replicated) axis of the expert-bank weights, not the
+# divisibility properties under test here. Full-scale real dims are
+# exercised by `test_layout_map_live_presets` below, which has its own
+# per-width-class memory-budget skip (accounting for the MoE expert banks,
+# the real parameter bulk) so it never attempts a full-scale build locally
+# either -- true full-scale verification happens offline on a machine with
+# more RAM (Tier 4 in the design doc), not on this box.
+GPT_OSS_20B_DIMS = {
+    "source_preset": "gpt_oss_20b_en (real ratio, memory-scaled dims)",
+    "vocabulary_size": 2000,
+    "num_layers": 1,  # depth is irrelevant to spec matching/divisibility.
+    "num_query_heads": 16,
+    "num_key_value_heads": 2,  # real ratio: GQA, 8:1 (64:8).
+    "hidden_dim": 256,
+    "intermediate_dim": 1024,
+    "head_dim": 32,
+    "num_experts": 8,  # real 32, scaled down; leading axis is replicated.
+    "top_k": 2,
+}
+GPT_OSS_120B_DIMS = {
+    "source_preset": "gpt_oss_120b_en (real ratio, memory-scaled dims)",
+    "vocabulary_size": 3000,
+    "num_layers": 1,
+    "num_query_heads": 24,
+    "num_key_value_heads": 3,  # real ratio: GQA, 8:1 (64:8).
+    "hidden_dim": 384,
+    "intermediate_dim": 1536,
+    "head_dim": 32,
+    "num_experts": 16,  # real 128, scaled down.
+    "top_k": 4,  # matches real top_k=4.
+}
+
+# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
+# 10-shape matrix from the testing-strategy doc is
+# 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
+# 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
+# DROPPED here due to a demonstrated systemd-oomd OOM kill of the entire
+# desktop app on this shared machine during an earlier attempt at this same
+# pipeline (confirmed via journalctl; see `gemma_backbone_test.py`'s
+# identical constant/comment). Do not attempt the dropped shapes even
+# experimentally on this box -- revisiting them requires a dedicated or CI
+# machine, not this one.
+CAPPED_MESH_SHAPES = [
+    (2, 4),
+    (1, 8),
+    (4, 4),
+    (2, 2, 2),
+    (1, 1, 8),
+    (2, 2, 4),
+]
+
+# Same expected_shardings patterns as GptOssBackboneTest.test_distribution
+# (post-QKV-axis-fix), reused by the Tier-2 and Tier-3 mesh sweeps below.
+_EXPECTED_SHARDINGS = {
+    "token_embedding/embeddings": ("model", "batch"),
+    "token_embedding/reverse_embeddings": ("batch", "model"),
+    "self_attention.*query.kernel": ("batch", "model", None),
+    "self_attention.*(key|value).kernel": ("batch", None, None),
+    "self_attention.*attention_output.kernel": ("model", None, "batch"),
+    "sparse_moe_block/experts/gate_up_proj$": (None, "batch", "model"),
+    "sparse_moe_block/experts/down_proj$": (None, "model", "batch"),
+    "sparse_moe_block/router/router_dense.kernel": ("batch", None),
+}
+
+# Weights that are intentionally left fully replicated (see get_layout_map's
+# comments): 2-D query/key/value biases and 2-D MoE expert biases. Reused by
+# the Tier-2/3 mesh sweeps' coverage assertion below and passed directly to
+# `run_distribution_test` for the Tier-1 helper-based test.
+_ALLOW_REPLICATED = (
+    "self_attention.*(query|key|value).bias",
+    "sparse_moe_block/experts/gate_up_proj_bias",
+    "sparse_moe_block/experts/down_proj_bias",
+)
+
+
+def _assert_gpt_oss_shardings_and_coverage(test_case, model, layout_map):
+    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
+    for pattern, expected in _EXPECTED_SHARDINGS.items():
+        matches = [w for w in model.weights if re.search(pattern, w.path)]
+        test_case.assertGreater(len(matches), 0)
+        for w in matches:
+            test_case.assertEqual(tuple(w.value.sharding.spec), expected)
+    offending = [
+        w.path
+        for w in model.weights
+        if len(w.shape) >= 2
+        and layout_map[w.path] is None
+        and not any(re.search(p, w.path) for p in _ALLOW_REPLICATED)
+    ]
+    test_case.assertEqual(
+        offending,
+        [],
+        f"The following rank>=2 weights are unmapped: {offending}",
+    )
 
 
 class GptOssBackboneTest(TestCase):
@@ -50,3 +172,266 @@ class GptOssBackboneTest(TestCase):
         # - MoE: router (w+b) + experts (gate_up_proj (w+b), down_proj (w+b))
         # - Layer norms: hidden_dim each
         self.assertEqual(model.count_params(), 3780)
+
+    def test_distribution(self):
+        # Note (preserved from the pre-refactor manual test): mesh is
+        # pinned to exactly 2 devices (not len(devices), see the shared
+        # helper) so that the default test config's
+        # num_key_value_heads=4 is exercised deterministically. Unlike
+        # Gemma's num_key_value_heads=1, key/value are *always* left
+        # replicated in GPT-OSS's (post-fix) layout map regardless of
+        # divisibility -- only num_query_heads needs to divide the model
+        # axis, and 8 % 2 == 0 here, so this config exercises the normal
+        # (non-skip) path; the dedicated divisibility-skip path is
+        # exercised by test_layout_map_mesh_shapes/live_presets below.
+        self.run_distribution_test(
+            cls=GptOssBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_shardings=dict(_EXPECTED_SHARDINGS),
+            allow_replicated=_ALLOW_REPLICATED,
+            is_moe=True,
+        )
+
+    @parameterized.named_parameters(
+        (
+            f"{dims['source_preset'].split(' ')[0]}_mesh"
+            f"_{'x'.join(str(s) for s in shape)}",
+            dims,
+            shape,
+        )
+        for dims in (GPT_OSS_20B_DIMS, GPT_OSS_120B_DIMS)
+        for shape in CAPPED_MESH_SHAPES
+    )
+    def test_layout_map_mesh_shapes(self, dims, mesh_shape):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        n_needed = 1
+        for s in mesh_shape:
+            n_needed *= s
+        if n_needed > len(devices):
+            self.skipTest(
+                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
+                f"{len(devices)} available. Run with "
+                f"XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{n_needed} to exercise this shape locally."
+            )
+
+        # Query-head-divisibility skip rule: an inherent tensor-parallelism
+        # ceiling, not a bug. model_axis_size is the mesh's last axis,
+        # matching this repo's axis_names=(..., "model") convention. Note
+        # key/value heads never need this check -- they're always left
+        # replicated in GPT-OSS's layout map (see get_layout_map's
+        # comment), so only num_query_heads divisibility can skip a combo.
+        model_axis_size = mesh_shape[-1]
+        num_query_heads = dims["num_query_heads"]
+        if num_query_heads % model_axis_size != 0:
+            self.skipTest(
+                f"num_query_heads={num_query_heads} not divisible by "
+                f"model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
+        devices = devices[:n_needed]
+        if len(mesh_shape) == 2:
+            axis_names = ("batch", "model")
+        else:
+            # 3D shape: the extra axis is named "seq" per the plan/
+            # testing-strategy convention, but get_layout_map only names
+            # "batch"/"model" -- the "seq" axis simply replicates weights
+            # (no rule targets it), matching every other 3D-mesh test in
+            # this PR series.
+            axis_names = ("batch", "seq", "model")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape,
+            axis_names=axis_names,
+            devices=devices,
+        )
+        layout_map = GptOssBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
+        with distribution.scope():
+            # bfloat16: a memory mitigation for this shared dev machine --
+            # spec assertions are dtype-independent.
+            model = GptOssBackbone(dtype="bfloat16", **init_kwargs)
+            _assert_gpt_oss_shardings_and_coverage(self, model, layout_map)
+        del model
+        gc.collect()
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.multi_device
+    @pytest.mark.extra_large
+    def test_layout_map_live_presets(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+
+        # Fetch every preset's config only (no weights), then dedupe by the
+        # divisibility-relevant dims so width-classes that share a config
+        # are only built once per mesh shape -- a memory/time necessity on
+        # this machine, while every preset in the registry is still fetched
+        # and evaluated, preserving full registry coverage.
+        dim_keys = (
+            "vocabulary_size",
+            "num_query_heads",
+            "num_key_value_heads",
+            "hidden_dim",
+            "intermediate_dim",
+            "head_dim",
+            "num_experts",
+            "top_k",
+        )
+        width_classes = {}  # dedupe key -> (config dict, [preset names])
+        fetch_failures = []
+        for preset in GptOssBackbone.presets:
+            try:
+                path = get_file(preset, CONFIG_FILE)
+                cfg = json.load(open(path))["config"]
+            except Exception as e:
+                # A preset this account can't reach (e.g. an unaccepted
+                # Kaggle license consent click-through) is logged, not
+                # fatal -- the rest of the registry still gets exercised.
+                fetch_failures.append((preset, str(e)))
+                continue
+            # num_layers is forced to 1 below regardless of the real
+            # value -- layout rules are per-decoder-block regexes, so
+            # depth is irrelevant to spec matching/divisibility, and 1
+            # layer keeps build memory bounded on this shared machine.
+            cfg = dict(cfg)
+            cfg["num_layers"] = 1
+            key = tuple(cfg.get(k) for k in dim_keys)
+            if key not in width_classes:
+                width_classes[key] = (cfg, [])
+            width_classes[key][1].append(preset)
+
+        if fetch_failures:
+            print(
+                f"test_layout_map_live_presets: {len(fetch_failures)} "
+                f"preset config fetches failed (logged, non-fatal): "
+                f"{fetch_failures}"
+            )
+        if not width_classes:
+            self.skipTest(
+                "No preset configs were reachable "
+                f"({len(fetch_failures)} fetch failures) -- likely a "
+                "Kaggle license-consent gate on this account for the "
+                "gpt_oss family. See the module comment above "
+                "CAPPED_MESH_SHAPES."
+            )
+        print(
+            f"test_layout_map_live_presets: {len(width_classes)} unique "
+            f"width-classes across {len(GptOssBackbone.presets)} registry "
+            "presets:"
+        )
+        for cfg, presets in width_classes.values():
+            print(f"  {presets}")
+
+        devices = keras.distribution.list_devices("CPU")
+        skip_reasons = []
+        ran_any = False
+        for cfg, presets in width_classes.values():
+            num_query_heads = cfg["num_query_heads"]
+            for mesh_shape in CAPPED_MESH_SHAPES:
+                combo_label = f"{presets[0]}@{mesh_shape}"
+                with self.subTest(combo=combo_label):
+                    n_needed = 1
+                    for s in mesh_shape:
+                        n_needed *= s
+                    if n_needed > len(devices):
+                        reason = (
+                            f"{combo_label}: needs {n_needed} devices, "
+                            f"only {len(devices)} available"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+                    model_axis_size = mesh_shape[-1]
+                    if num_query_heads % model_axis_size != 0:
+                        reason = (
+                            f"{combo_label}: num_query_heads="
+                            f"{num_query_heads} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    # Memory-budget guard: this shared dev machine cannot
+                    # locally build full-scale presets (see
+                    # CAPPED_MESH_SHAPES' comment for the OOM history that
+                    # established this rule). Estimate this width-class's
+                    # single-decoder-block bf16 footprint. Unlike a dense
+                    # model, GPT-OSS's parameter bulk is its MoE expert
+                    # banks (gate_up_proj + down_proj, per expert), so the
+                    # estimate explicitly includes
+                    # num_experts * (hidden*2*intermediate +
+                    # intermediate*hidden) on top of the embedding-table +
+                    # attention-projection estimate -- omitting the expert
+                    # banks would dangerously undercount a MoE model's real
+                    # footprint (real gpt_oss_120b_en's 128 experts alone
+                    # are >20GB even at 1 layer bf16, verified by hand
+                    # before writing this guard). Times a 3x safety margin
+                    # for JAX/XLA transient copies during
+                    # construction/resharding. The config-fetch, dedup, and
+                    # divisibility-skip logic above still exercises every
+                    # registry preset either way; only the expensive
+                    # build+assert step is capped.
+                    hidden = cfg["hidden_dim"]
+                    inter = cfg["intermediate_dim"]
+                    num_experts = cfg["num_experts"]
+                    est_params = (
+                        cfg["vocabulary_size"] * hidden
+                        + 3 * hidden * inter  # attention q/k/v/o approx.
+                        + num_experts * (hidden * 2 * inter + inter * hidden)
+                    )
+                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
+                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    if est_bytes > max_local_bytes:
+                        reason = (
+                            f"{combo_label}: estimated build memory "
+                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
+                            f"{max_local_bytes / 1e6:.0f}MB local safety "
+                            "threshold on this shared, RAM-constrained "
+                            "dev machine -- verify this width-class on a "
+                            "machine with more RAM or in CI"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    combo_devices = devices[:n_needed]
+                    if len(mesh_shape) == 2:
+                        axis_names = ("batch", "model")
+                    else:
+                        axis_names = ("batch", "seq", "model")
+                    device_mesh = keras.distribution.DeviceMesh(
+                        shape=mesh_shape,
+                        axis_names=axis_names,
+                        devices=combo_devices,
+                    )
+                    layout_map = GptOssBackbone.get_layout_map(device_mesh)
+                    distribution = keras.distribution.ModelParallel(
+                        layout_map=layout_map, batch_dim_name="batch"
+                    )
+                    init_kwargs = {
+                        k: v for k, v in cfg.items() if k in dim_keys
+                    }
+                    init_kwargs["num_layers"] = 1
+                    with distribution.scope():
+                        model = GptOssBackbone(dtype="bfloat16", **init_kwargs)
+                        _assert_gpt_oss_shardings_and_coverage(
+                            self, model, layout_map
+                        )
+                    del model
+                    gc.collect()
+                    ran_any = True
+
+        print(
+            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
+            f"skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
+        )
+        if not ran_any:
+            self.skipTest(
+                "All (width-class, mesh-shape) combos were skipped: "
+                f"{skip_reasons}"
+            )

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
@@ -288,7 +288,8 @@ class GptOssBackboneTest(TestCase):
         for preset in GptOssBackbone.presets:
             try:
                 path = get_file(preset, CONFIG_FILE)
-                cfg = json.load(open(path))["config"]
+                with open(path, encoding="utf-8") as f:
+                    cfg = json.load(f)["config"]
             except Exception as e:
                 # A preset this account can't reach (e.g. an unaccepted
                 # Kaggle license consent click-through) is logged, not
@@ -380,9 +381,17 @@ class GptOssBackboneTest(TestCase):
                     hidden = cfg["hidden_dim"]
                     inter = cfg["intermediate_dim"]
                     num_experts = cfg["num_experts"]
+                    num_kv_heads = cfg["num_key_value_heads"]
+                    # Attention projections map hidden_dim<->hidden_dim
+                    # (q and o), and hidden_dim<->(hidden_dim scaled by
+                    # the kv/query head ratio) for GQA's k and v -- none
+                    # of the four touch intermediate_dim, which is the
+                    # FFN/expert width instead.
+                    kv_ratio = num_kv_heads / num_query_heads
                     est_params = (
                         cfg["vocabulary_size"] * hidden
-                        + 3 * hidden * inter  # attention q/k/v/o approx.
+                        + 2 * hidden * hidden  # attention q/o
+                        + 2 * hidden * hidden * kv_ratio  # attention k/v
                         + num_experts * (hidden * 2 * inter + inter * hidden)
                     )
                     est_bytes = est_params * 2 * 3  # bf16 * safety margin

--- a/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py
@@ -173,6 +173,7 @@ class GptOssBackboneTest(TestCase):
         # - Layer norms: hidden_dim each
         self.assertEqual(model.count_params(), 5512)
 
+    @pytest.mark.multi_device
     def test_distribution(self):
         # Note (preserved from the pre-refactor manual test): mesh is
         # pinned to exactly 2 devices (not len(devices), see the shared
@@ -203,6 +204,7 @@ class GptOssBackboneTest(TestCase):
         for dims in (GPT_OSS_20B_DIMS, GPT_OSS_120B_DIMS)
         for shape in CAPPED_MESH_SHAPES
     )
+    @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")


### PR DESCRIPTION
Closes #2836

Part of https://github.com/keras-team/keras-hub/issues/2807. Depends on #2809 (`TestCase.run_distribution_test`) for CI to pass -- this PR's own diff is independent (based on master, not stacked), so it stays small and reviewable regardless of merge order.

## Summary

Adds `GptOssBackbone.get_layout_map` so `GptOssBackbone` (a sparse MoE model) can be sharded across a device mesh with `keras.distribution.ModelParallel`, following the same Megatron-style column/row-parallel convention already used elsewhere in this series (e.g. Gemma, Qwen3), extended to cover the MoE expert-bank and router weights.

Sharding rules:
- `token_embedding/embeddings`: `(model_dim, data_dim)` -- vocab-parallel input embedding.
- `token_embedding/reverse_embeddings`: `(data_dim, model_dim)`. This is the transpose of the input embedding (`(hidden, vocab)`, not `(vocab, hidden)`), so it needs its own spec rather than reusing the input embedding's tuple.
- `self_attention.*query.kernel`: `(data_dim, model_dim, None)`. QKV kernels are `(hidden_dim, num_heads, head_dim)` (the contracting `hidden_dim` axis comes first, not the heads axis -- unlike Gemma's `(num_heads, hidden_dim, head_dim)` layout), so `hidden_dim` shards on the data axis and heads shard on the model axis, matching the `attention_output` rule below.
- `self_attention.*(key|value).kernel`: `(data_dim, None, None)`. Key/value heads are sized by `num_key_value_heads` (GQA), independent of and typically much smaller than `num_query_heads`, so sharding that axis on the model-parallel dim would raise an `IndivisibleError` whenever the model-mesh dimension doesn't divide it evenly; `hidden_dim` still shards on the data axis.
- `attention_output.kernel`: `(model_dim, None, data_dim)`.
- Query/key/value biases (`(num_heads, head_dim)`, 2-D): left fully replicated -- tiny relative to the kernels, and sharding either axis adds divisibility risk (GQA `num_key_value_heads` is often small) for negligible memory savings. Covered by the test's `allow_replicated` list rather than a `layout_map` rule.
- `sparse_moe_block/experts/gate_up_proj`: `(None, data_dim, model_dim)`. The leading (expert-count) axis is left replicated so the map works for the small `num_experts` values used in tests. `gate_up_proj` fuses the SwiGLU gate and up projections into one tensor (column-parallel).
- `sparse_moe_block/experts/down_proj`: `(None, model_dim, data_dim)` -- row-parallel.
- Expert biases (`(num_experts, ...)`, 2-D): left fully replicated, same rationale as the attention biases.
- `sparse_moe_block/router/router_dense.kernel`: `(data_dim, None)`. `num_experts` is typically small, so only the hidden-dim axis is sharded.

## Tests

`gpt_oss_backbone_test.py` adds three tiers, mirroring the pattern already reviewed and merged for Gemma (`gemma_backbone_test.py`):

- **Tier 1** (`test_distribution`): exact end-to-end sharding-spec + coverage + forward/backward/optimizer-step + numerical-parity check via the `TestCase.run_distribution_test` helper from #2809, on a real 2-device mesh (pinned to exactly 2, not `len(devices)`, so the default test config's `num_key_value_heads=4` is exercised deterministically), with `is_moe=True` so the helper also validates the expert-bank/router weights.
- **Tier 2** (`test_layout_map_mesh_shapes`): CI-safe sweep over `CAPPED_MESH_SHAPES` (`(2,4)`, `(1,8)`, `(4,4)`, `(2,2,2)`, `(1,1,8)`, `(2,2,4)` -- capped at 16 total simulated devices) crossed with two synthetic width classes (`GPT_OSS_20B_DIMS`, `GPT_OSS_120B_DIMS`) that preserve the real presets' exact 8:1 query:kv head ratio while scaling every other dimension (vocab, hidden, intermediate, expert count) down ~20-30x from the real preset so the sweep is cheap to build repeatedly. Asserts the same spec-coverage helper (`_assert_gpt_oss_shardings_and_coverage`), i.e. every rank>=2 weight is mapped. Skips (not fails) any `(width, mesh)` combo where `num_query_heads` doesn't divide the mesh's model axis, since that's an inherent tensor-parallelism limit, not a bug.
- **Tier 3** (`test_layout_map_live_presets`, opt-in via `kaggle_key_required` + `multi_device` + `extra_large` markers): fetches every real preset's `config.json` (cheap metadata only, never weights), dedupes by divisibility-relevant dims, and for each unique width class estimates its bf16 build footprint before attempting a build. Unlike a dense model, the estimate explicitly adds the MoE expert-bank cost (`num_experts * (hidden*2*intermediate + intermediate*hidden)`) on top of the embedding/attention-projection estimate, since omitting it would badly undercount a MoE model's real footprint (the real `gpt_oss_120b_en`'s 128 experts alone are >20GB even at 1 layer in bf16). Skips (via `self.subTest` + a logged reason) any combo that would exceed a 300MB local safety threshold rather than risking an OOM on a real multi-GB checkpoint.

### Verification

Ran Tier 1 and Tier 2 locally against a checkout with #2809's `run_distribution_test` helper patched in (this branch's own base, master, doesn't include it yet):

```
KERAS_BACKEND=jax JAX_PLATFORMS=cpu XLA_FLAGS=--xla_force_host_platform_device_count=16 \
  pytest keras_hub/src/models/gpt_oss/gpt_oss_backbone_test.py \
  -k "test_distribution or test_layout_map_mesh_shapes" -n 2
```

All 13 cases pass: `test_distribution` (Tier 1, 2-device mesh) plus all 12 `test_layout_map_mesh_shapes` combinations (Tier 2: 2 width classes x 6 capped mesh shapes up to 16 simulated devices). Tier 3 (`test_layout_map_live_presets`) is opt-in (`kaggle_key_required` + `multi_device` + `extra_large`) and not run as part of normal CI/local verification.

## Limitations

The model-parallel mesh axis can't usefully exceed a preset's `num_query_heads`, since that's the axis this layout map actually tensor-parallelizes -- see [the design doc's "hard limit" section](https://github.com/keras-team/keras-hub/issues/2807#issuecomment-5006606419) for why.

For gpt_oss's real presets, `num_query_heads` is 64 across the board, so the safe ceiling is the same for all four:

| preset | num_query_heads | safe model-axis up to | first failing model-axis |
|---|---|---|---|
| `gpt_oss_120b_en` | 64 | 64 | 128 |
| `gpt_oss_20b_en` | 64 | 64 | 128 |
| `gpt_oss_safeguard_120b_en` | 64 | 64 | 128 |
| `gpt_oss_safeguard_20b_en` | 64 | 64 | 128 |

Separately: gpt_oss is MoE, and at the first-failing model-axis (128) the expert-bank weights (`sparse_moe_block/experts/gate_up_proj`, `sparse_moe_block/experts/down_proj`) fail alongside the query/attention-output weights, not instead of them -- `hidden_dim`/`intermediate_dim` (2880 for every preset above) also stop dividing evenly at that point. The two mechanisms happen to bottom out together here, but they're distinct constraints (attention head count vs. hidden/intermediate width), and for other MoE presets with different dims they won't necessarily coincide.
