### PR TITLE
Part of #2101: Make TensorFlow optional at import time

### DIFF
--- a/keras_hub/src/models/blip2/blip2_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/blip2/blip2_causal_lm_preprocessor.py
@@ -1,5 +1,4 @@
 import keras
-import tensorflow as tf
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.models.blip2.blip2_backbone import BLIP2Backbone
@@ -8,6 +7,11 @@ from keras_hub.src.models.causal_lm_preprocessor import CausalLMPreprocessor
 from keras_hub.src.models.t5.t5_tokenizer import T5Tokenizer
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
 from keras_hub.src.utils.tensor_utils import preprocessing_function
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_hub_export("keras_hub.models.BLIP2CausalLMPreprocessor")

--- a/keras_hub/src/models/blip2/blip2_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/blip2/blip2_causal_lm_preprocessor.py
@@ -6,6 +6,7 @@ from keras_hub.src.models.blip2.blip2_image_converter import BLIP2ImageConverter
 from keras_hub.src.models.causal_lm_preprocessor import CausalLMPreprocessor
 from keras_hub.src.models.t5.t5_tokenizer import T5Tokenizer
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 try:
@@ -199,6 +200,7 @@ class BLIP2CausalLMPreprocessor(CausalLMPreprocessor):
         if token_ids.ndim == 1:
             stripped = token_ids[mask].tolist()
         else:
