### PR TITLE
Fix ModelParallel layout map axis order for LlamaBackbone

### DIFF
--- a/keras_hub/src/models/llama/llama_backbone.py
+++ b/keras_hub/src/models/llama/llama_backbone.py
@@ -305,11 +305,37 @@ class LlamaBackbone(Backbone):
         # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (
-            model_dim,
+        # tie_word_embeddings defaults to False, so a separate
+        # token_embedding/reverse_embeddings output-projection tensor exists
+        # for essentially every real Llama model. The tensor is
+        # (hidden_dim, vocabulary_size); vocab-parallel output projection
+        # wants vocab sharded on the model axis, consistent with
+        # token_embedding/embeddings (vocab, hidden) = (model_dim, data_dim)
+        # above.
+        layout_map["token_embedding/reverse_embeddings"] = (
             data_dim,
+            model_dim,
+        )
+        # Query kernel is (hidden_dim, num_query_heads, head_dim) -- the
+        # contracting hidden dim goes on the data axis and heads go on the
+        # model axis (Megatron column-parallel), matching
+        # attention_output's own (heads, head_dim, hidden) -> (model, None,
+        # data) row-parallel convention below.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            data_dim,
+            model_dim,
+            None,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small heads axis on the model-parallel dim would
+        # raise an IndivisibleError whenever the model mesh dimension
+        # doesn't divide it, so the heads axis is left fully replicated on
+        # model while the hidden (contracting) dim is sharded on data for
+        # memory savings, mirroring the Gemma-family convention.
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            data_dim,
+            None,
             None,
         )
         layout_map["transformer_layer.*attention_output.kernel"] = (

--- a/keras_hub/src/models/llama/llama_backbone.py
+++ b/keras_hub/src/models/llama/llama_backbone.py
@@ -285,24 +285,22 @@ class LlamaBackbone(Backbone):
         if not isinstance(device_mesh, keras.distribution.DeviceMesh):
             raise ValueError(
                 "Invalid device_mesh type. Expected "
-                f"`keras.distribution.Device`, got {type(device_mesh)}"
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
             )
         if model_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{model_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
         if data_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{data_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
         # Note that it is possible to further config the mesh to be 3D, eg
         # (data, seq, model). We leave it as 2D for now for simplicity.
         data_dim = data_parallel_dim_name
         model_dim = model_parallel_dim_name
-        # The sharding config is based on the Gemma team training config.
-        # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
         # tie_word_embeddings defaults to False, so a separate

--- a/keras_hub/src/models/llama/llama_backbone_test.py
+++ b/keras_hub/src/models/llama/llama_backbone_test.py
@@ -1,5 +1,4 @@
 import gc
-import json
 import os
 import re
 
@@ -10,8 +9,7 @@ from keras import ops
 
 from keras_hub.src.models.llama.llama_backbone import LlamaBackbone
 from keras_hub.src.tests.test_case import TestCase
-from keras_hub.src.utils.preset_utils import CONFIG_FILE
-from keras_hub.src.utils.preset_utils import get_file
+from keras_hub.src.utils.preset_utils import load_json
 
 # Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
 # dimensions, frozen as literals and sourced once, offline -- do not add a
@@ -209,7 +207,7 @@ class LlamaTest(TestCase):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")
         devices = keras.distribution.list_devices("CPU")
-        if len(devices) == 1:
+        if len(devices) < 2:
             # Need more than 1 device for distribution testing.
             self.skipTest("`ModelParallel` testing requires multiple devices.")
         # Pinned to exactly 2 devices -- see test_distribution's comment.
@@ -330,9 +328,7 @@ class LlamaTest(TestCase):
         fetch_failures = []
         for preset in LlamaBackbone.presets:
             try:
-                path = get_file(preset, CONFIG_FILE)
-                with open(path) as f:
-                    cfg = json.load(f)["config"]
+                cfg = load_json(preset)["config"]
             except Exception as e:
                 # A preset this account can't reach (e.g. an unaccepted
                 # Kaggle license consent click-through, or no

--- a/keras_hub/src/models/llama/llama_backbone_test.py
+++ b/keras_hub/src/models/llama/llama_backbone_test.py
@@ -174,6 +174,7 @@ class LlamaTest(TestCase):
                 input_data=self.input_data,
             )
 
+    @pytest.mark.multi_device
     def test_distribution(self):
         # Note (preserved from the pre-refactor manual test): mesh is
         # pinned to exactly 2 devices (not len(devices), see the shared
@@ -203,6 +204,7 @@ class LlamaTest(TestCase):
             allow_replicated=(),
         )
 
+    @pytest.mark.multi_device
     def test_distribution_with_lora(self):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")
@@ -248,6 +250,7 @@ class LlamaTest(TestCase):
         for dims in (LLAMA2_7B_DIMS, LLAMA2_70B_DIMS)
         for shape in CAPPED_MESH_SHAPES
     )
