### PR TITLE
Add HRM-Text-1B model support

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -445,6 +445,18 @@ from keras_hub.src.models.hgnetv2.hgnetv2_image_classifier import (
 from keras_hub.src.models.hgnetv2.hgnetv2_image_classifier_preprocessor import (
     HGNetV2ImageClassifierPreprocessor as HGNetV2ImageClassifierPreprocessor,
 )
+from keras_hub.src.models.hrm_text.hrm_text_backbone import (
+    HrmTextBackbone as HrmTextBackbone,
+)
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm import (
+    HrmTextCausalLM as HrmTextCausalLM,
+)
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
+    HrmTextCausalLMPreprocessor as HrmTextCausalLMPreprocessor,
+)
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import (
+    HrmTextTokenizer as HrmTextTokenizer,
+)
 from keras_hub.src.models.image_classifier import (
     ImageClassifier as ImageClassifier,
 )

--- a/keras_hub/api/tokenizers/__init__.py
+++ b/keras_hub/api/tokenizers/__init__.py
@@ -62,6 +62,9 @@ from keras_hub.src.models.gpt_neo_x.gpt_neo_x_tokenizer import (
 from keras_hub.src.models.gpt_oss.gpt_oss_tokenizer import (
     GptOssTokenizer as GptOssTokenizer,
 )
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import (
+    HrmTextTokenizer as HrmTextTokenizer,
+)
 from keras_hub.src.models.llama.llama_tokenizer import (
     LlamaTokenizer as LlamaTokenizer,
 )

--- a/keras_hub/src/models/hrm_text/__init__.py
+++ b/keras_hub/src/models/hrm_text/__init__.py
@@ -1,0 +1,17 @@
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm import HrmTextCausalLM
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
+    HrmTextCausalLMPreprocessor,
+)
+from keras_hub.src.models.hrm_text.hrm_text_presets import backbone_presets
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
+from keras_hub.src.utils.preset_utils import register_presets
+
+register_presets(backbone_presets, HrmTextBackbone)
+
+__all__ = [
+    "HrmTextBackbone",
+    "HrmTextCausalLM",
+    "HrmTextCausalLMPreprocessor",
+    "HrmTextTokenizer",
+]

--- a/keras_hub/src/models/hrm_text/hrm_text_backbone.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_backbone.py
@@ -66,6 +66,11 @@ class HrmTextBackbone(Backbone):
     each model call; autoregressive generation instead caches the key/value
     tensors for every logical stack invocation.
 
+    During training, ``l_bp_cycles`` reproduces HRM-Text's bounded-gradient
+    recurrence: only the configured trailing L updates in each H cycle retain
+    gradients. It does not change forward or inference results. The checkpoint
+    low-level initial state is frozen, matching the reference implementation.
+
     Inputs are a dictionary with ``token_ids``, ``padding_mask``, and
     ``token_type_ids``. Set ``token_type_ids`` to zero for ordinary causal
     attention. Positions marked one form a bidirectional PrefixLM prefix;
@@ -87,8 +92,13 @@ class HrmTextBackbone(Backbone):
         rope_theta: Rotary-position-embedding base. Defaults to ``10000.0``.
         rms_norm_epsilon: Epsilon used by RMS normalization. Defaults to
             ``1e-6``.
+        l_bp_cycles: Per-H-cycle counts of trailing L iterations that retain
+            gradients. Short lists are left-padded with one. Defaults to
+            ``[2]``. This is an inference-time no-op.
+        initializer_range: Standard deviation of the normal initializer used
+            for embedding and projection weights. Defaults to ``0.02``.
         embedding_scale: Scale applied to token embeddings before recurrence.
-            Defaults to ``1.0``.
+            When ``None``, defaults to ``1 / initializer_range``.
         tie_word_embeddings: Whether input and output embeddings are tied.
             Defaults to ``False``.
         dtype: Dtype policy for the backbone.
@@ -129,7 +139,9 @@ class HrmTextBackbone(Backbone):
         max_sequence_length=4096,
         rope_theta=10000.0,
         rms_norm_epsilon=1e-6,
-        embedding_scale=1.0,
+        l_bp_cycles=None,
+        initializer_range=0.02,
+        embedding_scale=None,
         tie_word_embeddings=False,
         dtype=None,
         **kwargs,
@@ -145,12 +157,39 @@ class HrmTextBackbone(Backbone):
         self.max_sequence_length = max_sequence_length
         self.rope_theta = rope_theta
         self.rms_norm_epsilon = rms_norm_epsilon
-        self.embedding_scale = embedding_scale
+        if initializer_range <= 0:
+            raise ValueError("`initializer_range` must be positive.")
+        if l_bp_cycles is None:
+            l_bp_cycles = [2]
+        if len(l_bp_cycles) > h_cycles:
+            raise ValueError(
+                "`l_bp_cycles` cannot contain more entries than `h_cycles`."
+            )
+        if any(
+            not isinstance(value, int) or value < 0 for value in l_bp_cycles
+        ):
+            raise ValueError(
+                "`l_bp_cycles` entries must be non-negative integers."
+            )
+        self.l_bp_cycles = list(l_bp_cycles)
+        self._l_bp_cycles_padded = [1] * (
+            h_cycles - len(self.l_bp_cycles)
+        ) + self.l_bp_cycles
+        self.initializer_range = initializer_range
+        self.embedding_scale = (
+            1.0 / initializer_range
+            if embedding_scale is None
+            else embedding_scale
+        )
         self.tie_word_embeddings = tie_word_embeddings
+        kernel_initializer = keras.initializers.RandomNormal(
+            stddev=initializer_range
+        )
         self.token_embedding = ReversibleEmbedding(
             input_dim=vocabulary_size,
             output_dim=hidden_dim,
             tie_weights=tie_word_embeddings,
+            embeddings_initializer=kernel_initializer,
             name="token_embedding",
             dtype=dtype,
         )
@@ -160,6 +199,7 @@ class HrmTextBackbone(Backbone):
             "intermediate_dim": intermediate_dim,
             "rope_theta": rope_theta,
             "rms_norm_epsilon": rms_norm_epsilon,
+            "kernel_initializer": kernel_initializer,
         }
         self.L_module = HrmTextStack(
             num_layers_per_stack, name="L_module", dtype=dtype, **block_kwargs
@@ -202,6 +242,8 @@ class HrmTextBackbone(Backbone):
         high = self.token_embedding(token_ids) * self.embedding_scale
         low = self.initial_state(high)
         for high_cycle in range(self.h_cycles):
+            num_grad_iterations = self._l_bp_cycles_padded[high_cycle]
+            grad_threshold = self.l_cycles - num_grad_iterations
             for low_cycle in range(self.l_cycles):
                 offset = (
                     high_cycle * (self.l_cycles + 1) + low_cycle
@@ -209,6 +251,8 @@ class HrmTextBackbone(Backbone):
                 low = self.L_module(
                     low + high, attention_mask, cycle_offset=offset
                 )
+                if low_cycle < grad_threshold:
+                    low = ops.stop_gradient(low)
             offset = (
                 high_cycle * (self.l_cycles + 1) + self.l_cycles
             ) * self.num_layers_per_stack
@@ -284,6 +328,8 @@ class HrmTextBackbone(Backbone):
                 "max_sequence_length": self.max_sequence_length,
                 "rope_theta": self.rope_theta,
                 "rms_norm_epsilon": self.rms_norm_epsilon,
+                "l_bp_cycles": self.l_bp_cycles,
+                "initializer_range": self.initializer_range,
                 "embedding_scale": self.embedding_scale,
                 "tie_word_embeddings": self.tie_word_embeddings,
             }

--- a/keras_hub/src/models/hrm_text/hrm_text_backbone.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_backbone.py
@@ -1,0 +1,217 @@
+"""HRM-Text backbone."""
+
+import keras
+from keras import ops
+from keras.layers import ReversibleEmbedding
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.hrm_text.hrm_text_layers import HrmTextAttentionMask
+from keras_hub.src.models.hrm_text.hrm_text_layers import HrmTextInitialState
+from keras_hub.src.models.hrm_text.hrm_text_layers import HrmTextStack
+
+
+def make_hrm_text_attention_mask(token_type_ids, padding_mask):
+    """Builds HRM-Text's causal/PrefixLM boolean attention mask."""
+    sequence_length = ops.shape(token_type_ids)[1]
+    positions = ops.arange(sequence_length)
+    causal = positions[None, :] <= positions[:, None]
+    prefix = ops.cast(token_type_ids == 1, "bool")
+    prefix_mask = ops.logical_and(prefix[:, :, None], prefix[:, None, :])
+    allowed = ops.logical_or(causal[None, :, :], prefix_mask)
+    valid = ops.cast(padding_mask, "bool")
+    valid_mask = ops.logical_and(valid[:, :, None], valid[:, None, :])
+    return ops.logical_and(allowed, valid_mask)
+
+
+def make_hrm_text_cache_mask(
+    token_ids, cache_update_index, token_type_ids=None
+):
+    """Builds a prefill PrefixLM mask or a causal decode mask."""
+    batch_size = ops.shape(token_ids)[0]
+    sequence_length = ops.shape(token_ids)[1]
+    query_positions = ops.arange(
+        cache_update_index, cache_update_index + sequence_length
+    )[:, None]
+    key_positions = ops.arange(cache_update_index + sequence_length)[None, :]
+    causal = key_positions <= query_positions
+    causal = ops.broadcast_to(
+        causal[None, :, :],
+        (batch_size, sequence_length, cache_update_index + sequence_length),
+    )
+    if token_type_ids is None:
+        return causal
+    prefix = ops.cast(token_type_ids == 1, "bool")
+    return ops.logical_or(
+        causal, ops.logical_and(prefix[:, :, None], prefix[:, None, :])
+    )
+
+
+@keras_hub_export("keras_hub.models.HrmTextBackbone")
+class HrmTextBackbone(Backbone):
+    """HRM-Text recurrent decoder backbone."""
+
+    def __init__(
+        self,
+        vocabulary_size,
+        hidden_dim,
+        intermediate_dim,
+        num_layers_per_stack,
+        num_attention_heads,
+        head_dim,
+        h_cycles=2,
+        l_cycles=3,
+        max_sequence_length=4096,
+        rope_theta=10000.0,
+        rms_norm_epsilon=1e-6,
+        embedding_scale=1.0,
+        tie_word_embeddings=False,
+        dtype=None,
+        **kwargs,
+    ):
+        self.vocabulary_size = vocabulary_size
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.num_layers_per_stack = num_layers_per_stack
+        self.num_attention_heads = num_attention_heads
+        self.head_dim = head_dim
+        self.h_cycles = h_cycles
+        self.l_cycles = l_cycles
+        self.max_sequence_length = max_sequence_length
+        self.rope_theta = rope_theta
+        self.rms_norm_epsilon = rms_norm_epsilon
+        self.embedding_scale = embedding_scale
+        self.tie_word_embeddings = tie_word_embeddings
+        self.token_embedding = ReversibleEmbedding(
+            input_dim=vocabulary_size,
+            output_dim=hidden_dim,
+            tie_weights=tie_word_embeddings,
+            name="token_embedding",
+            dtype=dtype,
+        )
+        block_kwargs = {
+            "num_heads": num_attention_heads,
+            "head_dim": head_dim,
+            "intermediate_dim": intermediate_dim,
+            "rope_theta": rope_theta,
+            "rms_norm_epsilon": rms_norm_epsilon,
+        }
+        self.L_module = HrmTextStack(
+            num_layers_per_stack, name="L_module", dtype=dtype, **block_kwargs
+        )
+        self.H_module = HrmTextStack(
+            num_layers_per_stack, name="H_module", dtype=dtype, **block_kwargs
+        )
+        self.initial_state = HrmTextInitialState(
+            hidden_dim, name="initial_state", dtype=dtype
+        )
+        self.attention_mask = HrmTextAttentionMask(
+            name="attention_mask", dtype=dtype
+        )
+
+        token_ids = keras.Input(shape=(None,), dtype="int32", name="token_ids")
+        padding_mask = keras.Input(
+            shape=(None,), dtype="int32", name="padding_mask"
+        )
+        token_type_ids = keras.Input(
+            shape=(None,), dtype="int32", name="token_type_ids"
+        )
+        hidden_states = self._forward(token_ids, padding_mask, token_type_ids)
+        super().__init__(
+            inputs={
+                "token_ids": token_ids,
+                "padding_mask": padding_mask,
+                "token_type_ids": token_type_ids,
+            },
+            outputs=hidden_states,
+            dtype=dtype,
+            **kwargs,
+        )
+
+    @property
+    def cache_slots(self):
+        return self.num_layers_per_stack * self.h_cycles * (self.l_cycles + 1)
+
+    def _forward(self, token_ids, padding_mask, token_type_ids):
+        attention_mask = self.attention_mask(token_type_ids, padding_mask)
+        high = self.token_embedding(token_ids) * self.embedding_scale
+        low = self.initial_state(high)
+        for high_cycle in range(self.h_cycles):
+            for low_cycle in range(self.l_cycles):
+                offset = (
+                    high_cycle * (self.l_cycles + 1) + low_cycle
+                ) * self.num_layers_per_stack
+                low = self.L_module(
+                    low + high, attention_mask, cycle_offset=offset
+                )
+            offset = (
+                high_cycle * (self.l_cycles + 1) + self.l_cycles
+            ) * self.num_layers_per_stack
+            high = self.H_module(
+                high + low, attention_mask, cycle_offset=offset
+            )
+        return high
+
+    def call_with_cache(
+        self, token_ids, cache, cache_update_index, token_type_ids=None
+    ):
+        """Runs HRM-Text with one KV cache per recurrent invocation."""
+        attention_mask = make_hrm_text_cache_mask(
+            token_ids, cache_update_index, token_type_ids
+        )
+        high = self.token_embedding(token_ids) * self.embedding_scale
+        low = self.initial_state(high)
+        for high_cycle in range(self.h_cycles):
+            for low_cycle in range(self.l_cycles):
+                offset = (
+                    high_cycle * (self.l_cycles + 1) + low_cycle
+                ) * self.num_layers_per_stack
+                low, updates = self.L_module(
+                    low + high,
+                    attention_mask,
+                    cache=cache,
+                    cache_update_index=cache_update_index,
+                    cycle_offset=offset,
+                )
+                cache = ops.slice_update(
+                    cache,
+                    [0, offset, 0, 0, 0, 0],
+                    ops.stack(updates, axis=1),
+                )
+            offset = (
+                high_cycle * (self.l_cycles + 1) + self.l_cycles
+            ) * self.num_layers_per_stack
+            high, updates = self.H_module(
+                high + low,
+                attention_mask,
+                cache=cache,
+                cache_update_index=cache_update_index,
+                cycle_offset=offset,
+            )
+            cache = ops.slice_update(
+                cache,
+                [0, offset, 0, 0, 0, 0],
+                ops.stack(updates, axis=1),
+            )
+        return high, cache
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "vocabulary_size": self.vocabulary_size,
+                "hidden_dim": self.hidden_dim,
+                "intermediate_dim": self.intermediate_dim,
+                "num_layers_per_stack": self.num_layers_per_stack,
+                "num_attention_heads": self.num_attention_heads,
+                "head_dim": self.head_dim,
+                "h_cycles": self.h_cycles,
+                "l_cycles": self.l_cycles,
+                "max_sequence_length": self.max_sequence_length,
+                "rope_theta": self.rope_theta,
+                "rms_norm_epsilon": self.rms_norm_epsilon,
+                "embedding_scale": self.embedding_scale,
+                "tie_word_embeddings": self.tie_word_embeddings,
+            }
+        )
+        return config

