### PR TITLE
Add a vLLM attention route for Phi-3, and fix its su rope scaling

### DIFF
--- a/keras_hub/src/models/phi3/phi3_attention.py
+++ b/keras_hub/src/models/phi3/phi3_attention.py
@@ -241,7 +241,9 @@ class Phi3Attention(keras.layers.Layer):
         token decoded past the pretraining length still gets long-context
         frequencies.
         """
-        positions = ops.reshape(vllm_context.positions, (-1, 1))
+        positions = ops.reshape(
+            vllm_context.positions, ops.shape(hidden_states)[:-1]
+        )
         query = self.rotary_embedding_layer(
             self.query_dense(hidden_states), positions=positions
         )

--- a/keras_hub/src/models/phi3/phi3_attention.py
+++ b/keras_hub/src/models/phi3/phi3_attention.py
@@ -236,24 +236,19 @@ class Phi3Attention(keras.layers.Layer):
         hands the (unexpanded) K/V to the shared paged-attention bridge. The
         kernel handles grouped-query attention via ``num_kv_heads``.
 
-        Su-scaled presets get their rotary embedding built here rather than
-        by `Phi3SuScaledRotaryEmbedding`: that layer indexes positions as a
-        contiguous range and picks its short/long frequency factor from the
-        length of the current input, which under paged decode is one token
-        however far into the sequence it sits.
+        Su-scaled presets work the same way: their rotary layer reads the
+        absolute positions and picks its frequency factors from them, so a
+        token decoded past the pretraining length still gets long-context
+        frequencies.
         """
         positions = ops.reshape(vllm_context.positions, (-1, 1))
-        query = self.query_dense(hidden_states)
-        key = self.key_dense(hidden_states)
+        query = self.rotary_embedding_layer(
+            self.query_dense(hidden_states), positions=positions
+        )
+        key = self.rotary_embedding_layer(
+            self.key_dense(hidden_states), positions=positions
+        )
         value = self.value_dense(hidden_states)
-
-        if self.rope_scaling_type is None:
-            query = self.rotary_embedding_layer(query, positions=positions)
-            key = self.rotary_embedding_layer(key, positions=positions)
-        else:
-            cos, sin = self._compute_vllm_su_embedding(query, positions)
-            query = query * cos + self._rotate_half(query) * sin
-            key = key * cos + self._rotate_half(key) * sin
 
         attention_output = vllm_paged_attention(
             query,
@@ -266,50 +261,6 @@ class Phi3Attention(keras.layers.Layer):
         if cache is not None:
             return attention_output, cache
         return attention_output
-
-    def _compute_vllm_su_embedding(self, query, positions):
-        """Builds su-scaled cos/sin at vLLM's absolute token positions.
-
-        Mirrors `Phi3SuScaledRotaryEmbedding`, except the long-context
-        factor is chosen by how far into the sequence the positions sit
-        rather than by how many tokens this step carries.
-        """
-        rotary = self.rotary_embedding_layer
-        rotary_dim = ops.shape(query)[-1]
-        inverse_freq = rotary._get_inverse_freq(rotary_dim)
-        # Cast first: the context supplies integer positions, and mixing
-        # them with floats is an error on some backends.
-        positions = ops.cast(positions, "float32")
-        sequence_length = ops.max(positions) + 1.0
-        inverse_freq = ops.where(
-            sequence_length > rotary.pretraining_sequence_length,
-            ops.divide(
-                inverse_freq,
-                ops.convert_to_tensor(rotary.inverese_freq_long_factor),
-            ),
-            ops.divide(
-                inverse_freq,
-                ops.convert_to_tensor(rotary.inverese_freq_short_factor),
-            ),
-        )
-
-        freq = ops.einsum("bi,j->bij", positions, inverse_freq)
-        embedding = ops.stack((freq, freq), axis=-2)
-        embedding = ops.reshape(
-            embedding, (*ops.shape(freq)[:-1], ops.shape(freq)[-1] * 2)
-        )
-        # (tokens, seq, rotary_dim) -> broadcast over the head axis.
-        embedding = ops.expand_dims(embedding, axis=2)
-        scale = rotary.embedding_scaling_factor
-        cos = ops.cast(ops.cos(embedding) * scale, query.dtype)
-        sin = ops.cast(ops.sin(embedding) * scale, query.dtype)
-        return cos, sin
-
-    def _rotate_half(self, tensor):
-        """Rotates the halves of the last axis, as RoPE requires."""
-        x1, x2 = ops.split(tensor, 2, axis=-1)
-        half = ops.stack((-x2, x1), axis=-2)
-        return ops.reshape(half, ops.shape(tensor))
 
     def _compute_attention(self, query, key, value, attention_mask=None):
         if fused_attention_op_available():

--- a/keras_hub/src/models/phi3/phi3_attention.py
+++ b/keras_hub/src/models/phi3/phi3_attention.py
@@ -9,6 +9,8 @@ from keras_hub.src.models.phi3.phi3_rotary_embedding import (
 )
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
+from keras_hub.src.vllm.attention import vllm_paged_attention
+from keras_hub.src.vllm.context import get_vllm_context
 
 
 class Phi3Attention(keras.layers.Layer):
@@ -161,6 +163,17 @@ class Phi3Attention(keras.layers.Layer):
         cache_update_index=None,
         training=None,
     ):
