### PR TITLE
 Add Qwen Agent World Model to Hub

### DIFF
--- a/keras_hub/src/utils/transformers/convert_qwen3_5_moe.py
+++ b/keras_hub/src/utils/transformers/convert_qwen3_5_moe.py
@@ -36,6 +36,8 @@ def load_image_converter_config(preset, transformers_config):
     """Return kwargs for Qwen3_5ImageConverter, or None for text-only."""
     if "vision_config" not in transformers_config:
         return None
+    if transformers_config.get("language_model_only", False):
+        return None
 
     vision_config = transformers_config["vision_config"]
     preprocessor_config = load_json(preset, "preprocessor_config.json")
@@ -66,6 +68,8 @@ def load_video_converter_config(preset, transformers_config):
     pixel budgets that differ from the image preprocessor config.
     """
     if "vision_config" not in transformers_config:
+        return None
+    if transformers_config.get("language_model_only", False):
         return None
 
     vision_config = transformers_config["vision_config"]
@@ -102,6 +106,7 @@ def convert_backbone_config(transformers_config):
 
     top_level_vision_config = transformers_config.get("vision_config", None)
     top_level_hidden_size = transformers_config.get("hidden_size", None)
+    language_model_only = transformers_config.get("language_model_only", False)
 
     if "text_config" in transformers_config:
         transformers_config = transformers_config["text_config"]
@@ -120,7 +125,7 @@ def convert_backbone_config(transformers_config):
 
     vision_encoder = None
     vision_config = top_level_vision_config
-    if vision_config is not None:
+    if vision_config is not None and not language_model_only:
         text_hidden = transformers_config.get(
             "hidden_size", top_level_hidden_size
         )

--- a/tools/checkpoint_conversion/convert_qwen3_5_moe_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_qwen3_5_moe_checkpoints.py
@@ -25,6 +25,7 @@ from absl import app
 from absl import flags
 from keras import ops
 from PIL import Image
+from transformers import AutoConfig
 from transformers import AutoModelForCausalLM
 from transformers import AutoModelForImageTextToText
 from transformers import AutoProcessor
@@ -599,8 +600,6 @@ def save_preset(keras_model, preset_name):
 # ---------------------------------------------------------------
 def _is_text_only(hf_preset):
     """Check if a HuggingFace preset is text-only (no vision weights)."""
-    from transformers import AutoConfig
-
     config = AutoConfig.from_pretrained(hf_preset)
     return getattr(config, "language_model_only", False)
 

--- a/tools/checkpoint_conversion/convert_qwen3_5_moe_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_qwen3_5_moe_checkpoints.py
@@ -25,6 +25,7 @@ from absl import app
 from absl import flags
 from keras import ops
 from PIL import Image
+from transformers import AutoModelForCausalLM
 from transformers import AutoModelForImageTextToText
 from transformers import AutoProcessor
 from transformers import AutoTokenizer
@@ -42,6 +43,7 @@ PRESET_MAP = {
     "qwen3_5_moe_35b_a3b_base": "Qwen/Qwen3.5-35B-A3B-Base",
     "qwen3_5_moe_35b_a3b": "Qwen/Qwen3.5-35B-A3B",
     "qwen3_6_moe_35b_a3b": "Qwen/Qwen3.6-35B-A3B",
+    "qwen_agent_world_35b_a3b": "Qwen/Qwen-AgentWorld-35B-A3B",
 }
 
 IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -101,7 +103,37 @@ def _count_keras_params(backbone):
 
 
 # ---------------------------------------------------------------
-# 1. Precompute HF outputs (before freeing HF model)
+# 1a. Precompute text-only HF outputs (for language_model_only models)
+# ---------------------------------------------------------------
+def precompute_text_only_outputs(hf_model, hf_tokenizer):
+    """Precompute text-only HF outputs (no vision components)."""
+    results = {}
+
+    hf_ids = hf_tokenizer(TEXT_PROMPT, return_tensors="np")["input_ids"]
+    results["text_token_ids"] = hf_ids
+
+    with torch.no_grad():
+        hf_out = hf_model(
+            input_ids=torch.tensor(hf_ids, dtype=torch.long).to(device),
+        )
+    results["text_logits"] = hf_out.logits.detach().cpu().float().numpy()
+
+    if not FLAGS.skip_generation:
+        with torch.no_grad():
+            hf_gen = hf_model.generate(
+                input_ids=torch.tensor(hf_ids, dtype=torch.long).to(device),
+                max_new_tokens=32,
+                do_sample=False,
+            )
+        results["text_generated"] = hf_tokenizer.decode(
+            hf_gen[0], skip_special_tokens=True
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------
+# 1b. Precompute HF outputs (multimodal, before freeing HF model)
 # ---------------------------------------------------------------
 def precompute_hf_outputs(hf_model, hf_tokenizer, hf_preset):
     """Precompute all HF outputs needed for validation.
