### PR TITLE
 Implement Weight-Decomposed Low-Rank Adaptation (DoRA) support for Backbones

### DIFF
--- a/keras_hub/src/models/backbone.py
+++ b/keras_hub/src/models/backbone.py
@@ -223,6 +223,36 @@ class Backbone(keras.Model):
                         layer.enable_lora(rank)
                         self._lora_enabled_layers.append(i)
 
+    def enable_dora(self, rank, target_layer_names=None):
+        """Enable DoRA on the backbone.
+
+        Calling this method will freeze all weights on the backbone,
+        while enabling DoRA on the specified layers.
+
+        Args:
+            rank: The rank of the DoRA factorization.
+            target_layer_names: A list of strings, the names of the layers to
+                apply DoRA to. If `None`, this will be populated with the
+                default LoRA layer names as returned by
+                `backbone.default_lora_layer_names()`.
+        """
+        if target_layer_names is None:
+            target_layer_names = self.default_lora_layer_names()
+        self.trainable = True
+        self._dora_enabled_layers = []
+        self._dora_rank = rank
+        for layer in self._flatten_layers(include_self=False):
+            layer.trainable = False
+        all_layers = self._flatten_layers(include_self=False)
+        all_layers = [lyr for lyr in all_layers if lyr.weights]
+        for i, layer in enumerate(all_layers):
+            for name in target_layer_names:
+                if layer.name == name:
+                    if hasattr(layer, "enable_dora"):
+                        layer.trainable = True
+                        layer.enable_dora(rank)
+                        self._dora_enabled_layers.append(i)
+
     def save_lora_weights(self, filepath):
         if not getattr(self, "_lora_enabled_layers", []):
             raise ValueError(
@@ -275,6 +305,64 @@ class Backbone(keras.Model):
             lora_kernel_b = store.get(f"lora/{layer_index}")["lora_kernel_b"]
             layer.lora_kernel_a.assign(lora_kernel_a)
             layer.lora_kernel_b.assign(lora_kernel_b)
+        store.close()
+
+    def save_dora_weights(self, filepath):
+        if not getattr(self, "_dora_enabled_layers", []):
+            raise ValueError(
+                "There are no dora-enabled layers in this model. "
+                "Make sure to call `.enable_dora(rank)` first."
+            )
+        if not str(filepath).endswith(".dora.h5"):
+            raise ValueError(
+                "The filename must end in `.dora.h5`. "
+                f"Received: filepath={filepath}"
+            )
+
+        store = keras.src.saving.saving_lib.H5IOStore(filepath, mode="w")
+        lora_store = store.make("dora")
+        lora_store["rank"] = self._dora_rank
+        all_layers = self._flatten_layers(include_self=False)
+        all_layers = [lyr for lyr in all_layers if lyr.weights]
+        for layer_index in self._dora_enabled_layers:
+            layer = all_layers[layer_index]
+            inner_store = store.make(f"dora/{layer_index}")
+            if hasattr(layer, "dora_kernel_a"):
+                inner_store["dora_kernel_a"] = layer.dora_kernel_a
+                inner_store["dora_kernel_b"] = layer.dora_kernel_b
+            elif hasattr(layer, "dora_embeddings_a"):
+                inner_store["dora_embeddings_a"] = layer.dora_embeddings_a
+                inner_store["dora_embeddings_b"] = layer.dora_embeddings_b
+            inner_store["dora_magnitude"] = layer.dora_magnitude
+        store.close()
+
+    def load_dora_weights(self, filepath):
+        store = keras.src.saving.saving_lib.H5IOStore(filepath, mode="r")
+        lora_store = store.get("dora")
+        rank = int(lora_store["rank"][()])
+
+        if not getattr(self, "_dora_enabled_layers", []):
+            self.enable_dora(rank)
+        else:
+            if self._dora_rank != rank:
+                raise ValueError(
+                    f"The DoRA rank expected by file '{filepath}' "
+                    f"is rank={rank}, but the model was called with "
+                    f"`.enable_dora(rank={self._dora_rank})`. "
+                    "Both ranks must match."
+                )
+        all_layers = self._flatten_layers(include_self=False)
+        all_layers = [lyr for lyr in all_layers if lyr.weights]
+        for layer_index in self._dora_enabled_layers:
+            layer = all_layers[layer_index]
+            inner_store = store.get(f"dora/{layer_index}")
+            if "dora_kernel_a" in inner_store:
+                layer.dora_kernel_a.assign(inner_store["dora_kernel_a"])
+                layer.dora_kernel_b.assign(inner_store["dora_kernel_b"])
+            elif "dora_embeddings_a" in inner_store:
+                layer.dora_embeddings_a.assign(inner_store["dora_embeddings_a"])
+                layer.dora_embeddings_b.assign(inner_store["dora_embeddings_b"])
+            layer.dora_magnitude.assign(inner_store["dora_magnitude"])
         store.close()
 
     def export_to_transformers(self, path):

--- a/keras_hub/src/models/gemma/gemma_backbone_test.py
+++ b/keras_hub/src/models/gemma/gemma_backbone_test.py
@@ -12,7 +12,7 @@ class GemmaBackboneTest(TestCase):
             "vocabulary_size": 20,
             "num_layers": 2,
             "num_query_heads": 4,
-            "num_key_value_heads": 1,
+            "num_key_value_heads": 2,
             "hidden_dim": 16,
             "intermediate_dim": 32,
             "head_dim": 4,
@@ -154,6 +154,42 @@ class GemmaBackboneTest(TestCase):
                 )
             if "attention/value/lora_kernel_b" in w.path:
                 self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+
