### PR TITLE
Add/fix ModelParallel layout map for qwen3_5_moe

### DIFF
--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
@@ -369,8 +369,8 @@ class Qwen3_5MoeBackbone(Backbone):
         bank/router/shared-expert, and embeddings. A few tiny linear-attention
         weights (in_proj_a/in_proj_b, conv1d_kernel, dt_bias, A_log), the
         shared-expert gate, and the vision encoder/interleave weights are
-        intentionally left replicated -- see the comments below and the
-        Limitations in the PR description.
+        intentionally left replicated -- see the comments below for the
+        rationale for each.
 
         Args:
             device_mesh: keras.distribution.DeviceMesh. The device mesh

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone.py
@@ -355,6 +355,155 @@ class Qwen3_5MoeBackbone(Backbone):
         )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the
+        Qwen3_5Moe backbone's text-decoder full-attention and
+        linear-attention (GatedDeltaNet) layers, the MoE expert
+        bank/router/shared-expert, and embeddings. A few tiny linear-attention
+        weights (in_proj_a/in_proj_b, conv1d_kernel, dt_bias, A_log), the
+        shared-expert gate, and the vision encoder/interleave weights are
+        intentionally left replicated -- see the comments below and the
+        Limitations in the PR description.
+
+        Args:
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
+
+        Returns:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        # The reverse (output projection) embedding is a (hidden, vocab)
+        # tensor; the vocab-parallel logit projection wants vocab on the
+        # model axis, so it is the transpose of the input embedding layout.
+        layout_map["token_embedding/reverse_embeddings"] = (
+            data_dim,
+            model_dim,
+        )
+        # Full-attention (GQA) projections. The query/key/value kernels are
+        # (hidden_dim, num_heads, head_dim): the contracting hidden_dim is
+        # sharded on the data axis, and the query heads are sharded on the
+        # model axis (Megatron column-parallel). Key/value heads are sized by
+        # num_key_value_heads, which is independent of and typically much
+        # smaller than num_query_heads -- sharding that small axis on the
+        # model dim would raise an IndivisibleError whenever it doesn't evenly
+        # divide, so it is left replicated while the hidden_dim axis is still
+        # sharded on data. Only matches full_attention layers -- the
+        # linear_attn (GatedDeltaNet) sublayer uses different weight names,
+        # handled separately below.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            data_dim,
+            model_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            data_dim,
+            None,
+            None,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*attention_output.kernel"
+        ] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        # Linear-attention (GatedDeltaNet) input/output projections. These are
+        # 2-D (hidden_dim, proj) / (value_dim, hidden_dim) Dense kernels:
+        # in_proj_qkv fuses the q/k/v projections (column-parallel), in_proj_z
+        # is the gating projection (column-parallel), and out_proj is
+        # row-parallel. in_proj_a / in_proj_b (projections to num_v_heads,
+        # a tiny axis), conv1d_kernel (depthwise over channel-sharded
+        # activations, so a replicated kernel stays local), and the 1-D
+        # dt_bias / A_log are intentionally left replicated -- see the PR's
+        # test allow_replicated list.
+        layout_map["transformer_layer.*linear_attn.*in_proj_qkv.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*linear_attn.*in_proj_z.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*linear_attn.*out_proj.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        # Shared expert (always-active dense FFN) -- same naming as dense
+        # Qwen3_5's feedforward.
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        # Routed MoE experts. The leading dimension is the expert count and
+        # is left replicated so the map works for small num_experts values
+        # used in tests. expert_feedforward_gate_dense fuses the SwiGLU gate
+        # and up projections into one tensor (column-parallel);
+        # expert_feedforward_output_dense is row-parallel.
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_gate_dense$"
+        ] = (
+            None,
+            data_dim,
+            model_dim,
+        )
+        layout_map[
+            "transformer_layer.*experts/expert_feedforward_output_dense$"
+        ] = (
+            None,
+            model_dim,
+            data_dim,
+        )
+        # Router. num_experts is typically small, so only the hidden-dim
+        # axis is sharded.
+        layout_map["transformer_layer.*router_gate.kernel"] = (
+            data_dim,
+            None,
+        )
+        # The shared-expert gate is a (hidden_dim, 1) projection: its output
+        # dimension is 1, so there is nothing to shard on the model axis and
+        # it is intentionally left replicated -- see the test allow_replicated
+        # list.
+        return layout_map
+
     @classmethod
     def from_config(cls, config):
         config.update(

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
@@ -230,6 +230,7 @@ class Qwen3_5MoeBackboneTest(TestCase):
         for loss in model.losses:
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
 
+    @pytest.mark.multi_device
     def test_distribution(self):
         # The default config keeps num_key_value_heads=2 (not divisible by
         # every host's device count) and includes both a linear_attention and
@@ -295,6 +296,7 @@ class Qwen3_5MoeBackboneTest(TestCase):
         for dims in (QWEN3_5_MOE_35B_A3B_DIMS, QWEN3_5_MOE_SMALL_DIMS)
         for shape in CAPPED_MESH_SHAPES
     )
+    @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
@@ -1,4 +1,6 @@
 import gc
+import json
+import os
 import re
 
 import keras
@@ -10,17 +12,19 @@ from keras_hub.src.models.qwen3_5_moe.qwen3_5_moe_backbone import (
     Qwen3_5MoeBackbone,
 )
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
 
 # Dims for the Tier-2 CI-safe mesh-shape sweep: representative
 # Qwen3.5-MoE-35B-A3B-class shapes, frozen as literals and scaled down for
-# this shared, RAM-constrained dev box -- do NOT add a live `get_file` call to
-# the Tier-2 test body (that is what Tier 3, `test_layout_map_live_presets`,
+# memory-constrained local environments -- do NOT add a live `get_file` call
+# to the Tier-2 test body (that is what Tier 3, `test_layout_map_live_presets`,
 # is for).
 #
-# MEMORY NOTE: this local dev machine cannot load full-scale model dims, so
-# every dimension (vocab, hidden, intermediate, expert widths, head dims) is
-# scaled down ~20-30x from the real `Qwen/Qwen3.5-35B-A3B` config while
-# preserving the two properties this tier actually tests:
+# MEMORY NOTE: memory-constrained local environments cannot load full-scale
+# model dims, so every dimension (vocab, hidden, intermediate, expert widths,
+# head dims) is scaled down ~20-30x from the real `Qwen/Qwen3.5-35B-A3B`
+# config while preserving the two properties this tier actually tests:
 #   * the real query:kv head RATIO (8:1 GQA) and the real
 #     linear key:value head ratio (16:32 = 1:2), which drive the
 #     divisibility/sharding behaviour under test, and