@@ -565,6 +597,14 @@ def save_preset(keras_model, preset_name):
 # ---------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------
+def _is_text_only(hf_preset):
+    """Check if a HuggingFace preset is text-only (no vision weights)."""
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(hf_preset)
+    return getattr(config, "language_model_only", False)
+
+
 def main(_):
     preset = FLAGS.preset
     if preset not in PRESET_MAP:
@@ -574,21 +614,33 @@ def main(_):
         )
 
     hf_preset = PRESET_MAP[preset]
+    text_only = _is_text_only(hf_preset)
 
     # --- Phase 1: Load HF model and precompute all outputs ---
     print("-> Loading HF model...")
-    hf_model = AutoModelForImageTextToText.from_pretrained(
-        hf_preset,
-        device_map="cpu",
-        torch_dtype=torch.float32,
-    )
+    if text_only:
+        print("   (text-only model detected, using AutoModelForCausalLM)")
+        hf_model = AutoModelForCausalLM.from_pretrained(
+            hf_preset,
+            device_map="cpu",
+            torch_dtype=torch.float32,
+        )
+    else:
+        hf_model = AutoModelForImageTextToText.from_pretrained(
+            hf_preset,
+            device_map="cpu",
+            torch_dtype=torch.float32,
+        )
     hf_model.eval()
     hf_tokenizer = AutoTokenizer.from_pretrained(hf_preset)
     hf_params = sum(p.numel() for p in hf_model.parameters())
     print(f"   HF model loaded: {hf_params:,} params")
 
     print("\n-> Precomputing all HF outputs...")
-    hf_results = precompute_hf_outputs(hf_model, hf_tokenizer, hf_preset)
+    if text_only:
+        hf_results = precompute_text_only_outputs(hf_model, hf_tokenizer)
+    else:
+        hf_results = precompute_hf_outputs(hf_model, hf_tokenizer, hf_preset)
     hf_results["hf_param_count"] = hf_params
     print("   HF outputs precomputed!")
 


### PR DESCRIPTION
## Description of the change

Qwen-Agentworld :  https://huggingface.co/collections/Qwen/qwen-agentworld, it is text only language model.

## Qwen-AgentWorld:
 The first language world model to cover seven agent interaction domains within a single model. It simulates agentic environments via long chain-of-thought reasoning, predicting the next environment state given an agent's action and interaction history. Trained through a three-stage pipeline — CPT injects environment knowledge, SFT activates next-state-prediction reasoning, RL sharpens simulation fidelity — Qwen-AgentWorld is a native world model: environment modeling is the training objective from the CPT stage onward, not a post-hoc add-on.

## Highlights
- Seven Unified Domains. A single model covers MCP (tool calling), Search, Terminal, SWE (software engineering), Android, Web, and OS — spanning both text and GUI interaction environments.
- Native World Model. Environment modeling from CPT onward, not post-hoc adaptation on a general-purpose LLM.
- Generalizable, Scalable & Controllable Simulator. Zero-shot generalization to OOD environments (e.g., OpenClaw); controllable perturbations and fictional-world construction surpass real-environment training.
- Agent Foundation Model. LWM RL warm-up on single-turn, non-agentic trajectories transfers to multi-turn, tool-calling agentic tasks across 7 benchmarks, including 3 entirely out-of-domain.

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
 Numerics verification screenshot:

<img width="1512" height="597" alt="Screenshot 2026-07-27 at 5 46 45 PM" src="https://github.com/user-attachments/assets/2710ab4f-56ec-4d32-8529-9b4f66eacdf7" />


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