--- a/keras_hub/src/models/hrm_text/hrm_text_backbone.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_backbone.py
@@ -25,31 +25,96 @@ def make_hrm_text_attention_mask(token_type_ids, padding_mask):
 
 
 def make_hrm_text_cache_mask(
-    token_ids, cache_update_index, token_type_ids=None
+    token_ids, cache_update_index, cache_length, token_type_ids=None
 ):
     """Builds a prefill PrefixLM mask or a causal decode mask."""
     batch_size = ops.shape(token_ids)[0]
     sequence_length = ops.shape(token_ids)[1]
-    query_positions = ops.arange(
-        cache_update_index, cache_update_index + sequence_length
+    # Keep `arange()` bounds static for JAX's compiled sampler loop. The cache
+    # offset is dynamic during decoding, so add it after creating the range.
+    query_positions = (
+        ops.arange(sequence_length, dtype="int32") + cache_update_index
     )[:, None]
-    key_positions = ops.arange(cache_update_index + sequence_length)[None, :]
+    key_positions = ops.arange(cache_length, dtype="int32")[None, :]
     causal = key_positions <= query_positions
     causal = ops.broadcast_to(
         causal[None, :, :],
-        (batch_size, sequence_length, cache_update_index + sequence_length),
+        (batch_size, sequence_length, cache_length),
     )
     if token_type_ids is None:
         return causal
     prefix = ops.cast(token_type_ids == 1, "bool")
+    prefix_padding = ops.zeros(
+        (batch_size, cache_length - sequence_length), dtype="bool"
+    )
+    prefix_keys = ops.concatenate((prefix, prefix_padding), axis=1)
     return ops.logical_or(
-        causal, ops.logical_and(prefix[:, :, None], prefix[:, None, :])
+        causal,
+        ops.logical_and(prefix[:, :, None], prefix_keys[:, None, :]),
     )
 
 
 @keras_hub_export("keras_hub.models.HrmTextBackbone")
 class HrmTextBackbone(Backbone):
-    """HRM-Text recurrent decoder backbone."""
+    """HRM-Text hierarchical recurrent decoder backbone.
+
+    HRM-Text uses two shared Transformer stacks rather than a single sequence
+    of independent decoder layers. In every forward pass, a fast low-level
+    (L) stack runs ``l_cycles`` times for each high-level (H) stack update.
+    Each stack uses parameterless pre-RMS normalization, RoPE, gated
+    multi-head attention, and SwiGLU. The L and H states are reinitialized for
+    each model call; autoregressive generation instead caches the key/value
+    tensors for every logical stack invocation.
+
+    Inputs are a dictionary with ``token_ids``, ``padding_mask``, and
+    ``token_type_ids``. Set ``token_type_ids`` to zero for ordinary causal
+    attention. Positions marked one form a bidirectional PrefixLM prefix;
+    later positions remain causal.
+
+    Args:
+        vocabulary_size: Number of tokens in the vocabulary.
+        hidden_dim: Width of the token embeddings and Transformer states.
+        intermediate_dim: Width of the SwiGLU intermediate projection.
+        num_layers_per_stack: Number of shared decoder blocks in each H and L
+            stack.
+        num_attention_heads: Number of attention heads.
+        head_dim: Dimension of each attention head.
+        h_cycles: Number of high-level recurrent cycles. Defaults to ``2``.
+        l_cycles: Number of low-level updates within each high-level cycle.
+            Defaults to ``3``.
+        max_sequence_length: Maximum sequence length used by the preset.
+            Defaults to ``4096``.
+        rope_theta: Rotary-position-embedding base. Defaults to ``10000.0``.
+        rms_norm_epsilon: Epsilon used by RMS normalization. Defaults to
+            ``1e-6``.
+        embedding_scale: Scale applied to token embeddings before recurrence.
+            Defaults to ``1.0``.
+        tie_word_embeddings: Whether input and output embeddings are tied.
+            Defaults to ``False``.
+        dtype: Dtype policy for the backbone.
+
+    Examples:
+
+    ```python
+    backbone = keras_hub.models.HrmTextBackbone(
+        vocabulary_size=128,
+        hidden_dim=64,
+        intermediate_dim=128,
+        num_layers_per_stack=2,
+        num_attention_heads=4,
+        head_dim=16,
+        h_cycles=2,
+        l_cycles=2,
+        max_sequence_length=32,
+    )
+    inputs = {
+        "token_ids": np.array([[5, 9, 17, 0]], dtype="int32"),
+        "padding_mask": np.array([[1, 1, 1, 0]], dtype="int32"),
+        "token_type_ids": np.zeros((1, 4), dtype="int32"),
+    }
+    hidden_states = backbone(inputs)
+    ```
+    """
 
     def __init__(
         self,
@@ -155,9 +220,18 @@ class HrmTextBackbone(Backbone):
     def call_with_cache(
         self, token_ids, cache, cache_update_index, token_type_ids=None
     ):
-        """Runs HRM-Text with one KV cache per recurrent invocation."""
+        """Runs HRM-Text with one KV cache per recurrent invocation.
+
+        The official 1B configuration has 16 layers in each stack, two H
+        cycles, and three L cycles, so it needs ``16 * 2 * (3 + 1) == 128``
+        logical cache slots. These slots correspond to recurrent invocations,
+        not to the 32 parameterized Transformer blocks.
+        """
         attention_mask = make_hrm_text_cache_mask(
-            token_ids, cache_update_index, token_type_ids
+            token_ids,
+            cache_update_index,
+            ops.shape(cache)[3],
+            token_type_ids,
         )
         high = self.token_embedding(token_ids) * self.embedding_scale
         low = self.initial_state(high)

--- a/keras_hub/src/models/hrm_text/hrm_text_backbone_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_backbone_test.py
@@ -1,0 +1,75 @@
+import numpy as np
+from keras import ops
+
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.models.hrm_text.hrm_text_backbone import (
+    make_hrm_text_attention_mask,
+)
+from keras_hub.src.tests.test_case import TestCase
+
+
+class HrmTextBackboneTest(TestCase):
+    def setUp(self):
+        self.init_kwargs = {
+            "vocabulary_size": 32,
+            "hidden_dim": 16,
+            "intermediate_dim": 32,
+            "num_layers_per_stack": 2,
+            "num_attention_heads": 4,
+            "head_dim": 4,
+            "h_cycles": 2,
+            "l_cycles": 2,
+            "max_sequence_length": 8,
+        }
+        self.input_data = {
+            "token_ids": np.array([[1, 2, 3, 4]], dtype="int32"),
+            "padding_mask": np.array([[1, 1, 1, 1]], dtype="int32"),
+            "token_type_ids": np.array([[1, 1, 0, 0]], dtype="int32"),
+        }
+
+    def test_backbone_basics(self):
+        self.run_backbone_test(
+            cls=HrmTextBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_output_shape=(1, 4, 16),
+        )
+
+    def test_prefix_lm_attention_mask(self):
+        mask = make_hrm_text_attention_mask(
+            np.array([[1, 1, 0, 0]], dtype="int32"),
+            np.array([[1, 1, 1, 1]], dtype="int32"),
+        )
+        self.assertAllEqual(
+            mask,
+            np.array(
+                [
+                    [
+                        [1, 1, 0, 0],
+                        [1, 1, 0, 0],
+                        [1, 1, 1, 0],
+                        [1, 1, 1, 1],
+                    ]
+                ],
+                dtype="bool",
+            ),
+        )
+
+    def test_cached_forward_matches_full_forward(self):
+        backbone = HrmTextBackbone(**self.init_kwargs)
+        full_output = backbone(self.input_data)
+        cache = ops.zeros(
+            (1, backbone.cache_slots, 2, 4, 4, 4), dtype=backbone.compute_dtype
+        )
+        _, cache = backbone.call_with_cache(
+            self.input_data["token_ids"][:, :3],
+            cache,
+            cache_update_index=0,
+            token_type_ids=self.input_data["token_type_ids"][:, :3],
+        )
+        cached_output, _ = backbone.call_with_cache(
+            self.input_data["token_ids"][:, 3:],
+            cache,
+            cache_update_index=3,
+        )
+        self.assertAllClose(full_output[:, 3:], cached_output, atol=1e-5)

--- a/keras_hub/src/models/hrm_text/hrm_text_backbone_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_backbone_test.py
@@ -57,19 +57,54 @@ class HrmTextBackboneTest(TestCase):
 
     def test_cached_forward_matches_full_forward(self):
         backbone = HrmTextBackbone(**self.init_kwargs)
-        full_output = backbone(self.input_data)
+        input_data = {
+            "token_ids": np.array([[1, 2, 3, 4, 5, 6]], dtype="int32"),
+            "padding_mask": np.ones((1, 6), dtype="int32"),
+            "token_type_ids": np.array([[1, 1, 1, 0, 0, 0]], dtype="int32"),
+        }
+        full_output = backbone(input_data)
         cache = ops.zeros(
-            (1, backbone.cache_slots, 2, 4, 4, 4), dtype=backbone.compute_dtype
+            (1, backbone.cache_slots, 2, 6, 4, 4), dtype=backbone.compute_dtype
         )
         _, cache = backbone.call_with_cache(
-            self.input_data["token_ids"][:, :3],
+            input_data["token_ids"][:, :3],
             cache,
             cache_update_index=0,
-            token_type_ids=self.input_data["token_type_ids"][:, :3],
+            token_type_ids=input_data["token_type_ids"][:, :3],
         )
-        cached_output, _ = backbone.call_with_cache(
-            self.input_data["token_ids"][:, 3:],
-            cache,
-            cache_update_index=3,
+        for index in range(3, 6):
+            cached_output, cache = backbone.call_with_cache(
+                input_data["token_ids"][:, index : index + 1],
+                cache,
+                cache_update_index=index,
+            )
+            self.assertAllClose(
+                full_output[:, index : index + 1], cached_output, atol=1e-5
+            )
+
+    def test_frozen_initial_state(self):
+        backbone = HrmTextBackbone(**self.init_kwargs)
+        self.assertFalse(backbone.initial_state.z_L_init.trainable)
+        self.assertIn(
+            backbone.initial_state.z_L_init, backbone.non_trainable_weights
         )
-        self.assertAllClose(full_output[:, 3:], cached_output, atol=1e-5)
+
+    def test_l_bp_cycles_config(self):
+        backbone = HrmTextBackbone(
+            **self.init_kwargs,
+            l_bp_cycles=[0, 2],
+            initializer_range=0.03,
+            embedding_scale=None,
+        )
+        config = backbone.get_config()
+        self.assertEqual(config["l_bp_cycles"], [0, 2])
+        self.assertEqual(config["initializer_range"], 0.03)
+        self.assertAllClose(config["embedding_scale"], 1.0 / 0.03)
+
+    def test_l_bp_cycles_validation(self):
+        with self.assertRaises(ValueError):
+            HrmTextBackbone(**self.init_kwargs, l_bp_cycles=[1, 1, 1])
+        with self.assertRaises(ValueError):
+            HrmTextBackbone(**self.init_kwargs, l_bp_cycles=[-1])
+        with self.assertRaises(ValueError):
+            HrmTextBackbone(**self.init_kwargs, l_bp_cycles=[1.5])

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
@@ -1,0 +1,133 @@
+"""Causal language-model task for HRM-Text."""
+
+import keras
+from keras import ops
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.causal_lm import CausalLM
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
+    HrmTextCausalLMPreprocessor,
+)
+from keras_hub.src.utils.tensor_utils import any_equal
+
+
+@keras_hub_export("keras_hub.models.HrmTextCausalLM")
+class HrmTextCausalLM(CausalLM):
+    """End-to-end HRM-Text causal language model."""
+
+    backbone_cls = HrmTextBackbone
+    preprocessor_cls = HrmTextCausalLMPreprocessor
+
+    def __init__(self, backbone, preprocessor=None, **kwargs):
+        self.backbone = backbone
+        self.preprocessor = preprocessor
+        inputs = backbone.input
+        hidden_states = backbone(inputs)
+        outputs = backbone.token_embedding(hidden_states, reverse=True)
+        super().__init__(inputs=inputs, outputs=outputs, **kwargs)
+
+    def call_with_cache(
+        self, token_ids, cache, cache_update_index, token_type_ids=None
+    ):
+        hidden_states, cache = self.backbone.call_with_cache(
+            token_ids,
+            cache,
+            cache_update_index,
+            token_type_ids=token_type_ids,
+        )
+        logits = self.backbone.token_embedding(hidden_states, reverse=True)
+        return logits, hidden_states, cache
+
+    def make_generate_function(self):
+        """Build a TensorFlow graph without AutoGraph source conversion.
+
+        HRM-Text's recurrence uses a fixed Python loop and backend-native
+        `ops.while_loop` in the sampler. Disabling AutoGraph avoids retracing
+        the recurrent cache update closure while preserving graph execution.
+        """
+        if (
+            keras.config.backend() == "tensorflow"
+            and not self.run_eagerly
+            and self.generate_function is None
+        ):
+            import tensorflow as tf
+
+            self.generate_function = tf.function(
+                self.generate_step,
+                autograph=False,
+                # Dynamic cache indices in `ops.while_loop` are not XLA
+                # compilable on TensorFlow. Keep graph execution enabled.
+                jit_compile=False,
+            )
+        return super().make_generate_function()
+
+    def _build_cache(self, token_ids, token_type_ids):
+        batch_size = ops.shape(token_ids)[0]
+        max_length = ops.shape(token_ids)[1]
+        backbone = self.backbone
+        cache = ops.zeros(
+            [
+                batch_size,
+                backbone.cache_slots,
+                2,
+                max_length,
+                backbone.num_attention_heads,
+                backbone.head_dim,
+            ],
+            dtype=self.compute_dtype,
+        )
+        _, hidden_states, cache = self.call_with_cache(
+            token_ids, cache, 0, token_type_ids=token_type_ids
+        )
+        return hidden_states, cache
+
+    def generate_step(self, inputs, stop_token_ids=None):
+        token_ids = inputs["token_ids"]
+        padding_mask = inputs["padding_mask"]
+        token_type_ids = inputs.get("token_type_ids")
+        if token_type_ids is None:
+            token_type_ids = ops.cast(padding_mask, "int32")
+        hidden_states, cache = self._build_cache(token_ids, token_type_ids)
+        row_lengths = ops.sum(ops.cast(padding_mask, "int32"), axis=-1)
+        index = ops.min(row_lengths)
+
+        def next(prompt, cache, index):
+            cache_update_index = index - 1
+            batch_size = ops.shape(prompt)[0]
+            prompt = ops.slice(prompt, [0, cache_update_index], [batch_size, 1])
+            logits, hidden_states, cache = self.call_with_cache(
+                prompt, cache, cache_update_index
+            )
+            return (
+                ops.squeeze(logits, axis=1),
+                ops.squeeze(hidden_states, axis=1),
+                cache,
+            )
+
+        token_ids = self.sampler(
+            next=next,
+            prompt=token_ids,
+            cache=cache,
+            index=index,
+            mask=padding_mask,
+            stop_token_ids=stop_token_ids,
+            hidden_states=hidden_states,
+            model=self,
+        )
+        if stop_token_ids is not None:
+            end_locations = any_equal(
+                token_ids, stop_token_ids, ops.logical_not(padding_mask)
+            )
+            end_locations = ops.cast(end_locations, "int32")
+            cumsum = ops.cast(ops.cumsum(end_locations, axis=-1), "int32")
+            padding_mask = ops.logical_not(
+                ops.cast(cumsum - end_locations, "bool")
+            )
+        else:
+            padding_mask = ops.ones_like(token_ids, dtype="bool")
+        return {
+            "token_ids": token_ids,
+            "padding_mask": ops.cast(padding_mask, token_ids.dtype),
+            "token_type_ids": ops.cast(padding_mask, token_ids.dtype),
+        }

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
@@ -14,7 +14,46 @@ from keras_hub.src.utils.tensor_utils import any_equal
 
 @keras_hub_export("keras_hub.models.HrmTextCausalLM")
 class HrmTextCausalLM(CausalLM):
-    """End-to-end HRM-Text causal language model."""
+    """End-to-end HRM-Text model for causal language modeling.
+
+    This task pairs :class:`HrmTextBackbone` with an LM head and KerasHub's
+    sampler interface. It supports ordinary causal training as well as the
+    PrefixLM format used to pretrain HRM-Text. When a preprocessor is attached,
+    plain strings are causal examples and dictionaries with ``prefix`` and
+    ``response`` are packed as PrefixLM examples.
+
+    The official 1B weights are not bundled with the source distribution. Use
+    the conversion script to create a local preset, then load it with
+    :meth:`from_preset`.
+
+    Args:
+        backbone: An instance of `keras_hub.models.HrmTextBackbone`.
+        preprocessor: An optional
+            `keras_hub.models.HrmTextCausalLMPreprocessor`. If set, string
+            inputs are preprocessed during `fit()`, `evaluate()`, `predict()`,
+            and `generate()`.
+
+    Examples:
+
+    Generate from a converted local preset.
+    ```python
+    model = keras_hub.models.HrmTextCausalLM.from_preset(
+        "/path/to/hrm_text_1b"
+    )
+    model.compile(sampler="greedy")
+    model.generate("Summarize: Keras runs on multiple backends.", max_length=64)
+    ```
+
+    Train with PrefixLM inputs. Prefix tokens attend bidirectionally, while
+    response tokens are trained causally.
+    ```python
+    examples = {
+        "prefix": ["Question: What is 2 + 2?\\nAnswer:"],
+        "response": [" 4"],
+    }
+    model.fit(examples, batch_size=1)
+    ```
+    """
 
     backbone_cls = HrmTextBackbone
     preprocessor_cls = HrmTextCausalLMPreprocessor

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
@@ -70,6 +70,31 @@ class HrmTextCausalLM(CausalLM):
         outputs = backbone.token_embedding(hidden_states, reverse=True)
         super().__init__(inputs=inputs, outputs=outputs, **kwargs)
 
+    def generate(
+        self,
+        inputs,
+        max_length=None,
+        stop_token_ids="auto",
+        strip_prompt=False,
+    ):
+        """Generate from canonical HRM PrefixLM inference prompts.
+
+        Raw string instructions use the base model's ``direct`` condition.
+        The preprocessor adds ``<|im_start|>`` and ``generate()`` stops on its
+        ``<|box_end|>`` end token. Passing preprocessed backbone tensors still
+        follows the standard ``CausalLM.generate()`` contract.
+        """
+        if self.preprocessor is not None and isinstance(
+            inputs, (str, list, tuple)
+        ):
+            inputs = self.preprocessor.format_instruction(inputs, "direct")
+        return super().generate(
+            inputs,
+            max_length=max_length,
+            stop_token_ids=stop_token_ids,
+            strip_prompt=strip_prompt,
+        )
+
     def call_with_cache(
         self, token_ids, cache, cache_update_index, token_type_ids=None
     ):

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm.py
@@ -22,6 +22,10 @@ class HrmTextCausalLM(CausalLM):
     plain strings are causal examples and dictionaries with ``prefix`` and
     ``response`` are packed as PrefixLM examples.
 
+    Condition tokens such as the official ``direct`` or ``synth,cot`` tokens
+    belong inside the PrefixLM prefix. They are prompt-formatting inputs, not
+    separate recurrent state.
+
     The official 1B weights are not bundled with the source distribution. Use
     the conversion script to create a local preset, then load it with
     :meth:`from_preset`.

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
@@ -1,0 +1,133 @@
+"""Causal language-model preprocessing for HRM-Text."""
+
+import keras
+from keras import ops
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.preprocessing.multi_segment_packer import (
+    MultiSegmentPacker,
+)
+from keras_hub.src.models.causal_lm_preprocessor import CausalLMPreprocessor
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
+from keras_hub.src.utils.tensor_utils import in_tf_function
+from keras_hub.src.utils.tensor_utils import preprocessing_function
+
+
+@keras_hub_export("keras_hub.models.HrmTextCausalLMPreprocessor")
+class HrmTextCausalLMPreprocessor(CausalLMPreprocessor):
+    """Preprocesses causal and PrefixLM data for `HrmTextCausalLM`.
+
+    A plain string is treated as causal language-model text. For PrefixLM
+    training, pass a dictionary containing ``prefix`` and ``response``. Only
+    response-token labels receive training weight; prefix tokens can attend to
+    one another bidirectionally.
+    """
+
+    backbone_cls = HrmTextBackbone
+    tokenizer_cls = HrmTextTokenizer
+
+    def build(self, input_shape):
+        self.packer = MultiSegmentPacker(
+            start_value=self.tokenizer.start_token_id,
+            sep_value=self.tokenizer.end_token_id,
+            end_value=self.tokenizer.end_token_id,
+            pad_value=self.tokenizer.pad_token_id,
+            sequence_length=self.sequence_length,
+            truncate="waterfall",
+        )
+        self.built = True
+
+    def _pack(self, segments, sequence_length, add_end_value):
+        token_ids, segment_ids = self.packer(
+            segments,
+            sequence_length=sequence_length,
+            add_start_value=self.add_start_token,
+            add_end_value=add_end_value,
+        )
+        padding_mask = ops.cast(
+            token_ids != self.tokenizer.pad_token_id, "int32"
+        )
+        return token_ids, padding_mask, segment_ids
+
+    def _call_python(self, x, y=None, sample_weight=None, sequence_length=None):
+        if not self.built:
+            self.build(None)
+        sequence_length = sequence_length or self.sequence_length
+        if isinstance(x, dict):
+            segments = (
+                self.tokenizer(x["prefix"]),
+                self.tokenizer(x["response"]),
+            )
+            prefix_lm = True
+        else:
+            segments = self.tokenizer(x)
+            prefix_lm = False
+        token_ids, padding_mask, segment_ids = self._pack(
+            segments,
+            sequence_length + 1,
+            add_end_value=self.add_end_token,
+        )
+        if prefix_lm:
+            token_type_ids = ops.cast(segment_ids == 0, "int32") * padding_mask
+        else:
+            token_type_ids = ops.zeros_like(padding_mask)
+        inputs = {
+            "token_ids": token_ids[..., :-1],
+            "padding_mask": padding_mask[..., :-1],
+            "token_type_ids": token_type_ids[..., :-1],
+        }
+        labels = token_ids[..., 1:]
+        weights = padding_mask[..., 1:]
+        if prefix_lm:
+            weights = weights * ops.cast(segment_ids[..., 1:] == 1, "int32")
+        return keras.utils.pack_x_y_sample_weight(inputs, labels, weights)
+
+    @preprocessing_function
+    def _call_tf(self, x, y=None, sample_weight=None, sequence_length=None):
+        return self._call_python(
+            x, y=y, sample_weight=sample_weight, sequence_length=sequence_length
+        )
+
+    def call(self, x, y=None, sample_weight=None, sequence_length=None):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._call_tf(
+                x,
+                y=y,
+                sample_weight=sample_weight,
+                sequence_length=sequence_length,
+            )
+        return self._call_python(
+            x,
+            y=y,
+            sample_weight=sample_weight,
+            sequence_length=sequence_length,
+        )
+
+    def _generate_preprocess_python(self, x, sequence_length=None):
+        if not self.built:
+            self.build(None)
+        sequence_length = sequence_length or self.sequence_length
+        token_ids, padding_mask, _ = self._pack(
+            self.tokenizer(x),
+            sequence_length=sequence_length,
+            add_end_value=False,
+        )
+        return {
+            "token_ids": token_ids,
+            "padding_mask": ops.cast(padding_mask, "int32"),
+            "token_type_ids": ops.cast(padding_mask, "int32"),
+        }
+
+    @preprocessing_function
+    def _generate_preprocess_tf(self, x, sequence_length=None):
+        return self._generate_preprocess_python(x, sequence_length)
+
+    def generate_preprocess(self, x, sequence_length=None):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._generate_preprocess_tf(
+                x, sequence_length=sequence_length
+            )
+        return self._generate_preprocess_python(
+            x, sequence_length=sequence_length
+        )

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
@@ -56,6 +56,39 @@ class HrmTextCausalLMPreprocessor(CausalLMPreprocessor):
     backbone_cls = HrmTextBackbone
     tokenizer_cls = HrmTextTokenizer
 
+    condition_tokens = {
+        "direct": "<|object_ref_start|>",
+        "cot": "<|object_ref_end|>",
+        "noisy": "<|quad_start|>",
+        "synth": "<|quad_end|>",
+    }
+
+    def format_instruction(self, instruction, condition="direct"):
+        """Format an HRM inference instruction without ``<|im_start|>``.
+
+        ``HrmTextCausalLM.generate()`` calls this method for raw string
+        inputs. ``generate_preprocess()`` then owns the leading
+        ``<|im_start|>`` token, producing the upstream PrefixLM prompt:
+        ``<|im_start|><condition>instruction<|im_end|>``. Generated output is
+        terminated by the tokenizer's ``<|box_end|>`` end token.
+        """
+        if condition not in self.condition_tokens:
+            raise ValueError(
+                "Unknown HRM-Text condition. Expected one of "
+                f"{sorted(self.condition_tokens)}."
+            )
+        prefix = self.condition_tokens[condition]
+        suffix = self.tokenizer.prefix_end_token
+        if isinstance(instruction, str):
+            return prefix + instruction + suffix
+        if isinstance(instruction, (list, tuple)):
+            if not all(isinstance(value, str) for value in instruction):
+                raise ValueError("HRM-Text instructions must be strings.")
+            return [prefix + value + suffix for value in instruction]
+        if getattr(instruction, "dtype", None) == tf.string:
+            return tf.strings.join([prefix, instruction, suffix])
+        raise ValueError("HRM-Text instructions must be strings.")
+
     def build(self, input_shape):
         self.packer = MultiSegmentPacker(
             start_value=self.tokenizer.start_token_id,

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
@@ -22,7 +22,10 @@ class HrmTextCausalLMPreprocessor(CausalLMPreprocessor):
     A plain string is treated as causal language-model text. For PrefixLM
     training, pass a dictionary containing ``prefix`` and ``response``. Only
     response-token labels receive training weight; prefix tokens can attend to
-    one another bidirectionally.
+    one another bidirectionally. Place official condition tokens inside the
+    ``prefix`` string, after ``<|im_start|>``; for example, the upstream
+    ``synth,cot`` condition begins with
+    ``<|im_start|><|quad_end|><|object_ref_end|>``.
 
     Args:
         tokenizer: An instance of `keras_hub.models.HrmTextTokenizer`.

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor.py
@@ -1,6 +1,7 @@
 """Causal language-model preprocessing for HRM-Text."""
 
 import keras
+import tensorflow as tf
 from keras import ops
 
 from keras_hub.src.api_export import keras_hub_export
@@ -22,6 +23,31 @@ class HrmTextCausalLMPreprocessor(CausalLMPreprocessor):
     training, pass a dictionary containing ``prefix`` and ``response``. Only
     response-token labels receive training weight; prefix tokens can attend to
     one another bidirectionally.
+
+    Args:
+        tokenizer: An instance of `keras_hub.models.HrmTextTokenizer`.
+        sequence_length: Packed sequence length. Defaults to ``128``.
+        add_start_token: Whether to prepend ``<|im_start|>``. Defaults to
+            ``True``.
+        add_end_token: Whether to append ``<|box_end|>``. Defaults to
+            ``True``.
+
+    Examples:
+
+    ```python
+    preprocessor = keras_hub.models.HrmTextCausalLMPreprocessor.from_preset(
+        "/path/to/hrm_text_1b", sequence_length=128
+    )
+
+    # Ordinary causal LM inputs.
+    x, y, sample_weight = preprocessor(["A short document."])
+
+    # PrefixLM inputs: only response labels receive nonzero sample weights.
+    x, y, sample_weight = preprocessor({
+        "prefix": ["Question: What is 2 + 2?\\nAnswer:"],
+        "response": [" 4"],
+    })
+    ```
     """
 
     backbone_cls = HrmTextBackbone
@@ -85,9 +111,44 @@ class HrmTextCausalLMPreprocessor(CausalLMPreprocessor):
 
     @preprocessing_function
     def _call_tf(self, x, y=None, sample_weight=None, sequence_length=None):
-        return self._call_python(
-            x, y=y, sample_weight=sample_weight, sequence_length=sequence_length
+        if not self.built:
+            self.build(None)
+        sequence_length = sequence_length or self.sequence_length
+        if isinstance(x, dict):
+            segments = (
+                self.tokenizer(x["prefix"]),
+                self.tokenizer(x["response"]),
+            )
+            prefix_lm = True
+        else:
+            segments = self.tokenizer(x)
+            prefix_lm = False
+        token_ids, segment_ids = self.packer(
+            segments,
+            sequence_length=sequence_length + 1,
+            add_start_value=self.add_start_token,
+            add_end_value=self.add_end_token,
         )
+        padding_mask = tf.cast(
+            tf.not_equal(token_ids, self.tokenizer.pad_token_id), tf.int32
+        )
+        if prefix_lm:
+            token_type_ids = tf.cast(tf.equal(segment_ids, 0), tf.int32)
+            token_type_ids = token_type_ids * padding_mask
+        else:
+            token_type_ids = tf.zeros_like(padding_mask)
+        inputs = {
+            "token_ids": token_ids[..., :-1],
+            "padding_mask": padding_mask[..., :-1],
+            "token_type_ids": token_type_ids[..., :-1],
+        }
+        labels = token_ids[..., 1:]
+        weights = padding_mask[..., 1:]
+        if prefix_lm:
+            weights = weights * tf.cast(
+                tf.equal(segment_ids[..., 1:], 1), tf.int32
+            )
+        return keras.utils.pack_x_y_sample_weight(inputs, labels, weights)
 
     def call(self, x, y=None, sample_weight=None, sequence_length=None):
         if not self._allow_python_workflow or in_tf_function():
@@ -121,7 +182,23 @@ class HrmTextCausalLMPreprocessor(CausalLMPreprocessor):
 
     @preprocessing_function
     def _generate_preprocess_tf(self, x, sequence_length=None):
-        return self._generate_preprocess_python(x, sequence_length)
+        if not self.built:
+            self.build(None)
+        sequence_length = sequence_length or self.sequence_length
+        token_ids, _ = self.packer(
+            self.tokenizer(x),
+            sequence_length=sequence_length,
+            add_start_value=self.add_start_token,
+            add_end_value=False,
+        )
+        padding_mask = tf.cast(
+            tf.not_equal(token_ids, self.tokenizer.pad_token_id), tf.int32
+        )
+        return {
+            "token_ids": token_ids,
+            "padding_mask": padding_mask,
+            "token_type_ids": padding_mask,
+        }
 
     def generate_preprocess(self, x, sequence_length=None):
         if not self._allow_python_workflow or in_tf_function():

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor_test.py
@@ -74,6 +74,29 @@ class HrmTextCausalLMPreprocessorTest(TestCase):
 
     def test_generate_round_trip(self):
         preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
-        inputs = preprocessor.generate_preprocess(" airplane")
+        formatted = preprocessor.format_instruction(" airplane")
+        self.assertEqual(
+            formatted, "<|object_ref_start|> airplane<|im_end|>"
+        )
+        inputs = preprocessor.generate_preprocess(formatted)
         self.assertAllEqual(inputs["token_type_ids"], inputs["padding_mask"])
-        self.assertEqual(preprocessor.generate_postprocess(inputs), " airplane")
+        self.assertAllEqual(
+            inputs["token_ids"],
+            [
+                3,
+                self.tokenizer.direct_condition_token_id,
+                27,
+                18,
+                self.tokenizer.prefix_end_token_id,
+                2,
+                2,
+            ],
+        )
+        self.assertEqual(
+            preprocessor.generate_postprocess(inputs), " airplane"
+        )
+
+    def test_format_instruction_rejects_unknown_condition(self):
+        preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
+        with self.assertRaisesRegex(ValueError, "Unknown HRM-Text condition"):
+            preprocessor.format_instruction(" airplane", "unknown")

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_preprocessor_test.py
@@ -1,0 +1,79 @@
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
+    HrmTextCausalLMPreprocessor,
+)
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer_test import (
+    make_tokenizer_assets,
+)
+from keras_hub.src.tests.test_case import TestCase
+
+
+class HrmTextCausalLMPreprocessorTest(TestCase):
+    def setUp(self):
+        vocabulary, merges = make_tokenizer_assets()
+        self.tokenizer = HrmTextTokenizer(vocabulary=vocabulary, merges=merges)
+        self.init_kwargs = {
+            "tokenizer": self.tokenizer,
+            "sequence_length": 7,
+        }
+
+    def test_causal_preprocessor(self):
+        self.run_preprocessor_test(
+            cls=HrmTextCausalLMPreprocessor,
+            init_kwargs=self.init_kwargs,
+            input_data=[" airplane at airport"],
+            expected_output=(
+                {
+                    "token_ids": [[3, 27, 18, 28, 27, 20, 1]],
+                    "padding_mask": [[1, 1, 1, 1, 1, 1, 1]],
+                    "token_type_ids": [[0, 0, 0, 0, 0, 0, 0]],
+                },
+                [[27, 18, 28, 27, 20, 1, 2]],
+                [[1, 1, 1, 1, 1, 1, 0]],
+            ),
+        )
+
+    def test_prefix_lm_preprocessor(self):
+        preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
+        outputs = preprocessor(
+            {"prefix": [" airplane"], "response": [" at airport"]}
+        )
+        inputs, labels, weights = outputs
+        self.assertAllEqual(inputs["token_ids"], [[3, 27, 18, 1, 28, 27, 1]])
+        self.assertAllEqual(inputs["padding_mask"], [[1, 1, 1, 1, 1, 1, 1]])
+        self.assertAllEqual(inputs["token_type_ids"], [[1, 1, 1, 1, 0, 0, 0]])
+        self.assertAllEqual(labels, [[27, 18, 1, 28, 27, 1, 2]])
+        self.assertAllEqual(weights, [[0, 0, 0, 1, 1, 1, 0]])
+
+    def test_empty_prefix(self):
+        preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
+        inputs, _, weights = preprocessor(
+            {"prefix": [""], "response": [" airplane"]}
+        )
+        self.assertAllEqual(inputs["token_type_ids"], [[1, 1, 0, 0, 0, 0, 0]])
+        self.assertAllEqual(weights, [[0, 1, 1, 1, 0, 0, 0]])
+
+    def test_empty_response(self):
+        preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
+        inputs, _, weights = preprocessor(
+            {"prefix": [" airplane"], "response": [""]}
+        )
+        self.assertAllEqual(inputs["token_type_ids"], [[1, 1, 1, 1, 0, 0, 0]])
+        self.assertAllEqual(weights, [[0, 0, 0, 1, 0, 0, 0]])
+
+    def test_mixed_length_batch(self):
+        preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
+        inputs, _, weights = preprocessor(
+            {
+                "prefix": [" airplane", ""],
+                "response": [" at airport", " airplane"],
+            }
+        )
+        self.assertAllEqual(inputs["token_ids"].shape, (2, 7))
+        self.assertAllEqual(weights.shape, (2, 7))
+
+    def test_generate_round_trip(self):
+        preprocessor = HrmTextCausalLMPreprocessor(**self.init_kwargs)
+        inputs = preprocessor.generate_preprocess(" airplane")
+        self.assertAllEqual(inputs["token_type_ids"], inputs["padding_mask"])
+        self.assertEqual(preprocessor.generate_postprocess(inputs), " airplane")

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm import HrmTextCausalLM
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
+    HrmTextCausalLMPreprocessor,
+)
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
+from keras_hub.src.tests.test_case import TestCase
+
+
+class HrmTextCausalLMTest(TestCase):
+    def setUp(self):
+        self.merges = ["Ġ a", "Ġ t", "Ġ i", "Ġ b", "a i", "p l", "n e"]
+        self.merges += [
+            "Ġa t",
+            "p o",
+            "r t",
+            "Ġt h",
+            "ai r",
+            "pl a",
+            "po rt",
+        ]
+        self.merges += ["Ġai r", "Ġa i", "pla ne"]
+        vocabulary = []
+        for merge in self.merges:
+            left, right = merge.split(" ")
+            vocabulary.extend([left, right, left + right])
+        vocabulary += ["!", "<|im_start|>", "<|box_end|>", "<|endoftext|>"]
+        vocabulary = dict(
+            (token, index)
+            for index, token in enumerate(sorted(set(vocabulary)))
+        )
+        self.preprocessor = HrmTextCausalLMPreprocessor(
+            HrmTextTokenizer(vocabulary=vocabulary, merges=self.merges),
+            sequence_length=7,
+        )
+        self.backbone = HrmTextBackbone(
+            vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
+            hidden_dim=16,
+            intermediate_dim=32,
+            num_layers_per_stack=2,
+            num_attention_heads=4,
+            head_dim=4,
+            h_cycles=2,
+            l_cycles=2,
+            max_sequence_length=8,
+        )
+        self.init_kwargs = {
+            "backbone": self.backbone,
+            "preprocessor": self.preprocessor,
+        }
+        self.train_data = ([" airplane at airport", " airplane at airport"],)
+        self.input_data = self.preprocessor(*self.train_data)[0]
+
+    def test_causal_lm_basics(self):
+        self.run_task_test(
+            cls=HrmTextCausalLM,
+            init_kwargs=self.init_kwargs,
+            train_data=self.train_data,
+            expected_output_shape=(2, 7, self.backbone.vocabulary_size),
+        )
+
+    def test_prefix_lm_response_weights(self):
+        inputs, _, sample_weight = self.preprocessor(
+            {"prefix": [" airplane"], "response": [" at airport"]}
+        )
+        self.assertEqual(inputs["token_type_ids"][0, 0], 1)
+        self.assertTrue(np.any(inputs["token_type_ids"][0] == 0))
+        self.assertEqual(sample_weight[0, 0], 0)
+        self.assertTrue(np.any(sample_weight[0] == 1))
+
+    def test_generate(self):
+        causal_lm = HrmTextCausalLM(**self.init_kwargs)
+        prompt = " airplane"
+        prompt_ids = self.preprocessor.generate_preprocess(
+            [prompt], sequence_length=7
+        )
+        causal_lm.preprocessor = None
+        outputs = causal_lm.generate(prompt_ids, stop_token_ids=None)
+        self.assertAllEqual(
+            outputs["token_ids"][:, :2], prompt_ids["token_ids"][:, :2]
+        )
+        self.assertAllEqual(
+            outputs["padding_mask"][:, :2], prompt_ids["padding_mask"][:, :2]
+        )

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
@@ -1,4 +1,9 @@
+import os
+from unittest.mock import patch
+
+import keras
 import numpy as np
+import pytest
 from keras import ops
 
 from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
@@ -76,6 +81,9 @@ class HrmTextCausalLMTest(TestCase):
     def test_generate(self):
         causal_lm = HrmTextCausalLM(**self.init_kwargs)
         prompt = " airplane"
+        output = causal_lm.generate(prompt)
+        self.assertTrue(isinstance(output, str))
+        self.assertTrue(prompt in output)
         prompt_ids = self.preprocessor.generate_preprocess(
             [prompt], sequence_length=7
         )
@@ -87,3 +95,133 @@ class HrmTextCausalLMTest(TestCase):
         self.assertAllEqual(
             outputs["padding_mask"][:, :2], prompt_ids["padding_mask"][:, :2]
         )
+
+    def test_generate_strip_prompt(self):
+        causal_lm = HrmTextCausalLM(**self.init_kwargs)
+        prompt = " airplane"
+        output = causal_lm.generate(prompt, strip_prompt=True)
+        self.assertFalse(output.startswith(prompt))
+
+    def test_generate_compilation(self):
+        causal_lm = HrmTextCausalLM(**self.init_kwargs)
+        causal_lm.generate(" airplane")
+        first_function = causal_lm.generate_function
+        causal_lm.generate(" airplane")
+        self.assertEqual(first_function, causal_lm.generate_function)
+        causal_lm.compile(sampler="greedy")
+        self.assertIsNone(causal_lm.generate_function)
+
+    def test_early_stopping_with_unequal_prompts(self):
+        causal_lm = HrmTextCausalLM(**self.init_kwargs)
+        call_with_cache = causal_lm.call_with_cache
+
+        def wrapper(*args, **kwargs):
+            logits, hidden_states, cache = call_with_cache(*args, **kwargs)
+            index = self.preprocessor.tokenizer.end_token_id
+            update = ops.ones_like(logits)[:, :, index] * 1.0e9
+            logits = ops.slice_update(
+                logits,
+                (0, 0, index),
+                ops.expand_dims(update, axis=-1),
+            )
+            return logits, hidden_states, cache
+
+        prompts = [" airplane at airport", " airplane"]
+        with patch.object(causal_lm, "call_with_cache", wraps=wrapper):
+            outputs = causal_lm.generate(prompts)
+        self.assertEqual(outputs, prompts)
+
+    def test_tied_and_untied_embeddings(self):
+        for tie_word_embeddings in (True, False):
+            backbone = HrmTextBackbone(
+                vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
+                hidden_dim=16,
+                intermediate_dim=32,
+                num_layers_per_stack=1,
+                num_attention_heads=4,
+                head_dim=4,
+                h_cycles=1,
+                l_cycles=1,
+                tie_word_embeddings=tie_word_embeddings,
+            )
+            model = HrmTextCausalLM(backbone, self.preprocessor)
+            outputs = model(self.input_data)
+            self.assertEqual(
+                outputs.shape[-1], self.preprocessor.tokenizer.vocabulary_size()
+            )
+            self.assertEqual(
+                backbone.token_embedding.tie_weights, tie_word_embeddings
+            )
+
+    def test_l_bp_cycles_control_training_gradients(self):
+        def make_model(l_bp_cycles):
+            backbone = HrmTextBackbone(
+                vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
+                hidden_dim=16,
+                intermediate_dim=32,
+                num_layers_per_stack=1,
+                num_attention_heads=4,
+                head_dim=4,
+                h_cycles=2,
+                l_cycles=2,
+                l_bp_cycles=l_bp_cycles,
+            )
+            model = HrmTextCausalLM(backbone, self.preprocessor)
+            model.compile(
+                optimizer=keras.optimizers.SGD(learning_rate=0.01),
+                loss=keras.losses.SparseCategoricalCrossentropy(
+                    from_logits=True
+                ),
+            )
+            return model
+
+        train_data = {
+            "prefix": [" airplane", " airplane"],
+            "response": [" at airport", " at airport"],
+        }
+        frozen_model = make_model([0, 0])
+        frozen_before = [
+            ops.convert_to_numpy(weight).copy()
+            for weight in frozen_model.backbone.L_module.weights
+        ]
+        frozen_model.fit(train_data, batch_size=2, epochs=1, verbose=0)
+        frozen_after = [
+            ops.convert_to_numpy(weight)
+            for weight in frozen_model.backbone.L_module.weights
+        ]
+        for before, after in zip(frozen_before, frozen_after):
+            self.assertAllClose(before, after)
+
+        enabled_model = make_model([2, 2])
+        enabled_before = [
+            ops.convert_to_numpy(weight).copy()
+            for weight in enabled_model.backbone.L_module.weights
+        ]
+        enabled_model.fit(train_data, batch_size=2, epochs=1, verbose=0)
+        enabled_after = [
+            ops.convert_to_numpy(weight)
+            for weight in enabled_model.backbone.L_module.weights
+        ]
+        self.assertTrue(
+            any(
+                not np.allclose(before, after)
+                for before, after in zip(enabled_before, enabled_after)
+            )
+        )
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=HrmTextCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )
+
+    @pytest.mark.large
+    def test_local_preset_round_trip(self):
+        model = HrmTextCausalLM(**self.init_kwargs)
+        expected = model(self.input_data)
+        preset_dir = os.path.join(self.get_temp_dir(), "hrm_text_preset")
+        model.save_to_preset(preset_dir)
+        restored = HrmTextCausalLM.from_preset(preset_dir)
+        self.assertAllClose(expected, restored(self.input_data))

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+from keras import ops
 
 from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
 from keras_hub.src.models.hrm_text.hrm_text_causal_lm import HrmTextCausalLM
@@ -66,9 +67,13 @@ class HrmTextCausalLMTest(TestCase):
             {"prefix": [" airplane"], "response": [" at airport"]}
         )
         self.assertEqual(inputs["token_type_ids"][0, 0], 1)
-        self.assertTrue(np.any(inputs["token_type_ids"][0] == 0))
+        self.assertTrue(
+            np.any(ops.convert_to_numpy(inputs["token_type_ids"][0] == 0))
+        )
         self.assertEqual(sample_weight[0, 0], 0)
-        self.assertTrue(np.any(sample_weight[0] == 1))
+        self.assertTrue(
+            np.any(ops.convert_to_numpy(sample_weight[0] == 1))
+        )
 
     def test_generate(self):
         causal_lm = HrmTextCausalLM(**self.init_kwargs)

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
@@ -92,8 +92,9 @@ class HrmTextCausalLMTest(TestCase):
         output = causal_lm.generate(prompt)
         self.assertTrue(isinstance(output, str))
         self.assertTrue(prompt in output)
+        formatted_prompt = self.preprocessor.format_instruction(prompt)
         prompt_ids = self.preprocessor.generate_preprocess(
-            [prompt], sequence_length=7
+            [formatted_prompt], sequence_length=7
         )
         causal_lm.preprocessor = None
         outputs = causal_lm.generate(prompt_ids, stop_token_ids=None)

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
@@ -71,9 +71,7 @@ class HrmTextCausalLMTest(TestCase):
             np.any(ops.convert_to_numpy(inputs["token_type_ids"][0] == 0))
         )
         self.assertEqual(sample_weight[0, 0], 0)
-        self.assertTrue(
-            np.any(ops.convert_to_numpy(sample_weight[0] == 1))
-        )
+        self.assertTrue(np.any(ops.convert_to_numpy(sample_weight[0] == 1)))
 
     def test_generate(self):
         causal_lm = HrmTextCausalLM(**self.init_kwargs)

--- a/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_causal_lm_test.py
@@ -37,6 +37,14 @@ class HrmTextCausalLMTest(TestCase):
             (token, index)
             for index, token in enumerate(sorted(set(vocabulary)))
         )
+        for token in (
+            "<|im_end|>",
+            "<|object_ref_start|>",
+            "<|object_ref_end|>",
+            "<|quad_start|>",
+            "<|quad_end|>",
+        ):
+            vocabulary[token] = len(vocabulary)
         self.preprocessor = HrmTextCausalLMPreprocessor(
             HrmTextTokenizer(vocabulary=vocabulary, merges=self.merges),
             sequence_length=7,
@@ -221,7 +229,29 @@ class HrmTextCausalLMTest(TestCase):
     def test_local_preset_round_trip(self):
         model = HrmTextCausalLM(**self.init_kwargs)
         expected = model(self.input_data)
+        expected_special_token_ids = {
+            "start": self.preprocessor.tokenizer.start_token_id,
+            "prefix_end": self.preprocessor.tokenizer.prefix_end_token_id,
+            "end": self.preprocessor.tokenizer.end_token_id,
+            "pad": self.preprocessor.tokenizer.pad_token_id,
+            "direct": self.preprocessor.tokenizer.direct_condition_token_id,
+            "cot": self.preprocessor.tokenizer.cot_condition_token_id,
+            "noisy": self.preprocessor.tokenizer.noisy_condition_token_id,
+            "synth": self.preprocessor.tokenizer.synth_condition_token_id,
+        }
         preset_dir = os.path.join(self.get_temp_dir(), "hrm_text_preset")
         model.save_to_preset(preset_dir)
         restored = HrmTextCausalLM.from_preset(preset_dir)
         self.assertAllClose(expected, restored(self.input_data))
+        restored_tokenizer = restored.preprocessor.tokenizer
+        actual_special_token_ids = {
+            "start": restored_tokenizer.start_token_id,
+            "prefix_end": restored_tokenizer.prefix_end_token_id,
+            "end": restored_tokenizer.end_token_id,
+            "pad": restored_tokenizer.pad_token_id,
+            "direct": restored_tokenizer.direct_condition_token_id,
+            "cot": restored_tokenizer.cot_condition_token_id,
+            "noisy": restored_tokenizer.noisy_condition_token_id,
+            "synth": restored_tokenizer.synth_condition_token_id,
+        }
+        self.assertEqual(actual_special_token_ids, expected_special_token_ids)

--- a/keras_hub/src/models/hrm_text/hrm_text_layers.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_layers.py
@@ -128,7 +128,7 @@ class HrmTextAttention(keras.layers.Layer):
 
     def _apply_rope(self, inputs, start_index):
         sequence_length = ops.shape(inputs)[1]
-        positions = ops.arange(start_index, start_index + sequence_length)
+        positions = ops.arange(sequence_length, dtype="int32") + start_index
         frequencies = ops.arange(0, self.head_dim, 2, dtype="float32")
         frequencies = 1.0 / (self.rope_theta ** (frequencies / self.head_dim))
         angles = (
@@ -176,15 +176,10 @@ class HrmTextAttention(keras.layers.Layer):
             value_cache = ops.slice_update(
                 value_cache, [0, start_index, 0, 0], value_update
             )
-            key_length = start_index + sequence_length
-            cache_shape = [
-                batch_size,
-                key_length,
-                self.num_heads,
-                self.head_dim,
-            ]
-            key = ops.slice(key_cache, [0, 0, 0, 0], cache_shape)
-            value = ops.slice(value_cache, [0, 0, 0, 0], cache_shape)
+            # Attend over the full, statically shaped cache. The causal mask
+            # excludes its not-yet-written positions. This avoids dynamic
+            # slice sizes in JAX's compiled generation loop.
+            key, value = key_cache, value_cache
             cache = ops.stack((key_cache, value_cache), axis=1)
 
         scores = ops.einsum("bqhd,bkhd->bhqk", query, key)

--- a/keras_hub/src/models/hrm_text/hrm_text_layers.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_layers.py
@@ -3,6 +3,8 @@
 import keras
 from keras import ops
 
+from keras_hub.src.utils.keras_utils import clone_initializer
+
 
 class HrmTextAttentionMask(keras.layers.Layer):
     """Builds the dynamic causal or PrefixLM attention mask."""
@@ -38,7 +40,7 @@ class HrmTextRMSNorm(keras.layers.Layer):
 
 
 class HrmTextInitialState(keras.layers.Layer):
-    """Broadcasts HRM-Text's learned low-level initial state."""
+    """Broadcasts HRM-Text's frozen checkpoint low-level initial state."""
 
     def __init__(self, hidden_dim, **kwargs):
         super().__init__(**kwargs)
@@ -49,7 +51,7 @@ class HrmTextInitialState(keras.layers.Layer):
             name="z_L_init",
             shape=(self.hidden_dim,),
             initializer="zeros",
-            trainable=True,
+            trainable=False,
         )
         super().build(inputs_shape)
 
@@ -66,9 +68,12 @@ class HrmTextInitialState(keras.layers.Layer):
 class HrmTextMLP(keras.layers.Layer):
     """SwiGLU feed-forward network."""
 
-    def __init__(self, intermediate_dim, **kwargs):
+    def __init__(
+        self, intermediate_dim, kernel_initializer="glorot_uniform", **kwargs
+    ):
         super().__init__(**kwargs)
         self.intermediate_dim = intermediate_dim
+        self.kernel_initializer = keras.initializers.get(kernel_initializer)
 
     def build(self, inputs_shape):
         hidden_dim = inputs_shape[-1]
@@ -77,18 +82,21 @@ class HrmTextMLP(keras.layers.Layer):
             use_bias=False,
             name="gate_proj",
             dtype=self.dtype_policy,
+            kernel_initializer=clone_initializer(self.kernel_initializer),
         )
         self.up_proj = keras.layers.Dense(
             self.intermediate_dim,
             use_bias=False,
             name="up_proj",
             dtype=self.dtype_policy,
+            kernel_initializer=clone_initializer(self.kernel_initializer),
         )
         self.down_proj = keras.layers.Dense(
             hidden_dim,
             use_bias=False,
             name="down_proj",
             dtype=self.dtype_policy,
+            kernel_initializer=clone_initializer(self.kernel_initializer),
         )
         super().build(inputs_shape)
 
@@ -98,19 +106,34 @@ class HrmTextMLP(keras.layers.Layer):
 
     def get_config(self):
         config = super().get_config()
-        config.update({"intermediate_dim": self.intermediate_dim})
+        config.update(
+            {
+                "intermediate_dim": self.intermediate_dim,
+                "kernel_initializer": keras.initializers.serialize(
+                    self.kernel_initializer
+                ),
+            }
+        )
         return config
 
 
 class HrmTextAttention(keras.layers.Layer):
     """Multi-head RoPE attention with HRM-Text's sigmoid output gate."""
 
-    def __init__(self, num_heads, head_dim, rope_theta=10000.0, **kwargs):
+    def __init__(
+        self,
+        num_heads,
+        head_dim,
+        rope_theta=10000.0,
+        kernel_initializer="glorot_uniform",
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.num_heads = num_heads
         self.head_dim = head_dim
         self.rope_theta = rope_theta
         self.hidden_dim = num_heads * head_dim
+        self.kernel_initializer = keras.initializers.get(kernel_initializer)
 
     def build(self, inputs_shape):
         for name in ("q_proj", "k_proj", "v_proj", "gate_proj", "o_proj"):
@@ -122,6 +145,9 @@ class HrmTextAttention(keras.layers.Layer):
                     use_bias=False,
                     name=name,
                     dtype=self.dtype_policy,
+                    kernel_initializer=clone_initializer(
+                        self.kernel_initializer
+                    ),
                 ),
             )
         super().build(inputs_shape)
