### PR TITLE
Add a vLLM attention route for Mixtral

### DIFF
--- a/keras_hub/src/models/mixtral/mixtral_attention.py
+++ b/keras_hub/src/models/mixtral/mixtral_attention.py
@@ -10,6 +10,8 @@ from keras_hub.src.utils.keras_utils import fused_attention_op_available
 from keras_hub.src.utils.keras_utils import gpu_supports_fused_attention_op
 from keras_hub.src.utils.keras_utils import running_on_gpu
 from keras_hub.src.utils.keras_utils import running_on_tpu
+from keras_hub.src.vllm.attention import vllm_paged_attention
+from keras_hub.src.vllm.context import get_vllm_context
 
 
 class CachedMixtralAttention(keras.layers.Layer):
@@ -130,6 +132,17 @@ class CachedMixtralAttention(keras.layers.Layer):
         cache_update_index=None,
         training=None,
     ):
+        # Route to vLLM paged attention while serving on TPU; otherwise the
+        # original dense path below runs unchanged.
+        vllm_context = get_vllm_context()
+        if (
+            vllm_context is not None
+            and vllm_context.paged_attention_func is not None
+        ):
+            return self._compute_vllm_attention(
+                hidden_states, cache, vllm_context
+            )
+
         start_index = (
             cache_update_index if cache_update_index is not None else 0
         )
@@ -203,6 +216,36 @@ class CachedMixtralAttention(keras.layers.Layer):
             return "attn_logits_soft_cap" in sig.parameters
         else:
             return False
+
+    def _compute_vllm_attention(self, hidden_states, cache, vllm_context):
+        """vLLM paged-attention route (serving on TPU only).
+
+        Projects Q/K/V, applies RoPE at the engine's per-token positions, and
+        hands the (unexpanded) K/V to the shared paged-attention bridge,
+        forwarding Mixtral's sliding window. The mixture-of-experts block
+        sits after attention and is untouched by this route.
+        """
+        positions = ops.reshape(vllm_context.positions, (-1, 1))
+        query = self.rotary_embedding_layer(
+            self.query_dense(hidden_states), positions=positions
+        )
+        key = self.rotary_embedding_layer(
+            self.key_dense(hidden_states), positions=positions
+        )
+        value = self.value_dense(hidden_states)
+
+        attention_output = vllm_paged_attention(
+            query,
+            key,
+            value,
+            self._inv_norm_factor,
+            num_kv_heads=self.num_key_value_heads,
+            sliding_window=self.sliding_window,
+        )
+        attention_output = self.output_dense(attention_output)
+        if cache is not None:
+            return attention_output, cache
+        return attention_output
 
     def _compute_attention(self, query, key, value, attention_mask=None):
         if self._use_fused_attention_op():

--- a/keras_hub/src/vllm/mixtral_route_test.py
+++ b/keras_hub/src/vllm/mixtral_route_test.py
@@ -1,0 +1,94 @@
+"""CPU tests for Mixtral's vLLM attention route.
+
+Drives a real `CachedMixtralAttention` with a recording stand-in kernel, so
+no TPU or vLLM install is needed.
+"""
+
+from keras import ops
+
+from keras_hub.src.models.mixtral.mixtral_attention import (
+    CachedMixtralAttention,
+)
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.vllm import context as vllm_context
+from keras_hub.src.vllm.attention_test import RecordingKernel
+from keras_hub.src.vllm.attention_test import activate_serving
+
+
+class MixtralRouteTest(TestCase):
+    def tearDown(self):
+        vllm_context.clear_vllm_context()
+        super().tearDown()
+
+    def _build_layer(self, sliding_window=512):
+        layer = CachedMixtralAttention(
+            num_query_heads=4,
+            num_key_value_heads=2,
+            sliding_window=sliding_window,
+        )
+        inputs = ops.ones((3, 1, 8))
+        layer.build(ops.shape(inputs))
+        return layer, inputs
+
+    def test_route_passes_unexpanded_kv_and_sliding_window(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["XC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        call = kernel.calls[0]
+        # The kernel expands K/V for grouped-query attention itself.
+        self.assertEqual(call["num_kv_heads"], 2)
+        self.assertEqual(call["num_heads"], 4)
+        self.assertEqual(call["sliding_window"], 512)
+        self.assertAllClose(call["scale"], layer._inv_norm_factor)
+
+    def test_route_applies_rope_at_serving_positions(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        positions = ops.convert_to_tensor([0, 1, 2])
+        activate_serving(kernel, kv_caches=["XC0"], positions=positions)
+        layer(inputs)
+
+        expected_query = layer.rotary_embedding_layer(
+            layer.query_dense(inputs),
+            positions=ops.reshape(positions, (-1, 1)),
+        )
+        self.assertAllClose(
+            kernel.calls[0]["q"], ops.reshape(expected_query, (3, -1))
+        )
+
+    def test_route_forwards_no_sliding_window_when_unset(self):
+        layer, inputs = self._build_layer(sliding_window=None)
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["XC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        self.assertIsNone(kernel.calls[0]["sliding_window"])
+
+    def test_off_path_byte_identical(self):
+        layer, inputs = self._build_layer()
+
+        before = layer(inputs)
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["XC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        vllm_context.clear_vllm_context()
+        after = layer(inputs)
+
+        self.assertAllClose(before, after)
+        self.assertEqual(kernel.calls, [])


### PR DESCRIPTION
## Description of the change

Adds a vLLM attention route to Mixtral, so `CachedMixtralAttention` can serve through vLLM's TPU backend on the native flax/nnx path, following the routes already in #2794 for GPT-2, Llama, Qwen, and Gemma.

In `keras_hub/src/models/mixtral/mixtral_attention.py`, `call()` delegates to a new `_compute_vllm_attention` while a serving context is active and runs the original dense path otherwise. The route projects Q/K/V, applies RoPE at the engine's per-token positions, and calls the shared paged-attention bridge. The layer's `cache` argument comes back untouched: while serving, vLLM owns the paged KV cache, so the dense one is bypassed.

Its sliding window is applied by the decoder's mask in the dense path. While serving there is no dense mask, so the window goes to the kernel instead. The mixture-of-experts block sits after attention, so the route does not touch it.

## Tests

`keras_hub/src/vllm/mixtral_route_test.py` drives a real `CachedMixtralAttention` with a recording stand-in kernel, so it runs on CPU with no TPU or vLLM install:

- the route passes the unexpanded K/V head count, the right query head count, the layer's own scale, and the sliding window
- RoPE is applied at the serving positions, checked against a recomputed tensor
- the window is `None` when the layer has none
- off the serving path the layer's output is unchanged and the kernel is never called

Runs on the jax, tensorflow, and torch backends.

## Reference

Depends on keras-team/keras-hub#2794, which adds `keras_hub/src/vllm/` and the bridge this route calls; that should merge first. Companion backend PR: vllm-project/tpu-inference#3104.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends.
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md).
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