+    @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")

--- a/keras_hub/src/models/llama/llama_backbone_test.py
+++ b/keras_hub/src/models/llama/llama_backbone_test.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import os
 import re
 
 import keras
@@ -17,9 +18,10 @@ from keras_hub.src.utils.preset_utils import get_file
 # `get_file` call to the Tier-2 test body itself (that's what Tier 3,
 # `test_layout_map_live_presets` below, is for).
 #
-# MEMORY NOTE: this local dev machine cannot load full-scale model dims (see
-# gemma_backbone_test.py's identical note for the OOM history that motivated
-# this pattern). What actually matters for the divisibility/sharding
+# MEMORY NOTE: memory-constrained local environments cannot load full-scale
+# model dims (see gemma_backbone_test.py's identical note for the OOM
+# history that motivated this pattern). What actually matters for the
+# divisibility/sharding
 # properties this tier tests is the RATIO of query heads to kv heads and
 # whether hidden/intermediate/vocab divide the mesh's model-axis sizes -- not
 # the absolute parameter count. So these dims are scaled down by roughly
@@ -37,7 +39,7 @@ from keras_hub.src.utils.preset_utils import get_file
 # the 13B/70B scale, which is not in this repo's preset registry but is a
 # well-known public dimension used here only to exercise a second,
 # GQA-ratio width class in the CI-safe sweep). Kaggle credentials were not
-# available in this environment to fetch the registry configs live, so
+# available when authoring this test to fetch the registry configs live, so
 # these dims are taken from the well-documented public Llama-2 architecture
 # rather than a live `get_file` pull -- `test_layout_map_live_presets`
 # performs the live pull for the actual registry presets.
@@ -61,14 +63,14 @@ LLAMA2_70B_DIMS = {
     "intermediate_dim": 1408,  # real 28672, scaled ~20x.
 }
 
-# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
-# 10-shape matrix from the testing-strategy doc is
+# Hard-capped mesh-shape list for memory-constrained local environments. The
+# full 10-shape matrix from the testing-strategy doc is
 # 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
 # 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
-# DROPPED here due to a demonstrated systemd-oomd OOM kill of the entire
-# desktop app on this shared machine during an earlier attempt at this same
-# pipeline. Do not attempt the dropped shapes even experimentally on this
-# box -- revisiting them requires a dedicated or CI machine, not this one.
+# DROPPED here due to a demonstrated OOM kill during an earlier attempt at
+# this same pipeline on a memory-constrained machine. Do not attempt the
+# dropped shapes even experimentally on such environments -- revisiting
+# them requires a dedicated or CI machine with more memory.
 CAPPED_MESH_SHAPES = [
     (2, 4),
     (1, 8),
@@ -296,8 +298,8 @@ class LlamaTest(TestCase):
         )
         init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
         with distribution.scope():
-            # bfloat16: a memory mitigation for this shared dev machine --
-            # spec assertions are dtype-independent.
+            # bfloat16: a memory mitigation for memory-constrained local
+            # environments -- spec assertions are dtype-independent.
             model = LlamaBackbone(dtype="bfloat16", **init_kwargs)
             _assert_llama_shardings_and_coverage(self, model, layout_map)
         del model
@@ -314,8 +316,9 @@ class LlamaTest(TestCase):
         # divisibility-relevant dims so width-classes that share a config
         # (e.g. the int8/instruct/vicuna variants, all real Llama-2-7B
         # width) are only built once per mesh shape -- a memory/time
