### PR TITLE
Convert TF tensors to numpy without going through the backend

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ import pytest
 # OpenVINO supported test paths
 OPENVINO_SUPPORTED_PATHS = [
     "integration_tests",
+    "keras_hub/src/metrics",
     "keras_hub/src/tokenizers",
     "keras_hub/src/models/albert",
     "keras_hub/src/models/basnet",
@@ -33,6 +34,7 @@ OPENVINO_SUPPORTED_PATHS = [
     "keras_hub/src/models/mobilenet",
     "keras_hub/src/models/mobilenetv5",
     "keras_hub/src/models/opt",
+    "keras_hub/src/models/pali_gemma",
     "keras_hub/src/models/parseq",
     "keras_hub/src/models/phi3",
     "keras_hub/src/models/qwen",
@@ -41,14 +43,17 @@ OPENVINO_SUPPORTED_PATHS = [
     "keras_hub/src/models/qwen_moe",
     "keras_hub/src/models/roberta",
     "keras_hub/src/models/rqvae",
+    "keras_hub/src/models/siglip",
     "keras_hub/src/models/smollm3",
     "keras_hub/src/models/swin_transformer",
+    "keras_hub/src/models/t5",
     "keras_hub/src/models/t5gemma2",
     "keras_hub/src/models/vae",
     "keras_hub/src/models/vgg",
     "keras_hub/src/models/vit_det",
     "keras_hub/src/models/whisper",
     "keras_hub/src/models/xception",
+    "keras_hub/src/models/xlm_roberta",
     "keras_hub/src/models/xlnet",
 ]
 

--- a/keras_hub/src/metrics/edit_distance.py
+++ b/keras_hub/src/metrics/edit_distance.py
@@ -1,6 +1,7 @@
 import keras
 
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
 from keras_hub.src.utils.tensor_utils import is_float_dtype
 
 try:
@@ -126,7 +127,9 @@ class EditDistance(keras.metrics.Metric):
 
         if self.normalize:
             self._aggregate_reference_length.assign_add(
-                tf.cast(tf.size(y_true.flat_values), dtype=self.dtype)
+                convert_to_numpy(
+                    tf.cast(tf.size(y_true.flat_values), dtype=self.dtype)
+                )
             )
 
         def calculate_edit_distance(args):
@@ -135,7 +138,7 @@ class EditDistance(keras.metrics.Metric):
             reference = tf.sparse.from_dense([reference])
             hypothesis = tf.sparse.from_dense([hypothesis])
 
-            edit_distance = tf.squeeze(
+            return tf.squeeze(
                 tf.edit_distance(
                     hypothesis=hypothesis,
                     truth=reference,
@@ -143,18 +146,24 @@ class EditDistance(keras.metrics.Metric):
                 )
             )
 
-            self._aggregate_unnormalized_edit_distance.assign_add(
-                tf.cast(edit_distance, dtype=self.dtype)
-            )
-            if not self.normalize:
-                self._number_of_samples.assign_add(tf.cast(1, dtype=self.dtype))
-            return 0
-
-        _ = tf.map_fn(
+        # `tf.map_fn` traces its body into a graph, so the aggregation has to
+        # happen outside of it: the state variables belong to the Keras backend,
+        # which is not necessarily TensorFlow.
+        edit_distances = tf.map_fn(
             fn=calculate_edit_distance,
             elems=(y_true, y_pred),
-            fn_output_signature="int8",
+            fn_output_signature=self.dtype,
         )
+
+        self._aggregate_unnormalized_edit_distance.assign_add(
+            convert_to_numpy(tf.reduce_sum(edit_distances))
+        )
+        if not self.normalize:
+            self._number_of_samples.assign_add(
+                convert_to_numpy(
+                    tf.cast(tf.shape(edit_distances)[0], dtype=self.dtype)
+                )
+            )
 
     def result(self):
         if self.normalize:

--- a/keras_hub/src/metrics/rouge_base.py
+++ b/keras_hub/src/metrics/rouge_base.py
@@ -1,6 +1,7 @@
 import keras
 from keras import ops
 
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
 from keras_hub.src.utils.tensor_utils import is_float_dtype
 from keras_hub.src.utils.tensor_utils import tensor_to_list
 
@@ -153,7 +154,7 @@ class RougeBase(keras.metrics.Metric):
             self._rouge_f1_score.assign_add(score[2])
 
         self._number_of_samples.assign_add(
-            ops.cast(batch_size, dtype=self.dtype)
+            ops.cast(convert_to_numpy(batch_size), dtype=self.dtype)
         )
 
     def result(self):

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
@@ -9,6 +9,7 @@ from keras.src.saving import serialization_lib
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.tokenizers import tokenizer
 from keras_hub.src.utils.tensor_utils import assert_tf_libs_installed
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
@@ -344,7 +345,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
                 or keras.ops.is_tensor(inputs)
                 or (tf is not None and isinstance(inputs, tf.Tensor))
             ):
-                inputs = keras.ops.convert_to_numpy(inputs)
+                inputs = convert_to_numpy(inputs)
                 if inputs.ndim == 0:
                     val = inputs.item()
                     if isinstance(val, bytes):

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -88,6 +88,26 @@ def preprocessing_function(fn):
     return wrapper
 
 
+def convert_to_numpy(x):
+    """Convert `x` to a numpy array.
+
+    Unlike `keras.ops.convert_to_numpy`, this does not require `x` to be a
+    tensor of the current backend. Preprocessing layers, tokenizers and metrics
+    all work in TensorFlow regardless of the active backend, so they routinely
+    hold `tf.Tensor`s that the backend cannot convert. Only backend tensors are
+    handed to the backend; everything else is converted directly.
+    """
+    if isinstance(x, np.ndarray):
+        return x
+    if tf is not None and isinstance(x, tf.RaggedTensor):
+        return x.numpy()
+    if tf is not None and isinstance(x, tf.Tensor):
+        return np.asarray(x)
+    if ops.is_tensor(x):
+        return ops.convert_to_numpy(x)
+    return np.array(x)
+
+
 def convert_preprocessing_inputs(x):
     """Convert raw inputs for preprocessing.
 


### PR DESCRIPTION
## Description of the change
This PR applies the same pattern as keras-team/keras#22594: only backend tensors go through backend.convert_to_numpy, everything else is converted directly. keras-hub preprocessors, tokenizers and metrics run in TensorFlow whatever the active backend, so they hold tf.Tensors the backend can't convert, and per discussed in that PR, it shouldn't have to.

Adds convert_to_numpy to tensor_utils.py and uses it at the three sites that handed TF tensors to keras.ops. edit_distance.py needed a small refactor instead: two assign_add calls sat inside tf.map_fn, so map_fn now returns the per-sample distances and aggregation happens outside it.


- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