+    def test_distribution_with_dora(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, len(devices)),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = GemmaBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = GemmaBackbone(**self.init_kwargs)
+            model.enable_dora(rank=4)
+
+        for w in model.weights:
+            if "attention/query/dora_kernel_a" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, None, None)
+                )
+            if "attention/query/dora_kernel_b" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+            if "attention/query/dora_magnitude" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ())
+            if "attention/value/dora_kernel_a" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, None, None)
+                )
+            if "attention/value/dora_kernel_b" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+            if "attention/value/dora_magnitude" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ())
 
 
 class Gemma2BackboneTest(TestCase):

--- a/keras_hub/src/models/gemma/gemma_dora_test.py
+++ b/keras_hub/src/models/gemma/gemma_dora_test.py
@@ -1,0 +1,115 @@
+import os
+
+import numpy as np
+
+from keras_hub.src.models.gemma.gemma_backbone import GemmaBackbone
+from keras_hub.src.tests.test_case import TestCase
+
+
+class GemmaDoraTest(TestCase):
+    def setUp(self):
+        self._init_kwargs = {
+            "vocabulary_size": 50,
+            "num_layers": 2,
+            "num_query_heads": 2,
+            "num_key_value_heads": 2,
+            "hidden_dim": 32,
+            "intermediate_dim": 16,
+            "head_dim": 16,
+            "layer_norm_epsilon": 1e-6,
+        }
+
+    def test_dora_fine_tuning(self):
+        # Set up backbone and preprocessor.
+        backbone = GemmaBackbone(**self._init_kwargs)
+        backbone.enable_dora(4)
+        # 4 layers, 3 weights per layer
+        self.assertLen(backbone.trainable_weights, 4 * 3)
+        self.assertLen(backbone.non_trainable_weights, 20)
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+        targets = np.random.normal(size=(2, 5, self._init_kwargs["hidden_dim"]))
+
+        # Test fine-tuning
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        # Test saving and reloading.
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        backbone.save_weights(temp_filepath)
+        new_backbone = GemmaBackbone(**self._init_kwargs)
+        new_backbone.load_weights(temp_filepath)
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+    def test_dora_fine_tuning_target_names(self):
+        # Set up backbone and preprocessor.
+        backbone = GemmaBackbone(**self._init_kwargs)
+        backbone.enable_dora(4, target_layer_names=["query"])
+        # 2 layers, 3 weights per layer
+        self.assertLen(backbone.trainable_weights, 2 * 3)
+        self.assertLen(backbone.non_trainable_weights, 20)
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+        targets = np.random.normal(size=(2, 5, self._init_kwargs["hidden_dim"]))
+
+        # Test fine-tuning
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        # Test saving and reloading.
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        backbone.save_weights(temp_filepath)
+        new_backbone = GemmaBackbone(**self._init_kwargs)
+        new_backbone.load_weights(temp_filepath)
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+    def test_dora_saving_and_reloading(self):
+        backbone = GemmaBackbone(**self._init_kwargs)
+        initial_model_filepath = os.path.join(
+            self.get_temp_dir(), "base.weights.h5"
+        )
+        backbone.save_weights(initial_model_filepath)
+
+        backbone.enable_dora(4)
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+        targets = np.random.normal(size=(2, 5, self._init_kwargs["hidden_dim"]))
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        dora_filepath = os.path.join(self.get_temp_dir(), "dora_model.dora.h5")
+        backbone.save_dora_weights(dora_filepath)
+
+        # New backbone with same initial weights
+        new_backbone = GemmaBackbone(**self._init_kwargs)
+        new_backbone.load_weights(initial_model_filepath)
+        new_backbone.enable_dora(4)
+        new_backbone.load_dora_weights(dora_filepath)
+
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+        # Test exceptions
+        backbone = GemmaBackbone(**self._init_kwargs)
+        with self.assertRaisesRegex(ValueError, "no dora-enabled layers"):
+            backbone.save_dora_weights(dora_filepath)
+        backbone.enable_dora(5)
+        with self.assertRaisesRegex(ValueError, "ranks must match"):
+            backbone.load_dora_weights(dora_filepath)
+        with self.assertRaisesRegex(ValueError, "filename must end in"):
+            backbone.save_dora_weights("bad_filepath")

