### PR TITLE
Fix Falcon ALiBi bias when using the KV cache

### DIFF
--- a/keras_hub/src/models/falcon/falcon_causal_lm_test.py
+++ b/keras_hub/src/models/falcon/falcon_causal_lm_test.py
@@ -148,6 +148,40 @@ class FalconCausalLMTest(TestCase):
             # We should immediately abort and output the prompt.
             self.assertEqual(prompt, output)
 
+    def test_cached_decoding_logits_match_full_forward(self):
+        # Cached prefill followed by single-token decode steps must produce
+        # the same logits as a full forward pass without a cache.
+        causal_lm = FalconCausalLM(**self.init_kwargs)
+        batch_size, seq_length, kv_length = 2, 8, 16
+        prefill_length = 4
+        token_ids = ops.zeros((batch_size, seq_length), dtype="int32")
+        # Full-forward pass without a cache.
+        full_logits = causal_lm(
+            {
+                "token_ids": token_ids,
+                "padding_mask": ops.ones_like(token_ids),
+            }
+        )
+        # Cached pass: prefill, then decode one token at a time.
+        num_layers = self.backbone.num_layers
+        num_heads = self.backbone.num_attention_heads
+        head_dim = self.backbone.hidden_dim // num_heads
+        cache = ops.zeros(
+            (batch_size, num_layers, 2, kv_length, num_heads, head_dim),
+            dtype="float32",
+        )
+        logits, _, cache = causal_lm.call_with_cache(
+            token_ids[:, :prefill_length], cache, 0
+        )
+        cached_logits = [logits]
+        for i in range(prefill_length, seq_length):
+            logits, _, cache = causal_lm.call_with_cache(
+                token_ids[:, i : i + 1], cache, i
+            )
+            cached_logits.append(logits)
+        cached_logits = ops.concatenate(cached_logits, axis=1)
+        self.assertAllClose(cached_logits, full_logits, atol=1e-5, rtol=1e-5)
+
     def test_generate_compilation(self):
         causal_lm = FalconCausalLM(**self.init_kwargs)
         # Assert we do not recompile with successive calls.

--- a/keras_hub/src/models/falcon/falcon_transformer_decoder.py
+++ b/keras_hub/src/models/falcon/falcon_transformer_decoder.py
@@ -118,10 +118,19 @@ class FalconTransformerDecoder(keras.layers.Layer):
 
         x = self.input_layernorm(inputs)
 
-        mask = decoder_padding_mask
-        if mask is None:
-            batch_size, seq_length = ops.shape(inputs)[:2]
-            mask = ops.ones((batch_size, seq_length), dtype="int32")
+        if attention_cache is not None:
+            # Keys and values span the full cache length, so the ALiBi
+            # bias must as well. Positions are absolute: an all-ones mask
+            # yields `arange` positions over the cache, and unused cache
+            # slots are masked out by the causal attention mask.
+            batch_size = ops.shape(inputs)[0]
+            kv_length = ops.shape(attention_cache)[2]
+            mask = ops.ones((batch_size, kv_length), dtype="int32")
+        else:
+            mask = decoder_padding_mask
+            if mask is None:
+                batch_size, seq_length = ops.shape(inputs)[:2]
+                mask = ops.ones((batch_size, seq_length), dtype="int32")
         alibi = self._build_alibi_tensor(self.num_attention_heads, mask)
 
         # Attention block.


### PR DESCRIPTION
## Summary

Fixes #2861.

Falcon's ALiBi bias was built over the **current query length**, but the attention scores span the **KV-cache length**. When the two differ, this breaks in two ways:

1. **Crash.** Prefilling a cache longer than the prompt (`call_with_cache` with query length < cache length) raises a broadcast error: `The size of tensor a (32) must match the size of tensor b (8) at non-singleton dimension 3`.
2. **Silent corruption during `generate()`.** At every single-token decode step the bias tensor has shape `[batch, heads, 1, 1]`, which *broadcasts* over the cache length without error — but its value is `slope * 0 = 0`. So `generate()` runs to completion while adding **no ALiBi bias at all** at decode time, and the generated tokens diverge from the correct non-cached output.

## Fix

In `FalconTransformerDecoder.call`, when a KV cache is present, build the ALiBi bias over the full cache length instead of the query length. ALiBi positions are absolute (position `j` gets bias `slope * j`), so an all-ones mask over the cache yields exactly the same per-position values as a full forward pass; unused cache slots are excluded by the causal attention mask. The no-cache code path is untouched.

## Numeric verification (before → after)

Setup: torch backend, CPU, float32. "Full-forward" = a normal forward pass with no cache (training/inference path).

| Check | Before | After |
|---|---|---|
| Full-forward logits, small random model | — | **bit-identical** to before (max diff `0.0`) |
| Full-forward logits, `falcon_refinedweb_1b_en` architecture (`load_weights=False`) | — | **bit-identical** to before (max diff `0.0`) |
| Cached prefill (query len 8, cache len 32) | **crash** (broadcast error) | works; max diff vs full-forward `3.3e-07` |
| Teacher-forced cached decode steps | **crash** | works; max diff vs full-forward `4.8e-07` |
| Greedy `generate()` vs non-cached greedy reference | **mismatch** (silent corruption) | **exact match** |

So: the only behavior that changes is the cached path, which was previously broken (crash or wrong outputs); everything that worked before produces bit-identical outputs.

The regression test added in `falcon_causal_lm_test.py` (`test_cached_decoding_logits_match_full_forward`) fails on master with the broadcast error and passes with this fix. Full falcon test suite: 19 passed, 4 skipped.