+        # Route to vLLM paged attention while serving on TPU; otherwise the
+        # original dense path below runs unchanged.
+        vllm_context = get_vllm_context()
+        if (
+            vllm_context is not None
+            and vllm_context.paged_attention_func is not None
+        ):
+            return self._compute_vllm_attention(
+                hidden_states, cache, vllm_context
+            )
+
         start_index = (
             cache_update_index if cache_update_index is not None else 0
         )
@@ -215,6 +228,88 @@ class Phi3Attention(keras.layers.Layer):
         if attention_mask is not None:
             return self.softmax(attention_scores, attention_mask[:, None, :, :])
         return self.softmax(attention_scores)
+
+    def _compute_vllm_attention(self, hidden_states, cache, vllm_context):
+        """vLLM paged-attention route (serving on TPU only).
+
+        Projects Q/K/V, applies RoPE at the engine's per-token positions, and
+        hands the (unexpanded) K/V to the shared paged-attention bridge. The
+        kernel handles grouped-query attention via ``num_kv_heads``.
+
+        Su-scaled presets get their rotary embedding built here rather than
+        by `Phi3SuScaledRotaryEmbedding`: that layer indexes positions as a
+        contiguous range and picks its short/long frequency factor from the
+        length of the current input, which under paged decode is one token
+        however far into the sequence it sits.
+        """
+        positions = ops.reshape(vllm_context.positions, (-1, 1))
+        query = self.query_dense(hidden_states)
+        key = self.key_dense(hidden_states)
+        value = self.value_dense(hidden_states)
+
+        if self.rope_scaling_type is None:
+            query = self.rotary_embedding_layer(query, positions=positions)
+            key = self.rotary_embedding_layer(key, positions=positions)
+        else:
+            cos, sin = self._compute_vllm_su_embedding(query, positions)
+            query = query * cos + self._rotate_half(query) * sin
+            key = key * cos + self._rotate_half(key) * sin
+
+        attention_output = vllm_paged_attention(
+            query,
+            key,
+            value,
+            self._inv_norm_factor,
+            num_kv_heads=self.num_key_value_heads,
+        )
+        attention_output = self.output_dense(attention_output)
+        if cache is not None:
+            return attention_output, cache
+        return attention_output
+
+    def _compute_vllm_su_embedding(self, query, positions):
+        """Builds su-scaled cos/sin at vLLM's absolute token positions.
+
+        Mirrors `Phi3SuScaledRotaryEmbedding`, except the long-context
+        factor is chosen by how far into the sequence the positions sit
+        rather than by how many tokens this step carries.
+        """
+        rotary = self.rotary_embedding_layer
+        rotary_dim = ops.shape(query)[-1]
+        inverse_freq = rotary._get_inverse_freq(rotary_dim)
+        # Cast first: the context supplies integer positions, and mixing
+        # them with floats is an error on some backends.
+        positions = ops.cast(positions, "float32")
+        sequence_length = ops.max(positions) + 1.0
+        inverse_freq = ops.where(
+            sequence_length > rotary.pretraining_sequence_length,
+            ops.divide(
+                inverse_freq,
+                ops.convert_to_tensor(rotary.inverese_freq_long_factor),
+            ),
+            ops.divide(
+                inverse_freq,
+                ops.convert_to_tensor(rotary.inverese_freq_short_factor),
+            ),
+        )
+
+        freq = ops.einsum("bi,j->bij", positions, inverse_freq)
+        embedding = ops.stack((freq, freq), axis=-2)
+        embedding = ops.reshape(
+            embedding, (*ops.shape(freq)[:-1], ops.shape(freq)[-1] * 2)
+        )
+        # (tokens, seq, rotary_dim) -> broadcast over the head axis.
+        embedding = ops.expand_dims(embedding, axis=2)
+        scale = rotary.embedding_scaling_factor
+        cos = ops.cast(ops.cos(embedding) * scale, query.dtype)
+        sin = ops.cast(ops.sin(embedding) * scale, query.dtype)
+        return cos, sin
+
+    def _rotate_half(self, tensor):
+        """Rotates the halves of the last axis, as RoPE requires."""
+        x1, x2 = ops.split(tensor, 2, axis=-1)
+        half = ops.stack((-x2, x1), axis=-2)
+        return ops.reshape(half, ops.shape(tensor))
 
     def _compute_attention(self, query, key, value, attention_mask=None):
         if fused_attention_op_available():