@@ -83,13 +87,13 @@ QWEN3_5_MOE_SMALL_DIMS = {
     "router_aux_loss_coefficient": 0.001,
 }
 
-# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
-# 10-shape matrix from the testing-strategy doc is
+# Hard-capped mesh-shape list for memory-constrained local environments. The
+# full 10-shape matrix from the testing-strategy doc is
 # 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
 # 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY DROPPED
-# here (they need >16 simulated devices and OOM-kill this shared box). Do not
-# add them even experimentally on this machine; they belong on a dedicated or
-# CI runner. Every shape below fits within 16 virtual devices.
+# here (they need >16 simulated devices and can OOM-kill a memory-constrained
+# machine). These shapes require a dedicated or CI machine with more memory.
+# Every shape below fits within 16 virtual devices.
 CAPPED_MESH_SHAPES = [
     (2, 4),
     (1, 8),
@@ -309,6 +313,22 @@ class Qwen3_5MoeBackboneTest(TestCase):
                 "tensor-parallelism limit, not a bug"
             )
 
+        # Linear-attention (GatedDeltaNet) fused in_proj_qkv width must also
+        # divide the model axis: get_layout_map shards in_proj_qkv's fused
+        # output (2*key_dim + value_dim) on model_dim, so an indivisible
+        # width would otherwise fail inside `ModelParallel` construction
+        # below with an opaque error instead of a clean, documented skip.
+        linear_qkv_width = (
+            2 * dims["linear_num_key_heads"] * dims["linear_key_head_dim"]
+            + dims["linear_num_value_heads"] * dims["linear_value_head_dim"]
+        )
+        if linear_qkv_width % model_axis_size != 0:
+            self.skipTest(
+                f"linear_attn in_proj_qkv fused width={linear_qkv_width} "
+                f"not divisible by model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
         devices = devices[:n_needed]
         if len(mesh_shape) == 2:
             axis_names = ("batch", "model")
@@ -329,8 +349,8 @@ class Qwen3_5MoeBackboneTest(TestCase):
         )
         init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
         with distribution.scope():
