### PR TITLE
Switch CI to self-hosted runners and parallelize tests to fix TF CPU timeouts

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,28 +29,25 @@ jobs:
             version: keras-nightly
           - backend: openvino
             version: keras-nightly
-    runs-on: ubuntu-latest
+
+    container:
+      image: python:3.11-slim
+
+    runs-on: linux-x86-n2-16
+    timeout-minutes: 120
     env:
       KERAS_BACKEND: ${{ matrix.backend }}
     steps:
+    - name: Install binary dependencies
+      # build-essential for C extensions (tokenizers, torch)
+      # curl, git, gnupg for checkout and other actions
+      run: |
+        apt-get update
+        apt-get -y install build-essential curl git gnupg
+        git config --global --add safe.directory '*'
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
-    - name: Set up Python 3.11
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-      with:
-        python-version: '3.11'
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install --upgrade pip setuptools
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: pip cache
-      # zizmor: ignore[cache-poisoning]
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-common.txt') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('pyproject.toml') }}
     - name: Install dependencies
       run: |
           pip install -r requirements.txt --progress-bar off
@@ -68,7 +65,7 @@ jobs:
         pip install keras-nightly --no-cache-dir --progress-bar off
     - name: Test with pytest
       run: |
-        pytest keras_hub/
+        pytest keras_hub/ -n auto --dist loadfile --durations=50
     - name: Run integration tests
       run: |
         python pip_build.py --install

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -13,6 +13,7 @@ packaging
 ruff
 pytest
 pytest-cov
+pytest-xdist
 build
 namex
 # Optional deps.


### PR DESCRIPTION
## Description of the change

The Test the code (tensorflow, keras-stable) job has been consistently timing out on GitHub Actions, running 6+ hours without completing on every PR and master, while JAX and Torch finish in 80-90 minutes.

Root Cause

TF eager mode on CPU is significantly slower for the repeated model instantiation pattern in KerasHub tests
Test suite has grown ~80 model families, all running sequentially on a 2-core ubuntu-latest runner
No timeout-minutes was set, so jobs run the full 6-hour GitHub default before being killed


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