--- a/keras_hub/src/models/phi3/phi3_rotary_embedding.py
+++ b/keras_hub/src/models/phi3/phi3_rotary_embedding.py
@@ -80,7 +80,7 @@ class Phi3SuScaledRotaryEmbedding(RotaryEmbedding):
             positions = ops.expand_dims(positions, axis=batch_axis)
         else:
             positions = ops.cast(positions, "float32")
-            if len(ops.shape(positions)) == 1:
+            if ops.ndim(positions) == 1:
                 positions = ops.expand_dims(positions, axis=batch_axis)
 
         # Multiply inverse_freq by a factor, chosen by how far into the

--- a/keras_hub/src/models/phi3/phi3_rotary_embedding.py
+++ b/keras_hub/src/models/phi3/phi3_rotary_embedding.py
@@ -31,6 +31,9 @@ class Phi3SuScaledRotaryEmbedding(RotaryEmbedding):
         start_index: An integer or integer tensor. The starting position to
             compute the rotary embedding from. This is useful during cached
             decoding, where each position is predicted separately in a loop.
+        positions: Optional tensor of absolute positions, shaped
+            `(sequence_length,)` or `(batch_size, sequence_length)`, taking
+            precedence over `start_index`.
 
     References:
      - [Phi-3-mini-128k-instruct original implementation](https://huggingface.co/microsoft/Phi-3-mini-128k-instruct/blob/0693e0b867d29e7318280ddd3ff9d5e66698f488/modeling_phi3.py#L142)
@@ -65,40 +68,49 @@ class Phi3SuScaledRotaryEmbedding(RotaryEmbedding):
         self.inverese_freq_long_factor = inverese_freq_long_factor
 
     def _compute_cos_sin_embedding(self, inputs, start_index=0, positions=None):
-        feature_axis = len(inputs.shape) - 1
+        batch_axis = 0
         sequence_axis = 1
+        feature_axis = len(inputs.shape) - 1
 
         rotary_dim = ops.shape(inputs)[feature_axis]
         inverse_freq = self._get_inverse_freq(rotary_dim)
 
-        # Multiply inverse_freq by a factor.
-        if ops.shape(inputs)[sequence_axis] > self.pretraining_sequence_length:
-            inverse_freq = ops.divide(
-                inverse_freq,
-                ops.convert_to_tensor(self.inverese_freq_long_factor),
-            )
-        else:
-            inverse_freq = ops.divide(
-                inverse_freq,
-                ops.convert_to_tensor(self.inverese_freq_short_factor),
-            )
-
         if positions is None:
             positions = self._compute_positions(inputs, start_index)
+            positions = ops.expand_dims(positions, axis=batch_axis)
         else:
             positions = ops.cast(positions, "float32")
+            if len(ops.shape(positions)) == 1:
+                positions = ops.expand_dims(positions, axis=batch_axis)
 
-        freq = ops.einsum("i,j->ij", positions, inverse_freq)
+        # Multiply inverse_freq by a factor, chosen by how far into the
+        # sequence these positions sit rather than by how many tokens this
+        # call carries. Cached decoding passes one token at a time, so
+        # keying on the input's length would apply short-context
+        # frequencies at every generated position, however long the
+        # sequence has grown.
+        sequence_length = ops.max(positions) + 1.0
+        inverse_freq = ops.where(
+            sequence_length > self.pretraining_sequence_length,
+            ops.divide(
+                inverse_freq,
+                ops.convert_to_tensor(self.inverese_freq_long_factor),
+            ),
+            ops.divide(
+                inverse_freq,
+                ops.convert_to_tensor(self.inverese_freq_short_factor),
+            ),
+        )
+
+        freq = ops.einsum("bi,j->bij", positions, inverse_freq)
         embedding = ops.stack((freq, freq), axis=-2)
         embedding = ops.reshape(
             embedding, (*ops.shape(freq)[:-1], ops.shape(freq)[-1] * 2)
         )
 
         # Reshape the embedding to be broadcastable with input shape.
-        if feature_axis < sequence_axis:
-            embedding = ops.transpose(embedding)
         for axis in range(len(inputs.shape)):
-            if axis != sequence_axis and axis != feature_axis:
+            if axis not in (batch_axis, sequence_axis, feature_axis):
                 embedding = ops.expand_dims(embedding, axis)
 
         cos_emb = ops.cast(

--- a/keras_hub/src/models/phi3/phi3_rotary_embedding_test.py
+++ b/keras_hub/src/models/phi3/phi3_rotary_embedding_test.py
@@ -1,0 +1,62 @@
+from keras import ops
+
+from keras_hub.src.models.phi3.phi3_rotary_embedding import (
+    Phi3SuScaledRotaryEmbedding,
+)
+from keras_hub.src.tests.test_case import TestCase
+
+
+class Phi3SuScaledRotaryEmbeddingTest(TestCase):
+    def _build_layer(self, pretraining_sequence_length=4):
+        return Phi3SuScaledRotaryEmbedding(
+            inverese_freq_short_factor=[1.0, 1.0],
+            inverese_freq_long_factor=[8.0, 8.0],
+            max_sequence_length=64,
+            pretraining_sequence_length=pretraining_sequence_length,
+        )
+
+    def test_decode_step_matches_a_prompt_of_the_same_length(self):
+        """Which factor applies is a property of how far the sequence has
+        run, so decoding the token at position k must match position k of a
+        prompt holding k + 1 tokens. Keying on the input's own length gives
+        a single decoded token short-context frequencies forever."""
+        layer = self._build_layer(pretraining_sequence_length=4)
+        token = ops.ones((1, 1, 2, 4))
+
+        for index in range(8):
+            prompt = ops.ones((1, index + 1, 2, 4))
+            self.assertAllClose(
+                layer(prompt)[:, index : index + 1],
+                layer(token, start_index=index),
+            )
+
+    def test_long_factor_takes_over_past_the_pretraining_length(self):
+        layer = self._build_layer(pretraining_sequence_length=4)
+        token = ops.ones((1, 1, 2, 4))
+
+        within = layer(token, start_index=2)
+        beyond = layer(token, start_index=100)
+
+        self.assertNotAllClose(within, beyond)
+
+    def test_explicit_positions_match_start_index(self):
+        layer = self._build_layer()
+        inputs = ops.ones((1, 1, 2, 4))
+
+        stepped = layer(inputs, start_index=3)
+        unbatched = layer(inputs, positions=ops.convert_to_tensor([3.0]))
+        batched = layer(inputs, positions=ops.convert_to_tensor([[3.0]]))
+
+        self.assertAllClose(stepped, unbatched)
+        self.assertAllClose(stepped, batched)
+
+    def test_positions_are_per_token(self):
+        """Two tokens given unrelated positions must be rotated by their
+        own angles, not by a shared range."""
+        layer = self._build_layer()
+        inputs = ops.ones((1, 2, 2, 4))
+
+        scattered = layer(inputs, positions=ops.convert_to_tensor([[5.0, 9.0]]))
+        at_five = layer(ops.ones((1, 1, 2, 4)), start_index=5)
+
+        self.assertAllClose(scattered[:, 0:1], at_five)

--- a/keras_hub/src/vllm/phi3_route_test.py
+++ b/keras_hub/src/vllm/phi3_route_test.py
@@ -1,0 +1,143 @@
+"""CPU tests for Phi-3's vLLM attention route.
+
+Drives a real `Phi3Attention` with a recording stand-in kernel, so no TPU or
+vLLM install is needed.
+"""
+
+from keras import ops
+
+from keras_hub.src.models.phi3.phi3_attention import Phi3Attention
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.vllm import context as vllm_context
+from keras_hub.src.vllm.attention_test import RecordingKernel
+from keras_hub.src.vllm.attention_test import activate_serving
+
+
+class Phi3RouteTest(TestCase):
+    def tearDown(self):
+        vllm_context.clear_vllm_context()
+        super().tearDown()
+
+    def _build_layer(self, **kwargs):
+        layer = Phi3Attention(
+            num_query_heads=4,
+            num_key_value_heads=2,
+            **kwargs,
+        )
+        inputs = ops.ones((3, 1, 8))
+        layer.build(ops.shape(inputs))
+        return layer, inputs
+
+    def _build_su_layer(self):
+        return self._build_layer(
+            rope_scaling_type="su",
+            rope_scaling_short_factor=[1.0],
+            rope_scaling_long_factor=[2.0],
+            pretraining_sequence_length=8,
+            max_sequence_length=64,
+        )
+
+    def test_route_passes_unexpanded_kv_heads(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["PC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        call = kernel.calls[0]
+        # The kernel expands K/V for grouped-query attention itself.
+        self.assertEqual(call["num_kv_heads"], 2)
+        self.assertEqual(call["num_heads"], 4)
+        self.assertIsNone(call["sliding_window"])
+        self.assertAllClose(call["scale"], layer._inv_norm_factor)
+
+    def test_route_applies_rope_at_serving_positions(self):
+        layer, inputs = self._build_layer()
+
+        kernel = RecordingKernel()
+        positions = ops.convert_to_tensor([0, 1, 2])
+        activate_serving(kernel, kv_caches=["PC0"], positions=positions)
+        layer(inputs)
+
+        expected_query = layer.rotary_embedding_layer(
+            layer.query_dense(inputs),
+            positions=ops.reshape(positions, (-1, 1)),
+        )
+        self.assertAllClose(
+            kernel.calls[0]["q"], ops.reshape(expected_query, (3, -1))
+        )
+
+    def test_su_rope_matches_the_layers_own_embedding(self):
+        """The route rebuilds su-scaled cos/sin because the rotary layer
+        indexes a contiguous range. Within the pretraining length the two
+        must agree exactly."""
+        layer, inputs = self._build_layer(
+            rope_scaling_type="su",
+            rope_scaling_short_factor=[1.0],
+            rope_scaling_long_factor=[2.0],
+            pretraining_sequence_length=8,
+            max_sequence_length=64,
+        )
+
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["PC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+
+        # The same three tokens as one contiguous sequence, which is what
+        # `Phi3SuScaledRotaryEmbedding` builds its own positions for.
+        sequence = ops.ones((1, 3, 8))
+        expected_query = layer.rotary_embedding_layer(
+            layer.query_dense(sequence)
+        )
+        self.assertAllClose(
+            kernel.calls[0]["q"], ops.reshape(expected_query, (3, -1))
+        )
+
+    def test_su_rope_uses_long_factor_far_into_the_sequence(self):
+        """A single decoded token past the pretraining length must get
+        long-context frequencies, which keying on the input's length would
+        never do."""
+        layer, inputs = self._build_su_layer()
+
+        near = RecordingKernel()
+        activate_serving(
+            near,
+            kv_caches=["PC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        layer(inputs)
+        vllm_context.clear_vllm_context()
+
+        far = RecordingKernel()
+        activate_serving(
+            far,
+            kv_caches=["PC0"],
+            positions=ops.convert_to_tensor([100, 101, 102]),
+        )
+        layer(inputs)
+
+        self.assertNotAllClose(near.calls[0]["q"], far.calls[0]["q"])
+
+    def test_off_path_byte_identical(self):
+        layer, inputs = self._build_layer()
+
+        before = layer(inputs)
+        kernel = RecordingKernel()
+        activate_serving(
+            kernel,
+            kv_caches=["PC0"],
+            positions=ops.convert_to_tensor([0, 1, 2]),
+        )
+        vllm_context.clear_vllm_context()
+        after = layer(inputs)
+
+        self.assertAllClose(before, after)
+        self.assertEqual(kernel.calls, [])


### PR DESCRIPTION
## Description of the change

Adds a vLLM attention route to Phi-3, so `Phi3Attention` can serve through vLLM's TPU backend on the native flax/nnx path, following the routes already in #2794. It also fixes two bugs in `Phi3SuScaledRotaryEmbedding` that su-scaled presets (the 128k ones) need before they can serve; one changes `generate()` output.

### The route

In `keras_hub/src/models/phi3/phi3_attention.py`, `call()` delegates to a new `_compute_vllm_attention` while a serving context is active and runs the original dense path otherwise. The route projects Q/K/V, applies RoPE at the engine's per-token positions, and calls the shared paged-attention bridge. The layer's `cache` argument comes back untouched: while serving, vLLM owns the paged KV cache, so the dense one is bypassed. The kernel expands K/V itself, so the route passes the unexpanded `num_key_value_heads`. Scaled and unscaled presets take the same path, since both rotary layers now read absolute positions.

### The rotary fixes

**Positions.** `_compute_cos_sin_embedding` used `ops.einsum("i,j->ij", positions, inverse_freq)`, which needs 1-D positions, while the base `RotaryEmbedding.call` hands it a 2-D tensor, so explicit positions raised `Einstein sum subscript 'i' does not contain the correct number of indices`. It now uses `"bi,j->bij"`, matching the base class.

**Which factor applies.** Phi-3 picked between its short- and long-context RoPE frequencies using the number of tokens in the call. Generation passes one at a time, so it always picked short, even far past the pretraining length. It now picks using the largest position in the batch, like the reference implementation. This changes `generate()` output for su-scaled presets past that length.

## Tests

`keras_hub/src/models/phi3/phi3_rotary_embedding_test.py` covers the rotary layer. Decoding one token at position k must match position k of a prompt of k + 1 tokens, what the factor bug broke. It also covers explicit positions, batched and unbatched, and per-token positions.

`keras_hub/src/vllm/phi3_route_test.py` drives a real `Phi3Attention` with a recording stand-in kernel, so it runs on CPU with no TPU or vLLM install:

- head counts and the layer's own scale reach the kernel, with K/V unexpanded
- RoPE is applied at the serving positions, checked against a recomputed tensor
- a su-scaled preset routes correctly, and a token past the pretraining length picks up the long factor
- off the serving path the layer's output is unchanged and the kernel is never called

Runs on the jax, tensorflow, and torch backends.

## Reference

Depends on keras-team/keras-hub#2794, which adds `keras_hub/src/vllm/` and the bridge this route calls. Companion backend PR: vllm-project/tpu-inference#3104.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends.
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md).
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