@@ -202,6 +228,9 @@ class HrmTextAttention(keras.layers.Layer):
                 "num_heads": self.num_heads,
                 "head_dim": self.head_dim,
                 "rope_theta": self.rope_theta,
+                "kernel_initializer": keras.initializers.serialize(
+                    self.kernel_initializer
+                ),
             }
         )
         return config
@@ -217,6 +246,7 @@ class HrmTextDecoderBlock(keras.layers.Layer):
         intermediate_dim,
         rope_theta=10000.0,
         rms_norm_epsilon=1e-6,
+        kernel_initializer="glorot_uniform",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -225,6 +255,7 @@ class HrmTextDecoderBlock(keras.layers.Layer):
         self.intermediate_dim = intermediate_dim
         self.rope_theta = rope_theta
         self.rms_norm_epsilon = rms_norm_epsilon
+        self.kernel_initializer = keras.initializers.get(kernel_initializer)
 
     def build(self, inputs_shape):
         self.input_layernorm = HrmTextRMSNorm(
@@ -236,6 +267,7 @@ class HrmTextDecoderBlock(keras.layers.Layer):
             self.num_heads,
             self.head_dim,
             self.rope_theta,
+            kernel_initializer=clone_initializer(self.kernel_initializer),
             name="self_attn",
             dtype=self.dtype_policy,
         )