-        # necessity on this machine, while every preset in the registry is
-        # still fetched and evaluated, preserving full registry coverage.
+        # necessity for memory-constrained local environments, while every
+        # preset in the registry is still fetched and evaluated, preserving
+        # full registry coverage.
         dim_keys = (
             "vocabulary_size",
             "num_query_heads",
@@ -328,7 +331,8 @@ class LlamaTest(TestCase):
         for preset in LlamaBackbone.presets:
             try:
                 path = get_file(preset, CONFIG_FILE)
-                cfg = json.load(open(path))["config"]
+                with open(path) as f:
+                    cfg = json.load(f)["config"]
             except Exception as e:
                 # A preset this account can't reach (e.g. an unaccepted
                 # Kaggle license consent click-through, or no
@@ -339,7 +343,8 @@ class LlamaTest(TestCase):
             # num_layers is forced to 1 below regardless of the real
             # value -- layout rules are per-decoder-block regexes, so
             # depth is irrelevant to spec matching/divisibility, and 1
-            # layer keeps build memory bounded on this shared machine.
+            # layer keeps build memory bounded in memory-constrained local
+            # environments.
             cfg = dict(cfg)
             cfg["num_layers"] = 1
             key = tuple(cfg.get(k) for k in dim_keys)
@@ -398,10 +403,10 @@ class LlamaTest(TestCase):
                         skip_reasons.append(reason)
                         continue
 
-                    # Memory-budget guard: this shared dev machine cannot
-                    # locally build full-scale presets (see
-                    # CAPPED_MESH_SHAPES' comment for the OOM history that
-                    # motivated this). Estimate this width-class's
+                    # Memory-budget guard: memory-constrained local
+                    # environments cannot locally build full-scale presets
+                    # (see CAPPED_MESH_SHAPES' comment for the OOM history
+                    # that motivated this). Estimate this width-class's
                     # single-decoder-block bf16 footprint (embedding table
                     # + one FFN block's 3 matrices, times a 3x safety
                     # margin for JAX/XLA transient copies during
@@ -410,19 +415,38 @@ class LlamaTest(TestCase):
                     # config-fetch, dedup, and divisibility-skip logic
                     # above still exercises every registry preset either
                     # way; only the expensive build+assert step is capped.
+                    # `tie_word_embeddings` defaults to False for Llama, so
+                    # the input embedding table and the output
+                    # `reverse_embeddings` projection are two separate
+                    # vocab*hidden tensors -- both are counted. Query and
+                    # attention_output are each hidden*hidden (contracting
+                    # dim times num_query_heads*head_dim, which equals
+                    # hidden_dim); key/value scale down from that by the
+                    # kv/query head ratio (GQA).
+                    hidden = cfg["hidden_dim"]
+                    num_query_heads = cfg["num_query_heads"]
+                    num_kv_heads = cfg["num_key_value_heads"]
+                    kv_ratio = num_kv_heads / num_query_heads
                     est_params = (
-                        cfg["vocabulary_size"] * cfg["hidden_dim"]
-                        + 3 * cfg["hidden_dim"] * cfg["intermediate_dim"]
+                        2 * cfg["vocabulary_size"] * hidden  # embed + revemb
+                        + 2 * hidden * hidden  # attention q/o
+                        + 2 * hidden * hidden * kv_ratio  # attention k/v
+                        + 3 * hidden * cfg["intermediate_dim"]  # FFN
                     )
                     est_bytes = est_params * 2 * 3  # bf16 * safety margin
-                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    max_local_bytes = int(
+                        os.environ.get(
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
+                            300 * 1024 * 1024,
+                        )
+                    )
                     if est_bytes > max_local_bytes:
                         reason = (
                             f"{combo_label}: estimated build memory "
                             f"~{est_bytes / 1e9:.2f}GB exceeds the "
                             f"{max_local_bytes / 1e6:.0f}MB local safety "
-                            "threshold on this shared, RAM-constrained "
-                            "dev machine -- verify this width-class on a "
+                            "threshold for memory-constrained local "
+                            "environments -- verify this width-class on a "
                             "machine with more RAM or in CI"
                         )
                         skip_reasons.append(reason)
@@ -442,9 +466,12 @@ class LlamaTest(TestCase):
                     distribution = keras.distribution.ModelParallel(
                         layout_map=layout_map, batch_dim_name="batch"
                     )
-                    init_kwargs = {
-                        k: v for k, v in cfg.items() if k in dim_keys
-                    }
+                    # `cfg` is a full serialized `get_config()` dict, which
+                    # may include a `"dtype"` key (a serialized dtype-policy
+                    # dict, only present for quantized presets) -- drop it
+                    # so the explicit `dtype="bfloat16"` override below
+                    # doesn't collide with a duplicate keyword argument.
+                    init_kwargs = {k: v for k, v in cfg.items() if k != "dtype"}
                     init_kwargs["num_layers"] = 1
                     with distribution.scope():
                         model = LlamaBackbone(dtype="bfloat16", **init_kwargs)

--- a/keras_hub/src/models/llama/llama_backbone_test.py
+++ b/keras_hub/src/models/llama/llama_backbone_test.py
@@ -1,9 +1,115 @@
+import gc
+import json
+import re
+
 import keras
 import pytest
+from absl.testing import parameterized
 from keras import ops
 
 from keras_hub.src.models.llama.llama_backbone import LlamaBackbone
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
+
+# Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
+# dimensions, frozen as literals and sourced once, offline -- do not add a
+# `get_file` call to the Tier-2 test body itself (that's what Tier 3,
+# `test_layout_map_live_presets` below, is for).
+#
+# MEMORY NOTE: this local dev machine cannot load full-scale model dims (see
+# gemma_backbone_test.py's identical note for the OOM history that motivated
+# this pattern). What actually matters for the divisibility/sharding
+# properties this tier tests is the RATIO of query heads to kv heads and
+# whether hidden/intermediate/vocab divide the mesh's model-axis sizes -- not
+# the absolute parameter count. So these dims are scaled down by roughly
+# 20-30x from the real presets while preserving each preset's real
+# query:kv head ratio and keeping hidden/intermediate/vocab as clean powers
+# of 2 divisible by every mesh shape in CAPPED_MESH_SHAPES. Full-scale real
+# dims are exercised by `test_layout_map_live_presets` below, which has its
+# own per-width-class memory-budget skip so it never attempts a full-scale
+# build locally either.
+#
+# All 5 registry presets (llama2_7b_en and its int8/instruct/vicuna
+# variants) share the real Llama-2-7B architecture: vocab_size=32000,
+# hidden_size=4096, intermediate_size=11008, num_attention_heads=32,
+# num_key_value_heads=32 (7B has no GQA -- multi-query grouping starts at
+# the 13B/70B scale, which is not in this repo's preset registry but is a
+# well-known public dimension used here only to exercise a second,
+# GQA-ratio width class in the CI-safe sweep). Kaggle credentials were not
+# available in this environment to fetch the registry configs live, so
+# these dims are taken from the well-documented public Llama-2 architecture
+# rather than a live `get_file` pull -- `test_layout_map_live_presets`
+# performs the live pull for the actual registry presets.
+LLAMA2_7B_DIMS = {
+    "source_preset": "llama2_7b_en (real ratio, memory-scaled dims)",
+    "vocabulary_size": 1600,  # real 32000, scaled ~20x.
+    "num_layers": 1,  # depth is irrelevant to spec matching/divisibility.
+    "num_query_heads": 32,  # real ratio: no GQA, 1:1.
+    "num_key_value_heads": 32,
+    "hidden_dim": 256,  # real 4096, scaled 16x.
+    "intermediate_dim": 512,  # real 11008, scaled ~21x.
+}
+LLAMA2_70B_DIMS = {
+    "source_preset": "llama2_70b (public arch, real ratio, "
+    "memory-scaled dims -- not in this repo's preset registry)",
+    "vocabulary_size": 1600,  # real 32000, scaled ~20x.
+    "num_layers": 1,
+    "num_query_heads": 64,  # real ratio: GQA, 8:1.
+    "num_key_value_heads": 8,
+    "hidden_dim": 512,  # real 8192, scaled 16x.
+    "intermediate_dim": 1408,  # real 28672, scaled ~20x.
+}
+
+# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
+# 10-shape matrix from the testing-strategy doc is
+# 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
+# 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
+# DROPPED here due to a demonstrated systemd-oomd OOM kill of the entire
+# desktop app on this shared machine during an earlier attempt at this same
+# pipeline. Do not attempt the dropped shapes even experimentally on this
+# box -- revisiting them requires a dedicated or CI machine, not this one.
+CAPPED_MESH_SHAPES = [
+    (2, 4),
+    (1, 8),
+    (4, 4),
+    (2, 2, 2),
+    (1, 1, 8),
+    (2, 2, 4),
+]
+
+# Same expected_shardings patterns as LlamaTest.test_distribution
+# (post-QKV-axis-fix), reused by the Tier-2 and Tier-3 mesh sweeps below.
+_EXPECTED_SHARDINGS = {
+    "token_embedding/embeddings": ("model", "batch"),
+    "token_embedding/reverse_embeddings": ("batch", "model"),
+    "self_attention/query/kernel": ("batch", "model", None),
+    "self_attention/key/kernel": ("batch", None, None),
+    "self_attention/value/kernel": ("batch", None, None),
+    "self_attention/attention_output/kernel": ("model", None, "batch"),
+    "feedforward_intermediate_dense/kernel": ("batch", "model"),
+    "feedforward_gate_dense/kernel": ("batch", "model"),
+    "feedforward_output_dense/kernel": ("model", "batch"),
+}
+
+
+def _assert_llama_shardings_and_coverage(test_case, model, layout_map):
+    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
+    for pattern, expected in _EXPECTED_SHARDINGS.items():
+        matches = [w for w in model.weights if re.search(pattern, w.path)]
+        test_case.assertGreater(len(matches), 0)
+        for w in matches:
+            test_case.assertEqual(tuple(w.value.sharding.spec), expected)
+    offending = [
+        w.path
+        for w in model.weights
+        if len(w.shape) >= 2 and layout_map[w.path] is None
+    ]
+    test_case.assertEqual(
+        offending,
+        [],
+        f"The following rank>=2 weights are unmapped: {offending}",
+    )
 
 
 class LlamaTest(TestCase):
@@ -69,55 +175,33 @@ class LlamaTest(TestCase):
             )
 
     def test_distribution(self):
