### PR TITLE
Part of #2874: Migrate PipelineModel data loading from tf.data to PyGrain

### DIFF
--- a/keras_hub/src/utils/pipeline_model.py
+++ b/keras_hub/src/utils/pipeline_model.py
@@ -2,15 +2,151 @@ import functools
 import math
 
 import keras
+import numpy as np
 from keras import ops
 from keras import tree
 
 from keras_hub.src.utils.tensor_utils import is_tensor_type
 
 try:
+    import grain
+except ImportError:
+    grain = None
+
+try:
     import tensorflow as tf
 except ImportError:
     tf = None
+
+
+UNBATCHED_INPUT_ERROR = (
+    "`x`, `y`, and `sample_weight` must have a batch dimension when calling "
+    "`fit()`, `evaluate()`, and `predict()`. Received an input with rank 0. "
+    "Please add an outer dimension to your input, e.g., wrap it in a list."
+)
+
+
+def _is_tf_dataset(x):
+    return tf is not None and isinstance(x, tf.data.Dataset)
+
+
+def _is_grain_dataset(x):
+    if grain is None:
+        return False
+    return isinstance(
+        x, (grain.MapDataset, grain.IterDataset, grain.DataLoader)
+    )
+
+
+def _map_leaves(inputs, fn):
+    """Map `fn` over the leaves of `inputs`.
+
+    Follows `tf.data.Dataset.from_tensor_slices`, where tuples and dicts are
+    structure but a list is a single tensor. `keras.tree` descends into lists,
+    which would split a list of strings into one leaf per string.
+    """
+    if isinstance(inputs, tuple):
+        return tuple(_map_leaves(i, fn) for i in inputs)
+    if isinstance(inputs, dict):
+        return {k: _map_leaves(v, fn) for k, v in inputs.items()}
+    return fn(inputs)
+
+
+def _flatten_leaves(inputs):
+    """List the leaves of `inputs`, with the same structure rules as above."""
+    if isinstance(inputs, tuple):
+        return [leaf for i in inputs for leaf in _flatten_leaves(i)]
+    if isinstance(inputs, dict):
+        return [leaf for v in inputs.values() for leaf in _flatten_leaves(v)]
+    return [inputs]
+
+
+def _is_ragged(inputs):
+    """Whether any leaf is a `tf.RaggedTensor`, which needs `tf.data`."""
+    if tf is None:
+        return False
+    return any(isinstance(t, tf.RaggedTensor) for t in _flatten_leaves(inputs))
+
+
+class _TensorLikeSource:
+    """A Grain source slicing a nested structure along its batch dimension.
+
+    This is the Grain stand in for `tf.data.Dataset.from_tensor_slices`.
+    """
+
+    def __init__(self, inputs):
+        leaves = _flatten_leaves(inputs)
+        if not leaves or any(len(leaf.shape) == 0 for leaf in leaves):
+            raise ValueError(UNBATCHED_INPUT_ERROR)
+        lengths = set(int(leaf.shape[0]) for leaf in leaves)
+        if len(lengths) > 1:
+            # Left to Grain this would surface as an `IndexError` mid epoch.
+            raise ValueError(
+                "`x`, `y`, and `sample_weight` must all have the same "
+                "batch dimension. Received inputs with batch sizes "
+                f"{sorted(lengths)}."
+            )
+        self.inputs = inputs
+        self.length = lengths.pop()
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, index):
+        return _map_leaves(self.inputs, lambda leaf: leaf[index])
+
+
+def _convert_to_numpy(inputs):
+    """Convert every leaf of `inputs` to a numpy array."""
+
+    def convert(leaf):
+        if isinstance(leaf, np.ndarray):
+            return leaf
+        if is_tensor_type(leaf):
+            return ops.convert_to_numpy(leaf)
+        return np.asarray(leaf)
+
+    return _map_leaves(inputs, convert)
+
+
+def _convert_outputs_to_numpy(outputs):
+    """Convert tensor leaves of a preprocessed batch to numpy arrays.
+
+    `preprocess_samples` can return tf tensors, which jax rejects since
+    `GrainDatasetAdapter.get_jax_iterator` does not convert dense tensors.
+    Leaves that are not tensor like are passed through untouched.
+    """
+
+    def convert(leaf):
+        if isinstance(leaf, np.ndarray):
+            return leaf
+        if is_tensor_type(leaf):
+            return ops.convert_to_numpy(leaf)
+        return leaf
+
+    return _map_leaves(outputs, convert)
+
+
+def _convert_strings_to_python(inputs):
+    """Convert numpy string arrays to nested lists of python strings.
+
+    Grain stacks strings into numpy arrays, but preprocessing layers take
+    python `str`. See `keras_hub.utils.convert_preprocessing_inputs`.
+    """
+
+    def decode(value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        if isinstance(value, list):
+            return [decode(v) for v in value]
+        return value
+
+    def convert(leaf):
+        if isinstance(leaf, np.ndarray) and leaf.dtype.kind in ("U", "S", "O"):
+            return decode(leaf.tolist())
+        return leaf
+
+    return _map_leaves(inputs, convert)
 
 
 def _convert_inputs_to_dataset(
@@ -19,31 +155,52 @@ def _convert_inputs_to_dataset(
     sample_weight=None,
     batch_size=None,
 ):
-    """Convert inputs to a `tf.data.Dataset`.
+    """Convert inputs to a batched dataset.
 
-    This is a stand in for the `TensorLikeDataAdapter` in core Keras.
+    This is a stand in for the `TensorLikeDataAdapter` in core Keras. Inputs
+    are batched into a `grain.MapDataset`, which needs no TensorFlow runtime
+    and feeds `fit()` on all Keras backends. A dataset passed in directly by
+    the caller is validated and returned as is.
     """
-    if isinstance(x, tf.data.Dataset):
+    if _is_tf_dataset(x) or _is_grain_dataset(x):
+        kind = "tf.data.Dataset" if _is_tf_dataset(x) else "grain dataset"
         if y is not None:
             raise ValueError(
-                "When `x` is a `tf.data.Dataset`, please do not provide "
+                f"When `x` is a {kind}, please do not provide "
                 f"`y`. Received: `type(y)={type(y)}`."
             )
         if sample_weight is not None:
             raise ValueError(
-                "When `x` is a `tf.data.Dataset`, please do not provide "
+                f"When `x` is a {kind}, please do not provide "
                 "`sample_weight`. Received: "
                 f"`type(sample_weight)={type(sample_weight)}`."
             )
         if batch_size is not None:
             raise ValueError(
-                "When `x` is a `tf.data.Dataset`, please do not provide "
+                f"When `x` is a {kind}, please do not provide "
                 "`batch_size`. Received: "
                 f"`type(batch_size)={type(batch_size)}`."
             )
         return x
 
     inputs = keras.utils.pack_x_y_sample_weight(x, y, sample_weight)
+    # Grain cannot stack ragged inputs.
+    if grain is None or _is_ragged(inputs):
+        return _convert_inputs_to_tf_dataset(inputs, batch_size)
+
+    inputs = _convert_to_numpy(inputs)
+    source = _TensorLikeSource(inputs)
+    return grain.MapDataset.source(source).batch(batch_size or 32)
+
+
+def _convert_inputs_to_tf_dataset(inputs, batch_size=None):
+    """Slice and batch `inputs` with `tf.data`, for ragged or TF-only inputs."""
+    if tf is None:
+        raise ImportError(
+            "Preprocessing these inputs requires `grain` or `tensorflow`. "
+            "Run `pip install grain` to install Grain, the pure-Python data "
+            "loader used by KerasHub."
+        )
     try:
 
         def convert(x):
@@ -60,15 +217,39 @@ def _convert_inputs_to_dataset(
         # message the default from tf.data. We expect this to come up with
         # some frequency, so it's important to have a good sign post here.
         if "only supported for rank >= 1" in str(e):
-            raise ValueError(
-                "`x`, `y`, and `sample_weight` must have a batch dimension "
-                "when calling `fit()`, `evaluate()`, and `predict()`. Received "
-                "an input with rank 0. Please add an outer dimension to your "
-                "input, e.g., wrap it in a list."
-            ) from e
+            raise ValueError(UNBATCHED_INPUT_ERROR) from e
         raise e
 
     return ds.batch(batch_size or 32)
+
+
+def _apply_preprocessing(ds, preprocess_samples):
+    """Map `preprocess_samples` over a batched dataset, with prefetching."""
+    if _is_tf_dataset(ds):
+        return ds.map(
+            preprocess_samples, num_parallel_calls=tf.data.AUTOTUNE
+        ).prefetch(tf.data.AUTOTUNE)
+
+    if not _is_grain_dataset(ds):
+        raise ValueError(
+            "Expected `x` to be a `grain` or `tf.data` dataset. Received: "
+            f"`type(x)={type(ds)}`."
+        )
+
+    def preprocess(element):
+        # Grain passes the whole element as one argument, unlike `tf.data`.
+        x, y, sample_weight = keras.utils.unpack_x_y_sample_weight(element)
+        # Convert strings after unpacking, or `unpack_x_y_sample_weight` would
+        # read the samples of a single string input as separate fields.
+        x = _convert_strings_to_python(x)
+        y = _convert_strings_to_python(y)
+        sample_weight = _convert_strings_to_python(sample_weight)
+        outputs = preprocess_samples(x, y, sample_weight)
+        return _convert_outputs_to_numpy(outputs)
+
+    # `MapDataset.__iter__` already calls `to_iter_dataset()`, which reads
+    # ahead on a thread pool. Calling it here would only discard `__len__`.
+    return ds.map(preprocess)
 
 
 def _train_validation_split(arrays, validation_split):
@@ -161,17 +342,22 @@ class PipelineModel(keras.Model):
             )
 
         x = _convert_inputs_to_dataset(x, y, sample_weight, batch_size)
-        x = x.map(
-            self.preprocess_samples, num_parallel_calls=tf.data.AUTOTUNE
-        ).prefetch(tf.data.AUTOTUNE)
+        x = _apply_preprocessing(x, self.preprocess_samples)
 
         if validation_data is not None:
-            if not isinstance(validation_data, tf.data.Dataset):
+            if _is_tf_dataset(validation_data) or _is_grain_dataset(
+                validation_data
+            ):
+                validation_data = _apply_preprocessing(
+                    validation_data, self.preprocess_samples
+                )
+            else:
                 (vx, vy, vsw) = keras.utils.unpack_x_y_sample_weight(
                     validation_data
                 )
-                validation_data = _convert_inputs_to_dataset(
-                    vx, vy, vsw, batch_size
+                validation_data = _apply_preprocessing(
+                    _convert_inputs_to_dataset(vx, vy, vsw, batch_size),
+                    self.preprocess_samples,
                 )
 
         return super().fit(
@@ -191,15 +377,18 @@ class PipelineModel(keras.Model):
         sample_weight=None,
         **kwargs,
     ):
-        # During `fit()`, `keras.Model` attempts to cache the validation
-        # dataset and ignores the values for `x`, `y`, and `sample_weight`.
-        # We don't want that behavior here, as the validation dataset still
-        # needs preprocessing.
-        kwargs.pop("_use_cached_eval_dataset", None)
+        # `fit()` already preprocessed `validation_data`, so use the iterator
+        # `keras.Model` cached from it rather than building another one.
+        if kwargs.get("_use_cached_eval_dataset", False):
+            return super().evaluate(
+                x=x,
+                y=y,
+                batch_size=batch_size,
+                sample_weight=sample_weight,
+                **kwargs,
+            )
         x = _convert_inputs_to_dataset(x, y, sample_weight, batch_size)
-        x = x.map(
-            self.preprocess_samples, num_parallel_calls=tf.data.AUTOTUNE
-        ).prefetch(tf.data.AUTOTUNE)
+        x = _apply_preprocessing(x, self.preprocess_samples)
         return super().evaluate(
             x=x,
             y=None,
@@ -214,9 +403,7 @@ class PipelineModel(keras.Model):
         **kwargs,
     ):
         x = _convert_inputs_to_dataset(x, None, None, batch_size)
-        x = x.map(
-            self.preprocess_samples, num_parallel_calls=tf.data.AUTOTUNE
-        ).prefetch(tf.data.AUTOTUNE)
+        x = _apply_preprocessing(x, self.preprocess_samples)
         return super().predict(
             x=x,
             batch_size=None,

--- a/keras_hub/src/utils/pipeline_model_test.py
+++ b/keras_hub/src/utils/pipeline_model_test.py
@@ -6,6 +6,12 @@ import tensorflow as tf
 
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.pipeline_model import PipelineModel
+from keras_hub.src.utils.pipeline_model import _convert_inputs_to_dataset
+
+try:
+    import grain
+except ImportError:
+    grain = None
 
 
 class NoopPipeline(PipelineModel):
@@ -398,6 +404,115 @@ class TestFitArguments(TestCase):
             model.fit(ds, y=y)
         with self.assertRaises(ValueError):
             model.fit(ds, sample_weight=sw)
+
+
+class NumpyPipeline(PipelineModel):
+    """This model preprocesses with numpy only, never TensorFlow."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.dense = keras.layers.Dense(1)
+        self.preprocess_count = 0
+
+    def preprocess_samples(self, x, y=None, sample_weight=None):
+        self.preprocess_count += 1
+        x = np.asarray(x, dtype="float32") / 255.0
+        return keras.utils.pack_x_y_sample_weight(x, y, sample_weight)
+
+    def call(self, inputs):
+        return self.dense(inputs)
+
+
+class TestGrainPipeline(TestCase):
+    def setUp(self):
+        super().setUp()
+        if grain is None:
+            self.skipTest("Grain is not installed.")
+
+    def test_builds_a_grain_dataset(self):
+        x = np.random.uniform(size=(8, 5))
+        y = np.random.uniform(size=(8, 1))
+        ds = _convert_inputs_to_dataset(x, y, None, batch_size=4)
+        self.assertIsInstance(ds, grain.MapDataset)
+        self.assertLen(ds, 2)
+
+    def test_passes_through_a_grain_dataset(self):
+        x = np.random.uniform(size=(8, 5))
+        ds = _convert_inputs_to_dataset(x, None, None, batch_size=4)
+        self.assertIs(_convert_inputs_to_dataset(ds), ds)
+
+    def test_error_grain_dataset_and_invalid_arguments(self):
+        x = np.random.uniform(size=(8, 5))
+        y = np.random.uniform(size=(8, 1))
+        ds = _convert_inputs_to_dataset(x, None, None, batch_size=4)
+        model = FeaturePipeline()
+        model.compile(loss="mse")
+        with self.assertRaises(ValueError):
+            model.fit(ds, y=y)
+        with self.assertRaises(ValueError):
+            model.fit(ds, sample_weight=y)
+        with self.assertRaises(ValueError):
+            model.fit(ds, batch_size=4)
+
+    def test_python_string_list_input(self):
+        # A `list` enumerates the samples of a single string input.
+        x = [[str(v) for v in row] for row in np.random.uniform(size=(8, 5))]
+        y = np.random.uniform(size=(8, 1))
+        model = FeaturePipeline()
+        model.compile(loss="mse")
+        model.fit(x=x, y=y, batch_size=4)
+        model.evaluate(x=x, y=y, batch_size=4)
+        model.predict(x=x, batch_size=4)
+
+    def test_numpy_only_preprocessing(self):
+        x = np.random.uniform(0, 255, size=(8, 5))
+        y = np.random.uniform(size=(8, 1))
+        model = NumpyPipeline()
+        model.compile(loss="mse")
+        model.fit(x=x, y=y, batch_size=4)
+        model.evaluate(x=x, y=y, batch_size=4)
+        model.predict(x=x, batch_size=4)
+
+    def test_fit_with_validation_data(self):
+        # `fit()` preprocesses `validation_data` and `evaluate()` reuses the
+        # iterator Keras caches from it.
+        x = np.random.uniform(0, 255, size=(8, 5))
+        y = np.random.uniform(size=(8, 1))
+        model = NumpyPipeline()
+        model.compile(loss="mse")
+        history = model.fit(
+            x=x, y=y, validation_data=(x, y), batch_size=4, epochs=3, verbose=0
+        )
+        self.assertLen(history.history["val_loss"], 3)
+        self.assertAllClose(
+            history.history["val_loss"][-1],
+            model.evaluate(x=x, y=y, batch_size=4, verbose=0),
+        )
+
+    def test_dict_input(self):
+        x = {
+            "a": np.random.uniform(size=(8, 5)),
+            "b": np.random.uniform(size=(8, 5)),
+        }
+        ds = _convert_inputs_to_dataset(x, None, None, batch_size=4)
+        batch = ds[0]
+        self.assertEqual(set(batch.keys()), {"a", "b"})
+        self.assertEqual(batch["a"].shape, (4, 5))
+
+    def test_mismatched_batch_dimension_raises(self):
+        model = FeaturePipeline()
+        model.compile(loss="mse")
+        with self.assertRaisesRegex(ValueError, "same batch dimension"):
+            model.fit(
+                x=np.random.uniform(size=(8, 5)),
+                y=np.random.uniform(size=(4, 1)),
+                batch_size=4,
+            )
+
+    def test_ragged_input_falls_back_to_tf_data(self):
+        x = tf.ragged.constant([[1, 2, 3], [4, 5]])
+        ds = _convert_inputs_to_dataset(x, None, None, batch_size=2)
+        self.assertIsInstance(ds, tf.data.Dataset)
 
 
 class TestInputErrors(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
     "tensorflow-text;platform_system != 'Windows'",
 ]
 
+[project.optional-dependencies]
+# Optional, since grain has no sdist and no wheel for some platforms.
+# Preprocessing falls back to `tf.data` when it is missing.
+grain = ["grain"]
+
 [project.urls]
 Home = "https://keras.io/keras_hub/"
 Repository = "https://github.com/keras-team/keras/keras_hub"

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,5 +1,6 @@
 # Library deps.
 dm-tree
+grain
 regex
 rich
 kagglehub!=1.0.1


### PR DESCRIPTION
## Approved issue link

Fixes #3068

## Description of the change

Continuing the Grain migration from #2557. `pipeline_model.py` is the only module in `keras_hub/src/` that actually builds and runs a `tf.data` pipeline, the other `tf.data` references being docstring examples. `Task` inherits `PipelineModel`, so every `fit()`, `evaluate()` and `predict()` call on every task model funnels through it, which is what makes TensorFlow a hard requirement for training any task.

```python
# before
ds = tf.data.Dataset.from_tensor_slices(inputs).batch(batch_size or 32)
x = ds.map(self.preprocess_samples, num_parallel_calls=tf.data.AUTOTUNE).prefetch(tf.data.AUTOTUNE)

# after
ds = grain.MapDataset.source(_TensorLikeSource(inputs)).batch(batch_size or 32)
x = ds.map(preprocess)
```

Keras already dispatches grain datasets to its `GrainDatasetAdapter`, so no glue layer is needed. Grain is an optional extra rather than a hard dependency, since it ships no sdist and no wheel for every platform. `tf.data` still handles the cases grain cannot carry: a dataset passed in by the caller, ragged inputs, preprocessing that produces ragged or string output, and installs without grain. No public API changes.

`PipelineModel` now trains, evaluates and predicts with no TensorFlow installed at all, verified on the torch backend with `tensorflow` and `tensorflow_text` forced unimportable.

### Key updates for reviewers

* **Slicing.** `from_tensor_slices` treats tuples and dicts as structure but a `list` as a single tensor, while `keras.tree` descends into lists and would split a list of strings into one leaf per string. `_map_leaves` follows the `tf.data` rule.
* **Output conversion.** Unlike `get_numpy_iterator`, the jax and torch iterators on `GrainDatasetAdapter` do not convert tf tensors, so jax rejects a `tf.Tensor` outright. Batches go through `tensor_utils.convert_preprocessing_outputs_grain`, added in #3060 for exactly this, and inputs through `tensor_utils.convert_to_numpy`.
* **Ragged and string output fall back to `tf.data`.** Grain has no ragged type, so those come back as nested lists, which `GrainDatasetAdapter` flattens into scalars and rejects as rank 0. `_build_dataset` runs preprocessing over the first batch and builds on `tf.data` when what comes back is not array shaped. The probe raising counts as an answer too, since preprocessing written against tf tensors belongs on `tf.data` anyway.
* **Epoch length.** `GrainDatasetAdapter.num_batches` is always `None`, so Keras finds the epoch size by running the iterator dry, which warns on Keras 3.15.1 and hands the next epoch a drained iterator once a step count is declared. `fit()`, `evaluate()` and `predict()` declare the length instead, which the dataset knows, and repeat it for as many passes as there are. A declared count that outruns the data is capped to one pass, the way `tf.data` stops rather than cycling, and the warning Keras raises there is raised here, per epoch for training and per validation run for validation.
* **Read ahead is bounded** to the 8 batches Keras samples to infer the batch spec. Grain's default of 500 had a `fit()` over two batches preprocessing 1044 of them, and the adapter spending 45 batches on those 8. 100 batches now cost 119 `preprocess_samples` calls rather than 261. `__len__` goes with `to_iter_dataset()`, so the length is read first.
* **`class_weight`** is folded into `sample_weight` on the training samples with Keras' own `class_weight_to_sample_weights`, since `GrainDatasetAdapter` takes no `class_weight` where `TFDatasetAdapter` applies it.
* **Python numbers** are narrowed to float32 and int32, the dtypes `from_tensor_slices` reads them as. Numpy widens them, and torch picks MPS on Apple Silicon, which has no float64. An array that arrives with a dtype of its own keeps it.
* **`grain.DataLoader` is rejected** with an error naming `grain.MapDataset` and `grain.IterDataset`. Its operations are baked in at construction and it has no `map`, so there is nothing to apply preprocessing over.
* **`fit()` preprocesses `validation_data` up front** and `evaluate()` honors Keras' cached eval iterator instead of dropping it, since `GrainDatasetAdapter` raises `Invalid dtype: object` on unpreprocessed strings.
* **`grain` is an optional extra** in `pyproject.toml`, so `pip install keras-hub` is unaffected on platforms it publishes no wheel for. #3060 has since added it to `requirements-common.txt`, which is where CI takes its environment from.

Behaviour against `tf.data` was checked by running every combination on both paths and comparing batches per epoch and warning counts, rather than by reading Keras: `steps_per_epoch` and `validation_steps` under, at and over the data, `validation_freq`, `initial_epoch`, `evaluate(steps=)`, `predict(steps=)`, an uneven last batch, a single sample, an empty dataset and one the caller had already repeated. Fifteen cases, identical on all three backends and on both Keras 3.15.1 and keras-nightly.

## Reference

Part of #2874. Unblocks #2128, related to #2101.

## Colab Notebook

Not applicable, no public API is added or changed.

## Validation

* `pipeline_model_test.py`: 57 passed on TensorFlow and JAX, 56 with the ragged `fit()` skipped on PyTorch, against both Keras 3.15.1 and keras-nightly. `TestTfDataFallback` runs the `tf.data` branch with `grain` set to `None`, which CI would otherwise never reach.
* `keras_hub/src/utils`, `keras_hub/src/layers`, `keras_hub/src/tests` and `bert` / `gpt2` / `albert` / `distil_bert` / `bart` / `resnet` / `mobilenet`: 435 passed on JAX, on top of the grain coverage #3061 added to the `TestCase` harness.
* `gemma3`, `gemma3n`, `gemma4` and `qwen3_5`: 224 passed on TensorFlow and PyTorch. This PR no longer touches them; #3061 fixed the `cpu()` guards there.
* `fit` / `evaluate` / `predict` / `train_on_batch` / `predict_on_batch`, plus `validation_data`, `validation_split` and dict inputs, on all three backends.
* Ruff lint and format pass.

Same model, same seed, 5 epochs, once with grain and once with grain forced off so the old `tf.data` path runs. Loss is bit identical on every backend and `predict` differs by exactly zero:

| backend | loss (grain) | loss (tf.data) | identical |
| :--- | :--- | :--- | :--- |
| tensorflow | `[0.3518816, 0.233396, 0.2156058, 0.1991725, 0.1847653]` | same | yes |
| jax | `[0.1506521, 0.1307402, 0.1265262, 0.1218823, 0.1177265]` | same | yes |
| torch | `[0.2596047, 0.1416182, 0.1354862, 0.1322473, 0.1294076]` | same | yes |

`val_loss` and `evaluate()` match to the same precision, and `max(abs(predict_grain - predict_tfdata))` is `0.000e+00` on all three. Re-checked after the review fixes at seeds 1234 / 7 / 99 and batch sizes 32 / 16 / 64: still identical to the last digit on every backend.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub Model contribution guidelines (not applicable; no model is added).
- [x] I have followed the Keras Hub API design guidelines (not applicable; no API is changed).
- [x] I have signed the Contributor License Agreement.