@@ -245,7 +277,10 @@ class HrmTextDecoderBlock(keras.layers.Layer):
             dtype=self.dtype_policy,
         )
         self.mlp = HrmTextMLP(
-            self.intermediate_dim, name="mlp", dtype=self.dtype_policy
+            self.intermediate_dim,
+            kernel_initializer=clone_initializer(self.kernel_initializer),
+            name="mlp",
+            dtype=self.dtype_policy,
         )
         super().build(inputs_shape)
 
@@ -276,6 +311,9 @@ class HrmTextDecoderBlock(keras.layers.Layer):
                 "intermediate_dim": self.intermediate_dim,
                 "rope_theta": self.rope_theta,
                 "rms_norm_epsilon": self.rms_norm_epsilon,
+                "kernel_initializer": keras.initializers.serialize(
+                    self.kernel_initializer
+                ),
             }
         )
         return config

--- a/keras_hub/src/models/hrm_text/hrm_text_layers.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_layers.py
@@ -1,0 +1,335 @@
+"""Portable core layers for HRM-Text."""
+
+import keras
+from keras import ops
+
+
+class HrmTextAttentionMask(keras.layers.Layer):
+    """Builds the dynamic causal or PrefixLM attention mask."""
+
+    def call(self, token_type_ids, padding_mask):
+        sequence_length = ops.shape(token_type_ids)[1]
+        positions = ops.arange(sequence_length)
+        causal = positions[None, :] <= positions[:, None]
+        prefix = ops.cast(token_type_ids == 1, "bool")
+        prefix_mask = ops.logical_and(prefix[:, :, None], prefix[:, None, :])
+        allowed = ops.logical_or(causal[None, :, :], prefix_mask)
+        valid = ops.cast(padding_mask, "bool")
+        valid_mask = ops.logical_and(valid[:, :, None], valid[:, None, :])
+        return ops.logical_and(allowed, valid_mask)
+
+
+class HrmTextRMSNorm(keras.layers.Layer):
+    """Parameterless RMS normalization used by HRM-Text."""
+
+    def __init__(self, epsilon=1e-6, **kwargs):
+        super().__init__(**kwargs)
+        self.epsilon = epsilon
+
+    def call(self, inputs):
+        variance = ops.mean(ops.square(inputs), axis=-1, keepdims=True)
+        outputs = inputs * ops.rsqrt(variance + self.epsilon)
+        return ops.cast(outputs, inputs.dtype)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"epsilon": self.epsilon})
+        return config
+
+
+class HrmTextInitialState(keras.layers.Layer):
+    """Broadcasts HRM-Text's learned low-level initial state."""
+
+    def __init__(self, hidden_dim, **kwargs):
+        super().__init__(**kwargs)
+        self.hidden_dim = hidden_dim
+
+    def build(self, inputs_shape):
+        self.z_L_init = self.add_weight(
+            name="z_L_init",
+            shape=(self.hidden_dim,),
+            initializer="zeros",
+            trainable=True,
+        )
+        super().build(inputs_shape)
+
+    def call(self, inputs):
+        initial_state = ops.cast(self.z_L_init, inputs.dtype)
+        return ops.broadcast_to(initial_state, ops.shape(inputs))
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"hidden_dim": self.hidden_dim})
+        return config
+
+
+class HrmTextMLP(keras.layers.Layer):
+    """SwiGLU feed-forward network."""
+
+    def __init__(self, intermediate_dim, **kwargs):
+        super().__init__(**kwargs)
+        self.intermediate_dim = intermediate_dim
+
+    def build(self, inputs_shape):
+        hidden_dim = inputs_shape[-1]
+        self.gate_proj = keras.layers.Dense(
+            self.intermediate_dim,
+            use_bias=False,
+            name="gate_proj",
+            dtype=self.dtype_policy,
+        )
+        self.up_proj = keras.layers.Dense(
+            self.intermediate_dim,
+            use_bias=False,
+            name="up_proj",
+            dtype=self.dtype_policy,
+        )
+        self.down_proj = keras.layers.Dense(
+            hidden_dim,
+            use_bias=False,
+            name="down_proj",
+            dtype=self.dtype_policy,
+        )
+        super().build(inputs_shape)
+
+    def call(self, inputs):
+        hidden_states = ops.silu(self.gate_proj(inputs)) * self.up_proj(inputs)
+        return self.down_proj(hidden_states)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"intermediate_dim": self.intermediate_dim})
+        return config
+
+
+class HrmTextAttention(keras.layers.Layer):
+    """Multi-head RoPE attention with HRM-Text's sigmoid output gate."""
+
+    def __init__(self, num_heads, head_dim, rope_theta=10000.0, **kwargs):
+        super().__init__(**kwargs)
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.rope_theta = rope_theta
+        self.hidden_dim = num_heads * head_dim
+
+    def build(self, inputs_shape):
+        for name in ("q_proj", "k_proj", "v_proj", "gate_proj", "o_proj"):
+            setattr(
+                self,
+                name,
+                keras.layers.Dense(
+                    self.hidden_dim,
+                    use_bias=False,
+                    name=name,
+                    dtype=self.dtype_policy,
+                ),
+            )
+        super().build(inputs_shape)
+
+    def _apply_rope(self, inputs, start_index):
+        sequence_length = ops.shape(inputs)[1]
+        positions = ops.arange(start_index, start_index + sequence_length)
+        frequencies = ops.arange(0, self.head_dim, 2, dtype="float32")
+        frequencies = 1.0 / (self.rope_theta ** (frequencies / self.head_dim))
+        angles = (
+            ops.expand_dims(ops.cast(positions, "float32"), -1) * frequencies
+        )
+        angles = ops.concatenate((angles, angles), axis=-1)
+        cos = ops.cast(ops.cos(angles)[None, :, None, :], inputs.dtype)
+        sin = ops.cast(ops.sin(angles)[None, :, None, :], inputs.dtype)
+        half = self.head_dim // 2
+        rotated = ops.concatenate(
+            (-inputs[..., half:], inputs[..., :half]), axis=-1
+        )
+        return inputs * cos + rotated * sin
+
+    def call(
+        self,
+        hidden_states,
+        attention_mask,
+        cache=None,
+        cache_update_index=None,
+    ):
+        shape = ops.shape(hidden_states)
+        batch_size, sequence_length = shape[0], shape[1]
+        reshape_shape = (
+            batch_size,
+            sequence_length,
+            self.num_heads,
+            self.head_dim,
+        )
+        query = ops.reshape(self.q_proj(hidden_states), reshape_shape)
+        key_update = ops.reshape(self.k_proj(hidden_states), reshape_shape)
+        value_update = ops.reshape(self.v_proj(hidden_states), reshape_shape)
+        gate = ops.reshape(self.gate_proj(hidden_states), reshape_shape)
+        start_index = 0 if cache_update_index is None else cache_update_index
+        query = self._apply_rope(query, start_index)
+        key_update = self._apply_rope(key_update, start_index)
+
+        if cache is None:
+            key, value = key_update, value_update
+        else:
+            key_cache, value_cache = cache[:, 0], cache[:, 1]
+            key_cache = ops.slice_update(
+                key_cache, [0, start_index, 0, 0], key_update
+            )
+            value_cache = ops.slice_update(
+                value_cache, [0, start_index, 0, 0], value_update
+            )
+            key_length = start_index + sequence_length
+            cache_shape = [
+                batch_size,
+                key_length,
+                self.num_heads,
+                self.head_dim,
+            ]
+            key = ops.slice(key_cache, [0, 0, 0, 0], cache_shape)
+            value = ops.slice(value_cache, [0, 0, 0, 0], cache_shape)
+            cache = ops.stack((key_cache, value_cache), axis=1)
+
+        scores = ops.einsum("bqhd,bkhd->bhqk", query, key)
+        scores = scores * (self.head_dim**-0.5)
+        mask = ops.cast(attention_mask[:, None, :, :], "bool")
+        scores = ops.where(mask, scores, ops.cast(-1e30, scores.dtype))
+        weights = ops.softmax(scores, axis=-1)
+        output = ops.einsum("bhqk,bkhd->bqhd", weights, value)
+        output = ops.sigmoid(gate) * output
+        output = ops.reshape(
+            output, (batch_size, sequence_length, self.hidden_dim)
+        )
+        output = self.o_proj(output)
+        return (output, cache) if cache is not None else output
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "num_heads": self.num_heads,
+                "head_dim": self.head_dim,
+                "rope_theta": self.rope_theta,
+            }
+        )
+        return config
+
+
+class HrmTextDecoderBlock(keras.layers.Layer):
+    """Pre-norm HRM-Text transformer block."""
+
+    def __init__(
+        self,
+        num_heads,
+        head_dim,
+        intermediate_dim,
+        rope_theta=10000.0,
+        rms_norm_epsilon=1e-6,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.intermediate_dim = intermediate_dim
+        self.rope_theta = rope_theta
+        self.rms_norm_epsilon = rms_norm_epsilon
+
+    def build(self, inputs_shape):
+        self.input_layernorm = HrmTextRMSNorm(
+            self.rms_norm_epsilon,
+            name="input_layernorm",
+            dtype=self.dtype_policy,
+        )
+        self.self_attn = HrmTextAttention(
+            self.num_heads,
+            self.head_dim,
+            self.rope_theta,
+            name="self_attn",
+            dtype=self.dtype_policy,
+        )
+        self.post_attention_layernorm = HrmTextRMSNorm(
+            self.rms_norm_epsilon,
+            name="post_attention_layernorm",
+            dtype=self.dtype_policy,
+        )
+        self.mlp = HrmTextMLP(
+            self.intermediate_dim, name="mlp", dtype=self.dtype_policy
+        )
+        super().build(inputs_shape)
+
+    def call(
+        self, hidden_states, attention_mask, cache=None, cache_update_index=None
+    ):
+        residual = hidden_states
+        output = self.self_attn(
+            self.input_layernorm(hidden_states),
+            attention_mask,
+            cache=cache,
+            cache_update_index=cache_update_index,
+        )
+        if cache is not None:
+            output, cache = output
+        hidden_states = residual + output
+        hidden_states = hidden_states + self.mlp(
+            self.post_attention_layernorm(hidden_states)
+        )
+        return (hidden_states, cache) if cache is not None else hidden_states
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "num_heads": self.num_heads,
+                "head_dim": self.head_dim,
+                "intermediate_dim": self.intermediate_dim,
+                "rope_theta": self.rope_theta,
+                "rms_norm_epsilon": self.rms_norm_epsilon,
+            }
+        )
+        return config
+
+
+class HrmTextStack(keras.layers.Layer):
+    """One shared H or L stack with logical cache-slot indexing."""
+
+    def __init__(self, num_layers, **block_kwargs):
+        layer_kwargs = {}
+        for key in ("name", "dtype"):
+            if key in block_kwargs:
+                layer_kwargs[key] = block_kwargs.pop(key)
+        super().__init__(**layer_kwargs)
+        self.num_layers = num_layers
+        self.block_kwargs = block_kwargs
+        self.layers = [
+            HrmTextDecoderBlock(
+                name=f"layers_{index}", dtype=self.dtype_policy, **block_kwargs
+            )
+            for index in range(num_layers)
+        ]
+        self.final_norm = HrmTextRMSNorm(
+            block_kwargs["rms_norm_epsilon"],
+            name="final_norm",
+            dtype=self.dtype_policy,
+        )
+
+    def call(
+        self,
+        hidden_states,
+        attention_mask,
+        cache=None,
+        cache_update_index=None,
+        cycle_offset=0,
+    ):
+        updated_cache = [] if cache is not None else None
+        for index, layer in enumerate(self.layers):
+            if cache is None:
+                hidden_states = layer(hidden_states, attention_mask)
+            else:
+                hidden_states, layer_cache = layer(
+                    hidden_states,
+                    attention_mask,
+                    cache=cache[:, cycle_offset + index],
+                    cache_update_index=cache_update_index,
+                )
+                updated_cache.append(layer_cache)
+        hidden_states = self.final_norm(hidden_states)
+        if cache is None:
+            return hidden_states
+        return hidden_states, updated_cache

