### PR TITLE
 Shard CI tests across 4 parallel jobs per backend to reduce wall-clock time

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,17 +22,17 @@ jobs:
       matrix:
         backend: [tensorflow, jax, torch]
         version: [keras-stable]
-        shard: [0, 1, 2, 3]
+        shard: [1, 2, 3, 4]
         include:
           - backend: jax
             version: keras-3.15
-            shard: 0
+            shard: 1
           - backend: jax
             version: keras-nightly
-            shard: 0
+            shard: 1
           - backend: openvino
             version: keras-nightly
-            shard: 0
+            shard: 1
 
     container:
       image: python:3.11-slim
@@ -69,14 +69,14 @@ jobs:
         pip install keras-nightly --no-cache-dir --progress-bar off
     - name: Test with pytest
       run: |
-        pytest keras_hub/ -n auto --dist loadfile --durations=50 --shard-id=${{ matrix.shard }} --num-shards=4
+        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits 4 --group ${{ matrix.shard }} --splitting-algorithm least_duration
     - name: Run integration tests
-      if: ${{ matrix.shard == 0 }}
+      if: ${{ matrix.shard == 1 }}
       run: |
         python pip_build.py --install
         cd integration_tests && pytest . -k "not NoTensorflow"
     - name: Run no tensorflow integration test
-      if: ${{ matrix.backend != 'tensorflow' && matrix.shard == 0 }}
+      if: ${{ matrix.backend != 'tensorflow' && matrix.shard == 1 }}
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,19 +16,23 @@ concurrency:
 
 jobs:
   run_tests:
-    name: Test the code
+    name: Test the code (${{ matrix.backend }}, ${{ matrix.version }}, shard ${{ matrix.shard }})
     strategy:
       fail-fast: false
       matrix:
         backend: [tensorflow, jax, torch]
         version: [keras-stable]
+        shard: [0, 1, 2, 3]
         include:
           - backend: jax
             version: keras-3.15
+            shard: 0
           - backend: jax
             version: keras-nightly
+            shard: 0
           - backend: openvino
             version: keras-nightly
+            shard: 0
 
     container:
       image: python:3.11-slim
@@ -65,13 +69,14 @@ jobs:
         pip install keras-nightly --no-cache-dir --progress-bar off
     - name: Test with pytest
       run: |
-        pytest keras_hub/ -n auto --dist loadfile --durations=50
+        pytest keras_hub/ -n auto --dist loadfile --durations=50 --shard-id=${{ matrix.shard }} --num-shards=4
     - name: Run integration tests
+      if: ${{ matrix.shard == 0 }}
       run: |
         python pip_build.py --install
         cd integration_tests && pytest . -k "not NoTensorflow"
     - name: Run no tensorflow integration test
-      if: ${{ matrix.backend != 'tensorflow'}}
+      if: ${{ matrix.backend != 'tensorflow' && matrix.shard == 0 }}
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
         shard: [1, 2, 3, 4]
         include:
           - backend: jax
-            version: keras-3.15
+            version: keras-3.14
             shard: 1
           - backend: jax
             version: keras-nightly
@@ -56,12 +56,12 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
-    - name: Pin Keras 3.15
-      if: ${{ matrix.version == 'keras-3.15'}}
+    - name: Pin Keras 3.14
+      if: ${{ matrix.version == 'keras-3.14'}}
       run: |
         pip uninstall -y keras jaxlib jax
-        pip install keras==3.15.0 --progress-bar off
-        pip install jax==0.6.0 --progress-bar off
+        pip install keras==3.14.0 --progress-bar off
+        pip install jax==0.10.0 --progress-bar off
     - name: Pin Keras Nightly
       if: ${{ matrix.version == 'keras-nightly'}}
       run: |
@@ -69,7 +69,7 @@ jobs:
         pip install keras-nightly --no-cache-dir --progress-bar off
     - name: Test with pytest
       run: |
-        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits 4 --group ${{ matrix.shard }} --splitting-algorithm least_duration
+        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits 4 --group ${{ matrix.shard }}
     - name: Run integration tests
       if: ${{ matrix.shard == 1 }}
       run: |

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -14,6 +14,7 @@ ruff
 pytest
 pytest-cov
 pytest-xdist
+pytest-shard
 build
 namex
 # Optional deps.

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -14,7 +14,7 @@ ruff
 pytest
 pytest-cov
 pytest-xdist
-pytest-shard
+pytest-split
 build
 namex
 # Optional deps.


### PR DESCRIPTION
## Description of the change


Following up on #2856 which brought CI test time from 6+ hours to ~20 min by switching to self-hosted runners and adding pytest-xdist parallelization, this PR adds test sharding to further reduce wall-clock time.

Changes

.github/workflows/actions.yml

Add shard: [0, 1, 2, 3] to the test matrix — each backend (TF, JAX, Torch) now spawns 4 parallel jobs, each running ~25% of the test suite using pytest-shard
Each shard still uses -n auto (pytest-xdist) internally for core-level parallelism within the job
Integration tests run only on shard 0 to avoid duplicate execution
Special version jobs (keras-3.15, keras-nightly, openvino) run as single un-sharded jobs (already fast enough)
requirements-common.txt

Add pytest-shard dependency for --shard-id / --num-shards support

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