-        if keras.backend.backend() != "jax":
-            self.skipTest("`ModelParallel` testing requires the Jax backend.")
-        devices = keras.distribution.list_devices("CPU")
-        if len(devices) == 1:
-            self.skipTest("`ModelParallel` testing requires multiple devices.")
-        device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, len(devices)),
-            axis_names=("batch", "model"),
-            devices=devices,
+        # Note (preserved from the pre-refactor manual test): mesh is
+        # pinned to exactly 2 devices (not len(devices), see the shared
+        # helper) so that the default test config's num_key_value_heads=2
+        # -- intentionally not divisible by every host's device count --
+        # regression-tests that key/value kernels are left replicated
+        # rather than sharded. See get_layout_map's comment for why.
+        self.run_distribution_test(
+            cls=LlamaBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_shardings={
+                "token_embedding/embeddings": ("model", "batch"),
+                "token_embedding/reverse_embeddings": ("batch", "model"),
+                "self_attention/query/kernel": ("batch", "model", None),
+                "self_attention/key/kernel": ("batch", None, None),
+                "self_attention/value/kernel": ("batch", None, None),
+                "self_attention/attention_output/kernel": (
+                    "model",
+                    None,
+                    "batch",
+                ),
+                "feedforward_intermediate_dense/kernel": ("batch", "model"),
+                "feedforward_gate_dense/kernel": ("batch", "model"),
+                "feedforward_output_dense/kernel": ("model", "batch"),
+            },
+            allow_replicated=(),
         )