--- a/keras_hub/src/models/hrm_text/hrm_text_presets.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_presets.py
@@ -1,0 +1,28 @@
+"""HRM-Text preset configurations."""
+
+backbone_presets = {
+    "hrm_text_1b": {
+        "metadata": {
+            "description": (
+                "1B-parameter HRM-Text hierarchical recurrent model."
+            ),
+            "params": 1000000000,
+            "path": "hrm_text",
+        },
+        "config": {
+            "vocabulary_size": 65536,
+            "hidden_dim": 1536,
+            "intermediate_dim": 4096,
+            "num_layers_per_stack": 16,
+            "num_attention_heads": 12,
+            "head_dim": 128,
+            "h_cycles": 2,
+            "l_cycles": 3,
+            "max_sequence_length": 4096,
+            "rope_theta": 10000.0,
+            "rms_norm_epsilon": 1e-6,
+            "embedding_scale": 39.191835884530846,
+            "tie_word_embeddings": False,
+        },
+    }
+}

--- a/keras_hub/src/models/hrm_text/hrm_text_presets.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_presets.py
@@ -1,28 +1,3 @@
 """HRM-Text preset configurations."""
 
-backbone_presets = {
-    "hrm_text_1b": {
-        "metadata": {
-            "description": (
-                "1B-parameter HRM-Text hierarchical recurrent model."
-            ),
-            "params": 1000000000,
-            "path": "hrm_text",
-        },
-        "config": {
-            "vocabulary_size": 65536,
-            "hidden_dim": 1536,
-            "intermediate_dim": 4096,
-            "num_layers_per_stack": 16,
-            "num_attention_heads": 12,
-            "head_dim": 128,
-            "h_cycles": 2,
-            "l_cycles": 3,
-            "max_sequence_length": 4096,
-            "rope_theta": 10000.0,
-            "rms_norm_epsilon": 1e-6,
-            "embedding_scale": 39.191835884530846,
-            "tie_word_embeddings": False,
-        },
-    }
-}
+backbone_presets = {}