--- a/keras_hub/src/models/gemma3/gemma3_dora_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_dora_test.py
@@ -1,0 +1,104 @@
+import os
+
+import numpy as np
+
+from keras_hub.src.models.gemma3.gemma3_backbone import Gemma3Backbone
+from keras_hub.src.tests.test_case import TestCase
+
+
+class Gemma3DoraTest(TestCase):
+    def setUp(self):
+        self.text_init_kwargs = {
+            # vocabulary
+            "vocabulary_size": 256,
+            # image
+            "image_size": 16,
+            # model
+            "num_layers": 6,
+            "num_query_heads": 2,
+            "num_key_value_heads": 1,
+            "hidden_dim": 8,
+            "intermediate_dim": 16,
+            "head_dim": 4,
+            # other model args
+            "query_head_dim_normalize": True,
+            "use_query_key_norm": True,
+            "use_post_ffw_norm": True,
+            "use_post_attention_norm": True,
+            "final_logit_soft_cap": None,
+            "attention_logit_soft_cap": None,
+            "use_sliding_window_attention": True,
+            "sliding_window_size": 1024,
+            "vision_encoder": None,
+        }
+
+    def test_text_dora_fine_tuning(self):
+        # Set up backbone and preprocessor.
+        backbone = Gemma3Backbone(**self.text_init_kwargs)
+        backbone.enable_dora(4)
+
+        self.assertLen(backbone.trainable_weights, 36)
+        self.assertLen(backbone.non_trainable_weights, 80)
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+        targets = np.random.normal(
+            size=(2, 5, self.text_init_kwargs["hidden_dim"])
+        )
+
+        # Test fine-tuning
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        # Test saving and reloading.
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        backbone.save_weights(temp_filepath)
+        new_backbone = Gemma3Backbone(**self.text_init_kwargs)
+        new_backbone.load_weights(temp_filepath)
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+    def test_text_dora_saving_and_reloading(self):
+        backbone = Gemma3Backbone(**self.text_init_kwargs)
+        initial_model_filepath = os.path.join(
+            self.get_temp_dir(), "base.weights.h5"
+        )
+        backbone.save_weights(initial_model_filepath)
+
+        backbone.enable_dora(4)
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+        }
+        targets = np.random.normal(
+            size=(2, 5, self.text_init_kwargs["hidden_dim"])
+        )
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        dora_filepath = os.path.join(self.get_temp_dir(), "dora_model.dora.h5")
+        backbone.save_dora_weights(dora_filepath)
+
+        # New backbone with same initial weights
+        new_backbone = Gemma3Backbone(**self.text_init_kwargs)
+        new_backbone.load_weights(initial_model_filepath)
+        new_backbone.enable_dora(4)
+        new_backbone.load_dora_weights(dora_filepath)
+
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+        # Test exceptions
+        backbone = Gemma3Backbone(**self.text_init_kwargs)
+        with self.assertRaisesRegex(ValueError, "no dora-enabled layers"):
+            backbone.save_dora_weights(dora_filepath)
+        backbone.enable_dora(5)
+        with self.assertRaisesRegex(ValueError, "ranks must match"):
+            backbone.load_dora_weights(dora_filepath)
+        with self.assertRaisesRegex(ValueError, "filename must end in"):
+            backbone.save_dora_weights("bad_filepath")

