### PR TITLE
Add/fix ModelParallel layout map for qwen3_moe

### DIFF
--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
@@ -314,22 +314,34 @@ class Qwen3MoeBackbone(Backbone):
         model_dim = model_parallel_dim_name
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        # tie_word_embeddings defaults to False for this model, and untied
+        # real presets exist, so `reverse_embeddings` is a real, separate
+        # output-projection tensor. Its shape is (hidden, vocab); vocab-
+        # parallel output projection wants vocab-on-model, consistent with
+        # `token_embedding/embeddings` above -- i.e. transposed relative to
+        # embeddings, not the same tuple.
         layout_map["token_embedding/reverse_embeddings"] = (
-            model_dim,
             data_dim,
+            model_dim,
         )
-        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # QKV kernel is (hidden, heads, head_dim) (einsum "bqm,muh->bquh"),
+        # i.e. contracting-dim-first, unlike Gemma's (heads, hidden,
+        # head_dim). Query is column-parallel (Megatron): shard the
+        # contracting hidden dim on data and the heads dim on model.
+        # Key/value heads are sized by num_key_value_heads (GQA), which is
         # independent of and typically much smaller than num_query_heads --
-        # sharding that small axis on the data-parallel dim would raise an
-        # IndivisibleError whenever the batch mesh dimension doesn't divide
-        # it, so key/value are left fully replicated on that axis.
+        # sharding that small axis on the model-parallel dim would raise an
+        # IndivisibleError whenever the mesh's model-axis size doesn't
+        # divide it, so key/value are left replicated on that axis and only
+        # the (large, always-divisible) hidden dim is sharded on data for
+        # memory savings.
         layout_map["transformer_layer.*self_attention.*query.kernel"] = (
-            model_dim,
             data_dim,
+            model_dim,
             None,
         )
         layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