--- a/keras_hub/src/models/hrm_text/hrm_text_tokenizer.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_tokenizer.py
@@ -1,0 +1,27 @@
+"""Tokenizer for HRM-Text."""
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
+
+
+@keras_hub_export(
+    [
+        "keras_hub.tokenizers.HrmTextTokenizer",
+        "keras_hub.models.HrmTextTokenizer",
+    ]
+)
+class HrmTextTokenizer(BytePairTokenizer):
+    """Byte-pair tokenizer used by HRM-Text.
+
+    The official checkpoint uses the Qwen2 BPE vocabulary with HRM-Text's
+    start, end, and padding special tokens.
+    """
+
+    backbone_cls = HrmTextBackbone
+
+    def __init__(self, vocabulary=None, merges=None, **kwargs):
+        self._add_special_token("<|im_start|>", "start_token")
+        self._add_special_token("<|box_end|>", "end_token")
+        self._add_special_token("<|endoftext|>", "pad_token")
+        super().__init__(vocabulary=vocabulary, merges=merges, **kwargs)

--- a/keras_hub/src/models/hrm_text/hrm_text_tokenizer.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_tokenizer.py
@@ -23,8 +23,13 @@ class HrmTextTokenizer(BytePairTokenizer):
         vocabulary: Mapping from token strings to token ids.
         merges: Ordered BPE merge rules.
 