--- a/keras_hub/src/models/gemma4/gemma4_dora_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_dora_test.py
@@ -1,0 +1,103 @@
+import os
+
+import numpy as np
+
+from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.tests.test_case import TestCase
+
+
+class Gemma4DoraTest(TestCase):
+    def setUp(self):
+        self.text_init_kwargs = {
+            "vocabulary_size": 256,
+            "image_size": 16,
+            "num_layers": 6,
+            "num_query_heads": 2,
+            "num_key_value_heads": 1,
+            "hidden_dim": 8,
+            "intermediate_dim": 16,
+            "head_dim": 4,
+            "use_sliding_window_attention": True,
+            "sliding_window_size": 16,
+            "attention_logit_soft_cap": None,
+            "final_logit_soft_cap": None,
+            "vision_encoder": None,
+        }
+
+    def test_text_dora_fine_tuning(self):
+        backbone = Gemma4Backbone(**self.text_init_kwargs)
+        backbone.enable_dora(4)
+
+        # Ensure that only DoRA weights are trainable.
+        self.assertGreater(len(backbone.trainable_weights), 0)
+        self.assertGreater(len(backbone.non_trainable_weights), 0)
+
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+            "position_ids": np.tile(
+                np.arange(5, dtype="int32")[None, :], (2, 1)
+            ),
+        }
+        targets = np.random.normal(
+            size=(2, 5, self.text_init_kwargs["hidden_dim"])
+        )
+
+        # Test fine-tuning.
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        # Test saving and reloading.
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        backbone.save_weights(temp_filepath)
+        new_backbone = Gemma4Backbone(**self.text_init_kwargs)
+        new_backbone.load_weights(temp_filepath)
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+    def test_text_dora_saving_and_reloading(self):
+        backbone = Gemma4Backbone(**self.text_init_kwargs)
+        initial_model_filepath = os.path.join(
+            self.get_temp_dir(), "base.weights.h5"
+        )
+        backbone.save_weights(initial_model_filepath)
+
+        backbone.enable_dora(4)
+        input_data = {
+            "token_ids": np.ones((2, 5), dtype="int32"),
+            "padding_mask": np.ones((2, 5), dtype="int32"),
+            "position_ids": np.tile(
+                np.arange(5, dtype="int32")[None, :], (2, 1)
+            ),
+        }
+        targets = np.random.normal(
+            size=(2, 5, self.text_init_kwargs["hidden_dim"])
+        )
+        backbone.compile(optimizer="sgd", loss="mse")
+        backbone.fit(input_data, targets, epochs=1)
+
+        dora_filepath = os.path.join(self.get_temp_dir(), "dora_model.dora.h5")
+        backbone.save_dora_weights(dora_filepath)
+
+        # New backbone with same initial weights.
+        new_backbone = Gemma4Backbone(**self.text_init_kwargs)
+        new_backbone.load_weights(initial_model_filepath)
+        new_backbone.enable_dora(4)
+        new_backbone.load_dora_weights(dora_filepath)
+
+        ref_out = backbone(input_data)
+        new_out = new_backbone(input_data)
+        self.assertAllClose(ref_out, new_out)
+
+        # Test exceptions.
+        backbone = Gemma4Backbone(**self.text_init_kwargs)
+        with self.assertRaisesRegex(ValueError, "no dora-enabled layers"):
+            backbone.save_dora_weights(dora_filepath)
+        backbone.enable_dora(5)
+        with self.assertRaisesRegex(ValueError, "ranks must match"):
+            backbone.load_dora_weights(dora_filepath)
+        with self.assertRaisesRegex(ValueError, "filename must end in"):
+            backbone.save_dora_weights("bad_filepath")

