### PR TITLE
Add/fix ModelParallel layout map for qwen3_5

### DIFF
--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
@@ -360,6 +360,126 @@ class Qwen3_5Backbone(Backbone):
         )
         return config
 
+    @staticmethod
+    def get_layout_map(
+        device_mesh,
+        model_parallel_dim_name="model",
+        data_parallel_dim_name="batch",
+    ):
+        """Get a `keras.distribution.LayoutMap` for model parallel distribution.
+
+        The returned `LayoutMap` contains the sharding spec for the
+        Qwen3_5 backbone's text-decoder full-attention layers,
+        linear-attention (GatedDeltaNet) layers, feedforward layers, and
+        embeddings. The vision encoder/interleave weights are left
+        replicated for now -- see Limitations in the PR description.
+
+        Args:
+            device_mesh: keras.distribution.DeviceMesh. The device mesh
+                instance for distribution.
+            model_parallel_dim_name: str. The axis name of the device mesh,
+                where the weights should be partitioned on.
+            data_parallel_dim_name: str. The axis name of the device mesh,
+                where the data should be partitioned on.
+
+        Returns:
+            `keras.distribution.LayoutMap` that contains the sharding spec
+            for all the model weights.
+        """
+        if not isinstance(device_mesh, keras.distribution.DeviceMesh):
+            raise ValueError(
+                "Invalid device_mesh type. Expected "
+                f"`keras.distribution.DeviceMesh`, got {type(device_mesh)}"
+            )
+        if model_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{model_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+        if data_parallel_dim_name not in device_mesh.axis_names:
+            raise ValueError(
+                f"{data_parallel_dim_name} is not found in the "
+                f"device_mesh.axis_names. {device_mesh.axis_names=}"
+            )
+
+        data_dim = data_parallel_dim_name
+        model_dim = model_parallel_dim_name
+        layout_map = keras.distribution.LayoutMap(device_mesh)
+        layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
+        # reverse_embeddings is the (hidden, vocab) output-projection tensor
+        # (untied when tie_word_embeddings=False, the default). Its vocab
+        # axis is vocab-parallel on model_dim, mirroring the vocab-on-model
+        # sharding of token_embedding/embeddings above.
+        layout_map["token_embedding/reverse_embeddings"] = (
+            data_dim,
+            model_dim,
+        )
+        # Full-attention QKV kernels are (hidden, num_heads, head_dim): the
+        # heads axis is the tensor-parallel (Megatron column-parallel) axis
+        # and goes on model_dim, while the contracting hidden axis goes on
+        # data_dim for memory sharding. Key/value use num_key_value_heads
+        # (GQA), which is small and independent of num_query_heads, so their
+        # heads axis is left replicated -- sharding that small axis on
+        # model_dim would raise an IndivisibleError whenever the mesh
+        # dimension does not evenly divide it. These rules only match
+        # full_attention layers; the linear_attn (GatedDeltaNet) sublayer is
+        # handled by its own rules below.
+        layout_map["transformer_layer.*self_attention.*query.kernel"] = (
+            data_dim,
+            model_dim,
+            None,
+        )
+        layout_map["transformer_layer.*self_attention.*(key|value).kernel"] = (
+            data_dim,
+            None,
+            None,
+        )
+        layout_map[
+            "transformer_layer.*self_attention.*attention_output.kernel"
+        ] = (
+            model_dim,
+            None,
+            data_dim,
+        )
+        layout_map[
+            "transformer_layer.*feedforward_intermediate_dense.kernel"
+        ] = (data_dim, model_dim)
+        layout_map["transformer_layer.*feedforward_gate_dense.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*feedforward_output_dense.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        # Linear-attention (GatedDeltaNet) layers -- the parameter bulk of
+        # real presets, where most layers are linear_attention. All these
+        # kernels are 2-D (in, out) Dense weights. in_proj_qkv and in_proj_z
+        # are column-parallel (fused projection output on model_dim, hidden
+        # contracting axis on data_dim); out_proj is row-parallel (mirrors
+        # the feedforward_output_dense convention above).
+        layout_map["transformer_layer.*linear_attn.*in_proj_qkv.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*linear_attn.*in_proj_z.kernel"] = (
+            data_dim,
+            model_dim,
+        )
+        layout_map["transformer_layer.*linear_attn.*out_proj.kernel"] = (
+            model_dim,
+            data_dim,
+        )
+        # Deliberately left replicated (covered by the test's allow_replicated
+        # list): in_proj_a / in_proj_b project to num_value_heads, a small
+        # axis that need not be sharded and would risk indivisibility on
+        # model_dim; conv1d_kernel is a tiny depthwise (conv_dim, kernel_size)
+        # weight -- the depthwise conv runs per-channel over the
+        # model_dim-sharded in_proj_qkv output, so a replicated kernel stays
+        # local to each shard. dt_bias, A_log, and the RMSNorm scales are
+        # rank-1 and always replicated.
+        return layout_map
+
     @classmethod
     def from_config(cls, config):
         config.update(

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone.py
@@ -371,8 +371,8 @@ class Qwen3_5Backbone(Backbone):
         The returned `LayoutMap` contains the sharding spec for the
         Qwen3_5 backbone's text-decoder full-attention layers,
         linear-attention (GatedDeltaNet) layers, feedforward layers, and
-        embeddings. The vision encoder/interleave weights are left
-        replicated for now -- see Limitations in the PR description.
+        embeddings. The optional vision encoder's weights are intentionally
+        left replicated for now; only the text decoder is sharded.
 
         Args:
             device_mesh: keras.distribution.DeviceMesh. The device mesh

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import os
 import re
 
 import keras
@@ -21,26 +22,26 @@ from keras_hub.src.utils.preset_utils import get_file
 # `get_file` call to the Tier-2 test body itself (that's what Tier 3,
 # `test_layout_map_live_presets` below, is for).
 #
-# MEMORY NOTE: this local dev machine cannot load full-scale Qwen3.5 dims.
-# The real presets have vocabulary_size=248320 and hidden_dim up to 5120 with
-# 24-64 layers -- building even one such preset OOM-kills this shared 37GB
-# box. What actually matters for the divisibility/sharding properties this
-# tier tests is (a) whether num_query_heads divides the mesh's model-axis
-# size and (b) whether vocab/hidden/intermediate and the linear-attention
-# fused projection dims divide it -- not the absolute parameter count. So
-# these dims are scaled down ~20-120x from the real presets while preserving
-# each preset's real query:kv head ratio and its linear value:key head ratio
-# exactly, and keeping every model-axis-sharded dimension divisible by every
-# model-axis size in CAPPED_MESH_SHAPES (2, 4, 8). Real head_dim (256) and
-# real linear head dims (128) are also scaled to 32/16 to bound the fused
-# in_proj_qkv width. num_layers is fixed at 2 (not 1) because Qwen3.5 is a
-# *hybrid* stack: a single layer would only exercise one of the two token
-# mixers, so the sweep would silently never assert on either the
-# full-attention or the linear-attention rule set. Two scaled decoder blocks
-# (one of each type) are still ~1GB total RSS at the widest class -- verified.
-# Full-scale real dims are exercised by `test_layout_map_live_presets` below,
-# which has its own per-width-class memory-budget skip so it never attempts a
-# full-scale build locally either.
+# MEMORY NOTE: memory-constrained local environments cannot load full-scale
+# Qwen3.5 dims. The real presets have vocabulary_size=248320 and hidden_dim
+# up to 5120 with 24-64 layers -- building even one such preset can OOM a
+# constrained machine. What actually matters for the divisibility/sharding
+# properties this tier tests is (a) whether num_query_heads divides the
+# mesh's model-axis size and (b) whether vocab/hidden/intermediate and the
+# linear-attention fused projection dims divide it -- not the absolute
+# parameter count. So these dims are scaled down ~20-120x from the real
+# presets while preserving each preset's real query:kv head ratio and its
+# linear value:key head ratio exactly, and keeping every model-axis-sharded
+# dimension divisible by every model-axis size in CAPPED_MESH_SHAPES (2, 4,
+# 8). Real head_dim (256) and real linear head dims (128) are also scaled to
+# 32/16 to bound the fused in_proj_qkv width. num_layers is fixed at 2 (not
+# 1) because Qwen3.5 is a *hybrid* stack: a single layer would only exercise
+# one of the two token mixers, so the sweep would silently never assert on
+# either the full-attention or the linear-attention rule set. Two scaled
+# decoder blocks (one of each type) are still ~1GB total RSS at the widest
+# class -- verified. Full-scale real dims are exercised by
+# `test_layout_map_live_presets` below, which has its own per-width-class
+# memory-budget skip so it never attempts a full-scale build locally either.
 #
 # Provenance (fetched once via get_file(<preset>, CONFIG_FILE), 2026-07-17):
 #   qwen3_5_0.8b_base: vocab 248320, hidden 1024, intermediate 3584,
@@ -102,14 +103,13 @@ QWEN3_5_27B_DIMS = {
     "linear_conv_kernel_dim": 4,
 }
 
-# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
-# 10-shape matrix from the testing-strategy doc is
+# Hard-capped mesh-shape list for memory-constrained local environments. The
+# full 10-shape matrix from the testing-strategy doc is
 # 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
 # 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
-# DROPPED here due to a demonstrated systemd-oomd OOM kill of the entire
-# desktop app on this shared machine during an earlier attempt at this same
-# pipeline. Do not attempt the dropped shapes even experimentally on this
-# box -- revisiting them requires a dedicated or CI machine, not this one.
+# DROPPED here due to a demonstrated OOM kill during an earlier attempt at
+# this same pipeline on a memory-constrained machine. These shapes require a
+# dedicated or CI machine with more memory to exercise, even experimentally.
 CAPPED_MESH_SHAPES = [
     (2, 4),
     (1, 8),
@@ -292,6 +292,22 @@ class Qwen3_5BackboneTest(TestCase):
                 "tensor-parallelism limit, not a bug"
             )
 
+        # Linear-attention fused in_proj_qkv width must also divide the
+        # model axis: get_layout_map shards in_proj_qkv's fused output
+        # (2*key_dim + value_dim) on model_dim, so an indivisible width
+        # would otherwise fail inside `ModelParallel` construction below
+        # with an opaque error instead of a clean, documented skip.
+        linear_qkv_width = (
+            2 * dims["linear_num_key_heads"] * dims["linear_key_head_dim"]
+            + dims["linear_num_value_heads"] * dims["linear_value_head_dim"]
+        )
+        if linear_qkv_width % model_axis_size != 0:
+            self.skipTest(
+                f"linear_attn in_proj_qkv fused width={linear_qkv_width} "
+                f"not divisible by model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
         devices = devices[:n_needed]
         if len(mesh_shape) == 2:
             axis_names = ("batch", "model")
@@ -312,8 +328,8 @@ class Qwen3_5BackboneTest(TestCase):
         )
         init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
         with distribution.scope():
-            # bfloat16: a memory mitigation for this shared dev machine --
-            # spec assertions are dtype-independent.
+            # bfloat16: a memory mitigation for memory-constrained local
+            # environments -- spec assertions are dtype-independent.
             model = Qwen3_5Backbone(dtype="bfloat16", **init_kwargs)
             _assert_qwen3_5_shardings_and_coverage(self, model, layout_map)
         del model
@@ -329,9 +345,10 @@ class Qwen3_5BackboneTest(TestCase):
         # Fetch every preset's config only (no weights), then dedupe by the
         # divisibility-relevant dims so width-classes that share a config
         # (e.g. base vs instruction-tuned variants of the same size) are
-        # only built once per mesh shape -- a memory/time necessity on this
-        # machine -- while every preset in the registry is still fetched and
-        # evaluated, preserving full registry coverage.
+        # only built once per mesh shape -- a memory/time necessity in
+        # memory-constrained local environments -- while every preset in
+        # the registry is still fetched and evaluated, preserving full
+        # registry coverage.
         dim_keys = (
             "vocabulary_size",
             "num_query_heads",
@@ -414,32 +431,77 @@ class Qwen3_5BackboneTest(TestCase):
                         skip_reasons.append(reason)
                         continue
 
-                    # Memory-budget guard: this shared dev machine cannot
-                    # locally build full-scale presets. Estimate this
-                    # width-class's embedding table + one FFN block's 3
-                    # matrices (times a 3x safety margin for JAX/XLA
-                    # transient copies during construction/resharding) and
-                    # skip the actual build if it exceeds a conservative
-                    # local threshold. The config-fetch, dedup, and
-                    # divisibility-skip logic above still exercises every
-                    # registry preset either way; only the expensive
-                    # build+assert step is capped. (Real Qwen3.5 presets --
-                    # vocab 248320, hidden up to 5120 -- all exceed this and
-                    # are therefore verified offline / in CI, not here.)
+                    # Linear-attention fused in_proj_qkv width must also
+                    # divide the model axis -- see the matching guard and
+                    # comment in test_layout_map_mesh_shapes above.
+                    linear_qkv_width = (
+                        2
+                        * cfg["linear_num_key_heads"]
+                        * cfg["linear_key_head_dim"]
+                        + cfg["linear_num_value_heads"]
+                        * cfg["linear_value_head_dim"]
+                    )
+                    if linear_qkv_width % model_axis_size != 0:
+                        reason = (
+                            f"{combo_label}: linear_attn in_proj_qkv fused "
+                            f"width={linear_qkv_width} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    # Memory-budget guard: memory-constrained local
+                    # environments cannot locally build full-scale presets.
+                    # Estimate this width-class's embedding table (counted
+                    # twice: Qwen3.5 defaults to untied embeddings, so
+                    # token_embedding/reverse_embeddings is a second real
+                    # vocab*hidden weight, not just the input embedding) +
+                    # one FFN block's 3 matrices + one linear-attention
+                    # block's projections (in_proj_qkv, in_proj_z, out_proj
+                    # -- the parameter bulk of real presets, where most
+                    # layers are linear_attention) (times a 3x safety margin
+                    # for JAX/XLA transient copies during
+                    # construction/resharding) and skip the actual build if
+                    # it exceeds a tunable local threshold. The config-fetch,
+                    # dedup, and divisibility-skip logic above still
+                    # exercises every registry preset either way; only the
+                    # expensive build+assert step is capped. (Real Qwen3.5
+                    # presets -- vocab 248320, hidden up to 5120 -- all
+                    # exceed the default threshold and are therefore
+                    # verified on a bigger machine / in CI via the
+                    # KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET env var, not
+                    # here by default.)
+                    key_dim = (
+                        cfg["linear_num_key_heads"] * cfg["linear_key_head_dim"]
+                    )
+                    value_dim = (
+                        cfg["linear_num_value_heads"]
+                        * cfg["linear_value_head_dim"]
+                    )
                     est_params = (
-                        cfg["vocabulary_size"] * cfg["hidden_dim"]
+                        2 * cfg["vocabulary_size"] * cfg["hidden_dim"]
                         + 3 * cfg["hidden_dim"] * cfg["intermediate_dim"]
+                        + cfg["hidden_dim"] * (2 * key_dim + value_dim)
+                        + 2 * cfg["hidden_dim"] * value_dim
                     )
                     est_bytes = est_params * 2 * 3  # bf16 * safety margin
-                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    max_local_bytes = int(
+                        os.environ.get(
+                            "KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET",
+                            300 * 1024 * 1024,
+                        )
+                    )
                     if est_bytes > max_local_bytes:
                         reason = (
                             f"{combo_label}: estimated build memory "
                             f"~{est_bytes / 1e9:.2f}GB exceeds the "
                             f"{max_local_bytes / 1e6:.0f}MB local safety "
-                            "threshold on this shared, RAM-constrained "
-                            "dev machine -- verify this width-class on a "
-                            "machine with more RAM or in CI"
+                            "threshold on memory-constrained local "
+                            "environments -- verify this width-class on a "
+                            "machine with more RAM or in CI (override via "
+                            "the KERAS_HUB_DISTRIBUTION_TEST_MEM_BUDGET "
+                            "env var)"
                         )
                         skip_reasons.append(reason)
                         continue
@@ -458,9 +520,12 @@ class Qwen3_5BackboneTest(TestCase):
                     distribution = keras.distribution.ModelParallel(
                         layout_map=layout_map, batch_dim_name="batch"
                     )
-                    init_kwargs = {
-                        k: v for k, v in cfg.items() if k in dim_keys
-                    }
+                    # `cfg` is a full serialized `get_config()` dict, which
+                    # may include a `"dtype"` key (a serialized dtype-policy
+                    # dict, only present for quantized presets) -- drop it
+                    # so the explicit `dtype="bfloat16"` override below
+                    # doesn't collide with a duplicate keyword argument.
+                    init_kwargs = {k: v for k, v in cfg.items() if k != "dtype"}
                     # Force a tiny hybrid stack: one layer of each token
                     # mixer so both the full-attention and linear-attention
                     # rule sets are asserted, while keeping depth (and thus

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
@@ -1,5 +1,11 @@
+import gc
+import json
+import re
+
+import keras
 import numpy as np
 import pytest
+from absl.testing import parameterized
 from keras import ops
 
 from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
@@ -7,6 +13,164 @@ from keras_hub.src.models.qwen3_5.qwen3_5_vision_encoder import (
     Qwen3_5VisionEncoder,
 )
 from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.preset_utils import CONFIG_FILE
+from keras_hub.src.utils.preset_utils import get_file
+
+# Dims for the Tier-2 CI-safe mesh-shape sweep: representative real-preset
+# dimensions, frozen as literals and sourced once, offline -- do not add a
+# `get_file` call to the Tier-2 test body itself (that's what Tier 3,
+# `test_layout_map_live_presets` below, is for).
+#
+# MEMORY NOTE: this local dev machine cannot load full-scale Qwen3.5 dims.
+# The real presets have vocabulary_size=248320 and hidden_dim up to 5120 with
+# 24-64 layers -- building even one such preset OOM-kills this shared 37GB
+# box. What actually matters for the divisibility/sharding properties this
+# tier tests is (a) whether num_query_heads divides the mesh's model-axis
+# size and (b) whether vocab/hidden/intermediate and the linear-attention
+# fused projection dims divide it -- not the absolute parameter count. So
+# these dims are scaled down ~20-120x from the real presets while preserving
+# each preset's real query:kv head ratio and its linear value:key head ratio
+# exactly, and keeping every model-axis-sharded dimension divisible by every
+# model-axis size in CAPPED_MESH_SHAPES (2, 4, 8). Real head_dim (256) and
+# real linear head dims (128) are also scaled to 32/16 to bound the fused
+# in_proj_qkv width. num_layers is fixed at 2 (not 1) because Qwen3.5 is a
+# *hybrid* stack: a single layer would only exercise one of the two token
+# mixers, so the sweep would silently never assert on either the
+# full-attention or the linear-attention rule set. Two scaled decoder blocks
+# (one of each type) are still ~1GB total RSS at the widest class -- verified.
+# Full-scale real dims are exercised by `test_layout_map_live_presets` below,
+# which has its own per-width-class memory-budget skip so it never attempts a
+# full-scale build locally either.
+#
+# Provenance (fetched once via get_file(<preset>, CONFIG_FILE), 2026-07-17):
+#   qwen3_5_0.8b_base: vocab 248320, hidden 1024, intermediate 3584,
+#     num_query_heads 8, num_key_value_heads 2 (q:kv = 4:1), head_dim 256,
+#     linear_num_key_heads 16, linear_num_value_heads 16 (v:k = 1:1).
+#   qwen3_5_9b_base: vocab 248320, hidden 4096, intermediate 12288,
+#     num_query_heads 16, num_key_value_heads 4 (q:kv = 4:1), head_dim 256,
+#     linear_num_key_heads 16, linear_num_value_heads 32 (v:k = 2:1).
+#   qwen3_5_27b: vocab 248320, hidden 5120, intermediate 17408,
+#     num_query_heads 24, num_key_value_heads 4 (q:kv = 6:1), head_dim 256,
+#     linear_num_key_heads 16, linear_num_value_heads 48 (v:k = 3:1).
+_LINEAR_LAYER_TYPES = ["linear_attention", "full_attention"]
+QWEN3_5_0_8B_DIMS = {
+    "source_preset": "qwen3_5_0.8b_base (real ratios, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 2,
+    "layer_types": _LINEAR_LAYER_TYPES,
+    "num_query_heads": 8,
+    "num_key_value_heads": 2,  # real ratio: GQA, 4:1.
+    "hidden_dim": 256,
+    "intermediate_dim": 896,
+    "head_dim": 32,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 4,  # real ratio: 1:1.
+    "linear_key_head_dim": 16,
+    "linear_value_head_dim": 16,
+    "linear_conv_kernel_dim": 4,
+}
+QWEN3_5_9B_DIMS = {
+    "source_preset": "qwen3_5_9b_base (real ratios, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 2,
+    "layer_types": _LINEAR_LAYER_TYPES,
+    "num_query_heads": 16,
+    "num_key_value_heads": 4,  # real ratio: GQA, 4:1.
+    "hidden_dim": 512,
+    "intermediate_dim": 1536,
+    "head_dim": 32,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 8,  # real ratio: 2:1.
+    "linear_key_head_dim": 16,
+    "linear_value_head_dim": 16,
+    "linear_conv_kernel_dim": 4,
+}
+QWEN3_5_27B_DIMS = {
+    "source_preset": "qwen3_5_27b (real ratios, memory-scaled dims)",
+    "vocabulary_size": 2048,
+    "num_layers": 2,
+    "layer_types": _LINEAR_LAYER_TYPES,
+    "num_query_heads": 24,
+    "num_key_value_heads": 4,  # real ratio: GQA, 6:1.
+    "hidden_dim": 640,
+    "intermediate_dim": 2176,
+    "head_dim": 32,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 12,  # real ratio: 3:1.
+    "linear_key_head_dim": 16,
+    "linear_value_head_dim": 16,
+    "linear_conv_kernel_dim": 4,
+}
+
+# Hard-capped mesh-shape list for this shared 37GB dev machine. The full
+# 10-shape matrix from the testing-strategy doc is
+# 2x4, 1x8, 4x4, 8x8, 16x16, 2x2x2, 1x1x8, 2x2x4, 4x4x4, 4x4x8 -- shapes
+# 8x8, 16x16, 4x4x4, 4x4x8 (64-256 virtual devices) are DELIBERATELY
+# DROPPED here due to a demonstrated systemd-oomd OOM kill of the entire
+# desktop app on this shared machine during an earlier attempt at this same
+# pipeline. Do not attempt the dropped shapes even experimentally on this
+# box -- revisiting them requires a dedicated or CI machine, not this one.
+CAPPED_MESH_SHAPES = [
+    (2, 4),
+    (1, 8),
+    (4, 4),
+    (2, 2, 2),
+    (1, 1, 8),
+    (2, 2, 4),
+]
+
+# Same expected_shardings patterns as Qwen3_5BackboneTest.test_distribution
+# (post-QKV-axis-fix + linear_attn rules), reused by the Tier-2 and Tier-3
+# mesh sweeps below.
+_EXPECTED_SHARDINGS = {
+    "token_embedding/embeddings": ("model", "batch"),
+    "token_embedding/reverse_embeddings": ("batch", "model"),
+    "self_attention.*query.kernel": ("batch", "model", None),
+    "self_attention.*key.kernel": ("batch", None, None),
+    "self_attention.*value.kernel": ("batch", None, None),
+    "self_attention.*attention_output.kernel": ("model", None, "batch"),
+    "linear_attn.*in_proj_qkv.kernel": ("batch", "model"),
+    "linear_attn.*in_proj_z.kernel": ("batch", "model"),
+    "linear_attn.*out_proj.kernel": ("model", "batch"),
+    "feedforward_gate_dense.kernel": ("batch", "model"),
+    "feedforward_intermediate_dense.kernel": ("batch", "model"),
+    "feedforward_output_dense.kernel": ("model", "batch"),
+}
+
+# Rank>=2 weights intentionally left replicated (see get_layout_map's
+# comment): the linear-attention conv1d kernel (tiny depthwise weight, stays
+# local to each channel shard) and the in_proj_a / in_proj_b projections to
+# the small num_value_heads axis.
+_ALLOW_REPLICATED = (
+    "linear_attn.*conv1d_kernel",
+    "linear_attn.*in_proj_a.kernel",
+    "linear_attn.*in_proj_b.kernel",
+)
+
+
+def _assert_qwen3_5_shardings_and_coverage(test_case, model, layout_map):
+    """Shared spec + coverage assertions for the Tier-2/3 mesh sweeps."""
+    for pattern, expected in _EXPECTED_SHARDINGS.items():
+        matches = [w for w in model.weights if re.search(pattern, w.path)]
+        test_case.assertGreater(
+            len(matches),
+            0,
+            f"Expected sharding pattern {pattern!r} matched no weights.",
+        )
+        for w in matches:
+            test_case.assertEqual(tuple(w.value.sharding.spec), expected)
+    offending = [
+        w.path
+        for w in model.weights
+        if len(w.shape) >= 2
+        and layout_map[w.path] is None
+        and not any(re.search(p, w.path) for p in _ALLOW_REPLICATED)
+    ]
+    test_case.assertEqual(
+        offending,
+        [],
+        f"The following rank>=2 weights are unmapped: {offending}",
+    )
 
 
 class Qwen3_5BackboneTest(TestCase):
@@ -57,6 +221,271 @@ class Qwen3_5BackboneTest(TestCase):
     def test_num_parameters(self):
         model = Qwen3_5Backbone(**self.init_kwargs)
         self.assertGreater(model.count_params(), 0)
+
+    def test_distribution(self):
+        # The default config mixes linear_attention and full_attention
+        # layers so both token-mixer rule sets are exercised, and keeps
+        # num_key_value_heads=2 (deliberately not divisible by every host's
+        # device count) to regression-test that key/value kernels are left
+        # replicated on the model axis -- see get_layout_map's comment. The
+        # shared helper pins the mesh to exactly 2 devices for the same
+        # reason.
+        self.run_distribution_test(
+            cls=Qwen3_5Backbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_shardings={
+                "token_embedding/embeddings": ("model", "batch"),
+                "token_embedding/reverse_embeddings": ("batch", "model"),
+                "self_attention.*query.kernel": ("batch", "model", None),
+                "self_attention.*key.kernel": ("batch", None, None),
+                "self_attention.*value.kernel": ("batch", None, None),
+                "self_attention.*attention_output.kernel": (
+                    "model",
+                    None,
+                    "batch",
+                ),
+                "linear_attn.*in_proj_qkv.kernel": ("batch", "model"),
+                "linear_attn.*in_proj_z.kernel": ("batch", "model"),
+                "linear_attn.*out_proj.kernel": ("model", "batch"),
+                "feedforward_gate_dense.kernel": ("batch", "model"),
+                "feedforward_intermediate_dense.kernel": ("batch", "model"),
+                "feedforward_output_dense.kernel": ("model", "batch"),
+            },
+            allow_replicated=_ALLOW_REPLICATED,
+        )
+
+    @parameterized.named_parameters(
+        (
+            f"{dims['source_preset'].split(' ')[0]}_mesh"
+            f"_{'x'.join(str(s) for s in shape)}",
+            dims,
+            shape,
+        )
+        for dims in (QWEN3_5_0_8B_DIMS, QWEN3_5_9B_DIMS, QWEN3_5_27B_DIMS)
+        for shape in CAPPED_MESH_SHAPES
+    )
+    def test_layout_map_mesh_shapes(self, dims, mesh_shape):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        n_needed = 1
+        for s in mesh_shape:
+            n_needed *= s
+        if n_needed > len(devices):
+            self.skipTest(
+                f"Mesh shape {mesh_shape} needs {n_needed} devices, only "
+                f"{len(devices)} available. Run with "
+                f"XLA_FLAGS=--xla_force_host_platform_device_count="
+                f"{n_needed} to exercise this shape locally."
+            )
+
+        # Query-head-divisibility skip rule: an inherent tensor-parallelism
+        # ceiling, not a bug. model_axis_size is the mesh's last axis,
+        # matching this repo's axis_names=(..., "model") convention.
+        model_axis_size = mesh_shape[-1]
+        num_query_heads = dims["num_query_heads"]
+        if num_query_heads % model_axis_size != 0:
+            self.skipTest(
+                f"num_query_heads={num_query_heads} not divisible by "
+                f"model-axis={model_axis_size}: inherent "
+                "tensor-parallelism limit, not a bug"
+            )
+
+        devices = devices[:n_needed]
+        if len(mesh_shape) == 2:
+            axis_names = ("batch", "model")
+        else:
+            # 3D shape: the extra axis is named "seq"; get_layout_map only
+            # names "batch"/"model", so the "seq" axis simply replicates
+            # weights (no rule targets it), matching every other 3D-mesh
+            # test in this PR series.
+            axis_names = ("batch", "seq", "model")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=mesh_shape,
+            axis_names=axis_names,
+            devices=devices,
+        )
+        layout_map = Qwen3_5Backbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(
+            layout_map=layout_map, batch_dim_name="batch"
+        )
+        init_kwargs = {k: v for k, v in dims.items() if k != "source_preset"}
+        with distribution.scope():
+            # bfloat16: a memory mitigation for this shared dev machine --
+            # spec assertions are dtype-independent.
+            model = Qwen3_5Backbone(dtype="bfloat16", **init_kwargs)
+            _assert_qwen3_5_shardings_and_coverage(self, model, layout_map)
+        del model
+        gc.collect()
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.multi_device
+    @pytest.mark.extra_large
+    def test_layout_map_live_presets(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+
+        # Fetch every preset's config only (no weights), then dedupe by the
+        # divisibility-relevant dims so width-classes that share a config
+        # (e.g. base vs instruction-tuned variants of the same size) are
+        # only built once per mesh shape -- a memory/time necessity on this
+        # machine -- while every preset in the registry is still fetched and
+        # evaluated, preserving full registry coverage.
+        dim_keys = (
+            "vocabulary_size",
+            "num_query_heads",
+            "num_key_value_heads",
+            "hidden_dim",
+            "intermediate_dim",
+            "head_dim",
+            "linear_num_key_heads",
+            "linear_num_value_heads",
+            "linear_key_head_dim",
+            "linear_value_head_dim",
+            "linear_conv_kernel_dim",
+        )
+        width_classes = {}  # dedupe key -> (config dict, [preset names])
+        fetch_failures = []
+        for preset in Qwen3_5Backbone.presets:
+            try:
+                path = get_file(preset, CONFIG_FILE)
+                with open(path) as f:
+                    cfg = json.load(f)["config"]
+            except Exception as e:
+                # A preset this account can't reach (e.g. an unaccepted
+                # Kaggle license consent click-through) is logged, not
+                # fatal -- the rest of the registry still gets exercised.
+                fetch_failures.append((preset, str(e)))
+                continue
+            cfg = dict(cfg)
+            key = tuple(cfg.get(k) for k in dim_keys)
+            if key not in width_classes:
+                width_classes[key] = (cfg, [])
+            width_classes[key][1].append(preset)
+
+        if fetch_failures:
+            print(
+                f"test_layout_map_live_presets: {len(fetch_failures)} "
+                f"preset config fetches failed (logged, non-fatal): "
+                f"{fetch_failures}"
+            )
+        if not width_classes:
+            self.skipTest(
+                "No preset configs were reachable "
+                f"({len(fetch_failures)} fetch failures) -- likely a "
+                "Kaggle license-consent gate on this account for the "
+                "qwen3_5 family."
+            )
+        print(
+            f"test_layout_map_live_presets: {len(width_classes)} unique "
+            f"width-classes across {len(Qwen3_5Backbone.presets)} registry "
+            "presets:"
+        )
+        for cfg, presets in width_classes.values():
+            print(f"  {presets}")
+
+        devices = keras.distribution.list_devices("CPU")
+        skip_reasons = []
+        ran_any = False
+        for cfg, presets in width_classes.values():
+            num_query_heads = cfg["num_query_heads"]
+            for mesh_shape in CAPPED_MESH_SHAPES:
+                combo_label = f"{presets[0]}@{mesh_shape}"
+                with self.subTest(combo=combo_label):
+                    n_needed = 1
+                    for s in mesh_shape:
+                        n_needed *= s
+                    if n_needed > len(devices):
+                        reason = (
+                            f"{combo_label}: needs {n_needed} devices, "
+                            f"only {len(devices)} available"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+                    model_axis_size = mesh_shape[-1]
+                    if num_query_heads % model_axis_size != 0:
+                        reason = (
+                            f"{combo_label}: num_query_heads="
+                            f"{num_query_heads} not divisible by "
+                            f"model-axis={model_axis_size}: inherent "
+                            "tensor-parallelism limit, not a bug"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    # Memory-budget guard: this shared dev machine cannot
+                    # locally build full-scale presets. Estimate this
+                    # width-class's embedding table + one FFN block's 3
+                    # matrices (times a 3x safety margin for JAX/XLA
+                    # transient copies during construction/resharding) and
+                    # skip the actual build if it exceeds a conservative
+                    # local threshold. The config-fetch, dedup, and
+                    # divisibility-skip logic above still exercises every
+                    # registry preset either way; only the expensive
+                    # build+assert step is capped. (Real Qwen3.5 presets --
+                    # vocab 248320, hidden up to 5120 -- all exceed this and
+                    # are therefore verified offline / in CI, not here.)
+                    est_params = (
+                        cfg["vocabulary_size"] * cfg["hidden_dim"]
+                        + 3 * cfg["hidden_dim"] * cfg["intermediate_dim"]
+                    )
+                    est_bytes = est_params * 2 * 3  # bf16 * safety margin
+                    max_local_bytes = 300 * 1024 * 1024  # 300MB
+                    if est_bytes > max_local_bytes:
+                        reason = (
+                            f"{combo_label}: estimated build memory "
+                            f"~{est_bytes / 1e9:.2f}GB exceeds the "
+                            f"{max_local_bytes / 1e6:.0f}MB local safety "
+                            "threshold on this shared, RAM-constrained "
+                            "dev machine -- verify this width-class on a "
+                            "machine with more RAM or in CI"
+                        )
+                        skip_reasons.append(reason)
+                        continue
+
+                    combo_devices = devices[:n_needed]
+                    if len(mesh_shape) == 2:
+                        axis_names = ("batch", "model")
+                    else:
+                        axis_names = ("batch", "seq", "model")
+                    device_mesh = keras.distribution.DeviceMesh(
+                        shape=mesh_shape,
+                        axis_names=axis_names,
+                        devices=combo_devices,
+                    )
+                    layout_map = Qwen3_5Backbone.get_layout_map(device_mesh)
+                    distribution = keras.distribution.ModelParallel(
+                        layout_map=layout_map, batch_dim_name="batch"
+                    )
+                    init_kwargs = {
+                        k: v for k, v in cfg.items() if k in dim_keys
+                    }
+                    # Force a tiny hybrid stack: one layer of each token
+                    # mixer so both the full-attention and linear-attention
+                    # rule sets are asserted, while keeping depth (and thus
+                    # build memory) minimal. Real presets have 24-64 layers;
+                    # depth is irrelevant to per-decoder-block spec matching.
+                    init_kwargs["num_layers"] = 2
+                    init_kwargs["layer_types"] = _LINEAR_LAYER_TYPES
+                    with distribution.scope():
+                        model = Qwen3_5Backbone(dtype="bfloat16", **init_kwargs)
+                        _assert_qwen3_5_shardings_and_coverage(
+                            self, model, layout_map
+                        )
+                    del model
+                    gc.collect()
+                    ran_any = True
+
+        print(
+            f"test_layout_map_live_presets: {len(skip_reasons)} combo(s) "
+            f"skipped:\n" + "\n".join(f"  {r}" for r in skip_reasons)
+        )
+        if not ran_any:
+            self.skipTest(
+                "All (width-class, mesh-shape) combos were skipped: "
+                f"{skip_reasons}"
+            )
 
 
 class Qwen3_5MultimodalBackboneTest(TestCase):

--- a/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py
@@ -222,6 +222,7 @@ class Qwen3_5BackboneTest(TestCase):
         model = Qwen3_5Backbone(**self.init_kwargs)
         self.assertGreater(model.count_params(), 0)
 
+    @pytest.mark.multi_device
     def test_distribution(self):
         # The default config mixes linear_attention and full_attention
         # layers so both token-mixer rule sets are exercised, and keeps
@@ -265,6 +266,7 @@ class Qwen3_5BackboneTest(TestCase):
         for dims in (QWEN3_5_0_8B_DIMS, QWEN3_5_9B_DIMS, QWEN3_5_27B_DIMS)
         for shape in CAPPED_MESH_SHAPES
     )
+    @pytest.mark.multi_device
     def test_layout_map_mesh_shapes(self, dims, mesh_shape):
         if keras.backend.backend() != "jax":
             self.skipTest("`ModelParallel` testing requires the Jax backend.")


### PR DESCRIPTION
Closes #2837

Part of https://github.com/keras-team/keras-hub/issues/2807. Depends on #2809 (`TestCase.run_distribution_test`) for CI to pass -- this PR's own diff is independent (based on master, not stacked), so it stays small and reviewable regardless of merge order.

## Summary

- Add the QKV kernel sharding spec, using the kernel's actual `(hidden, heads, head_dim)` axis order: the contracting hidden axis (first) goes on the data-parallel axis and the heads axis (second) goes on the model-parallel axis. Also add `token_embedding/reverse_embeddings` sharding that mirrors its transposed `(hidden, vocab)` shape rather than following `token_embedding/embeddings`'s `(vocab, hidden)` layout.
- Added layout-map rules for the linear-attention (GatedDeltaNet) sublayer's `in_proj_qkv`, `in_proj_z`, and `out_proj` kernels. These make up the bulk of parameters in real Qwen3.5 presets (most decoder layers are `linear_attention`, not `full_attention`) and were previously left entirely unmapped/replicated.
- `in_proj_a` / `in_proj_b` (small `num_value_heads`-sized projections) and the depthwise `conv1d_kernel` are deliberately left replicated -- documented inline and covered by the test's `allow_replicated` list.

## Limitations

- The optional vision encoder and its interleave weights are left replicated for now; `get_layout_map` only shards the text decoder (full-attention, linear-attention, feedforward, and embedding weights).
- The model-parallel mesh axis can't usefully exceed a preset's `num_query_heads` -- that's the axis actually being tensor-parallelized here -- see [the design doc's "hard limit" section](https://github.com/keras-team/keras-hub/issues/2807#issuecomment-5006606419) for why. For Qwen3.5's real presets, the safe upper bound is:

  | preset | num_query_heads | safe model-axis up to | first failing model-axis |
  |---|---|---|---|
  | `qwen3_5_0.8b` | 8 | 8 | 16 |
  | `qwen3_5_0.8b_base` | 8 | 8 | 16 |
  | `qwen3_5_2b` | 8 | 8 | 16 |
  | `qwen3_5_2b_base` | 8 | 8 | 16 |
  | `qwen3_5_4b` | 16 | 16 | 32 |
  | `qwen3_5_4b_base` | 16 | 16 | 32 |
  | `qwen3_5_9b` | 16 | 16 | 32 |
  | `qwen3_5_9b_base` | 16 | 16 | 32 |
  | `qwen3_5_27b` | 24 | 8 | 16 |

  Note `qwen3_5_27b` caps out at model-axis=8 rather than its full 24 query heads -- 24 isn't a power of two, so the largest power-of-two mesh axis that still divides it evenly is 8, and that's what shows up as the safe ceiling.

## Testing

- **Tier 1** (`test_distribution`): exercises the existing small default config on a real 2-device mesh via the shared `run_distribution_test` helper, asserting both full-attention and linear-attention sharding specs plus full rank>=2 weight coverage.
- **Tier 2** (`test_layout_map_mesh_shapes`, parameterized): a CI-safe sweep across 3 memory-scaled width classes (derived from `qwen3_5_0.8b_base`, `qwen3_5_9b_base`, `qwen3_5_27b`, preserving each preset's real query:kv and linear value:key head ratios) x the repo's capped mesh-shape list (2x4, 1x8, 4x4, 2x2x2, 1x1x8, 2x2x4).
- **Tier 3** (`test_layout_map_live_presets`, `extra_large` + `kaggle_key_required`): fetches real preset configs from the registry (config JSON only, no weights), dedupes into width-classes, and asserts the same coverage -- with a per-combo memory-budget estimate that skips (never silently drops) any build exceeding a conservative safety threshold, so it never attempts a full-scale build in memory-constrained environments.

Tests were run against a checkout that already has #2809's `run_distribution_test` helper cherry-picked in, since this branch's own base doesn't yet have it. Real local results (JAX backend, `XLA_FLAGS=--xla_force_host_platform_device_count=16`):

```
keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py::Qwen3_5BackboneTest::test_distribution PASSED
======================== 1 passed in 255.63s (0:04:15) =========================

keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py::Qwen3_5BackboneTest -k test_layout_map_mesh_shapes
====================== 18 passed, 6 deselected in 40.22s =======================

keras_hub/src/models/qwen3_5/qwen3_5_backbone_test.py::Qwen3_5BackboneTest::test_layout_map_live_presets --run_extra_large
test_layout_map_live_presets: 5 unique width-classes across 10 registry presets
==================== 1 skipped, 30 subtests passed in 2.92s ====================
```

The Tier 3 outer test shows as `SKIPPED` per pytest's convention when every subTest is skipped/passes-via-subtest rather than the outer test body executing an assert directly -- the important number is **30 subtests passed** (0 failed, 0 errored): every (width-class, mesh-shape) combo either ran and asserted successfully, or was skipped for an explicit, logged, non-silent reason (the memory-budget guard rejecting full-scale builds, or an inherent query-head/mesh-axis divisibility limit).