-            # bfloat16: a memory mitigation for this shared dev machine --
-            # spec assertions are dtype-independent.
+            # bfloat16: a memory mitigation for memory-constrained local
+            # environments -- spec assertions are dtype-independent.
             model = Qwen3_5MoeBackbone(dtype="bfloat16", **init_kwargs)
             _assert_shardings_and_coverage(
                 self, model, layout_map, _SWEEP_EXPECTED_SHARDINGS
@@ -342,19 +362,15 @@ class Qwen3_5MoeBackboneTest(TestCase):
     @pytest.mark.multi_device
     @pytest.mark.extra_large
     def test_layout_map_live_presets(self):
-        import json
-
-        from keras_hub.src.utils.preset_utils import CONFIG_FILE
-        from keras_hub.src.utils.preset_utils import get_file
-
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")
 
         # Fetch every preset's config only (no weights), then dedupe by the
         # divisibility-relevant dims so width-classes that share a config are
-        # only built once per mesh shape -- a memory/time necessity on this
-        # machine -- while every preset in the registry is still fetched and
-        # evaluated, preserving full registry coverage.
+        # only built once per mesh shape -- a memory/time necessity for
+        # memory-constrained local environments -- while every preset in the
+        # registry is still fetched and evaluated, preserving full registry
+        # coverage.
         dim_keys = (
             "vocabulary_size",
             "num_query_heads",
@@ -439,34 +455,71 @@ class Qwen3_5MoeBackboneTest(TestCase):
                         )
                         continue
 
-                    # Memory-budget guard: this shared dev machine cannot
-                    # locally build full-scale presets. Estimate this
-                    # width-class's single-decoder-block bf16 footprint
-                    # (embedding table + one expert bank's two fused
-                    # matrices, times a 3x safety margin for JAX/XLA
-                    # transient copies) and skip the build if it exceeds a
-                    # conservative local threshold. The fetch/dedup/
-                    # divisibility logic above still exercises every
-                    # registry preset regardless.
+                    # Linear-attention fused in_proj_qkv width must also
+                    # divide the model axis -- see the matching guard and
+                    # comment in test_layout_map_mesh_shapes above.
+                    linear_qkv_width = (
+                        2
+                        * cfg["linear_num_key_heads"]
+                        * cfg["linear_key_head_dim"]
+                        + cfg["linear_num_value_heads"]
+                        * cfg["linear_value_head_dim"]
+                    )
+                    if linear_qkv_width % model_axis_size != 0:
+                        skip_reasons.append(
+                            f"{combo_label}: linear_attn in_proj_qkv fused "
+                            f"width={linear_qkv_width} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        continue
+
+                    # Memory-budget guard: memory-constrained local
+                    # environments cannot locally build full-scale presets.
+                    # Estimate this width-class's single-decoder-block bf16
+                    # footprint -- embedding table (counted twice: Qwen3.5-MoE
+                    # defaults to untied embeddings, so
+                    # token_embedding/reverse_embeddings is a second real
+                    # vocab*hidden weight, not just the input embedding) +
+                    # GQA-scaled attention QKVO + the shared (always-active)
+                    # expert's 3 matrices + the routed expert bank's two
+                    # fused matrices, times a 3x safety margin for JAX/XLA
+                    # transient copies -- and skip the build if it exceeds a
+                    # tunable local threshold. The fetch/dedup/divisibility
+                    # logic above still exercises every registry preset
+                    # regardless.
                     vocab = cfg["vocabulary_size"]
                     hidden = cfg["hidden_dim"]
                     moe_int = cfg["moe_intermediate_dim"]
+                    shared_int = cfg["shared_expert_intermediate_size"]
                     n_exp = cfg["num_experts"]
+                    num_kv_heads = cfg["num_key_value_heads"]
+                    kv_ratio = num_kv_heads / num_query_heads
                     est_params = (
-                        vocab * hidden
-                        + n_exp * hidden * 2 * moe_int
-                        + n_exp * moe_int * hidden
+                        2 * vocab * hidden  # untied embeddings
+                        + 2 * hidden * hidden  # attention q/o
+                        + 2 * hidden * hidden * kv_ratio  # attention k/v
+                        + 3 * hidden * shared_int  # shared expert
+                        + n_exp * hidden * 2 * moe_int  # routed gate+up
+                        + n_exp * moe_int * hidden  # routed down
                     )
                     est_bytes = est_params * 2 * 3  # bf16 * safety margin
-                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    max_local_bytes = int(
+                        os.environ.get(
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
+                            300 * 1024 * 1024,
+                        )
+                    )
                     if est_bytes > max_local_bytes:
                         skip_reasons.append(
                             f"{combo_label}: estimated build memory "
                             f"~{est_bytes / 1e9:.2f}GB exceeds the "
                             f"{max_local_bytes / 1e6:.0f}MB local safety "
-                            "threshold on this shared, RAM-constrained "
-                            "dev machine -- verify this width-class on a "
-                            "machine with more RAM or in CI"
+                            "threshold for memory-constrained local "
+                            "environments -- verify this width-class on a "
+                            "machine with more RAM or in CI (override via "
+                            "the KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET "
+                            "env var)"
                         )
                         continue
 
@@ -484,29 +537,32 @@ class Qwen3_5MoeBackboneTest(TestCase):
                     distribution = keras.distribution.ModelParallel(
                         layout_map=layout_map, batch_dim_name="batch"
                     )
-                    # Build text-only from the constructor-relevant config
-                    # keys (drop serialized sub-objects like vision_encoder
-                    # and any get_config-only fields such as name/dtype).
-                    build_keys = (
-                        "vocabulary_size",
-                        "num_layers",
-                        "num_query_heads",
-                        "num_key_value_heads",
-                        "head_dim",
-                        "hidden_dim",
-                        "moe_intermediate_dim",
-                        "shared_expert_intermediate_size",
-                        "num_experts",
-                        "top_k",
-                        "layer_types",
-                        "partial_rotary_factor",
-                        "linear_num_key_heads",
-                        "linear_num_value_heads",
-                        "linear_key_head_dim",
-                        "linear_value_head_dim",
-                        "linear_conv_kernel_dim",
+                    # `cfg` is a full serialized `get_config()` dict, which
+                    # may include a `"dtype"` key (a serialized dtype-policy
+                    # dict, only present for quantized presets) -- drop it
+                    # so the explicit `dtype="bfloat16"` override below
+                    # doesn't collide with a duplicate keyword argument.
+                    # `name`/`trainable` pass through harmlessly via
+                    # `**kwargs`. Every other real architecture flag (rope
+                    # scaling, tie_word_embeddings, dropout,
+                    # sliding_window_size, mrope_section,
+                    # router_aux_loss_coefficient, ...) is preserved, unlike
+                    # a dims-only allowlist.
+                    build_kwargs = {
+                        k: v for k, v in cfg.items() if k != "dtype"
+                    }
+                    # `vision_encoder` is serialized by `get_config` via
+                    # `keras.layers.serialize` and must be deserialized back
+                    # into a layer instance (or left `None`) before it can be
+                    # passed to `__init__`, matching `from_config`'s handling
+                    # of this field.
+                    build_kwargs["vision_encoder"] = (
+                        None
+                        if build_kwargs.get("vision_encoder") is None
+                        else keras.layers.deserialize(
+                            build_kwargs["vision_encoder"]
+                        )
                     )
-                    build_kwargs = {k: cfg[k] for k in build_keys if k in cfg}
                     with distribution.scope():
                         model = Qwen3_5MoeBackbone(
                             dtype="bfloat16", **build_kwargs

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
@@ -32,20 +32,26 @@ from keras_hub.src.utils.preset_utils import get_file
 #     hidden, num_query_heads, moe_intermediate, shared-expert intermediate,
 #     and the linear value/qkv projection widths) by every mesh model-axis
 #     size in CAPPED_MESH_SHAPES (2, 4, 8).
-# num_layers is 1 always (layout rules are per-decoder-block regexes, so depth
-# is irrelevant to spec matching/divisibility) and the single layer is a
-# `full_attention` layer so the sweep exercises the corrected QKV-axis
-# divisibility -- the core of this fix -- alongside the always-present MoE
-# expert/router/shared-expert rules. The linear-attention projection rules are
-# exercised by the four-layer `test_distribution` config above, which runs a
-# real forward+backward pass over both layer types. Full-scale real dims are
+# num_layers is fixed at 2 (not 1) because Qwen3.5-MoE is a *hybrid* stack:
+# a single layer would only exercise one of the two token mixers, so the
+# sweep would silently never assert on either the full-attention or the
+# linear-attention rule set -- in particular the fused in_proj_qkv width
+# divisibility guard below would guard a weight that never exists in the
+# built model. Two decoder blocks (one of each type) alongside the
+# always-present MoE expert/router/shared-expert rules keep build memory
+# bounded while exercising both mixers' rule sets in every (width, mesh)
+# combo, not just in the four-layer `test_distribution` config above (which
+# only ever exercises a fixed 2-device mesh). Full-scale real dims are
 # exercised offline / by `test_layout_map_live_presets` (which has its own
 # per-width-class memory-budget skip so it never attempts a full-scale build
 # locally either).
+# One layer of each token mixer, matching sibling qwen3_5's hybrid sweep
+# (see qwen3_5_backbone_test.py's _LINEAR_LAYER_TYPES).
+_LINEAR_LAYER_TYPES = ["linear_attention", "full_attention"]
 QWEN3_5_MOE_35B_A3B_DIMS = {
     "source_preset": "qwen3_5_moe_35b_a3b (real ratios, memory-scaled dims)",
     "vocabulary_size": 2048,
-    "num_layers": 1,
+    "num_layers": 2,
     "num_query_heads": 32,
     "num_key_value_heads": 4,  # real ratio: GQA, 8:1.
     "head_dim": 32,
@@ -54,7 +60,7 @@ QWEN3_5_MOE_35B_A3B_DIMS = {
     "shared_expert_intermediate_size": 64,
     "num_experts": 8,
     "top_k": 2,
-    "layer_types": ["full_attention"],
+    "layer_types": _LINEAR_LAYER_TYPES,
     "partial_rotary_factor": 0.25,
     "linear_num_key_heads": 16,
     "linear_num_value_heads": 32,  # real ratio: 16:32 = 1:2.
@@ -68,7 +74,7 @@ QWEN3_5_MOE_35B_A3B_DIMS = {
 QWEN3_5_MOE_SMALL_DIMS = {
     "source_preset": "qwen3_5_moe_small (real ratios, memory-scaled dims)",
     "vocabulary_size": 2048,
-    "num_layers": 1,
+    "num_layers": 2,
     "num_query_heads": 16,
     "num_key_value_heads": 2,  # real ratio: GQA, 8:1.
     "head_dim": 32,
@@ -77,7 +83,7 @@ QWEN3_5_MOE_SMALL_DIMS = {
     "shared_expert_intermediate_size": 32,
     "num_experts": 8,
     "top_k": 2,
-    "layer_types": ["full_attention"],
+    "layer_types": _LINEAR_LAYER_TYPES,
     "partial_rotary_factor": 0.25,
     "linear_num_key_heads": 16,
     "linear_num_value_heads": 32,  # real ratio: 16:32 = 1:2.
@@ -104,9 +110,9 @@ CAPPED_MESH_SHAPES = [
 ]
 
 # Expected sharding specs shared by the Tier-2 and Tier-3 mesh sweeps. These
-# cover the always-present (embedding + full-attention + MoE) weight classes;
-# the single sweep layer is `full_attention`, so linear-attention specs are
-# intentionally absent here (they are asserted by test_distribution instead).
+# cover both the full-attention and linear-attention (GatedDeltaNet) sublayer
+# weight classes -- the sweep builds one layer of each mixer (see
+# _LINEAR_LAYER_TYPES above) -- plus the always-present MoE weight classes.
 _SWEEP_EXPECTED_SHARDINGS = {
     "token_embedding/embeddings": ("model", "batch"),
     "token_embedding/reverse_embeddings": ("batch", "model"),
@@ -114,6 +120,9 @@ _SWEEP_EXPECTED_SHARDINGS = {
     "self_attention.*key.kernel": ("batch", None, None),
     "self_attention.*value.kernel": ("batch", None, None),
     "self_attention.*attention_output.kernel": ("model", None, "batch"),
+    "linear_attn.*in_proj_qkv.kernel": ("batch", "model"),
+    "linear_attn.*in_proj_z.kernel": ("batch", "model"),
+    "linear_attn.*out_proj.kernel": ("model", "batch"),
     "shared_expert/feedforward_gate_dense.kernel": ("batch", "model"),
     "shared_expert/feedforward_intermediate_dense.kernel": ("batch", "model"),
     "shared_expert/feedforward_output_dense.kernel": ("model", "batch"),
@@ -395,12 +404,15 @@ class Qwen3_5MoeBackboneTest(TestCase):
                 fetch_failures.append((preset, str(e)))
                 continue
             cfg = dict(cfg)
-            cfg["num_layers"] = 1
-            # Force a single full_attention layer: layout rules are
-            # per-decoder-block regexes, so depth/type mix is irrelevant to
-            # spec matching, and one attention layer keeps build memory
-            # bounded while still exercising the QKV-axis + MoE rules.
-            cfg["layer_types"] = ["full_attention"]
+            # Force a tiny hybrid stack: one layer of each token mixer so
+            # both the full-attention and linear-attention rule sets are
+            # asserted -- a single-type stack would silently never assert
+            # one mixer's rule set (see _LINEAR_LAYER_TYPES above) -- while
+            # keeping depth (and thus build memory) minimal. Layout rules
+            # are per-decoder-block regexes, so depth beyond one-of-each is
+            # irrelevant to spec matching.
+            cfg["num_layers"] = 2
+            cfg["layer_types"] = _LINEAR_LAYER_TYPES
             key = tuple(cfg.get(k) for k in dim_keys)
             if key not in width_classes:
                 width_classes[key] = (cfg, [])
@@ -476,18 +488,22 @@ class Qwen3_5MoeBackboneTest(TestCase):
 
                     # Memory-budget guard: memory-constrained local
                     # environments cannot locally build full-scale presets.
-                    # Estimate this width-class's single-decoder-block bf16
-                    # footprint -- embedding table (counted twice: Qwen3.5-MoE
-                    # defaults to untied embeddings, so
-                    # token_embedding/reverse_embeddings is a second real
-                    # vocab*hidden weight, not just the input embedding) +
-                    # GQA-scaled attention QKVO + the shared (always-active)
-                    # expert's 3 matrices + the routed expert bank's two
-                    # fused matrices, times a 3x safety margin for JAX/XLA
-                    # transient copies -- and skip the build if it exceeds a
-                    # tunable local threshold. The fetch/dedup/divisibility
-                    # logic above still exercises every registry preset
-                    # regardless.
+                    # Estimate this width-class's two-decoder-block (one
+                    # full-attention, one linear-attention -- see
+                    # _LINEAR_LAYER_TYPES above) bf16 footprint -- embedding
+                    # table (counted twice: Qwen3.5-MoE defaults to untied
+                    # embeddings, so token_embedding/reverse_embeddings is a
+                    # second real vocab*hidden weight, not just the input
+                    # embedding) + GQA-scaled attention QKVO + the linear-
+                    # attention block's in_proj_qkv/in_proj_z/out_proj
+                    # projections (the parameter bulk of real presets, where
+                    # most layers are linear_attention) + the shared
+                    # (always-active) expert's 3 matrices + the routed
+                    # expert bank's two fused matrices, times a 3x safety
+                    # margin for JAX/XLA transient copies -- and skip the
+                    # build if it exceeds a tunable local threshold. The
+                    # fetch/dedup/divisibility logic above still exercises
+                    # every registry preset regardless.
                     vocab = cfg["vocabulary_size"]
                     hidden = cfg["hidden_dim"]
                     moe_int = cfg["moe_intermediate_dim"]
@@ -495,10 +511,17 @@ class Qwen3_5MoeBackboneTest(TestCase):
                     n_exp = cfg["num_experts"]
                     num_kv_heads = cfg["num_key_value_heads"]
                     kv_ratio = num_kv_heads / num_query_heads
+                    linear_z_width = (
+                        cfg["linear_num_value_heads"]
+                        * cfg["linear_value_head_dim"]
+                    )
                     est_params = (
                         2 * vocab * hidden  # untied embeddings
                         + 2 * hidden * hidden  # attention q/o
                         + 2 * hidden * hidden * kv_ratio  # attention k/v
+                        + hidden * linear_qkv_width  # linear_attn in_proj_qkv
+                        + hidden * linear_z_width  # linear_attn in_proj_z
+                        + linear_z_width * hidden  # linear_attn out_proj
                         + 3 * hidden * shared_int  # shared expert
                         + n_exp * hidden * 2 * moe_int  # routed gate+up
                         + n_exp * moe_int * hidden  # routed down

--- a/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py
@@ -1,10 +1,157 @@
+import gc
+import re
+
+import keras
 import pytest
+from absl.testing import parameterized
 from keras import ops
 
 from keras_hub.src.models.qwen3_5_moe.qwen3_5_moe_backbone import (
     Qwen3_5MoeBackbone,
 )
 from keras_hub.src.tests.test_case import TestCase
+
+# Dims for the Tier-2 CI-safe mesh-shape sweep: representative
+# Qwen3.5-MoE-35B-A3B-class shapes, frozen as literals and scaled down for
+# this shared, RAM-constrained dev box -- do NOT add a live `get_file` call to
+# the Tier-2 test body (that is what Tier 3, `test_layout_map_live_presets`,
+# is for).
+#
+# MEMORY NOTE: this local dev machine cannot load full-scale model dims, so
+# every dimension (vocab, hidden, intermediate, expert widths, head dims) is
+# scaled down ~20-30x from the real `Qwen/Qwen3.5-35B-A3B` config while
+# preserving the two properties this tier actually tests:
+#   * the real query:kv head RATIO (8:1 GQA) and the real
+#     linear key:value head ratio (16:32 = 1:2), which drive the
+#     divisibility/sharding behaviour under test, and
+#   * clean divisibility of every model-axis-sharded dimension (vocab,
+#     hidden, num_query_heads, moe_intermediate, shared-expert intermediate,
+#     and the linear value/qkv projection widths) by every mesh model-axis
+#     size in CAPPED_MESH_SHAPES (2, 4, 8).
+# num_layers is 1 always (layout rules are per-decoder-block regexes, so depth
+# is irrelevant to spec matching/divisibility) and the single layer is a
+# `full_attention` layer so the sweep exercises the corrected QKV-axis
+# divisibility -- the core of this fix -- alongside the always-present MoE
+# expert/router/shared-expert rules. The linear-attention projection rules are
+# exercised by the four-layer `test_distribution` config above, which runs a
+# real forward+backward pass over both layer types. Full-scale real dims are
+# exercised offline / by `test_layout_map_live_presets` (which has its own
+# per-width-class memory-budget skip so it never attempts a full-scale build
+# locally either).
+QWEN3_5_MOE_35B_A3B_DIMS = {
+    "source_preset": "qwen3_5_moe_35b_a3b (real ratios, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 1,
+    "num_query_heads": 32,
+    "num_key_value_heads": 4,  # real ratio: GQA, 8:1.
+    "head_dim": 32,
+    "hidden_dim": 512,
+    "moe_intermediate_dim": 64,
+    "shared_expert_intermediate_size": 64,
+    "num_experts": 8,
+    "top_k": 2,
+    "layer_types": ["full_attention"],
+    "partial_rotary_factor": 0.25,
+    "linear_num_key_heads": 16,
+    "linear_num_value_heads": 32,  # real ratio: 16:32 = 1:2.
+    "linear_key_head_dim": 8,
+    "linear_value_head_dim": 8,
+    "linear_conv_kernel_dim": 4,
+    "router_aux_loss_coefficient": 0.001,
+}
+# A second, smaller width-class with the same real head-count ratios, to
+# exercise a distinct set of divisible dimensions through the same sweep.
+QWEN3_5_MOE_SMALL_DIMS = {
+    "source_preset": "qwen3_5_moe_small (real ratios, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 1,
+    "num_query_heads": 16,
+    "num_key_value_heads": 2,  # real ratio: GQA, 8:1.
+    "head_dim": 32,
+    "hidden_dim": 256,
+    "moe_intermediate_dim": 32,
+    "shared_expert_intermediate_size": 32,
+    "num_experts": 8,
+    "top_k": 2,
+    "layer_types": ["full_attention"],
+    "partial_rotary_factor": 0.25,
+    "linear_num_key_heads": 16,
+    "linear_num_value_heads": 32,  # real ratio: 16:32 = 1:2.
+    "linear_key_head_dim": 8,
+    "linear_value_head_dim": 8,
+    "linear_conv_kernel_dim": 4,
+    "router_aux_loss_coefficient": 0.001,
+}
+
+# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
+# 10-shape matrix from the testing-strategy doc is
+# 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
+# 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY DROPPED
+# here (they need >16 simulated devices and OOM-kill this shared box). Do not
+# add them even experimentally on this machine; they belong on a dedicated or
+# CI runner. Every shape below fits within 16 virtual devices.
+CAPPED_MESH_SHAPES = [
+    (2, 4),
+    (1, 8),
+    (4, 4),
+    (2, 2, 2),
+    (1, 1, 8),
+    (2, 2, 4),
+]
+
+# Expected sharding specs shared by the Tier-2 and Tier-3 mesh sweeps. These
+# cover the always-present (embedding + full-attention + MoE) weight classes;
+# the single sweep layer is `full_attention`, so linear-attention specs are
+# intentionally absent here (they are asserted by test_distribution instead).
+_SWEEP_EXPECTED_SHARDINGS = {
+    "token_embedding/embeddings": ("model", "batch"),
+    "token_embedding/reverse_embeddings": ("batch", "model"),
+    "self_attention.*query.kernel": ("batch", "model", None),
+    "self_attention.*key.kernel": ("batch", None, None),
+    "self_attention.*value.kernel": ("batch", None, None),
+    "self_attention.*attention_output.kernel": ("model", None, "batch"),
+    "shared_expert/feedforward_gate_dense.kernel": ("batch", "model"),
+    "shared_expert/feedforward_intermediate_dense.kernel": ("batch", "model"),
+    "shared_expert/feedforward_output_dense.kernel": ("model", "batch"),
+    "experts/expert_feedforward_gate_dense": (None, "batch", "model"),
+    "experts/expert_feedforward_output_dense": (None, "model", "batch"),
+    "router_gate.kernel": ("batch", None),
+}
+
+# Rank>=2 weights that are intentionally left replicated (see
+# get_layout_map's comments): the tiny linear-attention a/b projections and
+# conv1d kernel, and the (hidden, 1) shared-expert gate.
+_ALLOW_REPLICATED = (
+    "linear_attn.*in_proj_a.kernel",
+    "linear_attn.*in_proj_b.kernel",
+    "linear_attn.*conv1d_kernel",
+    "shared_expert_gate.kernel",
+)
+
+
+def _assert_shardings_and_coverage(test_case, model, layout_map, expected):
+    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
+    for pattern, spec in expected.items():
+        matches = [w for w in model.weights if re.search(pattern, w.path)]
+        test_case.assertGreater(
+            len(matches),
+            0,
+            f"Expected sharding pattern {pattern!r} matched no weights.",
+        )
+        for w in matches:
+            test_case.assertEqual(tuple(w.value.sharding.spec), spec)
+    offending = [
+        w.path
+        for w in model.weights
+        if len(w.shape) >= 2
+        and layout_map[w.path] is None
+        and not any(re.search(p, w.path) for p in _ALLOW_REPLICATED)
+    ]
+    test_case.assertEqual(
+        offending,
+        [],
+        f"The following rank>=2 weights are unmapped: {offending}",
+    )
 
 
 class Qwen3_5MoeBackboneTest(TestCase):
@@ -69,3 +216,314 @@ class Qwen3_5MoeBackboneTest(TestCase):
         )
         for loss in model.losses:
             self.assertGreater(loss, 0.0, "Auxiliary loss should be positive")
+
+    def test_distribution(self):
+        # The default config keeps num_key_value_heads=2 (not divisible by
+        # every host's device count) and includes both a linear_attention and
+        # a full_attention layer, so the shared helper regression-tests that
+        # key/value kernels stay replicated on the model axis while both
+        # attention sublayers' and the MoE weights' layouts are asserted. The
+        # helper pins the mesh to exactly 2 devices; is_moe=True selects the
+        # looser MoE parity tolerance (sharded-reduction float noise is larger
+        # for MoE routing -- see the helper docstring).
+        self.run_distribution_test(
+            cls=Qwen3_5MoeBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_shardings={
+                "token_embedding/embeddings": ("model", "batch"),
+                "token_embedding/reverse_embeddings": ("batch", "model"),
+                "self_attention.*query.kernel": ("batch", "model", None),
+                "self_attention.*key.kernel": ("batch", None, None),
+                "self_attention.*value.kernel": ("batch", None, None),
+                "self_attention.*attention_output.kernel": (
+                    "model",
+                    None,
+                    "batch",
+                ),
+                "linear_attn.*in_proj_qkv.kernel": ("batch", "model"),
+                "linear_attn.*in_proj_z.kernel": ("batch", "model"),
+                "linear_attn.*out_proj.kernel": ("model", "batch"),
+                "shared_expert/feedforward_gate_dense.kernel": (
+                    "batch",
+                    "model",
+                ),
+                "shared_expert/feedforward_intermediate_dense.kernel": (
+                    "batch",
+                    "model",
+                ),
+                "shared_expert/feedforward_output_dense.kernel": (
+                    "model",
+                    "batch",
+                ),
+                "experts/expert_feedforward_gate_dense": (
+                    None,
+                    "batch",
+                    "model",
+                ),
+                "experts/expert_feedforward_output_dense": (
+                    None,
+                    "model",
+                    "batch",
+                ),
+                "router_gate.kernel": ("batch", None),
+            },
+            allow_replicated=_ALLOW_REPLICATED,
+            is_moe=True,
+        )
+
+    @parameterized.named_parameters(
+        (
+            f"{dims['source_preset'].split(' ')[0]}_mesh"
+            f"_{'x'.join(str(s) for s in shape)}",
+            dims,
+            shape,
+        )
+        for dims in (QWEN3_5_MOE_35B_A3B_DIMS, QWEN3_5_MOE_SMALL_DIMS)
+        for shape in CAPPED_MESH_SHAPES
+    )
+    def test_layout_map_mesh_shapes(self, dims, mesh_shape):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        n_needed = 1
+        for s in mesh_shape:
+            n_needed *= s
+        if n_needed > len(devices):
+            self.skipTest(
+                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
+                f"{len(devices)} available. Run with "
+                f"XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{n_needed} to exercise this shape locally."
+            )
+
+        # Query-head-divisibility skip rule: an inherent tensor-parallelism
+        # ceiling, not a bug. model_axis_size is the mesh's last axis,
+        # matching this repo's axis_names=(..., "model") convention.
+        model_axis_size = mesh_shape[-1]
+        num_query_heads = dims["num_query_heads"]
+        if num_query_heads % model_axis_size != 0:
+            self.skipTest(
+                f"num_query_heads={num_query_heads} not divisible by "
+                f"model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
+        devices = devices[:n_needed]
+        if len(mesh_shape) == 2:
+            axis_names = ("batch", "model")
+        else:
+            # 3D shape: the extra axis is "seq"; get_layout_map only names
+            # "batch"/"model", so the "seq" axis simply replicates weights
+            # (no rule targets it), matching every other 3D-mesh test in
+            # this PR series.
+            axis_names = ("batch", "seq", "model")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape,
+            axis_names=axis_names,
+            devices=devices,
+        )
+        layout_map = Qwen3_5MoeBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
+        with distribution.scope():
+            # bfloat16: a memory mitigation for this shared dev machine --
+            # spec assertions are dtype-independent.
+            model = Qwen3_5MoeBackbone(dtype="bfloat16", **init_kwargs)
+            _assert_shardings_and_coverage(
+                self, model, layout_map, _SWEEP_EXPECTED_SHARDINGS
+            )
+        del model
+        gc.collect()
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.multi_device
+    @pytest.mark.extra_large
+    def test_layout_map_live_presets(self):
+        import json
+
+        from keras_hub.src.utils.preset_utils import CONFIG_FILE
+        from keras_hub.src.utils.preset_utils import get_file
+
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+
+        # Fetch every preset's config only (no weights), then dedupe by the
+        # divisibility-relevant dims so width-classes that share a config are
+        # only built once per mesh shape -- a memory/time necessity on this
+        # machine -- while every preset in the registry is still fetched and
+        # evaluated, preserving full registry coverage.
+        dim_keys = (
+            "vocabulary_size",
+            "num_query_heads",
+            "num_key_value_heads",
+            "hidden_dim",
+            "head_dim",
+            "moe_intermediate_dim",
+            "shared_expert_intermediate_size",
+            "num_experts",
+        )
+        width_classes = {}  # dedupe key -> (config dict, [preset names])
+        fetch_failures = []
+        for preset in Qwen3_5MoeBackbone.presets:
+            try:
+                path = get_file(preset, CONFIG_FILE)
+                with open(path) as f:
+                    cfg = json.load(f)["config"]
+            except Exception as e:
+                # A preset this account can't reach (e.g. an unaccepted
+                # Kaggle license consent) is logged, not fatal -- the rest
+                # of the registry still gets exercised.
+                fetch_failures.append((preset, str(e)))
+                continue
+            cfg = dict(cfg)
+            cfg["num_layers"] = 1
+            # Force a single full_attention layer: layout rules are
+            # per-decoder-block regexes, so depth/type mix is irrelevant to
+            # spec matching, and one attention layer keeps build memory
+            # bounded while still exercising the QKV-axis + MoE rules.
+            cfg["layer_types"] = ["full_attention"]
+            key = tuple(cfg.get(k) for k in dim_keys)
+            if key not in width_classes:
+                width_classes[key] = (cfg, [])
+            width_classes[key][1].append(preset)
+
+        if fetch_failures:
+            print(
+                f"test_layout_map_live_presets: {len(fetch_failures)} "
+                f"preset config fetches failed (logged, non-fatal): "
+                f"{fetch_failures}"
+            )
+        if not width_classes:
+            self.skipTest(
+                "No preset configs were reachable "
+                f"({len(fetch_failures)} fetch failures) -- likely no "
+                "presets registered yet or a Kaggle license-consent gate "
+                "on this account. See the module comment above "
+                "CAPPED_MESH_SHAPES."
+            )
+        print(
+            f"test_layout_map_live_presets: {len(width_classes)} unique "
+            f"width-classes across {len(Qwen3_5MoeBackbone.presets)} "
+            "registry presets:"
+        )
+        for cfg, presets in width_classes.values():
+            print(f"  {presets}")
+
+        devices = keras.distribution.list_devices("CPU")
+        skip_reasons = []
+        ran_any = False
+        for cfg, presets in width_classes.values():
+            num_query_heads = cfg["num_query_heads"]
+            for mesh_shape in CAPPED_MESH_SHAPES:
+                combo_label = f"{presets[0]}@{mesh_shape}"
+                with self.subTest(combo=combo_label):
+                    n_needed = 1
+                    for s in mesh_shape:
+                        n_needed *= s
+                    if n_needed > len(devices):
+                        skip_reasons.append(
+                            f"{combo_label}: needs {n_needed} devices, "
+                            f"only {len(devices)} available"
+                        )
+                        continue
+                    model_axis_size = mesh_shape[-1]
+                    if num_query_heads % model_axis_size != 0:
+                        skip_reasons.append(
+                            f"{combo_label}: num_query_heads="
+                            f"{num_query_heads} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        continue
+
+                    # Memory-budget guard: this shared dev machine cannot
+                    # locally build full-scale presets. Estimate this
+                    # width-class's single-decoder-block bf16 footprint
+                    # (embedding table + one expert bank's two fused
+                    # matrices, times a 3x safety margin for JAX/XLA
+                    # transient copies) and skip the build if it exceeds a
+                    # conservative local threshold. The fetch/dedup/
+                    # divisibility logic above still exercises every
+                    # registry preset regardless.
+                    vocab = cfg["vocabulary_size"]
+                    hidden = cfg["hidden_dim"]
+                    moe_int = cfg["moe_intermediate_dim"]
+                    n_exp = cfg["num_experts"]
+                    est_params = (
+                        vocab * hidden
+                        + n_exp * hidden * 2 * moe_int
+                        + n_exp * moe_int * hidden
+                    )
+                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
+                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    if est_bytes > max_local_bytes:
+                        skip_reasons.append(
+                            f"{combo_label}: estimated build memory "
+                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
+                            f"{max_local_bytes / 1e6:.0f}MB local safety "
+                            "threshold on this shared, RAM-constrained "
+                            "dev machine -- verify this width-class on a "
+                            "machine with more RAM or in CI"
+                        )
+                        continue
+
+                    combo_devices = devices[:n_needed]
+                    if len(mesh_shape) == 2:
+                        axis_names = ("batch", "model")
+                    else:
+                        axis_names = ("batch", "seq", "model")
+                    device_mesh = keras.distribution.DeviceMesh(
+                        shape=mesh_shape,
+                        axis_names=axis_names,
+                        devices=combo_devices,
+                    )
+                    layout_map = Qwen3_5MoeBackbone.get_layout_map(device_mesh)
+                    distribution = keras.distribution.ModelParallel(
+                        layout_map=layout_map, batch_dim_name="batch"
+                    )
+                    # Build text-only from the constructor-relevant config
+                    # keys (drop serialized sub-objects like vision_encoder
+                    # and any get_config-only fields such as name/dtype).
+                    build_keys = (
+                        "vocabulary_size",
+                        "num_layers",
+                        "num_query_heads",
+                        "num_key_value_heads",
+                        "head_dim",
+                        "hidden_dim",
+                        "moe_intermediate_dim",
+                        "shared_expert_intermediate_size",
+                        "num_experts",
+                        "top_k",
+                        "layer_types",
+                        "partial_rotary_factor",
+                        "linear_num_key_heads",
+                        "linear_num_value_heads",
+                        "linear_key_head_dim",
+                        "linear_value_head_dim",
+                        "linear_conv_kernel_dim",
+                    )
+                    build_kwargs = {k: cfg[k] for k in build_keys if k in cfg}
+                    with distribution.scope():
+                        model = Qwen3_5MoeBackbone(
+                            dtype="bfloat16", **build_kwargs
+                        )
+                        _assert_shardings_and_coverage(
+                            self, model, layout_map, _SWEEP_EXPECTED_SHARDINGS
+                        )
+                    del model
+                    gc.collect()
+                    ran_any = True
+
+        print(
+            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
+            "skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
+        )
+        if not ran_any:
+            self.skipTest(
+                "All (width-class, mesh-shape) combos were skipped: "
+                f"{skip_reasons}"
+            )


### PR DESCRIPTION
Closes #2838

Part of https://github.com/keras-team/keras-hub/issues/2807. Depends on #2809 (`TestCase.run_distribution_test`) for CI to pass -- this PR's own diff is independent (based on master, not stacked), so it stays small and reviewable regardless of merge order.

## Summary

Adds `Qwen3_5MoeBackbone.get_layout_map` so `Qwen3_5MoeBackbone` (a hybrid full-attention/linear-attention MoE model) can be sharded across a device mesh with `keras.distribution.ModelParallel`, following the same Megatron-style column/row-parallel convention used elsewhere in this series (e.g. Gemma, Qwen3):

- **QKV / reverse-embedding sharding axes.** `query`/`key`/`value` kernels here are `(hidden_dim, num_heads, head_dim)` (contracting `hidden_dim` first), not Gemma's `(num_heads, hidden_dim, head_dim)`. `hidden_dim` shards on the data axis and heads shard on the model axis -- the correct orientation for Megatron-style tensor parallelism given this weight layout. `token_embedding/reverse_embeddings` (the `(hidden, vocab)` output projection) gets its own transposed spec rather than reusing the input embedding's tuple.
- **Linear-attention (GatedDeltaNet) projections.** `in_proj_qkv` and `in_proj_z` (column-parallel) and `out_proj` (row-parallel) have explicit layout rules. The tiny `in_proj_a`/`in_proj_b` (project to `num_v_heads`, a small axis), the depthwise `conv1d_kernel`, and the 1-D `dt_bias`/`A_log` are intentionally left replicated (documented in the code and covered by the test's `allow_replicated` list).
- **Shared-expert gate** (`(hidden_dim, 1)`) is intentionally left replicated -- its output dim is 1, so there's nothing to shard on the model axis.
- Key/value kernels stay replicated on the model axis (GQA `num_key_value_heads` is independent of and typically much smaller than `num_query_heads`; sharding it would raise an `IndivisibleError` whenever the model-mesh dimension doesn't divide it evenly), while `hidden_dim` still shards on the data axis.
- MoE expert bank (`expert_feedforward_gate_dense`/`expert_feedforward_output_dense`), router, and shared-expert dense layers use column/row-parallel sharding.

## Limitations

- The vision encoder and `interleave_embeddings` weights (used when a `vision_encoder` is attached for multimodal inputs) are not covered by any layout rule and stay fully replicated. `get_layout_map` only shards the text-decoder stack (attention/linear-attention/MoE/embeddings); sharding the vision tower is out of scope for this PR.
- The model-parallel mesh axis can't usefully exceed a preset's `num_query_heads` -- that's the axis actually being tensor-parallelized here -- see [the design doc's "hard limit" section](https://github.com/keras-team/keras-hub/issues/2807#issuecomment-5006606419) for the full reasoning. For this model's real presets:

  | preset | num_query_heads | safe model-axis up to | first failing model-axis |
  |---|---|---|---|
  | `qwen3_5_moe_35b_a3b` | 16 | 16 | 32 |
  | `qwen3_5_moe_35b_a3b_base` | 16 | 16 | 32 |

  Both presets use `num_key_value_heads=2`, so any mesh past model-axis=16 fails on the query/attention-output kernels specifically, not on `hidden_dim` or the MoE expert bank -- those stay divisible well past this range for both presets.

## Tests

`qwen3_5_moe_backbone_test.py` adds test tiers mirroring the pattern already reviewed for Gemma (`gemma_backbone_test.py`):

- **Tier 1** (`test_distribution`): exact end-to-end sharding-spec + full-weight-coverage + forward/backward/optimizer-step + numerical-parity/convergence check via `TestCase.run_distribution_test` from #2809, on a real 2-device mesh (pinned to exactly 2, not `len(devices)`, so the default config's `num_key_value_heads=2` is exercised deterministically). Uses `is_moe=True` for the looser MoE parity tolerance and asserts both the full-attention and linear-attention (GatedDeltaNet) sublayer specs, since the default 4-layer test config includes both layer types.
- **Tier 2** (`test_layout_map_mesh_shapes`): CI-safe sweep over `CAPPED_MESH_SHAPES` (`(2,4)`, `(1,8)`, `(4,4)`, `(2,2,2)`, `(1,1,8)`, `(2,2,4)` -- capped at 16 total simulated devices) crossed with two synthetic width classes (`QWEN3_5_MOE_35B_A3B_DIMS`, `QWEN3_5_MOE_SMALL_DIMS`) that preserve the real preset's query:kv head ratio (8:1 GQA) and linear key:value head ratio (1:2), scaled down ~20-30x from the real `Qwen3.5-35B-A3B`-class config. Each sweep case builds a two-layer hybrid stack -- one `linear_attention` layer and one `full_attention` layer -- so both token-mixer rule sets are asserted in every (width, mesh) combo, not just at the fixed 2-device mesh in Tier 1 (layout rules are per-decoder-block regexes, so depth beyond one-of-each doesn't affect spec matching), and asserts full-weight-coverage via a shared helper. Skips (not fails) any `(width, mesh)` combo where `num_query_heads` or the linear-attention fused `in_proj_qkv` width doesn't divide the mesh's model axis -- an inherent tensor-parallelism limit, not a bug.
- **Tier 3** (`test_layout_map_live_presets`, opt-in via `kaggle_key_required` + `multi_device` + `extra_large` markers): fetches every real preset's `config.json` (metadata only, no weights), dedupes by divisibility-relevant dims, forces the same two-layer hybrid stack as Tier 2 onto each width class, and for each unique width class estimates its bf16 two-decoder-block + expert-bank build footprint before attempting a build, skipping (via `self.subTest` + a logged reason) any combo that would exceed a 300MB local safety threshold.

### Verification

Real local test results (this branch's own base, `master`, doesn't yet include #2809's `run_distribution_test` helper, so these were run against a temporary checkout with #2809's helper commit applied on top of this PR's diff -- the diff itself is unchanged and unstacked):

```
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0
plugins: anyio-4.14.2, cov-7.1.0, xdist-3.8.0, jaxtyping-0.3.11
created: 2/2 workers
2 workers [20 items]

keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_backbone_basics PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_auxiliary_loss PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_distribution PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_35b_a3b_mesh_1x1x8 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_35b_a3b_mesh_1x8 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_35b_a3b_mesh_2x2x2 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_35b_a3b_mesh_2x2x4 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_35b_a3b_mesh_2x4 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_35b_a3b_mesh_4x4 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_small_mesh_1x1x8 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_small_mesh_1x8 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_small_mesh_2x2x2 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_small_mesh_2x2x4 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_small_mesh_2x4 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_mesh_shapes_qwen3_5_moe_small_mesh_4x4 PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_num_parameters PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_session PASSED
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_saved_model SKIPPED (needs --run_large)
keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py::Qwen3_5MoeBackboneTest::test_layout_map_live_presets SKIPPED (needs --run_extra_large / kaggle key)

================== 17 passed, 3 skipped in 333.92s (0:05:33) ===================
```

Run with `KERAS_BACKEND=jax XLA_FLAGS=--xla_force_host_platform_device_count=16 python -m pytest keras_hub/src/models/qwen3_5_moe/qwen3_5_moe_backbone_test.py -v -n 2`, capped at 16 simulated CPU devices per the mesh-shape matrix. Both skips are the expected default-config skips (`test_saved_model` needs `--run_large`; `test_layout_map_live_presets` needs `--run_extra_large` + Kaggle credentials and is intentionally not exercised in this pass by design -- see the module comment above `CAPPED_MESH_SHAPES`).

`ruff check` / `ruff format --check`: clean on both changed files.

