### PR TITLE
Fix backwards error checks in preset_utils get_file

### DIFF
--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -163,12 +163,20 @@ def get_file(preset, path):
             return kagglehub.model_download(kaggle_handle, path)
         except KaggleApiHTTPError as e:
             message = str(e)
-            # Kaggle serves a missing file as a 404 and a file that needs
-            # consent as a 403; both mean the preset has no usable file at
-            # `path`. Anything else is a real API error and surfaces as-is.
-            if "404 Client Error" in message or "403 Client Error" in message:
+            # Kaggle serves a missing file as a 404 and a gated file as a
+            # 403. Both raise FileNotFoundError so `check_file_exists` can
+            # probe optional preset files, but the 403 message points at
+            # the real fix. Anything else is an API error and surfaces
+            # as-is.
+            if "404 Client Error" in message:
                 raise FileNotFoundError(
                     f"`{path}` doesn't exist in preset directory `{preset}`."
+                )
+            elif "403 Client Error" in message:
+                raise FileNotFoundError(
+                    f"`{path}` is not accessible in preset directory "
+                    f"`{preset}`. If this model is gated, accept its "
+                    "terms on kaggle.com and retry."
                 )
             else:
                 raise ValueError(message)

--- a/keras_hub/src/utils/preset_utils.py
+++ b/keras_hub/src/utils/preset_utils.py
@@ -163,7 +163,10 @@ def get_file(preset, path):
             return kagglehub.model_download(kaggle_handle, path)
         except KaggleApiHTTPError as e:
             message = str(e)
-            if message.find("403 Client Error"):
+            # Kaggle serves a missing file as a 404 and a file that needs
+            # consent as a 403; both mean the preset has no usable file at
+            # `path`. Anything else is a real API error and surfaces as-is.
+            if "404 Client Error" in message or "403 Client Error" in message:
                 raise FileNotFoundError(
                     f"`{path}` doesn't exist in preset directory `{preset}`."
                 )
@@ -171,12 +174,12 @@ def get_file(preset, path):
                 raise ValueError(message)
         except ValueError as e:
             message = str(e)
-            if message.find("is not present in the model files"):
+            if "is not present in the model files" in message:
                 raise FileNotFoundError(
                     f"`{path}` doesn't exist in preset directory `{preset}`."
                 )
             else:
-                raise ValueError(message)
+                raise
     elif scheme in tf_registered_schemes():
         return tf_copy_gfile_to_cache(preset, path)
     elif scheme == MODELSCOPE_SCHEME:
@@ -202,14 +205,6 @@ def get_file(preset, path):
                 "(e.g., 'modelscope://username/bert_base_en')."
                 f"Received: preset='{preset}.'"
             ) from e
-        except EntryNotFoundError as e:
-            message = str(e)
-            if message.find("403 Client Error"):
-                raise FileNotFoundError(
-                    f"`{path}` not exist in preset directory `{preset}`."
-                )
-            else:
-                raise ValueError(message)
     elif scheme == HF_SCHEME:
         if huggingface_hub is None:
             raise ImportError(
@@ -229,13 +224,9 @@ def get_file(preset, path):
                 f"'hf://username/bert_base_en'. Received: preset={preset}."
             ) from e
         except EntryNotFoundError as e:
-            message = str(e)
-            if message.find("403 Client Error"):
-                raise FileNotFoundError(
-                    f"`{path}` doesn't exist in preset directory `{preset}`."
-                )
-            else:
-                raise ValueError(message)
+            raise FileNotFoundError(
+                f"`{path}` doesn't exist in preset directory `{preset}`."
+            ) from e
     elif os.path.exists(preset):
         # Assume a local filepath.pyth
         local_path = os.path.join(preset, path)

--- a/keras_hub/src/utils/preset_utils_test.py
+++ b/keras_hub/src/utils/preset_utils_test.py
@@ -220,9 +220,7 @@ class PresetUtilsTest(TestCase):
         # it), but the message points at gated-model consent.
         error = KaggleApiHTTPError("403 Client Error: Forbidden")
         with mock.patch("kagglehub.model_download", side_effect=error):
-            with self.assertRaisesRegex(
-                FileNotFoundError, "accept its terms"
-            ):
+            with self.assertRaisesRegex(FileNotFoundError, "accept its terms"):
                 get_file(preset, "missing.json")
         # Any other Kaggle API error should surface as-is, not as a
         # missing file.

--- a/keras_hub/src/utils/preset_utils_test.py
+++ b/keras_hub/src/utils/preset_utils_test.py
@@ -1,9 +1,11 @@
 import json
 import os
+from unittest import mock
 
 import keras
 import pytest
 from absl.testing import parameterized
