### PR TITLE
Add a vLLM attention route for Mistral

### DIFF
--- a/keras_hub/src/models/mistral/mistral_attention.py
+++ b/keras_hub/src/models/mistral/mistral_attention.py
@@ -6,6 +6,8 @@ from keras import ops
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
+from keras_hub.src.vllm.attention import vllm_paged_attention
+from keras_hub.src.vllm.context import get_vllm_context
 
 
 # This is just a self-attention layer in Mistral. But it can be generalized
@@ -136,6 +138,17 @@ class CachedMistralAttention(keras.layers.Layer):
         cache_update_index=None,
         training=None,
     ):
+        # Route to vLLM paged attention while serving on TPU; otherwise the
+        # original dense path below runs unchanged.
+        vllm_context = get_vllm_context()
+        if (
+            vllm_context is not None
+            and vllm_context.paged_attention_func is not None
+        ):
+            return self._compute_vllm_attention(
+                hidden_states, cache, vllm_context
+            )
+
         start_index = (
             cache_update_index if cache_update_index is not None else 0
         )
@@ -187,6 +200,37 @@ class CachedMistralAttention(keras.layers.Layer):
 
         attention_output = self._output_dense(attention_output)
 
+        if cache is not None:
+            return attention_output, cache
+        return attention_output
+
+    def _compute_vllm_attention(self, hidden_states, cache, vllm_context):
+        """vLLM paged-attention route (serving on TPU only).
+
+        Projects Q/K/V, applies RoPE at the engine's per-token positions,
+        and hands the (unexpanded) K/V to the shared paged-attention bridge,
+        forwarding Mistral's sliding window. The kernel handles
+        grouped-query attention via ``num_kv_heads``, so the dense path's
+        `ops.repeat` of K/V is not needed here.
+        """
+        positions = ops.reshape(vllm_context.positions, (-1, 1))
+        query = self.rotary_embedding_layer(
+            self._query_dense(hidden_states), positions=positions
+        )
+        key = self.rotary_embedding_layer(
+            self._key_dense(hidden_states), positions=positions
+        )
+        value = self._value_dense(hidden_states)
+
+        attention_output = vllm_paged_attention(
+            query,
+            key,
+            value,
+            self._inv_norm_factor,
+            num_kv_heads=self._num_key_value_heads,
+            sliding_window=self._sliding_window,
+        )
+        attention_output = self._output_dense(attention_output)
         if cache is not None:
             return attention_output, cache
         return attention_output

--- a/keras_hub/src/vllm/mistral_route_test.py
+++ b/keras_hub/src/vllm/mistral_route_test.py
@@ -1,0 +1,80 @@
+"""CPU tests for Mistral's vLLM attention route.
+
+Drives a real `CachedMistralAttention` with a recording stand-in kernel, so
+no TPU or vLLM install is needed.
+"""
+
+from keras import ops
+
+from keras_hub.src.models.mistral.mistral_attention import (
+    CachedMistralAttention,
+)
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.vllm import context as vllm_context
+from keras_hub.src.vllm.attention_test import RecordingKernel
+from keras_hub.src.vllm.attention_test import activate_serving
+
+
+class MistralRouteTest(TestCase):
+    def tearDown(self):
+        vllm_context.clear_vllm_context()
+        super().tearDown()
+
+    def _build_layer(self, sliding_window=512):
+        layer = CachedMistralAttention(
+            num_query_heads=4,
+            num_key_value_heads=2,
+            sliding_window=sliding_window,
+        )
+        inputs = ops.ones((3, 1, 8))
+        layer.build(ops.shape(inputs))
+        return layer, inputs
+
+    def test_route_passes_unexpanded_kv_and_sliding_window(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["MC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        call = kernel.calls[0]
+        # The kernel expands K/V for grouped-query attention itself, so the
+        # route must hand it the unexpanded head count.
+        self.assertEqual(call["num_kv_heads"], 2)
+        self.assertEqual(call["num_heads"], 4)
+        self.assertEqual(call["sliding_window"], 512)
+        self.assertAllClose(call["scale"], layer._inv_norm_factor)
+
+    def test_route_forwards_no_sliding_window_when_unset(self):
+        layer, inputs = self._build_layer(sliding_window=None)
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["MC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        self.assertIsNone(kernel.calls[0]["sliding_window"])
+
+    def test_off_path_byte_identical(self):
+        layer, inputs = self._build_layer()
+
+        # No serving context: the dense path must be untouched.
+        before = layer(inputs)
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["MC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        vllm_context.clear_vllm_context()
+        after = layer(inputs)
+
+        self.assertAllClose(before, after)
+        self.assertEqual(kernel.calls, [])


### PR DESCRIPTION
## Description of the change

Adds a vLLM attention route to Mistral, so `CachedMistralAttention` can serve through vLLM's TPU backend on the native flax/nnx path, following the routes already in #2794 for GPT-2, Llama, Qwen, and Gemma.

In `keras_hub/src/models/mistral/mistral_attention.py`, `call()` delegates to a new `_compute_vllm_attention` while a serving context is active and runs the original dense path otherwise. The route projects Q/K/V, applies RoPE at the engine's per-token positions, and calls the shared paged-attention bridge, forwarding Mistral's sliding window. The layer's `cache` argument comes back untouched: while serving, vLLM owns the paged KV cache, so the dense one is bypassed.

The kernel expands K/V for grouped-query attention itself, so the route passes the unexpanded `num_key_value_heads`.

Mistral's sliding window is applied by the decoder's mask in the dense path. While serving there is no dense mask, so the window goes to the kernel instead.

## Tests

`keras_hub/src/vllm/mistral_route_test.py` drives a real `CachedMistralAttention` with a recording stand-in kernel, so it runs on CPU with no TPU or vLLM install:

- the route passes the unexpanded K/V head count, the right query head count, and the layer's own scale
- the sliding window reaches the kernel, and is `None` when the layer has none
- off the serving path the layer's output is unchanged and the kernel is never called

Runs on the jax, tensorflow, and torch backends.

## Reference

Depends on keras-team/keras-hub#2794, which adds `keras_hub/src/vllm/` and the bridge this route calls; that should merge first. Companion backend PR: vllm-project/tpu-inference#3104.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends.
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md).
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
