### PR TITLE
Add a vLLM attention route for Qwen 3

### DIFF
--- a/keras_hub/src/models/qwen3/qwen3_attention.py
+++ b/keras_hub/src/models/qwen3/qwen3_attention.py
@@ -7,6 +7,8 @@ from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.models.qwen3.qwen3_layernorm import Qwen3LayerNorm
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
+from keras_hub.src.vllm.attention import vllm_paged_attention
+from keras_hub.src.vllm.context import get_vllm_context
 
 
 class Qwen3Attention(keras.layers.Layer):
@@ -182,6 +184,17 @@ class Qwen3Attention(keras.layers.Layer):
             attention_output: Output tensor after applying attention.
             cache: Updated cache tensors (if cache is provided).
         """
+        # Route to vLLM paged attention while serving on TPU; otherwise the
+        # original dense path below runs unchanged.
+        vllm_context = get_vllm_context()
+        if (
+            vllm_context is not None
+            and vllm_context.paged_attention_func is not None
+        ):
+            return self._compute_vllm_attention(
+                hidden_states, cache, vllm_context
+            )
+
         start_index = (
             cache_update_index if cache_update_index is not None else 0
         )
@@ -260,6 +273,36 @@ class Qwen3Attention(keras.layers.Layer):
                 attention_scores, attention_mask[:, None, :, :]
             )
         return self._softmax(attention_scores)
+
+    def _compute_vllm_attention(self, hidden_states, cache, vllm_context):
+        """vLLM paged-attention route (serving on TPU only).
+
+        Applies Qwen 3's query/key layer norms, then RoPE at the engine's
+        per-token positions, and hands the (unexpanded) K/V to the shared
+        paged-attention bridge. The kernel handles grouped-query attention
+        via ``num_kv_heads``.
+        """
+        positions = ops.reshape(vllm_context.positions, (-1, 1))
+        query = self._query_dense_layer_norm(self._query_dense(hidden_states))
+        query = self.rotary_embedding_layer(query, positions=positions)
+        key = self._key_dense_layer_norm(self._key_dense(hidden_states))
+        key = self.rotary_embedding_layer(key, positions=positions)
+        value = self._value_dense(hidden_states)
+
+        attention_output = vllm_paged_attention(
+            query,
+            key,
+            value,
+            self._inv_norm_factor,
+            num_kv_heads=self.num_key_value_heads,
+            sliding_window=self.sliding_window_size
+            if self.sliding_window_size
+            else None,
+        )
+        attention_output = self._output_dense(attention_output)
+        if cache is not None:
+            return attention_output, cache
+        return attention_output
 
     def _compute_attention(
         self, query, key, value, attention_mask=None, cache_update_index=None

--- a/keras_hub/src/vllm/qwen3_route_test.py
+++ b/keras_hub/src/vllm/qwen3_route_test.py
@@ -1,0 +1,111 @@
+"""CPU tests for Qwen 3's vLLM attention route.
+
+Drives a real `Qwen3Attention` with a recording stand-in kernel, so no TPU
+or vLLM install is needed.
+"""
+
+from keras import ops
+
+from keras_hub.src.models.qwen3.qwen3_attention import Qwen3Attention
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.vllm import context as vllm_context
+from keras_hub.src.vllm.attention_test import RecordingKernel
+from keras_hub.src.vllm.attention_test import activate_serving
+
+
+class Qwen3RouteTest(TestCase):
+    def tearDown(self):
+        vllm_context.clear_vllm_context()
+        super().tearDown()
+
+    def _build_layer(self, sliding_window_size=None):
+        layer = Qwen3Attention(
+            num_query_heads=4,
+            num_key_value_heads=2,
+            head_dim=4,
+            sliding_window_size=sliding_window_size,
+        )
+        inputs = ops.ones((3, 1, 8))
+        layer.build(ops.shape(inputs))
+        return layer, inputs
+
+    def test_route_passes_unexpanded_kv_heads(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["QC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        call = kernel.calls[0]
+        # The kernel expands K/V for grouped-query attention itself.
+        self.assertEqual(call["num_kv_heads"], 2)
+        self.assertEqual(call["num_heads"], 4)
+        self.assertAllClose(call["scale"], layer._inv_norm_factor)
+
+    def test_route_applies_query_key_layer_norms(self):
+        """Qwen 3 norms Q and K before RoPE; the route must do the same."""
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        positions = ops.convert_to_tensor([0, 1, 2])
+        activate_serving(kernel, kv_caches=["QC0"], positions=positions)
+        layer(inputs)
+
+        expected_positions = ops.reshape(positions, (-1, 1))
+        expected_query = layer.rotary_embedding_layer(
+            layer._query_dense_layer_norm(layer._query_dense(inputs)),
+            positions=expected_positions,
+        )
+        expected_key = layer.rotary_embedding_layer(
+            layer._key_dense_layer_norm(layer._key_dense(inputs)),
+            positions=expected_positions,
+        )
+        call = kernel.calls[0]
+        self.assertAllClose(call["q"], ops.reshape(expected_query, (3, -1)))
+        self.assertAllClose(call["k"], ops.reshape(expected_key, (3, -1)))
+
+    def test_route_forwards_sliding_window(self):
+        layer, inputs = self._build_layer(sliding_window_size=512)
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["QC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        self.assertEqual(kernel.calls[0]["sliding_window"], 512)
+
+    def test_route_omits_sliding_window_when_unset(self):
+        layer, inputs = self._build_layer(sliding_window_size=None)
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["QC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        self.assertIsNone(kernel.calls[0]["sliding_window"])
+
+    def test_off_path_byte_identical(self):
+        layer, inputs = self._build_layer()
+
+        before = layer(inputs)
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["QC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        vllm_context.clear_vllm_context()
+        after = layer(inputs)
+
+        self.assertAllClose(before, after)
+        self.assertEqual(kernel.calls, [])


### PR DESCRIPTION
## Description of the change

Adds a vLLM attention route to Qwen 3, so `Qwen3Attention` can serve through vLLM's TPU backend on the native flax/nnx path, following the routes already in #2794 for GPT-2, Llama, Qwen, and Gemma.

In `keras_hub/src/models/qwen3/qwen3_attention.py`, `call()` delegates to a new `_compute_vllm_attention` while a serving context is active and runs the original dense path otherwise. The route projects Q/K/V, applies RoPE at the engine's per-token positions, and calls the shared paged-attention bridge. The layer's `cache` argument comes back untouched: while serving, vLLM owns the paged KV cache, so the dense one is bypassed.

Qwen 3 normalizes queries and keys before RoPE. The route applies `_query_dense_layer_norm` and `_key_dense_layer_norm` in the dense path's order, and a test recomputes the expected tensors.

The kernel expands K/V for grouped-query attention itself, so the route passes the unexpanded `num_key_value_heads`.

## Tests

`keras_hub/src/vllm/qwen3_route_test.py` drives a real `Qwen3Attention` with a recording stand-in kernel, so it runs on CPU with no TPU or vLLM install:

- the route passes the unexpanded K/V head count, the right query head count, and the layer's own scale
- the query and key layer norms are applied before RoPE, checked against recomputed tensors
- the sliding window reaches the kernel when `sliding_window_size` is set, and is `None` otherwise
- off the serving path the layer's output is unchanged and the kernel is never called

Runs on the jax, tensorflow, and torch backends.

## Reference

Depends on keras-team/keras-hub#2794, which adds `keras_hub/src/vllm/` and the bridge this route calls; that should merge first. Companion backend PR: vllm-project/tpu-inference#3104.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends.
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md).
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
