### PR TITLE
Remove TensorFlow take_along_axis workarounds

### DIFF
--- a/keras_hub/src/layers/modeling/masked_lm_head.py
+++ b/keras_hub/src/layers/modeling/masked_lm_head.py
@@ -162,16 +162,9 @@ class MaskedLMHead(keras.layers.Layer):
         self.built = True
 
     def call(self, inputs, mask_positions):
-        if keras.config.backend() == "tensorflow":
-            import tensorflow as tf
-
-            # On the tf backend, we need to work around an issue with dynamic
-            # shape broadcasting in take_along_axis.
-            x = tf.gather(inputs, mask_positions, batch_dims=1)
-        else:
-            # Gather the encoded tokens at the masked indices.
-            mask_positions = ops.expand_dims(mask_positions, axis=-1)
-            x = ops.take_along_axis(inputs, mask_positions, axis=1)
+        # Gather the encoded tokens at the masked indices.
+        mask_positions = ops.expand_dims(mask_positions, axis=-1)
+        x = ops.take_along_axis(inputs, mask_positions, axis=1)
 
         # Apply a trainable linear transformation and a layer norm.
         x = self._intermediate_dense(x)

--- a/keras_hub/src/layers/modeling/masked_lm_head_test.py
+++ b/keras_hub/src/layers/modeling/masked_lm_head_test.py
@@ -1,3 +1,4 @@
+import keras
 from keras import random
 
 from keras_hub.src.layers.modeling.masked_lm_head import MaskedLMHead
@@ -8,6 +9,20 @@ from keras_hub.src.tests.test_case import TestCase
 
 
 class MaskedLMHeadTest(TestCase):
+    def test_dynamic_mask_positions(self):
+        inputs = keras.Input(shape=(None, 16))
+        mask_positions = keras.Input(shape=(None,), dtype="int32")
+        outputs = MaskedLMHead(vocabulary_size=100)(inputs, mask_positions)
+        model = keras.Model([inputs, mask_positions], outputs)
+        encoded_tokens = random.uniform(shape=(2, 6, 16))
+
+        for mask_count in (2, 4):
+            positions = random.randint(
+                minval=0, maxval=6, shape=(2, mask_count)
+            )
+            outputs = model([encoded_tokens, positions])
+            self.assertEqual(outputs.shape, (2, mask_count, 100))
+
     def test_layer_behaviors(self):
         self.run_layer_test(
             cls=MaskedLMHead,

--- a/keras_hub/src/models/roformer_v2/roformer_v2_masked_lm.py
+++ b/keras_hub/src/models/roformer_v2/roformer_v2_masked_lm.py
@@ -34,16 +34,9 @@ class RoformerV2MaskedLMHead(keras.layers.Layer):
         self.vocabulary_size = token_embedding.input_dim
 
     def call(self, inputs, mask_positions):
-        if keras.config.backend() == "tensorflow":
-            import tensorflow as tf
-
-            # On the tf backend, we need to work around an issue with dynamic
-            # shape broadcasting in take_along_axis.
-            x = tf.gather(inputs, mask_positions, batch_dims=1)
-        else:
-            # Gather the encoded tokens at the masked indices.
-            mask_positions = ops.expand_dims(mask_positions, axis=-1)
-            x = ops.take_along_axis(inputs, mask_positions, axis=1)
+        # Gather the encoded tokens at the masked indices.
+        mask_positions = ops.expand_dims(mask_positions, axis=-1)
+        x = ops.take_along_axis(inputs, mask_positions, axis=1)
 
         outputs = self.token_embedding(x, reverse=True)
 

--- a/keras_hub/src/models/roformer_v2/roformer_v2_masked_lm_test.py
+++ b/keras_hub/src/models/roformer_v2/roformer_v2_masked_lm_test.py
@@ -72,7 +72,6 @@ class RoformerV2MaskedLMDynamicMaskTest(TestCase):
         inputs = {
             "token_ids": np.array([[1, 2, 3, 4, 5]] * 2, dtype="int32"),
             "segment_ids": np.zeros((2, 5), dtype="int32"),
-            "padding_mask": np.ones((2, 5), dtype="int32"),
         }
 
         for mask_count in (2, 4):

--- a/keras_hub/src/models/roformer_v2/roformer_v2_masked_lm_test.py
+++ b/keras_hub/src/models/roformer_v2/roformer_v2_masked_lm_test.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from keras_hub.src.models.roformer_v2.roformer_v2_backbone import (
     RoformerV2Backbone,
 )
@@ -51,3 +53,31 @@ class RoformerV2MaskedLMTest(TestCase):
             train_data=self.train_data,
             expected_output_shape=(2, 5, 10),
         )
+
+
+class RoformerV2MaskedLMDynamicMaskTest(TestCase):
+    def test_dynamic_mask_positions(self):
+        backbone = RoformerV2Backbone(
+            vocabulary_size=10,
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=4,
+            intermediate_dim=8,
+            head_size=2,
+        )
+        model = RoformerV2MaskedLM(
+            backbone=backbone,
+            preprocessor=None,
+        )
+        inputs = {
+            "token_ids": np.array([[1, 2, 3, 4, 5]] * 2, dtype="int32"),
+            "segment_ids": np.zeros((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+
+        for mask_count in (2, 4):
+            inputs["mask_positions"] = np.tile(
+                np.arange(mask_count, dtype="int32"), (2, 1)
+            )
+            outputs = model(inputs)
+            self.assertEqual(outputs.shape, (2, mask_count, 10))


### PR DESCRIPTION
Tested on the latest TensorFlow and Keras versions — the original dynamic shape issue with `take_along_axis` appears to be fixed. So I removed the TensorFlow-specific workaround and switched everything to use `keras.ops.take_along_axis` uniformly. Cleaner code and more consistent across backends.

Also added tests for dynamic mask positions to catch any regressions.

Fixes #1312.
