### PR TITLE
Add a vLLM attention route for GPT-NeoX, and fix its cached RoPE

### DIFF
--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py
@@ -6,6 +6,8 @@ from keras import ops
 from keras_hub.src.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
+from keras_hub.src.vllm.attention import vllm_paged_attention
+from keras_hub.src.vllm.context import get_vllm_context
 
 
 class GPTNeoXAttention(keras.layers.Layer):
@@ -122,6 +124,54 @@ class GPTNeoXAttention(keras.layers.Layer):
                 )
         return self._softmax(attention_scores, attention_mask)
 
+    def _compute_vllm_attention(self, hidden_states, cache, vllm_context):
+        """vLLM paged-attention route (serving on TPU only).
+
+        Splits the fused QKV projection, rotates only the first
+        ``rotary_dim`` features at the engine's per-token positions and
+        passes the rest through, exactly as the dense path does, then hands
+        Q/K/V to the shared paged-attention bridge. GPT-NeoX has no
+        grouped-query attention, so key/value head count equals
+        ``num_heads``.
+        """
+        positions = ops.reshape(vllm_context.positions, (-1, 1))
+        query_key_value = self._qkv_dense(hidden_states)
+        query = query_key_value[..., : self.attn_head_size]
+        key = query_key_value[
+            ..., self.attn_head_size : 2 * self.attn_head_size
+        ]
+        value = query_key_value[..., 2 * self.attn_head_size :]
+
+        query_rot, query_pass = (
+            query[..., : self.rotary_dim],
+            query[..., self.rotary_dim :],
+        )
+        key_rot, key_pass = (
+            key[..., : self.rotary_dim],
+            key[..., self.rotary_dim :],
+        )
+        query_rot = self.rotary_embedding_layer(query_rot, positions=positions)
+        key_rot = self.rotary_embedding_layer(key_rot, positions=positions)
+        query = ops.concatenate((query_rot, query_pass), axis=-1)
+        key = ops.concatenate((key_rot, key_pass), axis=-1)
+
+        attention_output = vllm_paged_attention(
+            query,
+            key,
+            value,
+            self._inv_norm_factor,
+            num_kv_heads=self.num_heads,
+        )
+        attention_output = ops.reshape(
+            attention_output,
+            [
+                ops.shape(attention_output)[0],
+                ops.shape(attention_output)[1],
+                self.hidden_dim,
+            ],
+        )
+        return self._output_dense(attention_output), cache
+
     def _compute_attention(
         self, query, key, value, attention_mask=None, training=None
     ):
@@ -165,6 +215,17 @@ class GPTNeoXAttention(keras.layers.Layer):
         cache_update_index=None,
         training=None,
     ):
+        # Route to vLLM paged attention while serving on TPU; otherwise the
+        # original dense path below runs unchanged.
+        vllm_context = get_vllm_context()
+        if (
+            vllm_context is not None
+            and vllm_context.paged_attention_func is not None
+        ):
+            return self._compute_vllm_attention(
+                hidden_states, cache, vllm_context
+            )
+
         query_key_value = self._qkv_dense(hidden_states)
 
         query = query_key_value[..., : self.attn_head_size]

--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py
@@ -266,7 +266,16 @@ class GPTNeoXAttention(keras.layers.Layer):
             key[..., self.rotary_dim :],
         )
 
-        query_rot = self.rotary_embedding_layer(query_rot)
+        # The query holds only the tokens being decoded now, so it has to
+        # be rotated at their absolute positions. The cache stores keys
+        # unrotated and `key_rot` spans it from the start, so keys keep
+        # rotating from position 0.
+        start_index = (
+            cache_update_index if cache_update_index is not None else 0
+        )
+        query_rot = self.rotary_embedding_layer(
+            query_rot, start_index=start_index
+        )
         key_rot = self.rotary_embedding_layer(key_rot)
 
         query = ops.concatenate((query_rot, query_pass), axis=-1)

--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention_test.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention_test.py
@@ -23,9 +23,7 @@ class GPTNeoXAttentionTest(TestCase):
             mask = np.zeros((1, 1, length), dtype=bool)
             # The token being decoded sees the cache filled so far.
             mask[0, 0, : index + 1] = True