+            assert_tf_installed("BLIP2CausalLMPreprocessor with batched inputs")
             stripped = tf.ragged.constant(
                 [
                     token_ids[i][mask[i]].tolist()

--- a/keras_hub/src/models/clip/clip_preprocessor.py
+++ b/keras_hub/src/models/clip/clip_preprocessor.py
@@ -6,6 +6,7 @@ from keras_hub.src.models.causal_lm_preprocessor import CausalLMPreprocessor
 from keras_hub.src.models.clip.clip_backbone import CLIPBackbone
 from keras_hub.src.models.clip.clip_image_converter import CLIPImageConverter
 from keras_hub.src.models.clip.clip_tokenizer import CLIPTokenizer
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 try:
@@ -116,6 +117,7 @@ class CLIPPreprocessor(CausalLMPreprocessor):
         sequence_length = sequence_length or self.sequence_length
         images, prompts = x["images"], x["prompts"]
         if self.to_lower:
+            assert_tf_installed("CLIPPreprocessor with to_lower=True")
             prompts = tf.strings.lower(prompts)
         prompts = self.tokenizer(prompts)
         if images is not None and self.image_converter:

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
@@ -11,6 +11,7 @@ from keras_hub.src.models.gemma3.gemma3_image_converter import (
     Gemma3ImageConverter,
 )
 from keras_hub.src.models.gemma3.gemma3_tokenizer import Gemma3Tokenizer
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
 
@@ -255,6 +256,7 @@ class Gemma3CausalLMPreprocessor(CausalLMPreprocessor):
         num_vision_tokens_per_image=256,
         **kwargs,
     ):
+        assert_tf_installed("Gemma3CausalLMPreprocessor")
         super().__init__(
             tokenizer=tokenizer,
             sequence_length=sequence_length,

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
@@ -1,6 +1,5 @@
 import keras
 import numpy as np
-import tensorflow as tf
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.multi_segment_packer import (
@@ -14,6 +13,11 @@ from keras_hub.src.models.gemma3.gemma3_image_converter import (
 from keras_hub.src.models.gemma3.gemma3_tokenizer import Gemma3Tokenizer
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_hub_export("keras_hub.models.Gemma3CausalLMPreprocessor")

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
@@ -1,6 +1,5 @@
 import keras
 import numpy as np
-import tensorflow as tf
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.multi_segment_packer import (
@@ -17,6 +16,11 @@ from keras_hub.src.models.gemma3n.gemma3n_image_converter import (
 from keras_hub.src.models.gemma3n.gemma3n_tokenizer import Gemma3nTokenizer
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_hub_export("keras_hub.models.Gemma3nCausalLMPreprocessor")

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
@@ -14,6 +14,7 @@ from keras_hub.src.models.gemma3n.gemma3n_image_converter import (
     Gemma3nImageConverter,
 )
 from keras_hub.src.models.gemma3n.gemma3n_tokenizer import Gemma3nTokenizer
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
 
@@ -242,6 +243,7 @@ class Gemma3nCausalLMPreprocessor(CausalLMPreprocessor):
         num_audio_tokens_per_audio=188,
         **kwargs,
     ):
+        assert_tf_installed("Gemma3nCausalLMPreprocessor")
         super().__init__(
             tokenizer=tokenizer,
             sequence_length=sequence_length,

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
@@ -20,6 +20,7 @@ from keras_hub.src.models.gemma4.gemma4_tokenizer import Gemma4Tokenizer
 from keras_hub.src.models.gemma4.gemma4_video_converter import (
     Gemma4VideoConverter,
 )
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
 
@@ -175,6 +176,7 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
         video_fps=24.0,
         **kwargs,
     ):
+        assert_tf_installed("Gemma4CausalLMPreprocessor")
         super().__init__(
             tokenizer=tokenizer,
             sequence_length=sequence_length,

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
@@ -3,7 +3,6 @@ import re
 
 import keras
 import numpy as np
-import tensorflow as tf
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.multi_segment_packer import (
@@ -23,6 +22,11 @@ from keras_hub.src.models.gemma4.gemma4_video_converter import (
 )
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 def _get_num_vision_tokens(

--- a/keras_hub/src/models/metaclip_2/metaclip_2_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/metaclip_2/metaclip_2_causal_lm_preprocessor.py
@@ -12,6 +12,7 @@ from keras_hub.src.models.metaclip_2.metaclip_2_image_converter import (
 from keras_hub.src.models.metaclip_2.metaclip_2_tokenizer import (
     MetaCLIP2Tokenizer,
 )
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 try:
@@ -120,6 +121,9 @@ class MetaCLIP2CausalLMPreprocessor(CausalLMPreprocessor):
         sequence_length = sequence_length or self.sequence_length
         images, prompts = x["images"], x["prompts"]
         if self.to_lower:
+            assert_tf_installed(
+                "MetaCLIP2CausalLMPreprocessor with to_lower=True"
+            )
             prompts = tf.strings.lower(prompts)
         prompts = self.tokenizer(prompts)
         if images is not None and self.image_converter:

--- a/keras_hub/src/models/qwen3_5/qwen3_5_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_causal_lm_preprocessor.py
@@ -14,6 +14,7 @@ from keras_hub.src.models.qwen3_5.qwen3_5_tokenizer import Qwen3_5Tokenizer
 from keras_hub.src.models.qwen3_5.qwen3_5_video_converter import (
     Qwen3_5VideoConverter,
 )
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
 
@@ -491,6 +492,7 @@ class Qwen3_5CausalLMPreprocessor(CausalLMPreprocessor):
             )
 
         # Multimodal path.
+        assert_tf_installed("Qwen3_5CausalLMPreprocessor with images or videos")
         if not self.built:
             self.build(None)
 

--- a/keras_hub/src/models/qwen3_5/qwen3_5_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_causal_lm_preprocessor.py
@@ -2,7 +2,6 @@ import re
 
 import keras
 import numpy as np
-import tensorflow as tf
 from keras import ops
 
 from keras_hub.src.api_export import keras_hub_export
@@ -17,6 +16,11 @@ from keras_hub.src.models.qwen3_5.qwen3_5_video_converter import (
 )
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 from keras_hub.src.utils.tensor_utils import strip_to_ragged
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_hub_export("keras_hub.models.Qwen3_5CausalLMPreprocessor")

--- a/keras_hub/src/models/qwen3_5/qwen3_5_image_converter.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_image_converter.py
@@ -1,6 +1,5 @@
 import math
 
-import tensorflow as tf
 from keras import ops
 
 from keras_hub.src.api_export import keras_hub_export
@@ -8,6 +7,11 @@ from keras_hub.src.layers.preprocessing.image_converter import ImageConverter
 from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
 from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import preprocessing_function
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 def _compute_target_size(h, w, min_pixels, max_pixels, patch_stride):

--- a/keras_hub/src/models/qwen3_5/qwen3_5_video_converter.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_video_converter.py
@@ -1,6 +1,5 @@
 import math
 
-import tensorflow as tf
 from keras import ops
 
 from keras_hub.src.api_export import keras_hub_export
@@ -8,6 +7,11 @@ from keras_hub.src.layers.preprocessing.video_converter import VideoConverter
 from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
 from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import preprocessing_function
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_hub_export("keras_hub.layers.Qwen3_5VideoConverter")

--- a/keras_hub/src/models/siglip/siglip_preprocessor.py
+++ b/keras_hub/src/models/siglip/siglip_preprocessor.py
@@ -8,6 +8,7 @@ from keras_hub.src.models.siglip.siglip_image_converter import (
     SigLIPImageConverter,
 )
 from keras_hub.src.models.siglip.siglip_tokenizer import SigLIPTokenizer
+from keras_hub.src.utils.tensor_utils import assert_tf_installed
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 try:
@@ -106,6 +107,7 @@ class SigLIPPreprocessor(CausalLMPreprocessor):
         self.built = True
 
     def canonicalize_inputs(self, inputs):
+        assert_tf_installed("SigLIPPreprocessor with canonicalize_text=True")
         # Ref: https://github.com/google-research/big_vision/blob/main/big_vision/evaluators/proj/image_text/prompt_engineering.py
         inputs = tf.convert_to_tensor(inputs)
         # Do lower case.

--- a/keras_hub/src/tests/import_test.py
+++ b/keras_hub/src/tests/import_test.py
@@ -28,7 +28,8 @@ class ImportTest(TestCase):
                 continue
             if "tests" in path.relative_to(SRC_ROOT).parts:
                 continue
-            for node in ast.parse(path.read_text()).body:
+            source = path.read_text(encoding="utf-8")
+            for node in ast.parse(source).body:
                 packages = _imported_packages(node)
                 if any(p in OPTIONAL_PACKAGES for p in packages):
                     relative = path.relative_to(SRC_ROOT.parent)

--- a/keras_hub/src/tests/import_test.py
+++ b/keras_hub/src/tests/import_test.py
@@ -1,0 +1,42 @@
+import ast
+import pathlib
+
+from keras_hub.src.tests.test_case import TestCase
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[1]
+OPTIONAL_PACKAGES = ("tensorflow", "tensorflow_text")
+
+
+def _imported_packages(node):
+    if isinstance(node, ast.Import):
+        names = [alias.name for alias in node.names]
+    elif isinstance(node, ast.ImportFrom):
+        names = [node.module or ""]
+    else:
+        return []
+    return [name.split(".")[0] for name in names]
+
+
+class ImportTest(TestCase):
+    def test_no_module_level_optional_imports(self):
+        # `import keras_hub` must work without TensorFlow installed, so an
+        # optional package may only be imported inside the function that needs
+        # it, or behind a `try` that falls back to `None`. Tests are exempt.
+        offenders = []
+        for path in sorted(SRC_ROOT.rglob("*.py")):
+            if path.name.endswith("_test.py"):
+                continue
+            if "tests" in path.relative_to(SRC_ROOT).parts:
+                continue
+            for node in ast.parse(path.read_text()).body:
+                packages = _imported_packages(node)
+                if any(p in OPTIONAL_PACKAGES for p in packages):
+                    relative = path.relative_to(SRC_ROOT.parent)
+                    offenders.append(f"{relative}:{node.lineno}")
+
+        self.assertEqual(
+            offenders,
+            [],
+            "Wrap these imports in `try: ... except ImportError: ... = None`, "
+            f"or move them inside the function that needs them: {offenders}",
+        )


### PR DESCRIPTION
## Description of the change

`import keras_hub` fails outright when TensorFlow is not installed. Seven modules under `keras_hub/src/models/` import it at module level, and two of those are reached from `keras_hub/api/layers/__init__.py`:

```
ModuleNotFoundError: No module named 'tensorflow'
  keras_hub/src/models/qwen3_5/qwen3_5_image_converter.py:3
```

Every other module in the library already guards the import and falls back to `tf = None`. This does the same in the seven that do not, which turns out to be enough on its own. With no TensorFlow installed, on both the torch and jax backends:

```
import keras_hub                      -> OK
BytePairTokenizer (python path)("ab") -> [3]
MultiSegmentPacker(...)               -> constructed
```

So the pure Python tokenizer and preprocessing paths from #2557, #2628, #2734 and #2769 become reachable, instead of sitting behind a failing import.

### Key updates for reviewers

* No behaviour change when TensorFlow is installed. The guard is the same `try: import tensorflow as tf / except ImportError: tf = None` used elsewhere in the library.
* The three Gemma preprocessors now call `assert_tf_installed` in `__init__`. They override `call` and `generate_preprocess` with TensorFlow only implementations, so they bypass the Python path in `CausalLMPreprocessor` and cannot run without TensorFlow at all. Without the guard, making the import optional just moves the failure to a bare `AttributeError: 'NoneType' object has no attribute ...`.
* Everything else is guarded per branch, so the paths that work without TensorFlow keep working. `Qwen3_5CausalLMPreprocessor.generate_preprocess` delegates text only inputs to the base class, so the assert sits on the multimodal branch. `CLIPPreprocessor` and `MetaCLIP2CausalLMPreprocessor` only need `tf.strings.lower` under `to_lower=True`, `SigLIPPreprocessor` only under `canonicalize_text=True`, and `BLIP2CausalLMPreprocessor.generate_postprocess` only for batched inputs.
* The Qwen3.5 image and video converters need nothing, since they dispatch on `in_tf_function`.
* `Bleu`, `RougeBase` and `EditDistance` have the same problem but are metrics rather than models, so they are left for a follow up PR.
* `keras_hub/src/tests/import_test.py` walks the library for module level imports of `tensorflow` and `tensorflow_text`. Seven files made the same mistake, so a guard seemed worthwhile. Lazy imports inside a function and imports behind `try` both pass, and tests are exempt. Reverting the seven fixes makes it fail and name all seven with line numbers.

To find the guard sites I walked every `tf.` use in the library and filtered out the ones already protected, either by a `tf and ...` check, a `_call_tf` style method, an `in_tf_function` dispatch, or `PreprocessingLayer.__init__`, which already raises for any class that does not opt into the Python workflow. That last one covers most of the library: `ByteTokenizer()` and friends already report `ByteTokenizer requires 'tensorflow' and 'tensorflow-text'` today.

## Reference

Part of #2101. Independent of #2879, no shared files.

## Colab Notebook

Not applicable, no public API is added or changed.

## Validation

* `import keras_hub` with `tensorflow` and `tensorflow_text` forced unimportable, on the torch and jax backends. In that state `Gemma3CausalLMPreprocessor` raises `ImportError: ... requires 'tensorflow'`, while `Qwen3_5ImageConverter` and the `BytePairTokenizer` Python path still work.
* `blip2` / `gemma3` / `gemma3n` / `gemma4` / `qwen3_5` / `layers` / `utils`, plus the new test: 573 passed, 330 skipped.
* `clip` / `siglip` / `metaclip_2` / `blip2`, after adding the guards: 174 passed, 69 skipped.
* Ruff lint and format pass.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub Model contribution guidelines (not applicable; no model is added).
- [x] I have followed the Keras Hub API design guidelines (not applicable; no API is changed).
- [x] I have signed the Contributor License Agreement.