+from kagglehub.exceptions import KaggleApiHTTPError
 
 from keras_hub.src.models.albert.albert_text_classifier import (
     AlbertTextClassifier,
@@ -16,6 +18,11 @@ from keras_hub.src.utils.keras_utils import sharded_weights_available
 from keras_hub.src.utils.preset_utils import CONFIG_FILE
 from keras_hub.src.utils.preset_utils import get_file
 from keras_hub.src.utils.preset_utils import upload_preset
+
+try:
+    from huggingface_hub.utils import EntryNotFoundError
+except ImportError:
+    EntryNotFoundError = None
 
 
 class PresetUtilsTest(TestCase):
@@ -201,3 +208,34 @@ class PresetUtilsTest(TestCase):
 
         with self.assertRaises(FileNotFoundError):
             get_file(local_dir, fake_path)
+
+    def test_kaggle_error_translation(self):
+        preset = "kaggle://keras/bert/keras/bert_base_en"
+        # Kaggle serves a missing file as a 404 and a gated file as a 403;
+        # both translate to FileNotFoundError (check_file_exists relies on
+        # this to probe optional preset files).
+        for status in ("404 Client Error.", "403 Client Error: Forbidden"):
+            error = KaggleApiHTTPError(status)
+            with mock.patch("kagglehub.model_download", side_effect=error):
+                with self.assertRaises(FileNotFoundError):
+                    get_file(preset, "missing.json")
+        # Any other Kaggle API error should surface as-is, not as a
+        # missing file.
+        error = KaggleApiHTTPError("1994")
+        with mock.patch("kagglehub.model_download", side_effect=error):
+            with self.assertRaisesRegex(ValueError, "1994"):
+                get_file(preset, "vocabulary.json")
+        # Unrelated ValueErrors propagate as-is, never as a missing file.
+        error = ValueError("some other error")
+        with mock.patch("kagglehub.model_download", side_effect=error):
+            with self.assertRaisesRegex(ValueError, "some other error"):
+                get_file(preset, "vocabulary.json")
+
+    @pytest.mark.skipif(
+        EntryNotFoundError is None, reason="huggingface_hub is not installed"
+    )
+    def test_hf_missing_entry_translation(self):
+        error = EntryNotFoundError("404 Client Error")
+        with mock.patch("huggingface_hub.hf_hub_download", side_effect=error):
+            with self.assertRaises(FileNotFoundError):
+                get_file("hf://username/bert_base_en", "missing.json")

--- a/keras_hub/src/utils/preset_utils_test.py
+++ b/keras_hub/src/utils/preset_utils_test.py
@@ -211,14 +211,19 @@ class PresetUtilsTest(TestCase):
 
     def test_kaggle_error_translation(self):
         preset = "kaggle://keras/bert/keras/bert_base_en"
-        # Kaggle serves a missing file as a 404 and a gated file as a 403;
-        # both translate to FileNotFoundError (check_file_exists relies on
-        # this to probe optional preset files).
-        for status in ("404 Client Error.", "403 Client Error: Forbidden"):
-            error = KaggleApiHTTPError(status)
-            with mock.patch("kagglehub.model_download", side_effect=error):
-                with self.assertRaises(FileNotFoundError):
-                    get_file(preset, "missing.json")
+        # A 404 is a plain missing file.
+        error = KaggleApiHTTPError("404 Client Error.")
+        with mock.patch("kagglehub.model_download", side_effect=error):
+            with self.assertRaisesRegex(FileNotFoundError, "doesn't exist"):
+                get_file(preset, "missing.json")
+        # A 403 is still FileNotFoundError (check_file_exists relies on
+        # it), but the message points at gated-model consent.
+        error = KaggleApiHTTPError("403 Client Error: Forbidden")
+        with mock.patch("kagglehub.model_download", side_effect=error):
+            with self.assertRaisesRegex(
+                FileNotFoundError, "accept its terms"
+            ):
+                get_file(preset, "missing.json")
         # Any other Kaggle API error should surface as-is, not as a
         # missing file.
         error = KaggleApiHTTPError("1994")


### PR DESCRIPTION
## Description of the change

`preset_utils.py` classifies download errors like this:

```python
if message.find("403 Client Error"):
    raise FileNotFoundError(
        f"`{path}` doesn't exist in preset directory `{preset}`."
    )
```

`str.find` returns -1 when the substring is missing, and Python treats -1 as true in an `if` (only 0 counts as false). So the check is backwards: every Kaggle API error, whatever its cause, was reported as "file doesn't exist".
I hit this while debugging `Tokenizer.from_preset("qwen2.5_instruct_0.5b_en")`: the file is on Kaggleand the real failure is inside kagglehub (`HTTPError: 1994`, a separate kagglehub bug), but keras-hub reported the file as missing.

This PR fixes the error handling in `get_file`:

- **Kaggle:** a 404 (file not in the preset) and a 403 (gated file) both raise `FileNotFoundError` — `check_file_exists` depends on this to probe optional preset files, so `from_preset` works as before. The 403 message additionally says to accept the model's terms on kaggle.com, so gated models don't read as missing files. Any other Kaggle API error is raised as-is, so real problems are no longer hidden behind a wrong "missing file" message.
- **Hugging Face:** `EntryNotFoundError` always means the file is missing, so it raises `FileNotFoundError` directly instead of checking the message text.
- **ModelScope:** removed a block that caught `EntryNotFoundError`, a Hugging Face error that ModelScope never raises. It was also undefined when `huggingface_hub` is not installed, which would have caused a `NameError`.
- Added tests for the Kaggle and Hugging Face error translations.

For the Qwen preset above, the error changes from the misleading `FileNotFoundError: assets/tokenizer/vocabulary.json doesn't exist in preset directory` to the real `ValueError: 1994`.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works
  with all backends.
- [x] My PR is based on the latest changes of the main branch.