-
-        layout_map = LlamaBackbone.get_layout_map(device_mesh)
-        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
-        with distribution.scope():
-            model = LlamaBackbone(**self.init_kwargs)
-
-        for w in model.weights:
-            if "token_embedding/embeddings" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch")
-                )
-            if "self_attention/query/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
-                )
-            if "self_attention/key/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
-                )
-            if "self_attention/value/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
-                )
-            if "self_attention/attention_output/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", None, "batch")
-                )
-            if "feedforward_intermediate_dense/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("batch", "model")
-                )
-            if "feedforward_gate_dense/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("batch", "model")
-                )
-            if "feedforward_output_dense" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch")
-                )
 
     def test_distribution_with_lora(self):
         if keras.backend.backend() != "jax":
@@ -126,8 +210,10 @@ class LlamaTest(TestCase):
         if len(devices) == 1:
             # Need more than 1 device for distribution testing.
             self.skipTest("`ModelParallel` testing requires multiple devices.")
+        # Pinned to exactly 2 devices -- see test_distribution's comment.
+        devices = devices[:2]
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, len(devices)),
+            shape=(1, 2),
             axis_names=("batch", "model"),
             devices=devices,
         )
@@ -151,3 +237,230 @@ class LlamaTest(TestCase):
                 )
             if "self_attention/value/lora_kernel_b" in w.path:
                 self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+