-            model_dim,
+            data_dim,
             None,
             None,
         )

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
@@ -295,49 +295,42 @@ class Qwen3MoeBackbone(Backbone):
             `keras.distribution.LayoutMap` that contains the sharding spec
             for all the model weights.
         """
-        # The weight path and shape of the Llama backbone is like below
-        # token_embedding/embeddings                              (128256, 2048)
-        # repeat block for decoder
-        # transformer_layer_0/self_attention/query/kernel         (2048, 32, 64)
-        # transformer_layer_0/self_attention/key/kernel           (2048, 8, 64)
-        # transformer_layer_0/self_attention/value/kernel         (2048, 8, 64)
-        # transformer_layer_0/self_attention/attention_output/kernel
-        #                                                         (32, 64, 2048)
-        # transformer_layer_0/self_attention_layernorm/scale      (2048,)
-        # transformer_layer_0/feedforward_intermediate_dense/kernel
-        #                                                         (2048, 8192)
-        # transformer_layer_0/feedforward_gate_dense/kernel       (2048, 8192)
-        # transformer_layer_0/feedforward_output_dense/kerne      (8192, 2048)
-        # transformer_layer_0/feedforward_layernorm/scale         (2048,)
-
         if not isinstance(device_mesh, keras.distribution.DeviceMesh):
             raise ValueError(
                 "Invalid device_mesh type. Expected "
-                f"`keras.distribution.Device`, got {type(device_mesh)}"
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
             )
         if model_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{model_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
         if data_parallel_dim_name not in device_mesh.axis_names:
             raise ValueError(
                 f"{data_parallel_dim_name} is not found in the "
-                f"device_mesh.axis_names. {device_mesh.axis_name=}"
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
             )
-        # Note that it is possible to further config the mesh to be 3D, eg
-        # (data, seq, model). We leave it as 2D for now for simplicity.
         data_dim = data_parallel_dim_name
         model_dim = model_parallel_dim_name
-        # The sharding config is based on the Gemma team training config.
-        # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map[
-            "transformer_layer.*self_attention.*(query|key|value).kernel"
-        ] = (
+        layout_map["token_embedding/reverse_embeddings"] = (
             model_dim,
             data_dim,
+        )
+        # Key/value kernels are sized by num_key_value_heads (GQA), which is
+        # independent of and typically much smaller than num_query_heads --
+        # sharding that small axis on the data-parallel dim would raise an
+        # IndivisibleError whenever the batch mesh dimension doesn't divide
+        # it, so key/value are left fully replicated on that axis.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            model_dim,
+            data_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            model_dim,
+            None,
             None,
         )
         layout_map["transformer_layer.*attention_output.kernel"] = (
@@ -345,19 +338,25 @@ class Qwen3MoeBackbone(Backbone):
             None,
             data_dim,
         )
+        # Dense FFN fallback used in mlp_only_layers.
         layout_map[
-            "transformer_layer.*feedforward_intermediate_dense.kernel"
-        ] = (
-            data_dim,
-            model_dim,
-        )
-        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
-            data_dim,
-            model_dim,
-        )
-        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
-            model_dim,
-            data_dim,
-        )
-
+            "transformer_layer.*qwen3_moe_mlp.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*qwen3_moe_mlp.*feedforward_gate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*qwen3_moe_mlp.*feedforward_output_dense.kernel"
+        ] = (model_dim, data_dim)
+        # Routed experts.
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_gate_dense"
+        ] = (None, data_dim, model_dim)
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_output_dense"
+        ] = (None, model_dim, data_dim)
+        # Router.
+        layout_map[
+            "transformer_layer.*sparse_feedforward_gate_dense/kernel"
+        ] = (data_dim, None)
         return layout_map

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
@@ -176,6 +176,7 @@ class Qwen3MoeBackboneTest(TestCase):
         for loss in model.losses:
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
 
+    @pytest.mark.multi_device
     def test_distribution(self):
         # Note: the shared helper pins the mesh to exactly 2 devices (not
         # len(devices)), so the default test config's num_key_value_heads=2
@@ -244,6 +245,7 @@ class Qwen3MoeBackboneTest(TestCase):
         for dims in (QWEN3_MOE_30B_A3B_DIMS, QWEN3_MOE_235B_A22B_DIMS)
         for shape in CAPPED_MESH_SHAPES
     )
+    @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
@@ -1,9 +1,116 @@
+import gc
+import json
+import os
+import re
+
 import keras
 import pytest
+from absl.testing import parameterized
 from keras import ops
 
 from keras_hub.src.models.qwen3_moe.qwen3_moe_backbone import Qwen3MoeBackbone
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
+
+# Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
+# dimensions, frozen as literals and sourced once, offline (from each
+# preset's public HF/Kaggle config.json) -- do not add a `get_file` call to
+# the Tier-2 test body itself (that's what Tier 3, `test_layout_map_live_
+# presets` below, is for).
+#
+# MEMORY NOTE: memory-constrained local environments cannot load full-scale
+# model dims (see CAPPED_MESH_SHAPES comment below for the mesh-size OOM
+# history). What actually matters for the divisibility/sharding properties
+# this tier tests is the RATIO of query heads to kv heads and whether
+# hidden/intermediate/vocab divide the mesh's model-axis sizes -- not the
+# absolute parameter count. So these dims are scaled down by roughly 24x from
+# the real presets while preserving each preset's real query:kv head ratio
+# (8:1 and 16:1, both GQA) and keeping hidden/intermediate/moe_intermediate/
+# vocab as clean values divisible by every mesh shape's model-axis size in
+# CAPPED_MESH_SHAPES (2, 4, 8). Full-scale real dims are exercised by
+# `test_layout_map_live_presets` below, which has its own per-width-class
+# memory-budget skip so it never attempts a full-scale build in a
+# memory-constrained environment either -- true full-scale verification
+# happens on a dedicated or CI machine with more memory.
+QWEN3_MOE_30B_A3B_DIMS = {
+    "source_preset": "qwen3_moe_30b_a3b_en (real ratio, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 1,  # depth is irrelevant to spec matching/divisibility.
+    "num_query_heads": 8,
+    "num_key_value_heads": 1,  # real ratio: GQA, 32:4 == 8:1.
+    "hidden_dim": 128,
+    "intermediate_dim": 256,
+    "moe_intermediate_dim": 32,
+    "num_experts": 4,
+    "top_k": 2,
+    "head_dim": 32,
+}
+QWEN3_MOE_235B_A22B_DIMS = {
+    "source_preset": "qwen3_moe_235b_a22b_en (real ratio, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 1,
+    "num_query_heads": 16,
+    "num_key_value_heads": 1,  # real ratio: GQA, 64:4 == 16:1.
+    "hidden_dim": 256,
+    "intermediate_dim": 512,
+    "moe_intermediate_dim": 64,
+    "num_experts": 4,
+    "top_k": 2,
+    "head_dim": 32,
+}
+
+# Hard-capped mesh-shape list for memory-constrained local environments. The
+# full 10-shape matrix from the testing-strategy doc is
+# 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
+# 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
+# DROPPED here because they exhausted memory and triggered an OOM kill during
+# an earlier run of this pipeline in a memory-constrained environment. These
+# shapes require a dedicated or CI machine with more memory.
+CAPPED_MESH_SHAPES = [
+    (2, 4),
+    (1, 8),
+    (4, 4),
+    (2, 2, 2),
+    (1, 1, 8),
+    (2, 2, 4),
+]
+
+# Same expected_shardings patterns as Qwen3MoeBackboneTest.test_distribution
+# (post-QKV-axis-fix), reused by the Tier-2 and Tier-3 mesh sweeps below.
+# `mlp_only_layers` is left at its default (all-sparse) for these sweeps, so
+# only the routed-expert/router rules are exercised here, not the dense-FFN
+# fallback -- that fallback path is covered by test_distribution's explicit
+# `mlp_only_layers=[1]` config instead.
+_EXPECTED_SHARDINGS = {
+    "token_embedding/embeddings": ("model", "batch"),
+    "token_embedding/reverse_embeddings": ("batch", "model"),
+    "self_attention.*query.kernel": ("batch", "model", None),
+    "self_attention.*(key|value).kernel": ("batch", None, None),
+    "self_attention.*attention_output.kernel": ("model", None, "batch"),
+    "experts/expert_feedforward_gate_dense": (None, "batch", "model"),
+    "experts/expert_feedforward_output_dense": (None, "model", "batch"),
+    "sparse_feedforward_gate_dense/kernel": ("batch", None),
+}
+
+
+def _assert_qwen3_moe_shardings_and_coverage(test_case, model, layout_map):
+    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
+    for pattern, expected in _EXPECTED_SHARDINGS.items():
+        matches = [w for w in model.weights if re.search(pattern, w.path)]
+        test_case.assertGreater(len(matches), 0)
+        for w in matches:
+            test_case.assertEqual(tuple(w.value.sharding.spec), expected)
+    offending = [
+        w.path
+        for w in model.weights
+        if len(w.shape) >= 2 and layout_map[w.path] is None
+    ]
+    test_case.assertEqual(
+        offending,
+        [],
+        f"The following rank>=2 weights are unmapped: {offending}",
+    )
 
 
 class Qwen3MoeBackboneTest(TestCase):
@@ -70,73 +177,322 @@ class Qwen3MoeBackboneTest(TestCase):
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
 
     def test_distribution(self):
+        # Note: the shared helper pins the mesh to exactly 2 devices (not
+        # len(devices)), so the default test config's num_key_value_heads=2
+        # exercises the ordinary GQA-replication path deterministically
+        # regardless of how many virtual devices the test environment
+        # exposes. `mlp_only_layers=[1]` makes layer 1 use the dense FFN
+        # fallback (`qwen3_moe_mlp`) while layer 0 stays sparse, so both the
+        # dense-fallback and routed-expert layout rules are exercised in one
+        # call. This model defaults to `is_moe=True` tolerances since
+        # `num_experts > 0` is always active (unlike qwen_moe/mixtral, there
+        # is no dense-only mode for this backbone).
+        init_kwargs = dict(self.init_kwargs, mlp_only_layers=[1])
+        self.run_distribution_test(
+            cls=Qwen3MoeBackbone,
+            init_kwargs=init_kwargs,
+            input_data=self.input_data,
+            expected_shardings={
+                "token_embedding/embeddings": ("model", "batch"),
+                "token_embedding/reverse_embeddings": ("batch", "model"),
+                "self_attention.*query.kernel": ("batch", "model", None),
+                "self_attention.*(key|value).kernel": (
+                    "batch",
+                    None,
+                    None,
+                ),
+                "self_attention.*attention_output.kernel": (
+                    "model",
+                    None,
+                    "batch",
+                ),
+                "qwen3_moe_mlp.*feedforward_intermediate_dense.kernel": (
+                    "batch",
+                    "model",
+                ),
+                "qwen3_moe_mlp.*feedforward_gate_dense.kernel": (
+                    "batch",
+                    "model",
+                ),
+                "qwen3_moe_mlp.*feedforward_output_dense.kernel": (
+                    "model",
+                    "batch",
+                ),
+                "experts/expert_feedforward_gate_dense": (
+                    None,
+                    "batch",
+                    "model",
+                ),
+                "experts/expert_feedforward_output_dense": (
+                    None,
+                    "model",
+                    "batch",
+                ),
+                "sparse_feedforward_gate_dense/kernel": ("batch", None),
+            },
+            allow_replicated=(),
+            is_moe=True,
+        )
+
+    @parameterized.named_parameters(
+        (
+            f"{dims['source_preset'].split(' ')[0]}_mesh"
+            f"_{'x'.join(str(s) for s in shape)}",
+            dims,
+            shape,
+        )
+        for dims in (QWEN3_MOE_30B_A3B_DIMS, QWEN3_MOE_235B_A22B_DIMS)
+        for shape in CAPPED_MESH_SHAPES
+    )
+    def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")
         devices = keras.distribution.list_devices("CPU")
-        if len(devices) == 1:
-            self.skipTest("`ModelParallel` testing requires multiple devices.")
-        devices = devices[:2]
+        n_needed = 1
+        for s in mesh_shape:
+            n_needed *= s
+        if n_needed > len(devices):
+            self.skipTest(
+                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
+                f"{len(devices)} available. Run with "
+                f"XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{n_needed} to exercise this shape locally."
+            )
+
+        # Query-head-divisibility skip rule: an inherent tensor-parallelism
+        # ceiling, not a bug. model_axis_size is the mesh's last axis,
+        # matching this repo's axis_names=(..., "model") convention.
+        model_axis_size = mesh_shape[-1]
+        num_query_heads = dims["num_query_heads"]
+        if num_query_heads % model_axis_size != 0:
+            self.skipTest(
+                f"num_query_heads={num_query_heads} not divisible by "
+                f"model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
+        devices = devices[:n_needed]
+        if len(mesh_shape) == 2:
+            axis_names = ("batch", "model")
+        else:
+            # 3D shape: the extra axis is named "seq" per the plan/
+            # testing-strategy convention, but get_layout_map only names
+            # "batch"/"model" -- the "seq" axis simply replicates weights
+            # (no rule targets it), matching every other 3D-mesh test in
+            # this PR series.
+            axis_names = ("batch", "seq", "model")
         device_mesh = keras.distribution.DeviceMesh(
-            shape=(1, 2),
-            axis_names=("batch", "model"),
+            shape=mesh_shape,
+            axis_names=axis_names,
             devices=devices,
         )
-
         layout_map = Qwen3MoeBackbone.get_layout_map(device_mesh)
-        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
-        # `mlp_only_layers=[1]` makes layer 1 use the dense FFN fallback
-        # (`qwen3_moe_mlp`) while layer 0 stays sparse, so both the dense
-        # fallback and the routed-expert layout rules are exercised here.
-        init_kwargs = dict(self.init_kwargs, mlp_only_layers=[1])
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
         with distribution.scope():
-            model = Qwen3MoeBackbone(**init_kwargs)
+            # bfloat16: a memory mitigation for memory-constrained
+            # environments -- spec assertions are dtype-independent.
+            model = Qwen3MoeBackbone(dtype="bfloat16", **init_kwargs)
+            _assert_qwen3_moe_shardings_and_coverage(self, model, layout_map)
+        del model
+        gc.collect()
 
-        for w in model.weights:
-            if "token_embedding/embeddings" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch")
-                )
-            if "token_embedding/reverse_embeddings" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch")
-                )
-            if "self_attention/query/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch", None)
-                )
-            if "self_attention/key/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", None, None)
-                )
-            if "self_attention/value/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", None, None)
-                )
-            if "self_attention/attention_output/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", None, "batch")
-                )
-            if "qwen3_moe_mlp/feedforward_intermediate_dense/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("batch", "model")
-                )
-            if "qwen3_moe_mlp/feedforward_gate_dense/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("batch", "model")
-                )
-            if "qwen3_moe_mlp/feedforward_output_dense/kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), ("model", "batch")
-                )
-            if "experts/expert_feedforward_gate_dense" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec),
-                    (None, "batch", "model"),
-                )
-            if "experts/expert_feedforward_output_dense" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec),
-                    (None, "model", "batch"),
-                )
-            if "sparse_feedforward_gate_dense/kernel" in w.path:
-                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.multi_device
+    @pytest.mark.extra_large
+    def test_layout_map_live_presets(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+
+        # Fetch every preset's config only (no weights), then dedupe by the
+        # divisibility-relevant dims so width-classes that share a config
+        # are only built once per mesh shape -- a memory/time necessity in
+        # memory-constrained environments, while every preset in the registry
+        # is still fetched and evaluated, preserving full registry coverage.
+        dim_keys = (
+            "vocabulary_size",
+            "num_query_heads",
+            "num_key_value_heads",
+            "hidden_dim",
+            "intermediate_dim",
+            "moe_intermediate_dim",
+            "num_experts",
+            "top_k",
+            "head_dim",
+        )
+        width_classes = {}  # dedupe key -> (config dict, [preset names])
+        fetch_failures = []
+        for preset in Qwen3MoeBackbone.presets:
+            try:
+                path = get_file(preset, CONFIG_FILE)
+                with open(path) as f:
+                    cfg = json.load(f)["config"]
+            except Exception as e:
+                # A preset this account can't reach (e.g. an unaccepted
+                # Kaggle license consent click-through) is logged, not
+                # fatal -- the rest of the registry still gets exercised.
+                fetch_failures.append((preset, str(e)))
+                continue
+            # num_layers is forced to 1 below regardless of the real
+            # value -- layout rules are per-decoder-block regexes, so
+            # depth is irrelevant to spec matching/divisibility, and 1
+            # layer keeps build memory bounded.
+            cfg = dict(cfg)
+            cfg["num_layers"] = 1
+            key = tuple(cfg.get(k) for k in dim_keys)
+            if key not in width_classes:
+                width_classes[key] = (cfg, [])
+            width_classes[key][1].append(preset)
+
+        if fetch_failures:
+            print(
+                f"test_layout_map_live_presets: {len(fetch_failures)} "
+                f"preset config fetches failed (logged, non-fatal): "
+                f"{fetch_failures}"
+            )
+        if not width_classes:
+            self.skipTest(
+                "No preset configs were reachable "
+                f"({len(fetch_failures)} fetch failures) -- likely a "
+                "Kaggle license-consent gate on this account for the "
+                "qwen3_moe family. See the module comment above "
+                "CAPPED_MESH_SHAPES."
+            )
+        print(
+            f"test_layout_map_live_presets: {len(width_classes)} unique "
+            f"width-classes across {len(Qwen3MoeBackbone.presets)} "
+            "registry presets:"
+        )
+        for cfg, presets in width_classes.values():
+            print(f"  {presets}")
+
+        devices = keras.distribution.list_devices("CPU")
+        skip_reasons = []
+        ran_any = False
+        for cfg, presets in width_classes.values():
+            num_query_heads = cfg["num_query_heads"]
+            for mesh_shape in CAPPED_MESH_SHAPES:
+                combo_label = f"{presets[0]}@{mesh_shape}"
+                with self.subTest(combo=combo_label):
+                    n_needed = 1
+                    for s in mesh_shape:
+                        n_needed *= s
+                    if n_needed > len(devices):
+                        reason = (
+                            f"{combo_label}: needs {n_needed} devices, "
+                            f"only {len(devices)} available"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+                    model_axis_size = mesh_shape[-1]
+                    if num_query_heads % model_axis_size != 0:
+                        reason = (
+                            f"{combo_label}: num_query_heads="
+                            f"{num_query_heads} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    # Memory-budget guard: memory-constrained environments
+                    # cannot build full-scale presets. Estimate this
+                    # width-class's single-decoder-block bf16 footprint.
+                    # Qwen3-MoE has UNTIED embeddings (tie_word_embeddings
+                    # defaults False and real untied presets exist), so the
+                    # embedding term is counted twice (forward + reverse
+                    # output projection). Attention projections map
+                    # hidden<->hidden for query/output and hidden<->(hidden
+                    # scaled by the kv/query head ratio) for GQA's key/value;
+                    # none touch intermediate_dim (attention has no bias in
+                    # this model). The parameter bulk is the MoE expert bank:
+                    # gate_up is (num_experts, hidden, 2*moe_intermediate)
+                    # and down is (num_experts, moe_intermediate, hidden), so
+                    # the estimate includes an explicit num_experts term over
+                    # moe_intermediate_dim (the expert width, not the dense
+                    # intermediate_dim) -- omitting it would dangerously
+                    # undercount a MoE model's real footprint. Times a 3x
+                    # safety margin for JAX/XLA transient copies during
+                    # construction/resharding. The config-fetch, dedup, and
+                    # divisibility-skip logic above still exercises every
+                    # registry preset either way; only the expensive
+                    # build+assert step is capped.
+                    hidden = cfg["hidden_dim"]
+                    moe_inter = cfg["moe_intermediate_dim"]
+                    num_experts = cfg["num_experts"]
+                    num_kv_heads = cfg["num_key_value_heads"]
+                    kv_ratio = num_kv_heads / num_query_heads
+                    est_params = (
+                        2 * cfg["vocabulary_size"] * hidden  # untied embed
+                        + 2 * hidden * hidden  # attention q/o
+                        + 2 * hidden * hidden * kv_ratio  # attention k/v
+                        + num_experts
+                        * (hidden * 2 * moe_inter + moe_inter * hidden)
+                    )
+                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
+                    max_local_bytes = int(
+                        os.environ.get(
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
+                            300 * 1024 * 1024,
+                        )
+                    )
+                    if est_bytes > max_local_bytes:
+                        reason = (
+                            f"{combo_label}: estimated build memory "
+                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
+                            f"{max_local_bytes / 1e6:.0f}MB local safety "
+                            "threshold for memory-constrained environments "
+                            "-- verify this width-class on a machine with "
+                            "more memory or in CI (raise the budget via the "
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET env var)"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    combo_devices = devices[:n_needed]
+                    if len(mesh_shape) == 2:
+                        axis_names = ("batch", "model")
+                    else:
+                        axis_names = ("batch", "seq", "model")
+                    device_mesh = keras.distribution.DeviceMesh(
+                        shape=mesh_shape,
+                        axis_names=axis_names,
+                        devices=combo_devices,
+                    )
+                    layout_map = Qwen3MoeBackbone.get_layout_map(device_mesh)
+                    distribution = keras.distribution.ModelParallel(
+                        layout_map=layout_map, batch_dim_name="batch"
+                    )
+                    # `cfg` is the preset's full serialized `get_config()`
+                    # dict; pass all of it (real architecture flags such as
+                    # rope scaling, MoE routing, tie-embeddings, etc. must
+                    # survive to actually exercise the live preset's real
+                    # architecture) and only drop `"dtype"` so the explicit
+                    # `dtype="bfloat16"` override below doesn't collide with a
+                    # duplicate keyword argument. `num_layers` is forced to 1
+                    # (layout rules are per-decoder-block, so depth is
+                    # irrelevant and 1 layer keeps build memory bounded).
+                    init_kwargs = {k: v for k, v in cfg.items() if k != "dtype"}
+                    init_kwargs["num_layers"] = 1
+                    with distribution.scope():
+                        model = Qwen3MoeBackbone(
+                            dtype="bfloat16", **init_kwargs
+                        )
+                        _assert_qwen3_moe_shardings_and_coverage(
+                            self, model, layout_map
+                        )
+                    del model
+                    gc.collect()
+                    ran_any = True
+
+        print(
+            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
+            f"skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
+        )
+        if not ran_any:
+            self.skipTest(
+                "All (width-class, mesh-shape) combos were skipped: "
+                f"{skip_reasons}"
+            )

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py
@@ -1,3 +1,4 @@
+import keras
 import pytest
 from keras import ops
 
@@ -67,3 +68,75 @@ class Qwen3MoeBackboneTest(TestCase):
         )
         for loss in model.losses:
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
+
+    def test_distribution(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        devices = devices[:2]
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, 2),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = Qwen3MoeBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        # `mlp_only_layers=[1]` makes layer 1 use the dense FFN fallback
+        # (`qwen3_moe_mlp`) while layer 0 stays sparse, so both the dense
+        # fallback and the routed-expert layout rules are exercised here.
+        init_kwargs = dict(self.init_kwargs, mlp_only_layers=[1])
+        with distribution.scope():
+            model = Qwen3MoeBackbone(**init_kwargs)
+
+        for w in model.weights:
+            if "token_embedding/embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "token_embedding/reverse_embeddings" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "self_attention/query/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch", None)
+                )
+            if "self_attention/key/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/value/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, None)
+                )
+            if "self_attention/attention_output/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", None, "batch")
+                )
+            if "qwen3_moe_mlp/feedforward_intermediate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "qwen3_moe_mlp/feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("batch", "model")
+                )
+            if "qwen3_moe_mlp/feedforward_output_dense/kernel" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), ("model", "batch")
+                )
+            if "experts/expert_feedforward_gate_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "batch", "model"),
+                )
+            if "experts/expert_feedforward_output_dense" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec),
+                    (None, "model", "batch"),
+                )
+            if "sparse_feedforward_gate_dense/kernel" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ("batch", None))


### PR DESCRIPTION
Closes #2835

Part of https://github.com/keras-team/keras-hub/issues/2807. Depends on #2809 (`TestCase.run_distribution_test`) for CI to pass -- this PR's own diff is independent (based on master, not stacked), so it stays small and reviewable regardless of merge order.

## Update: full rework after a cross-model review

A cross-model review that compared this PR against its sibling layout-map PRs found that `Qwen3MoeBackbone`'s layout map and test had **never actually been reworked with the rest of the series** -- the original commit on this branch still shipped the exact pre-fix sharding this series exists to eliminate (the contracting `hidden` dim sharded on the model axis and query heads / vocab on the batch axis). That is the ~2.7x-extra-attention-collective-traffic bug, and it was also internally inconsistent with this same layer's already-correct `attention_output` row-parallel rule. The test file was likewise still in the old per-weight-`if` style and asserted the wrong (pre-fix) tuples.

This has now been fixed as a full rework (commit applies the axis fix to the backbone and rewrites the test onto the shared `run_distribution_test` helper). Details below.

## Summary

Fixes `Qwen3MoeBackbone.get_layout_map`:

- `self_attention` `query.kernel`: `(model, batch, None)` -> `(batch, model, None)`, and `(key|value).kernel`: `(model, None, None)` -> `(batch, None, None)`. The QKV kernels are `(hidden, heads, head_dim)` (einsum `bqm,muh->bquh`), so the contracting `hidden` dim shards on the batch axis and query heads shard on the model axis (Megatron column-parallel). GQA key/value heads (`num_key_value_heads`, independent of and typically much smaller than `num_query_heads`) stay replicated on the model axis so a model-axis size that doesn't divide them can't raise `IndivisibleError`.
- `token_embedding/reverse_embeddings`: `(model, batch)` -> `(batch, model)` so the untied output projection is vocab-parallel, consistent with `token_embedding/embeddings` and now internally consistent with the corrected QKV rules.
- `attention_output` is deliberately **left unchanged** -- it was already correct, and the QKV fix above makes the whole attention block internally consistent with it.
- Replaces the incoherent key/value-sharding comment (which argued about "the batch mesh dimension not dividing kv heads" while annotating a rule that sharded hidden-on-model) with the Gemma-style kv-replication rationale used across the sibling models.
- The dense-FFN fallback (`qwen3_moe_mlp.*`), routed experts (`experts/expert_feedforward_{gate,output}_dense`), router (`sparse_feedforward_gate_dense/kernel`), and `reverse_embeddings` rules remain mapped, and the corrected `axis_names` error messages are retained.

Rewrites `qwen3_moe_backbone_test.py`:

- `test_distribution` now uses the shared `TestCase.run_distribution_test(is_moe=True)` helper (forward + backward + optimizer step + numerical parity vs. an undistributed twin + a mapped/replicated coverage check), with `mlp_only_layers=[1]` so both the routed-expert and dense-FFN-fallback layout rules are exercised in one call.
- Adds a `CAPPED_MESH_SHAPES` Tier-2 sweep over two real-ratio, memory-scaled width-classes (`qwen3_moe_30b_a3b`'s 8:1 GQA and `qwen3_moe_235b_a22b`'s 16:1 GQA) x six mesh shapes (`2x4, 1x8, 4x4, 2x2x2, 1x1x8, 2x2x4`), asserting the spec and rank>=2 coverage for each.
- Adds a memory-budget-guarded Tier-3 `test_layout_map_live_presets` sweep (`kaggle_key_required`/`multi_device`/`extra_large`) that fetches every registry preset's config, dedupes by width-class, and asserts specs at each mesh shape.
- Live-preset build kwargs now pass the preset's **full** serialized config (minus `dtype`) instead of a dims-only allowlist, so real architecture flags (MoE routing, rope scaling, tie-embeddings, etc.) actually reach the build.
- The Tier-3 memory budget is tunable via the `KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET` env var (defaults to the prior 300MB), and its footprint estimate now counts untied embeddings twice, GQA-scaled attention QKVO, and the MoE expert bank over `moe_intermediate_dim`.
- Uses a `with open(...)` context manager for the preset config read and reworded comments/skip messages to be environment-neutral.

## Verification

Backend: JAX, CPU, with `XLA_FLAGS=--xla_force_host_platform_device_count=16` to simulate multiple devices. Run against a checkout that temporarily includes #2809's `TestCase.run_distribution_test` helper (this branch's own base doesn't yet include it, since this PR is independent/not stacked on #2809). `ruff check` and `ruff format` are clean.

```
KERAS_BACKEND=jax JAX_PLATFORMS=cpu \
  XLA_FLAGS=--xla_force_host_platform_device_count=16 \
  python -m pytest keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py \
  -k "distribution or mesh_shapes" -v

keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_distribution PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_235b_a22b_en_mesh_1x1x8 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_235b_a22b_en_mesh_1x8 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_235b_a22b_en_mesh_2x2x2 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_235b_a22b_en_mesh_2x2x4 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_235b_a22b_en_mesh_2x4 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_235b_a22b_en_mesh_4x4 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_30b_a3b_en_mesh_1x1x8 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_30b_a3b_en_mesh_1x8 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_30b_a3b_en_mesh_2x2x2 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_30b_a3b_en_mesh_2x2x4 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_30b_a3b_en_mesh_2x4 PASSED
keras_hub/src/models/qwen3_moe/qwen3_moe_backbone_test.py::Qwen3MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_moe_30b_a3b_en_mesh_4x4 PASSED

13 passed, 7 deselected in 30.78s
```

`test_layout_map_live_presets` (Tier 3, live-preset sweep) is `kaggle_key_required`/`extra_large` and is not part of this `-k "distribution or mesh_shapes"` selection; it requires Kaggle-authenticated network access to fetch preset `config.json` files and has its own per-width-class memory-budget skip guard (tunable via `KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET`) so it never attempts a full-scale build even when it does run.

## Limitations

The model-axis size of the mesh can't usefully exceed a preset's `num_query_heads`, since that's the axis this layout map actually tensor-parallelizes -- see [the design doc's "hard limit" section](https://github.com/keras-team/keras-hub/issues/2807#issuecomment-5006606419) for why.

For this model's real presets:

| preset | num_query_heads | safe model-axis up to | first failing model-axis |
|---|---|---|---|
| `qwen3_coder_instruct_30b_a3b_en` | 32 | 32 | 64 |
| `qwen3_moe_235b_a22b_en` | 64 | 64 | 128 |
| `qwen3_moe_30b_a3b_en` | 32 | 32 | 64 |

All three are routed-MoE presets, but the MoE expert bank doesn't introduce any earlier or separate failure threshold here -- the query-head ceiling above is the binding constraint for all of them.