-    The start, end, and padding tokens are ``<|im_start|>``, ``<|box_end|>``,
-    and ``<|endoftext|>``, respectively.
+    The active HRM-Text inference tokens are ``<|im_start|>``,
+    ``<|im_end|>``, ``<|box_end|>``, ``<|endoftext|>``, and the four
+    condition tokens ``<|object_ref_start|>``, ``<|object_ref_end|>``,
+    ``<|quad_start|>``, and ``<|quad_end|>``. They are registered as special
+    tokens so they are encoded atomically. The checkpoint retains additional
+    Qwen-style vocabulary tokens, but those are not part of this tokenizer's
+    active HRM-Text inference protocol.
 
     Examples:
 
@@ -40,6 +45,13 @@ class HrmTextTokenizer(BytePairTokenizer):
 
     def __init__(self, vocabulary=None, merges=None, **kwargs):
         self._add_special_token("<|im_start|>", "start_token")
+        self._add_special_token("<|im_end|>", "prefix_end_token")
         self._add_special_token("<|box_end|>", "end_token")
         self._add_special_token("<|endoftext|>", "pad_token")
+        self._add_special_token(
+            "<|object_ref_start|>", "direct_condition_token"
+        )
+        self._add_special_token("<|object_ref_end|>", "cot_condition_token")
+        self._add_special_token("<|quad_start|>", "noisy_condition_token")
+        self._add_special_token("<|quad_end|>", "synth_condition_token")
         super().__init__(vocabulary=vocabulary, merges=merges, **kwargs)

--- a/keras_hub/src/models/hrm_text/hrm_text_tokenizer.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_tokenizer.py
@@ -15,7 +15,25 @@ class HrmTextTokenizer(BytePairTokenizer):
     """Byte-pair tokenizer used by HRM-Text.
 
     The official checkpoint uses the Qwen2 BPE vocabulary with HRM-Text's
-    start, end, and padding special tokens.
+    start, end, and padding special tokens. Instantiate it from a converted
+    local preset, or construct it from the official tokenizer vocabulary and
+    merge rules.
+
+    Args:
+        vocabulary: Mapping from token strings to token ids.
+        merges: Ordered BPE merge rules.
+
+    The start, end, and padding tokens are ``<|im_start|>``, ``<|box_end|>``,
+    and ``<|endoftext|>``, respectively.
+
+    Examples:
+
+    ```python
+    tokenizer = keras_hub.models.HrmTextTokenizer.from_preset(
+        "/path/to/hrm_text_1b"
+    )
+    token_ids = tokenizer(["HRM-Text uses two recurrent Transformer stacks."])
+    ```
     """
 
     backbone_cls = HrmTextBackbone

--- a/keras_hub/src/models/hrm_text/hrm_text_tokenizer_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_tokenizer_test.py
@@ -22,6 +22,14 @@ def make_tokenizer_assets():
     vocabulary = {
         token: index for index, token in enumerate(sorted(set(vocabulary)))
     }
+    for token in (
+        "<|im_end|>",
+        "<|object_ref_start|>",
+        "<|object_ref_end|>",
+        "<|quad_start|>",
+        "<|quad_end|>",
+    ):
+        vocabulary[token] = len(vocabulary)
     return vocabulary, merges
 
 
@@ -53,11 +61,32 @@ class HrmTextTokenizerTest(TestCase):
 
     def test_special_tokens(self):
         self.assertEqual(self.tokenizer.start_token, "<|im_start|>")
+        self.assertEqual(self.tokenizer.prefix_end_token, "<|im_end|>")
         self.assertEqual(self.tokenizer.end_token, "<|box_end|>")
         self.assertEqual(self.tokenizer.pad_token, "<|endoftext|>")
         self.assertEqual(
+            self.tokenizer.direct_condition_token,
+            "<|object_ref_start|>",
+        )
+        self.assertEqual(
+            self.tokenizer.cot_condition_token,
+            "<|object_ref_end|>",
+        )
+        self.assertEqual(
+            self.tokenizer.noisy_condition_token,
+            "<|quad_start|>",
+        )
+        self.assertEqual(
+            self.tokenizer.synth_condition_token,
+            "<|quad_end|>",
+        )
+        self.assertEqual(
             self.tokenizer.start_token_id,
             self.vocabulary["<|im_start|>"],
+        )
+        self.assertEqual(
+            self.tokenizer.prefix_end_token_id,
+            self.vocabulary["<|im_end|>"],
         )
         self.assertEqual(
             self.tokenizer.end_token_id, self.vocabulary["<|box_end|>"]
@@ -66,10 +95,30 @@ class HrmTextTokenizerTest(TestCase):
             self.tokenizer.pad_token_id, self.vocabulary["<|endoftext|>"]
         )
 
+    def test_active_inference_tokens_are_atomic(self):
+        tokens = [
+            "<|im_start|>",
+            "<|im_end|>",
+            "<|box_end|>",
+            "<|endoftext|>",
+            "<|object_ref_start|>",
+            "<|object_ref_end|>",
+            "<|quad_start|>",
+            "<|quad_end|>",
+        ]
+        self.assertAllEqual(
+            self.tokenizer(tokens),
+            [[self.vocabulary[token]] for token in tokens],
+        )
+
     def test_config_round_trip(self):
         config = self.tokenizer.get_config()
         restored = HrmTextTokenizer.from_config(config)
         restored.set_vocabulary_and_merges(self.vocabulary, self.merges)
         self.assertAllEqual(
             self.tokenizer([" airplane"]), restored([" airplane"])
+        )
+        self.assertAllEqual(
+            self.tokenizer(["<|im_start|><|quad_end|><|im_end|>"]),
+            restored(["<|im_start|><|quad_end|><|im_end|>"]),
         )

--- a/keras_hub/src/models/hrm_text/hrm_text_tokenizer_test.py
+++ b/keras_hub/src/models/hrm_text/hrm_text_tokenizer_test.py
@@ -1,0 +1,75 @@
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
+from keras_hub.src.tests.test_case import TestCase
+
+
+def make_tokenizer_assets():
+    merges = ["Ġ a", "Ġ t", "Ġ i", "Ġ b", "a i", "p l", "n e"]
+    merges += [
+        "Ġa t",
+        "p o",
+        "r t",
+        "Ġt h",
+        "ai r",
+        "pl a",
+        "po rt",
+    ]
+    merges += ["Ġai r", "Ġa i", "pla ne"]
+    vocabulary = []
+    for merge in merges:
+        left, right = merge.split(" ")
+        vocabulary.extend([left, right, left + right])
+    vocabulary += ["!", "<|im_start|>", "<|box_end|>", "<|endoftext|>"]
+    vocabulary = {
+        token: index for index, token in enumerate(sorted(set(vocabulary)))
+    }
+    return vocabulary, merges
+
+
+class HrmTextTokenizerTest(TestCase):
+    def setUp(self):
+        self.vocabulary, self.merges = make_tokenizer_assets()
+        self.tokenizer = HrmTextTokenizer(
+            vocabulary=self.vocabulary, merges=self.merges
+        )
+
+    def test_tokenizer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=HrmTextTokenizer,
+            init_kwargs={
+                "vocabulary": self.vocabulary,
+                "merges": self.merges,
+            },
+            input_data=[" airplane", " at airport"],
+            expected_detokenize_output=[" airplane", " at airport"],
+        )
+
+    def test_tokenize_and_detokenize(self):
+        token_ids = self.tokenizer([" airplane", " at airport"])
+        self.assertAllEqual(token_ids, [[27, 18], [28, 27, 20]])
+        self.assertAllEqual(
+            self.tokenizer.detokenize(token_ids),
+            [" airplane", " at airport"],
+        )
+
+    def test_special_tokens(self):
+        self.assertEqual(self.tokenizer.start_token, "<|im_start|>")
+        self.assertEqual(self.tokenizer.end_token, "<|box_end|>")
+        self.assertEqual(self.tokenizer.pad_token, "<|endoftext|>")
+        self.assertEqual(
+            self.tokenizer.start_token_id,
+            self.vocabulary["<|im_start|>"],
+        )
+        self.assertEqual(
+            self.tokenizer.end_token_id, self.vocabulary["<|box_end|>"]
+        )
+        self.assertEqual(
+            self.tokenizer.pad_token_id, self.vocabulary["<|endoftext|>"]
+        )
+
+    def test_config_round_trip(self):
+        config = self.tokenizer.get_config()
+        restored = HrmTextTokenizer.from_config(config)
+        restored.set_vocabulary_and_merges(self.vocabulary, self.merges)
+        self.assertAllEqual(
+            self.tokenizer([" airplane"]), restored([" airplane"])
+        )

--- a/tools/checkpoint_conversion/convert_hrm_text_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_hrm_text_checkpoints.py
@@ -1,9 +1,18 @@
-"""Convert and validate the official HRM-Text checkpoint.
+"""Convert and validate the official HRM-Text-1B checkpoint.
+
+The script downloads the Apache-2.0 ``sapientinc/HRM-Text-1B`` checkpoint,
+maps every Hugging Face tensor to KerasHub, verifies logits against
+Transformers with ``atol=rtol=2e-4``, and writes a loadable local Keras preset.
+The converted preset includes the backbone, causal-LM task, and tokenizer.
 
 Run with:
 
     python tools/checkpoint_conversion/convert_hrm_text_checkpoints.py \
         --output_dir /tmp/hrm_text_1b
+
+Use ``--source`` to point at a pinned local Hugging Face snapshot. The source
+revision used for the initial port is
+``9f082d68b8cd0ebc56e33f1c88c45609174c272c``.
 """
 
 import json

--- a/tools/checkpoint_conversion/convert_hrm_text_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_hrm_text_checkpoints.py
@@ -1,0 +1,148 @@
+"""Convert and validate the official HRM-Text checkpoint.
+
+Run with:
+
+    python tools/checkpoint_conversion/convert_hrm_text_checkpoints.py \
+        --output_dir /tmp/hrm_text_1b
+"""
+
+import json
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "torch")
+
+import keras
+import numpy as np
+from absl import app
+from absl import flags
+from transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm import HrmTextCausalLM
+from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
+    HrmTextCausalLMPreprocessor,
+)
+from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string("output_dir", None, "Directory for the converted preset.")
+flags.DEFINE_string(
+    "source",
+    "sapientinc/HRM-Text-1B",
+    "Hugging Face model ID or a local snapshot directory.",
+)
+
+
+def create_backbone(config):
+    rope_parameters = getattr(config, "rope_parameters", None) or {}
+    rope_theta = getattr(
+        config, "rope_theta", rope_parameters.get("rope_theta", 10000.0)
+    )
+    num_layers_per_stack = (
+        getattr(config, "num_layers_per_stack", None)
+        or config.num_hidden_layers
+    )
+    return HrmTextBackbone(
+        vocabulary_size=config.vocab_size,
+        hidden_dim=config.hidden_size,
+        intermediate_dim=config.intermediate_size,
+        num_layers_per_stack=num_layers_per_stack,
+        num_attention_heads=config.num_attention_heads,
+        head_dim=config.head_dim,
+        h_cycles=config.H_cycles,
+        l_cycles=config.L_cycles,
+        max_sequence_length=config.max_position_embeddings,
+        rope_theta=rope_theta,
+        rms_norm_epsilon=getattr(config, "rms_norm_eps", 1e-6),
+        embedding_scale=getattr(config, "embedding_scale", 1.0),
+        tie_word_embeddings=config.tie_word_embeddings,
+        dtype="float32",
+    )
+
+
+def convert_weights(backbone, hf_model):
+    """Assigns all official model tensors, rejecting incomplete mappings."""
+    state = hf_model.state_dict()
+    assigned = set()
+
+    def assign(variable, name, transpose=False):
+        value = state[name].detach().cpu().numpy()
+        if transpose:
+            value = value.T
+        if tuple(variable.shape) != value.shape:
+            raise ValueError(
+                f"Shape mismatch for {name}: {variable.shape} vs {value.shape}"
+            )
+        variable.assign(value)
+        assigned.add(name)
+
+    assign(backbone.token_embedding.embeddings, "model.embed_tokens.weight")
+    assign(backbone.initial_state.z_L_init, "model.z_L_init")
+    for stack_name in ("L_module", "H_module"):
+        stack = getattr(backbone, stack_name)
+        for index, layer in enumerate(stack.layers):
+            prefix = f"model.{stack_name}.layers.{index}"
+            for projection in (
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "gate_proj",
+                "o_proj",
+            ):
+                assign(
+                    getattr(layer.self_attn, projection).kernel,
+                    f"{prefix}.self_attn.{projection}.weight",
+                    transpose=True,
+                )
+            for projection in ("gate_proj", "up_proj", "down_proj"):
+                assign(
+                    getattr(layer.mlp, projection).kernel,
+                    f"{prefix}.mlp.{projection}.weight",
+                    transpose=True,
+                )
+    assign(
+        backbone.token_embedding.reverse_embeddings,
+        "lm_head.weight",
+        transpose=True,
+    )
+    unused = sorted(set(state) - assigned)
+    if unused:
+        raise ValueError(f"Unmapped Hugging Face tensors: {unused}")
+
+
+def convert_tokenizer(hf_tokenizer):
+    """Converts the official Qwen2-style BPE tokenizer assets."""
+    tokenizer_json = json.loads(hf_tokenizer.backend_tokenizer.to_str())
+    model = tokenizer_json["model"]
+    merges = [" ".join(merge) for merge in model["merges"]]
+    return HrmTextTokenizer(vocabulary=model["vocab"], merges=merges)
+
+
+def main(_):
+    if not FLAGS.output_dir:
+        raise ValueError("--output_dir is required.")
+    keras.config.set_dtype_policy("float32")
+    hf_model = AutoModelForCausalLM.from_pretrained(FLAGS.source)
+    hf_model.eval()
+    hf_tokenizer = AutoTokenizer.from_pretrained(FLAGS.source)
+    backbone = create_backbone(hf_model.config)
+    convert_weights(backbone, hf_model)
+
+    tokenizer = convert_tokenizer(hf_tokenizer)
+    preprocessor = HrmTextCausalLMPreprocessor(tokenizer)
+    model = HrmTextCausalLM(backbone, preprocessor=preprocessor)
+    inputs = hf_tokenizer("HRM-Text", return_tensors="pt")
+    keras_inputs = {
+        "token_ids": inputs.input_ids.numpy(),
+        "padding_mask": inputs.attention_mask.numpy(),
+        "token_type_ids": np.zeros_like(inputs.input_ids.numpy()),
+    }
+    hf_logits = hf_model(**inputs).logits.detach().cpu().float().numpy()
+    keras_logits = keras.ops.convert_to_numpy(model(keras_inputs))
+    np.testing.assert_allclose(keras_logits, hf_logits, atol=2e-4, rtol=2e-4)
+    model.save_to_preset(FLAGS.output_dir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/tools/checkpoint_conversion/convert_hrm_text_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_hrm_text_checkpoints.py
@@ -3,11 +3,13 @@
 The script downloads the Apache-2.0 ``sapientinc/HRM-Text-1B`` checkpoint,
 maps every Hugging Face tensor to KerasHub, verifies logits against
 Transformers with ``atol=rtol=2e-4``, and writes a loadable local Keras preset.
-The converted preset includes the backbone, causal-LM task, and tokenizer.
+It also verifies the exact ``1,182,795,264`` parameter count, tiny PrefixLM
+gradient routing, and a saved-preset round-trip. The converted preset includes
+the backbone, causal-LM task, and tokenizer.
 
 Run with:
 
-    python tools/checkpoint_conversion/convert_hrm_text_checkpoints.py \
+    uv run python tools/checkpoint_conversion/convert_hrm_text_checkpoints.py \
         --output_dir /tmp/hrm_text_1b
 
 Use ``--source`` to point at a pinned local Hugging Face snapshot. The source
@@ -15,17 +17,22 @@ revision used for the initial port is
 ``9f082d68b8cd0ebc56e33f1c88c45609174c272c``.
 """
 