-            token = ops.convert_to_tensor(
-                np.array(inputs)[:, index : index + 1]
-            )
+            token = inputs[:, index : index + 1]
             output, cache = layer(
                 token,
                 attention_mask=ops.convert_to_tensor(mask),

--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention_test.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention_test.py
@@ -1,0 +1,70 @@
+import numpy as np
+from keras import ops
+
+from keras_hub.src.models.gpt_neo_x.gpt_neo_x_attention import GPTNeoXAttention
+from keras_hub.src.tests.test_case import TestCase
+
+
+class GPTNeoXAttentionTest(TestCase):
+    def _build_layer(self, rotary_percentage=1.0):
+        layer = GPTNeoXAttention(
+            num_heads=2,
+            hidden_dim=16,
+            rotary_percentage=rotary_percentage,
+        )
+        layer.build((1, 4, 16))
+        return layer
+
+    def _decode_step_by_step(self, layer, inputs, length):
+        """Runs `inputs` one token at a time through the cached path."""
+        cache = ops.zeros((1, 2, length, 2, 8))
+        outputs = []
+        for index in range(length):
+            mask = np.zeros((1, 1, length), dtype=bool)
+            # The token being decoded sees the cache filled so far.
+            mask[0, 0, : index + 1] = True
+            token = ops.convert_to_tensor(
+                np.array(inputs)[:, index : index + 1]
+            )
+            output, cache = layer(
+                token,
+                attention_mask=ops.convert_to_tensor(mask),
+                cache=cache,
+                cache_update_index=index,
+            )
+            outputs.append(output)
+        return ops.concatenate(outputs, axis=1)
+
+    def test_cached_decoding_matches_full_sequence(self):
+        """Each decoded token carries its own position, so generating one
+        token at a time must match a single pass over the whole sequence.
+        Rotating the query from position 0 every step silently breaks
+        this."""
+        layer = self._build_layer()
+        inputs = ops.convert_to_tensor(
+            np.random.default_rng(0).normal(size=(1, 4, 16)).astype("float32")
+        )
+        causal_mask = np.tril(np.ones((4, 4), dtype=bool))[None]
+
+        full, _ = layer(
+            inputs, attention_mask=ops.convert_to_tensor(causal_mask)
+        )
+        stepped = self._decode_step_by_step(layer, inputs, length=4)
+
+        self.assertAllClose(full, stepped)
+
+    def test_cached_decoding_matches_with_partial_rotary(self):
+        """The same holds when only part of each head is rotated, which is
+        GPT-NeoX's default."""
+        layer = self._build_layer(rotary_percentage=0.25)
+        inputs = ops.convert_to_tensor(
+            np.random.default_rng(1).normal(size=(1, 4, 16)).astype("float32")
+        )
+        causal_mask = np.tril(np.ones((4, 4), dtype=bool))[None]
+
+        full, _ = layer(
+            inputs, attention_mask=ops.convert_to_tensor(causal_mask)
+        )
+        stepped = self._decode_step_by_step(layer, inputs, length=4)
+
+        self.assertAllClose(full, stepped)

--- a/keras_hub/src/vllm/gpt_neo_x_route_test.py
+++ b/keras_hub/src/vllm/gpt_neo_x_route_test.py
@@ -1,0 +1,104 @@
+"""CPU tests for GPT-NeoX's vLLM attention route.
+
+Drives a real `GPTNeoXAttention` with a recording stand-in kernel, so no TPU
+or vLLM install is needed.
+"""
+
+from keras import ops
+
+from keras_hub.src.models.gpt_neo_x.gpt_neo_x_attention import GPTNeoXAttention
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.vllm import context as vllm_context
+from keras_hub.src.vllm.attention_test import RecordingKernel
+from keras_hub.src.vllm.attention_test import activate_serving
+
+
+class GPTNeoXRouteTest(TestCase):
+    def tearDown(self):
+        vllm_context.clear_vllm_context()
+        super().tearDown()
+
+    def _build_layer(self, rotary_percentage=0.25):
+        layer = GPTNeoXAttention(
+            num_heads=2,
+            hidden_dim=16,
+            rotary_percentage=rotary_percentage,
+        )
+        inputs = ops.ones((3, 1, 16))
+        layer.build(ops.shape(inputs))
+        return layer, inputs
+
+    def test_route_reports_head_counts_and_scale(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["NC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        call = kernel.calls[0]
+        # GPT-NeoX has no grouped-query attention.
+        self.assertEqual(call["num_heads"], 2)
+        self.assertEqual(call["num_kv_heads"], 2)
+        self.assertEqual(call["head_size"], layer.attn_head_size)
+        self.assertAllClose(call["scale"], layer._inv_norm_factor)
+
+    def test_route_rotates_only_the_rotary_slice(self):
+        """Only the first `rotary_dim` features are rotated; the rest of
+        each head passes through untouched."""
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        positions = ops.convert_to_tensor([0, 1, 2])
+        activate_serving(kernel, kv_caches=["NC0"], positions=positions)
+        layer(inputs)
+
+        query_key_value = layer._qkv_dense(inputs)
+        query = query_key_value[..., : layer.attn_head_size]
+        query_rot = layer.rotary_embedding_layer(
+            query[..., : layer.rotary_dim],
+            positions=ops.reshape(positions, (-1, 1)),
+        )
+        expected = ops.concatenate(
+            (query_rot, query[..., layer.rotary_dim :]), axis=-1
+        )
+        self.assertAllClose(
+            kernel.calls[0]["q"], ops.reshape(expected, (3, -1))
+        )
+
+    def test_route_returns_cache_unchanged(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["NC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        output, cache = layer(inputs, cache="UNUSED")
+
+        self.assertEqual(cache, "UNUSED")
+        self.assertEqual(ops.shape(output), ops.shape(inputs))
+
+    def test_off_path_byte_identical(self):
+        layer, inputs = self._build_layer()
+        # The dense path needs a mask: calling it without one trips a
+        # backend-specific `Softmax` signature issue that predates this
+        # route.
+        mask = ops.ones((3, 1, 1), dtype="bool")
+
+        before, _ = layer(inputs, attention_mask=mask)
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["NC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        vllm_context.clear_vllm_context()
+        after, _ = layer(inputs, attention_mask=mask)
+
+        self.assertAllClose(before, after)
+        self.assertEqual(kernel.calls, [])


### PR DESCRIPTION
## Description of the change

Adds a vLLM attention route to GPT-NeoX, so `GPTNeoXAttention` can serve through vLLM's TPU backend on the native flax/nnx path, following the routes already in #2794. It also fixes a dense-path bug, which changes `generate()` output.

### The route

In `keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention.py`, `call()` delegates to a new `_compute_vllm_attention` while a serving context is active and runs the original dense path otherwise.

GPT-NeoX fuses its QKV projection, so the route slices Q/K/V out of one tensor, rotates only the first `rotary_dim` features at the engine's per-token positions, passes the rest through, and calls the shared paged-attention bridge. There is no grouped-query attention, so the K/V head count equals `num_heads`. The layer's `cache` argument comes back untouched: while serving, vLLM owns the paged KV cache, so the dense one is bypassed.

### The dense path fix

`call()` applied RoPE with no `start_index`:

```python
query_rot = self.rotary_embedding_layer(query_rot)
```

During cached generation the query holds only the token being decoded, so every generated token was rotated at position 0 however far into the sequence it was. Keys were unaffected: the cache stores them unrotated and `key_rot` spans it from the start. The fix passes `cache_update_index` for the query and leaves the key path alone.

## Tests

`keras_hub/src/models/gpt_neo_x/gpt_neo_x_attention_test.py` (new) covers the fix: decoding one token at a time must match a single pass over the whole sequence, with full and partial rotary. These fail on the unfixed layer.

`keras_hub/src/vllm/gpt_neo_x_route_test.py` covers the route, driving a real `GPTNeoXAttention` with a recording stand-in kernel so it runs on CPU with no TPU or vLLM install:

- head counts, head size, and the layer's own scale reach the kernel
- only the rotary slice is rotated; the pass-through slice is untouched
- the cache is returned unchanged
- off the serving path the layer's output is unchanged and the kernel is never called

Runs on the jax, tensorflow, and torch backends.

## Reference

Depends on keras-team/keras-hub#2794, which adds `keras_hub/src/vllm/` and the bridge this route calls; that should merge first. Companion backend PR: vllm-project/tpu-inference#3104.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends.
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md).
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