--- a/keras_hub/src/models/llama/llama_backbone_test.py
+++ b/keras_hub/src/models/llama/llama_backbone_test.py
@@ -151,3 +151,39 @@ class LlamaTest(TestCase):
                 )
             if "self_attention/value/lora_kernel_b" in w.path:
                 self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+
+    def test_distribution_with_dora(self):
+        if keras.backend.backend() != "jax":
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
+        devices = keras.distribution.list_devices("CPU")
+        if len(devices) == 1:
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(1, len(devices)),
+            axis_names=("batch", "model"),
+            devices=devices,
+        )
+
+        layout_map = LlamaBackbone.get_layout_map(device_mesh)
+        distribution = keras.distribution.ModelParallel(layout_map=layout_map)
+        with distribution.scope():
+            model = LlamaBackbone(**self.init_kwargs)
+            model.enable_dora(rank=4)
+
+        for w in model.weights:
+            if "self_attention/query/dora_kernel_a" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, None, None)
+                )
+            if "self_attention/query/dora_kernel_b" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+            if "self_attention/query/dora_magnitude" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ())
+            if "self_attention/value/dora_kernel_a" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, None, None)
+                )
+            if "self_attention/value/dora_kernel_b" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), (None, None))
+            if "self_attention/value/dora_magnitude" in w.path:
+                self.assertEqual(tuple(w.value.sharding.spec), ())


### PR DESCRIPTION
## Description of the change
This PR introduces support for Weight-Decomposed Low-Rank Adaptation (DoRA) across Keras Hub backbones. DoRA enhances LoRA by decomposing the weights into magnitude and directional components and applying low-rank updates specifically to the directional component. This approach has been shown to offer superior learning capacity and stability compared to standard LoRA while maintaining efficiency.

Design Doc: https://docs.google.com/document/d/13iJl_vVot4tMs9LMLrwHvlD-9TBZAD8bTNDk7yJsJM4/edit?usp=sharing
Benchmarking: https://colab.research.google.com/drive/1WWBou-NH7najBu676yS2_UHk7LJCc5rk?resourcekey=0-b1mdPX0RsifeT2bo4J3a5A&usp=sharing

Tests on this PR will pass after the dora implementation in keras gets merged: https://github.com/keras-team/keras/pull/23269

Key Changes
   - Backbone Integration: Added enable_dora(), save_dora_weights(), and load_dora_weights() to the Backbone base class, following the existing LoRA API pattern.
   - Support for Key Models:
       - Full support and test coverage for Gemma, Gemma 3, and Gemma 4.
       - Verified compatibility with Llama through distribution testing.
   - Weight Management: Implemented logic to correctly identify, save, and load DoRA-specific weights (dora_kernel_a, dora_kernel_b, and dora_magnitude) for Dense, EinsumDense, and Embedding layers.
   - Distribution Support: Updated sharding expectations in JAX distribution tests to handle the 1D magnitude vectors, which are replicated across devices.


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