+import gc
 import json
+import math
 import os
 
 os.environ.setdefault("KERAS_BACKEND", "torch")
 
 import keras
 import numpy as np
+import tensorflow as tf
 from absl import app
 from absl import flags
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
+from transformers import HrmTextConfig
+from transformers import HrmTextForCausalLM
 
 from keras_hub.src.models.hrm_text.hrm_text_backbone import HrmTextBackbone
 from keras_hub.src.models.hrm_text.hrm_text_causal_lm import HrmTextCausalLM
@@ -35,11 +42,18 @@ from keras_hub.src.models.hrm_text.hrm_text_causal_lm_preprocessor import (
 from keras_hub.src.models.hrm_text.hrm_text_tokenizer import HrmTextTokenizer
 
 FLAGS = flags.FLAGS
+SOURCE_REVISION = "9f082d68b8cd0ebc56e33f1c88c45609174c272c"
+EXPECTED_PARAMETER_COUNT = 1_182_795_264
 flags.DEFINE_string("output_dir", None, "Directory for the converted preset.")
 flags.DEFINE_string(
     "source",
     "sapientinc/HRM-Text-1B",
     "Hugging Face model ID or a local snapshot directory.",
+)
+flags.DEFINE_string(
+    "revision",
+    SOURCE_REVISION,
+    "Pinned Hugging Face revision. Ignored for a local source directory.",
 )
 
 
@@ -64,30 +78,22 @@ def create_backbone(config):
         max_sequence_length=config.max_position_embeddings,
         rope_theta=rope_theta,
         rms_norm_epsilon=getattr(config, "rms_norm_eps", 1e-6),
+        l_bp_cycles=getattr(config, "L_bp_cycles", None),
+        initializer_range=getattr(config, "initializer_range", 0.02),
         embedding_scale=getattr(config, "embedding_scale", 1.0),
         tie_word_embeddings=config.tie_word_embeddings,
         dtype="float32",
     )
 
 
-def convert_weights(backbone, hf_model):
-    """Assigns all official model tensors, rejecting incomplete mappings."""
-    state = hf_model.state_dict()
-    assigned = set()
-
-    def assign(variable, name, transpose=False):
-        value = state[name].detach().cpu().numpy()
-        if transpose:
-            value = value.T
-        if tuple(variable.shape) != value.shape:
-            raise ValueError(
-                f"Shape mismatch for {name}: {variable.shape} vs {value.shape}"
-            )
-        variable.assign(value)
-        assigned.add(name)
-
-    assign(backbone.token_embedding.embeddings, "model.embed_tokens.weight")
-    assign(backbone.initial_state.z_L_init, "model.z_L_init")
+def iter_weight_mappings(backbone):
+    """Yields every Keras variable and its expanded HF state-dict name."""
+    yield (
+        backbone.token_embedding.embeddings,
+        "model.embed_tokens.weight",
+        False,
+    )
+    yield backbone.initial_state.z_L_init, "model.z_L_init", False
     for stack_name in ("L_module", "H_module"):
         stack = getattr(backbone, stack_name)
         for index, layer in enumerate(stack.layers):
@@ -99,25 +105,164 @@ def convert_weights(backbone, hf_model):
                 "gate_proj",
                 "o_proj",
             ):
-                assign(
+                yield (
                     getattr(layer.self_attn, projection).kernel,
                     f"{prefix}.self_attn.{projection}.weight",
-                    transpose=True,
+                    True,
                 )
             for projection in ("gate_proj", "up_proj", "down_proj"):
-                assign(
+                yield (
                     getattr(layer.mlp, projection).kernel,
                     f"{prefix}.mlp.{projection}.weight",
-                    transpose=True,
+                    True,
                 )
-    assign(
+    yield (
         backbone.token_embedding.reverse_embeddings,
         "lm_head.weight",
-        transpose=True,
+        True,
     )
+
+
+def convert_weights(
+    backbone, hf_model, expected_parameter_count=EXPECTED_PARAMETER_COUNT
+):
+    """Assigns all official model tensors, rejecting incomplete mappings."""
+    state = hf_model.state_dict()
+    assigned = set()
+    assigned_variables = set()
+
+    for variable, name, transpose in iter_weight_mappings(backbone):
+        if variable.path in assigned_variables:
+            raise ValueError(f"Keras variable assigned twice: {variable.path}")
+        value = state[name].detach().cpu().float().numpy()
+        if transpose:
+            value = value.T
+        if tuple(variable.shape) != value.shape:
+            raise ValueError(
+                f"Shape mismatch for {name}: {variable.shape} vs {value.shape}"
+            )
+        variable.assign(value)
+        assigned.add(name)
+        assigned_variables.add(variable.path)
+
     unused = sorted(set(state) - assigned)
     if unused:
         raise ValueError(f"Unmapped Hugging Face tensors: {unused}")
+    unassigned_variables = sorted(
+        variable.path
+        for variable in backbone.weights
+        if variable.path not in assigned_variables
+    )
+    if unassigned_variables:
+        raise ValueError(f"Unassigned Keras variables: {unassigned_variables}")
+
+    source_parameter_count = sum(
+        math.prod(tensor.shape) for tensor in state.values()
+    )
+    keras_parameter_count = backbone.count_params()
+    if source_parameter_count != keras_parameter_count:
+        raise ValueError(
+            "Source and Keras parameter counts differ: "
+            f"{source_parameter_count:,} != {keras_parameter_count:,}"
+        )
+    if (
+        expected_parameter_count is not None
+        and keras_parameter_count != expected_parameter_count
+    ):
+        raise ValueError(
+            "Unexpected Keras parameter count: "
+            f"{keras_parameter_count:,} != {expected_parameter_count:,}"
+        )
+    return {
+        "mapped_tensors": len(assigned),
+        "source_parameter_count": source_parameter_count,
+        "keras_parameter_count": keras_parameter_count,
+    }
+
+
+def validate_tiny_gradient_parity():
+    """Checks PrefixLM logits and routed gradients against Transformers."""
+    import torch
+
+    torch.manual_seed(2026)
+    config = HrmTextConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        head_dim=4,
+        H_cycles=2,
+        L_cycles=2,
+        L_bp_cycles=[0, 2],
+        max_position_embeddings=8,
+        embedding_scale=1.0,
+        prefix_lm=True,
+        tie_word_embeddings=False,
+    )
+    hf_model = HrmTextForCausalLM(config).float().eval()
+    backbone = create_backbone(hf_model.config)
+    device = backbone.weights[0].value.device
+    hf_model.to(device)
+    conversion = convert_weights(
+        backbone, hf_model, expected_parameter_count=None
+    )
+    model = HrmTextCausalLM(backbone)
+
+    token_ids = np.array([[1, 2, 3, 4]], dtype="int32")
+    token_type_ids = np.array([[1, 1, 0, 0]], dtype="int32")
+    padding_mask = np.ones_like(token_ids)
+    hf_logits = hf_model(
+        input_ids=torch.as_tensor(token_ids, device=device),
+        attention_mask=torch.as_tensor(padding_mask, device=device),
+        token_type_ids=torch.as_tensor(token_type_ids, device=device),
+        use_cache=False,
+    ).logits
+    keras_logits = model(
+        {
+            "token_ids": token_ids,
+            "padding_mask": padding_mask,
+            "token_type_ids": token_type_ids,
+        }
+    )
+    logit_max_abs = float(
+        torch.max(torch.abs(hf_logits - keras_logits)).detach().cpu()
+    )
+    hf_logits.square().mean().backward()
+    keras_logits.square().mean().backward()
+
+    hf_parameters = dict(hf_model.named_parameters())
+    gradient_errors = []
+    for variable, name, transpose in iter_weight_mappings(backbone):
+        keras_gradient = variable.value.grad
+        hf_gradient = hf_parameters[name].grad
+        if keras_gradient is None and hf_gradient is None:
+            continue
+        if keras_gradient is None or hf_gradient is None:
+            raise ValueError(f"Gradient presence differs for {name}.")
+        keras_gradient = keras_gradient.detach().cpu().numpy()
+        hf_gradient = hf_gradient.detach().cpu().numpy()
+        if transpose:
+            hf_gradient = hf_gradient.T
+        gradient_errors.append(
+            float(np.max(np.abs(keras_gradient - hf_gradient)))
+        )
+    gradient_max_abs = max(gradient_errors)
+    if logit_max_abs >= 1e-5 or gradient_max_abs >= 1e-5:
+        raise ValueError(
+            "Tiny gradient parity failed: "
+            f"logits={logit_max_abs:.3e}, gradients={gradient_max_abs:.3e}"
+        )
+    del hf_model, model, backbone
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    keras.backend.clear_session()
+    return {
+        **conversion,
+        "logit_max_abs": logit_max_abs,
+        "gradient_max_abs": gradient_max_abs,
+    }
 
 
 def convert_tokenizer(hf_tokenizer):
@@ -131,12 +276,21 @@ def convert_tokenizer(hf_tokenizer):
 def main(_):
     if not FLAGS.output_dir:
         raise ValueError("--output_dir is required.")
+    tf.config.set_visible_devices([], "GPU")
     keras.config.set_dtype_policy("float32")
-    hf_model = AutoModelForCausalLM.from_pretrained(FLAGS.source)
+    tiny_gradient_parity = validate_tiny_gradient_parity()
+    revision_kwargs = (
+        {} if os.path.isdir(FLAGS.source) else {"revision": FLAGS.revision}
+    )
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        FLAGS.source, dtype="float32", **revision_kwargs
+    )
     hf_model.eval()
-    hf_tokenizer = AutoTokenizer.from_pretrained(FLAGS.source)
+    hf_tokenizer = AutoTokenizer.from_pretrained(
+        FLAGS.source, **revision_kwargs
+    )
     backbone = create_backbone(hf_model.config)
-    convert_weights(backbone, hf_model)
+    conversion = convert_weights(backbone, hf_model)
 
     tokenizer = convert_tokenizer(hf_tokenizer)
     preprocessor = HrmTextCausalLMPreprocessor(tokenizer)
@@ -150,7 +304,51 @@ def main(_):
     hf_logits = hf_model(**inputs).logits.detach().cpu().float().numpy()
     keras_logits = keras.ops.convert_to_numpy(model(keras_inputs))
     np.testing.assert_allclose(keras_logits, hf_logits, atol=2e-4, rtol=2e-4)
+    conversion["logit_max_abs"] = float(
+        np.max(np.abs(keras_logits - hf_logits))
+    )
     model.save_to_preset(FLAGS.output_dir)
+
+    expected_special_token_ids = {
+        "start": tokenizer.start_token_id,
+        "end": tokenizer.end_token_id,
+        "pad": tokenizer.pad_token_id,
+    }
+    del hf_model, model, backbone
+    gc.collect()
+    keras.backend.clear_session()
+
+    restored = HrmTextCausalLM.from_preset(FLAGS.output_dir)
+    restored_logits = keras.ops.convert_to_numpy(restored(keras_inputs))
+    np.testing.assert_allclose(restored_logits, hf_logits, atol=2e-4, rtol=2e-4)
+    conversion["restored_logit_max_abs"] = float(
+        np.max(np.abs(restored_logits - hf_logits))
+    )
+    restored_tokenizer = restored.preprocessor.tokenizer
+    actual_special_token_ids = {
+        "start": restored_tokenizer.start_token_id,
+        "end": restored_tokenizer.end_token_id,
+        "pad": restored_tokenizer.pad_token_id,
+    }
+    if actual_special_token_ids != expected_special_token_ids:
+        raise ValueError(
+            "Tokenizer special-token IDs changed during preset round-trip: "
+            f"{actual_special_token_ids} != {expected_special_token_ids}"
+        )
+    conversion["special_token_ids"] = actual_special_token_ids
+    conversion["source_revision"] = (
+        "local" if os.path.isdir(FLAGS.source) else FLAGS.revision
+    )
+    print(
+        json.dumps(
+            {
+                "official_conversion": conversion,
+                "tiny_gradient_parity": tiny_gradient_parity,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Draft implementation of HRM-Text-1B support for KerasHub, shared to make the work concrete while the team discusses the proposal in #2846.

- Adds the HRM-Text backbone and CausalLM task
- Adds the tokenizer, CausalLM preprocessor, presets, and public API exports
- Adds checkpoint conversion from the official Hugging Face checkpoint
- Adds focused tests for the backbone, CausalLM, tokenizer, and preprocessor

## Validation

The accompanying [verification notebook](https://github.com/pzarzycki/hrm-text-keras-hub/blob/main/hrm_text_1b_colab.ipynb) converts the pinned official checkpoint and verifies:

- exact parameter accounting
- forward-logit and gradient parity against Transformers
- cached and non-cached decoding agreement
- local Keras preset save/load round-trip
- PrefixLM generation through the model's 128-slot cache

A separate [usage notebook](https://github.com/pzarzycki/hrm-text-keras-hub/blob/main/hrm_text_1b_usage.ipynb) demonstrates conversion, generation, and PrefixLM training inputs.

## Notes

This PR is intentionally a draft. It is not a request to merge yet; I opened it so the implementation can be inspected easily while the model-inclusion decision is pending.

Related to #2846.