+    @parameterized.named_parameters(
+        (
+            f"{dims['source_preset'].split(' ')[0]}_mesh"
+            f"_{'x'.join(str(s) for s in shape)}",
+            dims,
+            shape,
+        )
+        for dims in (LLAMA2_7B_DIMS, LLAMA2_70B_DIMS)
+        for shape in CAPPED_MESH_SHAPES
+    )
+    def test_layout_map_mesh_shapes(self, dims, mesh_shape):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        n_needed = 1
+        for s in mesh_shape:
+            n_needed *= s
+        if n_needed > len(devices):
+            self.skipTest(
+                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
+                f"{len(devices)} available. Run with "
+                f"XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{n_needed} to exercise this shape locally."
+            )
+
+        # Query-head-divisibility skip rule: an inherent tensor-parallelism
+        # ceiling, not a bug. model_axis_size is the mesh's last axis,
+        # matching this repo's axis_names=(..., "model") convention.
+        model_axis_size = mesh_shape[-1]
+        num_query_heads = dims["num_query_heads"]
+        if num_query_heads % model_axis_size != 0:
+            self.skipTest(
+                f"num_query_heads={num_query_heads} not divisible by "
+                f"model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
+        devices = devices[:n_needed]
+        if len(mesh_shape) == 2:
+            axis_names = ("batch", "model")
+        else:
+            # 3D shape: the extra axis is named "seq" per the plan/
+            # testing-strategy convention, but get_layout_map only names
+            # "batch"/"model" -- the "seq" axis simply replicates weights
+            # (no rule targets it), matching every other 3D-mesh test in
+            # this PR series.
+            axis_names = ("batch", "seq", "model")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape,
+            axis_names=axis_names,
+            devices=devices,
+        )
+        layout_map = LlamaBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
+        with distribution.scope():
+            # bfloat16: a memory mitigation for this shared dev machine --
+            # spec assertions are dtype-independent.
+            model = LlamaBackbone(dtype="bfloat16", **init_kwargs)
+            _assert_llama_shardings_and_coverage(self, model, layout_map)
+        del model
+        gc.collect()
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.multi_device
+    @pytest.mark.extra_large
+    def test_layout_map_live_presets(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+
+        # Fetch every preset's config only (no weights), then dedupe by the
+        # divisibility-relevant dims so width-classes that share a config
+        # (e.g. the int8/instruct/vicuna variants, all real Llama-2-7B
+        # width) are only built once per mesh shape -- a memory/time
+        # necessity on this machine, while every preset in the registry is
+        # still fetched and evaluated, preserving full registry coverage.
+        dim_keys = (
+            "vocabulary_size",
+            "num_query_heads",
+            "num_key_value_heads",
+            "hidden_dim",
+            "intermediate_dim",
+        )
+        width_classes = {}  # dedupe key -> (config dict, [preset names])
+        fetch_failures = []
+        for preset in LlamaBackbone.presets:
+            try:
+                path = get_file(preset, CONFIG_FILE)
+                cfg = json.load(open(path))["config"]
+            except Exception as e:
+                # A preset this account can't reach (e.g. an unaccepted
+                # Kaggle license consent click-through, or no
+                # KAGGLE_USERNAME/KAGGLE_KEY at all) is logged, not fatal --
+                # the rest of the registry still gets exercised.
+                fetch_failures.append((preset, str(e)))
+                continue
+            # num_layers is forced to 1 below regardless of the real
+            # value -- layout rules are per-decoder-block regexes, so
+            # depth is irrelevant to spec matching/divisibility, and 1
+            # layer keeps build memory bounded on this shared machine.
+            cfg = dict(cfg)
+            cfg["num_layers"] = 1
+            key = tuple(cfg.get(k) for k in dim_keys)
+            if key not in width_classes:
+                width_classes[key] = (cfg, [])
+            width_classes[key][1].append(preset)
+
+        if fetch_failures:
+            print(
+                f"test_layout_map_live_presets: {len(fetch_failures)} "
+                f"preset config fetches failed (logged, non-fatal): "
+                f"{fetch_failures}"
+            )
+        if not width_classes:
+            self.skipTest(
+                "No preset configs were reachable "
+                f"({len(fetch_failures)} fetch failures) -- likely missing "
+                "KAGGLE_USERNAME/KAGGLE_KEY or a Kaggle license-consent "
+                "gate on this account for the llama family. See the "
+                "module comment above CAPPED_MESH_SHAPES."
+            )
+        print(
+            f"test_layout_map_live_presets: {len(width_classes)} unique "
+            f"width-classes across {len(LlamaBackbone.presets)} registry "
+            "presets:"
+        )
+        for cfg, presets in width_classes.values():
+            print(f"  {presets}")
+
+        devices = keras.distribution.list_devices("CPU")
+        skip_reasons = []
+        ran_any = False
+        for cfg, presets in width_classes.values():
+            num_query_heads = cfg["num_query_heads"]
+            for mesh_shape in CAPPED_MESH_SHAPES:
+                combo_label = f"{presets[0]}@{mesh_shape}"
+                with self.subTest(combo=combo_label):
+                    n_needed = 1
+                    for s in mesh_shape:
+                        n_needed *= s
+                    if n_needed > len(devices):
+                        reason = (
+                            f"{combo_label}: needs {n_needed} devices, "
+                            f"only {len(devices)} available"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+                    model_axis_size = mesh_shape[-1]
+                    if num_query_heads % model_axis_size != 0:
+                        reason = (
+                            f"{combo_label}: num_query_heads="
+                            f"{num_query_heads} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    # Memory-budget guard: this shared dev machine cannot
+                    # locally build full-scale presets (see
+                    # CAPPED_MESH_SHAPES' comment for the OOM history that
+                    # motivated this). Estimate this width-class's
+                    # single-decoder-block bf16 footprint (embedding table
+                    # + one FFN block's 3 matrices, times a 3x safety
+                    # margin for JAX/XLA transient copies during
+                    # construction/resharding) and skip the actual build if
+                    # it exceeds a conservative local threshold. The
+                    # config-fetch, dedup, and divisibility-skip logic
+                    # above still exercises every registry preset either
+                    # way; only the expensive build+assert step is capped.
+                    est_params = (
+                        cfg["vocabulary_size"] * cfg["hidden_dim"]
+                        + 3 * cfg["hidden_dim"] * cfg["intermediate_dim"]
+                    )
+                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
+                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    if est_bytes > max_local_bytes:
+                        reason = (
+                            f"{combo_label}: estimated build memory "
+                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
+                            f"{max_local_bytes / 1e6:.0f}MB local safety "
+                            "threshold on this shared, RAM-constrained "
+                            "dev machine -- verify this width-class on a "
+                            "machine with more RAM or in CI"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    combo_devices = devices[:n_needed]
+                    if len(mesh_shape) == 2:
+                        axis_names = ("batch", "model")
+                    else:
+                        axis_names = ("batch", "seq", "model")
+                    device_mesh = keras.distribution.DeviceMesh(
+                        shape=mesh_shape,
+                        axis_names=axis_names,
+                        devices=combo_devices,
+                    )
+                    layout_map = LlamaBackbone.get_layout_map(device_mesh)
+                    distribution = keras.distribution.ModelParallel(
+                        layout_map=layout_map, batch_dim_name="batch"
+                    )
+                    init_kwargs = {
+                        k: v for k, v in cfg.items() if k in dim_keys
+                    }
+                    init_kwargs["num_layers"] = 1
+                    with distribution.scope():
+                        model = LlamaBackbone(dtype="bfloat16", **init_kwargs)
+                        _assert_llama_shardings_and_coverage(
+                            self, model, layout_map
+                        )
+                    del model
+                    gc.collect()
+                    ran_any = True
+
+        print(
+            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
+            f"skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
+        )
+        if not ran_any:
+            self.skipTest(
+                "All (width-class, mesh-shape) combos were skipped: "
+                f"{skip_reasons}"
+            )


### PR DESCRIPTION
Closes #2827

Part of https://github.com/keras-team/keras-hub/issues/2807. Depends on #2809 (`TestCase.run_distribution_test`) for CI to pass -- this PR's own diff is independent (based on master, not stacked), so it stays small and reviewable regardless of merge order.

## Summary

`LlamaBackbone.get_layout_map`'s `query` kernel, `key`/`value` kernels, and `token_embedding/reverse_embeddings` layout tuples had their data-parallel and model-parallel axis positions swapped relative to the actual weight tensor shapes. This didn't raise an error -- `LayoutMap` tuples are just assigned positionally to tensor axes -- so it silently produced the wrong sharding spec (e.g. `query.kernel`, shaped `(hidden_dim, num_query_heads, head_dim)`, was mapped `(model_dim, data_dim, None)` instead of `(data_dim, model_dim, None)`).

The fix corrects the axis order to the Megatron-style column/row-parallel convention already used by `attention_output` and the FFN kernels in this same function:
- `query` kernel: column-parallel -- contracting `hidden_dim` on the data axis, `num_query_heads` on the model axis (mirrors `attention_output`'s row-parallel `(model, None, data)`).
- `key`/`value` kernels: `num_key_value_heads` (GQA) stays fully replicated on the model axis (it's often not divisible by the model-mesh size), with the contracting `hidden_dim` sharded on the data axis for memory savings, mirroring the Gemma-family convention.
- `token_embedding/reverse_embeddings`: vocab sharded on the model axis, consistent with `token_embedding/embeddings`.

Also adds a `LlamaBackbone`-specific mesh-shape test suite mirroring the pattern already reviewed and merged for `GemmaBackbone`:
- A memory-capped Tier-2 sweep (`test_layout_map_mesh_shapes`) over 2 representative Llama width-classes (7B: no GQA, 70B: 8:1 GQA) x 6 mesh shapes, using dimensions scaled down ~16-20x from the real presets while preserving real query:kv head ratios.
- A Tier-3 live-preset sweep (`test_layout_map_live_presets`) that fetches real registry preset configs (JSON only) and builds each unique width-class at `num_layers=1`, with a per-combo memory-budget skip so it never attempts a full-scale build.

## Verification

Tests were run against a checkout that already has #2809's `TestCase.run_distribution_test` helper (this branch's own base doesn't yet have it, since this PR is intentionally not stacked on #2809). Real local results, JAX backend, CPU-only, `XLA_FLAGS=--xla_force_host_platform_device_count=16`:

```
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_backbone_basics PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_distribution PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_distribution_with_lora PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_70b_mesh_1x1x8 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_70b_mesh_1x8 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_70b_mesh_2x2x2 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_70b_mesh_2x2x4 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_70b_mesh_2x4 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_70b_mesh_4x4 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_7b_en_mesh_1x1x8 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_7b_en_mesh_1x8 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_7b_en_mesh_2x2x2 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_7b_en_mesh_2x2x4 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_7b_en_mesh_2x4 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_mesh_shapes_llama2_7b_en_mesh_4x4 PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_num_parameters PASSED
keras_hub/src/models/llama/llama_backbone_test.py::LlamaTest::test_layout_map_live_presets SKIPPED (tests only run with a kaggle api key)

17 passed, 1 skipped, 4 deselected (extra_large/large preset+saved-model tests, out of scope for this run) in 61.78s
```

`ruff check` and `ruff format --check` both pass clean on the two changed files.

## Limitations

The model-parallel mesh axis can't usefully exceed a preset's `num_query_heads` -- that's the axis actually being tensor-parallelized here -- see [the design doc's "hard limit" section](https://github.com/keras-team/keras-hub/issues/2807#issuecomment-5006606419) for the full reasoning.

For Llama specifically, none of the registry presets could be checked against the real arithmetic -- every `llama` and `llama2` preset on Kaggle (`llama2_7b_en`, `llama2_7b_en_int8`, `llama2_instruct_7b_en`, `llama2_instruct_7b_en_int8`, `vicuna_1.5_7b_en`) is gated behind Kaggle's consent flow, so it wasn't possible to pull their configs and confirm exact safe/failing model-axis sizes the way it was done for other models in this series. Treat the general rule above (model-axis <= `num_query_heads`) as the guidance until those numbers are confirmed against the real configs.

