### PR TITLE
[LiteRT-LM 20/28] Test Harness: Enable Export Tests (Remaining 8 Models)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -52,6 +52,10 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
+    - name: Install LiteRT-LM export dependencies
+      if: ${{ matrix.backend == 'torch' }}
+      run: |
+          pip install -e ".[litertlm]" --progress-bar off
     - name: Pin Keras 3.15
       if: ${{ matrix.version == 'keras-3.15'}}
       run: |

--- a/keras_hub/src/models/bloom/bloom_causal_lm_test.py
+++ b/keras_hub/src/models/bloom/bloom_causal_lm_test.py
@@ -183,3 +183,12 @@ class BloomCausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=BloomCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -489,6 +489,10 @@ class CausalLM(Task):
                   necessarily the model's true maximum context length. Pass
                   this explicitly to get a cache length independent of the
                   preprocessor.
+                - ``hf_tokenizer_path``: Optional ``str``. Path to a
+                  user-provided HuggingFace ``tokenizer.json`` file. When
+                  provided, it is bundled directly and native tokenizer
+                  validation is skipped. Defaults to ``None``.
                 - ``sampler_config``: Optional
                   ``keras_hub.src.utils.litertlm.model_specs.SamplerConfig``.
                   When given, populates the bundle's
@@ -520,6 +524,7 @@ class CausalLM(Task):
                 backend_constraint=kwargs.pop("backend_constraint", None),
                 prefill_seq_len=kwargs.pop("prefill_seq_len", None),
                 cache_length=kwargs.pop("cache_length", None),
+                hf_tokenizer_path=kwargs.pop("hf_tokenizer_path", None),
                 sampler_config=kwargs.pop("sampler_config", None),
                 llm_model_type=kwargs.pop("llm_model_type", None),
                 **kwargs,

--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -448,6 +448,90 @@ class CausalLM(Task):
 
         export_to_safetensors(self, path)
 
+    def export(
+        self,
+        filepath,
+        format="tf_saved_model",
+        verbose=None,
+        input_signature=None,
+        **kwargs,
+    ):
+        """Export the model as an artifact for inference.
+
+        This overrides the base ``Task.export`` to intercept
+        ``format="litertlm"`` and delegate to the LiteRT-LM exporter.
+
+        Args:
+            filepath: `str` or `pathlib.Path`. The path to save the artifact.
+            format: `str`. The export format. For LiteRT-LM, use
+                ``"litertlm"``. All other formats are forwarded to the
+                superclass.
+            verbose: `bool`. Whether to print a message during export.
+            input_signature: Optional input signature specification.
+                Not used for ``format="litertlm"``.
+            **kwargs: Additional keyword arguments.
+                For ``format="litertlm"``, supported kwargs are:
+
+                - ``backend_constraint``: Optional backend constraint such as
+                  ``"cpu"`` or ``"gpu"``.
+                - ``prefill_seq_len``: ``int`` or ``list[int]``. Sequence
+                  length(s) for prefill signature tracing. A list enables
+                  bucketing (e.g. ``[32, 64, 128, 256]``). Defaults to
+                  ``cache_length``.
+                - ``cache_length``: Optional ``int``. The KV-cache length
+                  (the model's maximum context window) to export with. If
+                  not given, this is inferred from
+                  ``backbone.max_sequence_length`` when the backbone defines
+                  it; most backbones (e.g. Gemma, Llama, Mistral, Qwen) do
+                  not, in which case it falls back to
+                  ``preprocessor.sequence_length`` and a ``UserWarning`` is
+                  raised, since that value is a tokenization default and not
+                  necessarily the model's true maximum context length. Pass
+                  this explicitly to get a cache length independent of the
+                  preprocessor.
+                - ``sampler_config``: Optional
+                  ``keras_hub.src.utils.litertlm.model_specs.SamplerConfig``.
+                  When given, populates the bundle's
+                  ``LlmMetadata.sampler_params``. The only named preset is
+                  ``GREEDY_SAMPLER_CONFIG`` (``top_k=1``, for deterministic
+                  generation). Defaults to ``None``, which leaves
+                  ``sampler_params`` unset (the runtime picks its own
+                  default sampling policy).
+                - ``llm_model_type``: Optional ``str``. Explicit model-type
+                  override for presets indistinguishable from another family
+                  by class/config/tokenizer -- currently ``"function_gemma"``
+                  (the ``function_gemma_instruct_270m`` preset). Exports as
+                  the ``function_gemma`` model type with function-calling
+                  metadata instead of ``gemma3``. Defaults to ``None``
+                  (auto-detect).
+                - ``**kwargs``: Any remaining keyword arguments are forwarded
+                  to ``litert_torch.signature(...)`` for advanced signature
+                  customization.
+
+        Returns:
+            The exported artifact path.
+        """
+        if format == "litertlm":
+            from keras_hub.src.utils.litertlm.export import export_to_litertlm
+
+            return export_to_litertlm(
+                self,
+                filepath,
+                backend_constraint=kwargs.pop("backend_constraint", None),
+                prefill_seq_len=kwargs.pop("prefill_seq_len", None),
+                cache_length=kwargs.pop("cache_length", None),
+                sampler_config=kwargs.pop("sampler_config", None),
+                llm_model_type=kwargs.pop("llm_model_type", None),
+                **kwargs,
+            )
+        return super().export(
+            filepath,
+            format=format,
+            verbose=verbose,
+            input_signature=input_signature,
+            **kwargs,
+        )
+
     def _post_quantize(self, mode, **kwargs):
         super()._post_quantize(mode, **kwargs)
         # Reset the compiled generate function.

--- a/keras_hub/src/models/gemma/gemma_causal_lm_test.py
+++ b/keras_hub/src/models/gemma/gemma_causal_lm_test.py
@@ -334,3 +334,13 @@ class GemmaCausalLMTest(TestCase):
         )
 
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=GemmaCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            prefill_seq_len=8,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_hub/src/models/gpt2/gpt2_causal_lm_test.py
@@ -245,6 +245,17 @@ class GPT2CausalLMTest(TestCase):
 
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
 
+    def test_litertlm_export(self):
+        """Test LiteRT-LM export for GPT2CausalLM with small test model."""
+        self.run_litertlm_export_test(
+            cls=GPT2CausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            prefill_seq_len=8,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )
+
 
 @pytest.mark.skipif(keras.src.backend.backend() != "jax", reason="JAX only")
 @pytest.mark.multi_device

--- a/keras_hub/src/models/gpt_neo_x/gpt_neo_x_causal_lm_test.py
+++ b/keras_hub/src/models/gpt_neo_x/gpt_neo_x_causal_lm_test.py
@@ -118,3 +118,12 @@ class GPTNeoXCausalLMTest(TestCase):
             input_data=self.input_data,
             output_thresholds={"*": {"max": 1e-3, "mean": 1e-4}},
         )
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=GPTNeoXCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/gpt_oss/gpt_oss_causal_lm_test.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_causal_lm_test.py
@@ -218,3 +218,12 @@ class GptOssCausalLMTest(TestCase):
         # Assert shapes for info exfiltrated into the parent context.
         self.assertEqual(ops.shape(embedded_prompts), expected_embedded_shape)
         self.assertEqual(ops.shape(scores), expected_score_shape)
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=GptOssCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/llama/llama_causal_lm_test.py
+++ b/keras_hub/src/models/llama/llama_causal_lm_test.py
@@ -206,3 +206,13 @@ class LlamaCausalLMTest(TestCase):
         # Assert shapes for info exfiltrated into the parent context.
         self.assertEqual(ops.shape(embedded_prompts), expected_embedded_shape)
         self.assertEqual(ops.shape(scores), expected_score_shape)
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=LlamaCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            prefill_seq_len=8,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/llama3/llama3_causal_lm_test.py
+++ b/keras_hub/src/models/llama3/llama3_causal_lm_test.py
@@ -152,3 +152,31 @@ class Llama3CausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        """Test LiteRT-LM export for Llama3CausalLM with small test model."""
+        preprocessor = Llama3CausalLMPreprocessor(
+            Llama3Tokenizer(vocabulary=self.vocab, merges=self.merges),
+            sequence_length=8,
+        )
+        backbone = Llama3Backbone(
+            vocabulary_size=preprocessor.tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_query_heads=4,
+            num_key_value_heads=2,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        init_kwargs = {
+            "preprocessor": preprocessor,
+            "backbone": backbone,
+        }
+        input_data = preprocessor(*self.train_data)[0]
+        self.run_litertlm_export_test(
+            cls=Llama3CausalLM,
+            init_kwargs=init_kwargs,
+            input_data=input_data,
+            prefill_seq_len=8,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/mistral/mistral_causal_lm_test.py
+++ b/keras_hub/src/models/mistral/mistral_causal_lm_test.py
@@ -263,3 +263,14 @@ class MistralCausalLMTest(TestCase):
         )
 
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
+
+    def test_litertlm_export(self):
+        """Test LiteRT-LM export for MistralCausalLM with small test model."""
+        self.run_litertlm_export_test(
+            cls=MistralCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            prefill_seq_len=8,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/mixtral/mixtral_causal_lm_test.py
+++ b/keras_hub/src/models/mixtral/mixtral_causal_lm_test.py
@@ -212,3 +212,13 @@ class MixtralCausalLMTest(TestCase):
         # Assert shapes for info exfiltrated into the parent context.
         self.assertEqual(ops.shape(embedded_prompts), expected_embedded_shape)
         self.assertEqual(ops.shape(scores), expected_score_shape)
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=MixtralCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            prefill_seq_len=8,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/opt/opt_causal_lm_test.py
+++ b/keras_hub/src/models/opt/opt_causal_lm_test.py
@@ -126,3 +126,12 @@ class OPTCausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=OPTCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/phi3/phi3_causal_lm_test.py
+++ b/keras_hub/src/models/phi3/phi3_causal_lm_test.py
@@ -156,3 +156,13 @@ class Phi3CausalLMTest(TestCase):
         )
 
         self.assertIsNone(causal_lm.get_quantization_layer_structure("int8"))
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=Phi3CausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            prefill_seq_len=12,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/qwen/qwen_causal_lm_test.py
+++ b/keras_hub/src/models/qwen/qwen_causal_lm_test.py
@@ -132,3 +132,12 @@ class QwenCausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=QwenCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="qwen2p5",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/qwen3/qwen3_causal_lm_test.py
+++ b/keras_hub/src/models/qwen3/qwen3_causal_lm_test.py
@@ -151,3 +151,33 @@ class Qwen3CausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        # Use a sequence length of 8 so the requested prefill length fits in
+        # the KV cache without altering the existing test fixtures.
+        preprocessor = Qwen3CausalLMPreprocessor(
+            self.preprocessor.tokenizer,
+            sequence_length=8,
+        )
+        backbone = Qwen3Backbone(
+            vocabulary_size=preprocessor.tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_query_heads=4,
+            num_key_value_heads=2,
+            hidden_dim=8,
+            head_dim=2,
+            intermediate_dim=16,
+        )
+        init_kwargs = {
+            "preprocessor": preprocessor,
+            "backbone": backbone,
+        }
+        input_data = preprocessor(*self.train_data)[0]
+        self.run_litertlm_export_test(
+            cls=Qwen3CausalLM,
+            init_kwargs=init_kwargs,
+            input_data=input_data,
+            prefill_seq_len=8,
+            verify_model_type="qwen3",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_causal_lm_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_causal_lm_test.py
@@ -144,3 +144,12 @@ class Qwen3MoeCausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=Qwen3MoeCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="qwen3",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/qwen_moe/qwen_moe_causal_lm_test.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_causal_lm_test.py
@@ -162,3 +162,12 @@ class QwenMoeCausalLMTest(TestCase):
                 preset=preset,
                 input_data=self.input_data,
             )
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=QwenMoeCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="qwen2p5",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/models/smollm3/smollm3_causal_lm_test.py
+++ b/keras_hub/src/models/smollm3/smollm3_causal_lm_test.py
@@ -238,3 +238,12 @@ class SmolLM3CausalLMTest(TestCase):
         # Assert shapes for info exfiltrated into the parent context.
         self.assertEqual(ops.shape(embedded_prompts), expected_embedded_shape)
         self.assertEqual(ops.shape(scores), expected_score_shape)
+
+    def test_litertlm_export(self):
+        self.run_litertlm_export_test(
+            cls=SmolLM3CausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            verify_model_type="generic_model",
+            verify_numerics=True,
+        )

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -1,4 +1,5 @@
 import gc
+import io
 import json
 import os
 import pathlib
@@ -816,6 +817,93 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             if model is not None and cls is not None:
                 del model
             gc.collect()
+
+    def _create_tflite_interpreter(self, tflite_path):
+        """Create a TFLite interpreter for verifying LiteRT-LM bundles.
+
+        We avoid XNNPACK because `litert_torch` bundles may contain ops/shapes
+        that the XNNPACK delegate cannot reshape at prepare time. We use the
+        built-in op resolver without default delegates so all LiteRT-LM ops
+        (including CUMSUM for multimodal models) remain available.
+        """
+        try:
+            from ai_edge_litert.interpreter import Interpreter
+            from ai_edge_litert.interpreter import OpResolverType
+
+            return Interpreter(
+                model_path=tflite_path,
+                experimental_op_resolver_type=OpResolverType.BUILTIN_WITHOUT_DEFAULT_DELEGATES,
+            )
+        except Exception:
+            pass
+        try:
+            return tf.lite.Interpreter(
+                model_path=tflite_path,
+                experimental_op_resolver_type=tf.lite.experimental.OpResolverType.BUILTIN_WITHOUT_DEFAULT_DELEGATES,
+            )
+        except Exception:
+            pass
+        return tf.lite.Interpreter(model_path=tflite_path)
+
+    def _parse_litertlm_bundle(self, litertlm_path):
+        """Read a `.litertlm` bundle and return its raw data + metadata table.
+
+        Returns:
+            A tuple of ``(data, metadata)`` where ``data`` is the bundle bytes
+            and ``metadata`` is the parsed ``LiteRTLMMetaData`` flatbuffer.
+        """
+        from litert_lm_builder import litertlm_peek
+
+        with open(litertlm_path, "rb") as f:
+            data = f.read()
+        metadata = litertlm_peek.read_litertlm_header(
+            litertlm_path, io.StringIO()
+        )
+        return data, metadata
+
+    def _extract_litertlm_tflite_interpreters(self, litertlm_path):
+        """Extract every TFLite model from a `.litertlm` bundle."""
+        from litert_lm_builder import litertlm_core as core
+
+        data, metadata = self._parse_litertlm_bundle(litertlm_path)
+
+        interpreters = []
+        for i in range(metadata.SectionMetadata().ObjectsLength()):
+            obj = metadata.SectionMetadata().Objects(i)
+            if (
+                core.any_section_data_type_to_string(obj.DataType())
+                != "TFLiteModel"
+            ):
+                continue
+            tflite_data = data[obj.BeginOffset() : obj.EndOffset()]
+            tflite_path = os.path.join(
+                self.get_temp_dir(),
+                f"litertlm_model_{len(interpreters)}.tflite",
+            )
+            with open(tflite_path, "wb") as f:
+                f.write(tflite_data)
+            interpreters.append(self._create_tflite_interpreter(tflite_path))
+        return interpreters
+
+    def _parse_litertlm_llm_metadata(self, litertlm_path):
+        """Parse the ``LlmMetadata`` protobuf from a `.litertlm` bundle."""
+        from litert_lm_builder import litertlm_core as core
+        from litert_lm_builder.runtime.proto import llm_metadata_pb2
+
+        data, metadata = self._parse_litertlm_bundle(litertlm_path)
+
+        for i in range(metadata.SectionMetadata().ObjectsLength()):
+            obj = metadata.SectionMetadata().Objects(i)
+            if (
+                core.any_section_data_type_to_string(obj.DataType())
+                != "LlmMetadataProto"
+            ):
+                continue
+            llm_meta_buf = data[obj.BeginOffset() : obj.EndOffset()]
+            meta = llm_metadata_pb2.LlmMetadata()
+            meta.ParseFromString(llm_meta_buf)
+            return meta
+        return None
 
     def _compare_outputs(
         self,

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -38,6 +38,15 @@ def convert_to_comparible_type(x):
     return x
 
 
+# Extra KV-cache slots (beyond the prompt length) to trace a LiteRT-LM bundle
+# with, when `run_litertlm_export_test` auto-derives `cache_length` for
+# text-only numeric-parity verification. This gives `_verify_litertlm_numerics`
+# room to decode one step past the prefilled prompt, so the decode step
+# genuinely attends across a populated cache instead of writing into the same
+# lone slot it just read from.
+_LITERTLM_DECODE_CACHE_HEADROOM = 4
+
+
 class TestCase(tf.test.TestCase, parameterized.TestCase):
     """Base test case class for KerasHub."""
 
@@ -904,6 +913,391 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             meta.ParseFromString(llm_meta_buf)
             return meta
         return None
+
+    def _attach_sentencepiece_tokenizer_asset(
+        self, tokenizer, proto_path, asset_name="vocabulary.spm"
+    ):
+        """Attach a test SentencePiece proto asset to a tokenizer.
+
+        LiteRT-LM export needs the tokenizer to declare its file assets and
+        know how to copy them into a preset directory. Test mock tokenizers do
+        not have a real preset asset, so this helper wires a single proto file
+        into ``tokenizer.save_to_preset`` for export-time bundling.
+        """
+        import shutil
+
+        from keras_hub.src.utils.preset_utils import TOKENIZER_ASSET_DIR
+
+        tokenizer.file_assets = [asset_name]
+
+        def _save_to_preset(preset_dir):
+            asset_dir = os.path.join(preset_dir, TOKENIZER_ASSET_DIR)
+            os.makedirs(asset_dir, exist_ok=True)
+            shutil.copy(proto_path, os.path.join(asset_dir, asset_name))
+
+        tokenizer.save_to_preset = _save_to_preset
+
+    def _verify_litertlm_numerics(
+        self,
+        model,
+        interpreter,
+        input_data,
+        atol,
+        rtol,
+        cache_length=None,
+    ):
+        """Compare Keras eager and TFLite prefill/decode outputs.
+
+        Args:
+            model: The KerasHub ``CausalLM`` producing the eager reference.
+            interpreter: The TFLite interpreter built from the exported
+                bundle's PREFILL_DECODE section.
+            input_data: A 2-D int token array ``[batch, seq_len]``.
+            atol: Absolute tolerance for the logits comparison.
+            rtol: Relative tolerance for the logits comparison.
+            cache_length: The exact cache length the bundle under test was
+                traced with (see `run_litertlm_export_test`). Threading it
+                through explicitly, rather than re-deriving it independently,
+                keeps this helper from silently drifting out of sync with
+                the cache length `export_to_litertlm` actually used. When
+                omitted, it is derived the same way `export_to_litertlm`
+                derives it by default.
+        """
+        import torch
+
+        # Local import to avoid a module-level dependency from this
+        # low-level, widely-imported test helper module onto the litertlm
+        # package -- matches the lazy-import convention `export.py` and
+        # `model_specs.py` already use for optional/heavy dependencies.
+        from keras_hub.src.utils.litertlm.model_specs import resolve_export_spec
+
+        tokens_np = ops.convert_to_numpy(input_data)
+        if tokens_np.ndim != 2:
+            raise ValueError(
+                "`input_data` for LiteRT-LM numeric parity must be a 2-D "
+                f"token tensor. Received: input_data.shape={tokens_np.shape}."
+            )
+
+        B, T = tokens_np.shape
+
+        # Derive cache dimensions/layout the same way the real export
+        # pipeline does, instead of a separate, drift-prone getattr chain.
+        spec = resolve_export_spec(model)
+        cache_cfg = spec.get_cache_config(model, cache_length=cache_length)
+        L = cache_cfg["num_layers"]
+        H = cache_cfg["num_kv_heads"]
+        D = cache_cfg["head_dim"]
+        cache_length = cache_cfg["cache_length"]
+        cache_layout = cache_cfg["cache_layout"]
+
+        if cache_layout == "gemma3n":
+            keras_cache_shape = (B, L, 2, H, cache_length, D)
+        else:
+            keras_cache_shape = (B, L, 2, cache_length, H, D)
+        per_layer_shape = spec.get_kv_cache_sample_shape(B, cache_length, H, D)
+
+        # Find the best prefill signature (bucketed or single).
+        sig_list = list(interpreter._get_full_signature_list().keys())
+        prefill_sig = None
+        if "prefill" in sig_list:
+            prefill_sig = "prefill"
+        else:
+            matching = sorted(
+                [
+                    s
+                    for s in sig_list
+                    if s.startswith("prefill_") and int(s.split("_")[1]) >= T
+                ]
+            )
+            if matching:
+                prefill_sig = matching[0]
+        if prefill_sig is None:
+            self.fail("No usable prefill signature found for numeric parity.")
+
+        cache_keras = np.zeros(keras_cache_shape, dtype=np.float32)
+        prefill_inputs = {
+            "tokens": tokens_np,
+            "input_pos": np.arange(T, dtype=np.int32),
+        }
+        for i in range(L):
+            prefill_inputs[f"kv_cache_k_{i}"] = np.zeros(
+                per_layer_shape, dtype=np.float32
+            )
+            prefill_inputs[f"kv_cache_v_{i}"] = np.zeros(
+                per_layer_shape, dtype=np.float32
+            )
+
+        prefill_runner = interpreter.get_signature_runner(prefill_sig)
+        tflite_prefill_out = prefill_runner(**prefill_inputs)
+
+        # Keras prefill.
+        with torch.no_grad():
+            _, _, keras_cache = model.call_with_cache(
+                torch.from_numpy(tokens_np),
+                torch.from_numpy(cache_keras),
+                0,
+            )
+        keras_cache = keras_cache.numpy()
+
+        # Compare prefill KV caches.
+        for i in range(L):
+            self.assertAllClose(
+                keras_cache[:, i, 0, ...],
+                tflite_prefill_out[f"kv_cache_k_{i}"],
+                atol=atol,
+                rtol=rtol,
+            )
+            self.assertAllClose(
+                keras_cache[:, i, 1, ...],
+                tflite_prefill_out[f"kv_cache_v_{i}"],
+                atol=atol,
+                rtol=rtol,
+            )
+
+        # Single decode step one position past the prefilled prompt, so
+        # decode genuinely attends across a populated cache instead of
+        # writing into the same lone slot it just read from (with causal
+        # masking, decoding at position 0 can only attend to itself). Falls
+        # back to the last valid cache slot if the caller didn't leave any
+        # headroom beyond the prompt (`cache_length == T`).
+        decode_pos = min(T, cache_length - 1)
+        # The decode token's identity does not matter for numeric parity
+        # (both backends run the identical op on it); reuse the prompt's
+        # last token rather than indexing at `decode_pos`, which may be past
+        # the end of the actual prompt tokens.
+        decode_token = tokens_np[:, -1:].copy()
+        with torch.no_grad():
+            keras_logits_dec, _, keras_cache_dec = model.call_with_cache(
+                torch.from_numpy(decode_token),
+                torch.from_numpy(keras_cache),
+                decode_pos,
+            )
+        keras_logits_dec = keras_logits_dec.numpy()
+        keras_cache_dec = keras_cache_dec.numpy()
+
+        decode_inputs = {
+            "tokens": decode_token,
+            "input_pos": np.array([decode_pos], dtype=np.int32),
+        }
+        for i in range(L):
+            decode_inputs[f"kv_cache_k_{i}"] = tflite_prefill_out[
+                f"kv_cache_k_{i}"
+            ]
+            decode_inputs[f"kv_cache_v_{i}"] = tflite_prefill_out[
+                f"kv_cache_v_{i}"
+            ]
+        decode_runner = interpreter.get_signature_runner("decode")
+        tflite_dec_out = decode_runner(**decode_inputs)
+
+        self.assertAllClose(
+            keras_logits_dec,
+            tflite_dec_out["logits"],
+            atol=atol,
+            rtol=rtol,
+        )
+        for i in range(L):
+            self.assertAllClose(
+                keras_cache_dec[:, i, 0, ...],
+                tflite_dec_out[f"kv_cache_k_{i}"],
+                atol=atol,
+                rtol=rtol,
+            )
+            self.assertAllClose(
+                keras_cache_dec[:, i, 1, ...],
+                tflite_dec_out[f"kv_cache_v_{i}"],
+                atol=atol,
+                rtol=rtol,
+            )
+
+    def run_litertlm_export_test(
+        self,
+        cls=None,
+        init_kwargs=None,
+        model=None,
+        input_data=None,
+        prefill_seq_len=None,
+        verify_numerics=True,
+        verify_model_type=None,
+        atol=1e-4,
+        rtol=1e-4,
+        **export_kwargs,
+    ):
+        """Export a KerasHub model to LiteRT-LM and verify the bundle.
+
+        Args:
+            cls: Model class to instantiate if ``model`` is not provided.
+            init_kwargs: Initialization arguments for ``cls``.
+            model: Pre-built model instance. If provided, ``cls`` and
+                ``init_kwargs`` are ignored.
+            input_data: Token ids tensor for text-only numeric parity, or
+                ``None`` to skip numeric verification.
+            prefill_seq_len: Sequence length passed to ``model.export``. May be
+                an ``int`` or a list of bucket sizes.
+            verify_numerics: Whether to run Keras vs TFLite numeric parity. Set
+                to ``False`` for preset models with random weights.
+            verify_model_type: Expected ``LlmMetadata`` oneof name, e.g.
+                ``"gemma3"`` or ``"generic_model"``.
+            atol: Absolute tolerance for numeric parity.
+            rtol: Relative tolerance for numeric parity.
+            **export_kwargs: Additional arguments forwarded to
+                ``model.export(..., format="litertlm", ...)``.
+        """
+
+        if keras.config.backend() != "torch":
+            self.skipTest("LiteRT-LM export requires the PyTorch backend.")
+
+        import importlib.util
+
+        if importlib.util.find_spec("litert_torch") is None:
+            self.skipTest(
+                "LiteRT-LM export requires `litert-torch`. "
+                "Install it with: pip install litert-torch"
+            )
+
+        if importlib.util.find_spec("litert_lm_builder") is None:
+            self.skipTest(
+                "LiteRT-LM export requires `litert-lm-builder`. "
+                "Install it with: pip install litert-lm-builder"
+            )
+
+        if model is None:
+            if cls is None or init_kwargs is None:
+                raise ValueError(
+                    "Either `model` or both `cls` and `init_kwargs` must be "
+                    "provided."
+                )
+            model = cls(**init_kwargs)
+
+        if isinstance(input_data, dict) and "padding_mask" in input_data:
+            input_data = dict(input_data)
+            input_data["padding_mask"] = ops.convert_to_numpy(
+                ops.cast(input_data["padding_mask"], "int32")
+            )
+
+        # Determine up front whether this call will exercise text-only
+        # numeric parity, so the cache-length bump below can be applied
+        # before tracing -- the bundle's cache length is fixed at trace
+        # time, so any adjustment must happen before `model.export`.
+        numeric_input = None
+        if verify_numerics and input_data is not None:
+            candidate_input = input_data
+            if isinstance(input_data, dict):
+                candidate_input = input_data.get("token_ids")
+            if candidate_input is not None:
+                # Skip numeric parity for inputs carrying anything beyond
+                # text tokens; the helper only validates text token
+                # prefill/decode KV-cache parity.
+                text_only_keys = {"token_ids", "padding_mask"}
+                is_text_only = not isinstance(
+                    input_data, dict
+                ) or text_only_keys.issuperset(input_data.keys())
+                if is_text_only:
+                    # The exported TFLite prefill signature is traced with
+                    # batch_size=1, so numeric parity must use a single
+                    # sample.
+                    numeric_input = ops.convert_to_numpy(candidate_input)
+                    if numeric_input.ndim >= 2 and numeric_input.shape[0] > 1:
+                        numeric_input = numeric_input[:1]
+
+        path = os.path.join(self.get_temp_dir(), "model.litertlm")
+        if prefill_seq_len is not None:
+            export_kwargs.setdefault("prefill_seq_len", prefill_seq_len)
+
+        if numeric_input is not None and "cache_length" not in export_kwargs:
+            # Trace with a few unused cache slots beyond the prompt so
+            # `_verify_litertlm_numerics` can decode one step past the
+            # prefilled prompt, genuinely exercising attention over a
+            # populated cache instead of decoding into the same lone slot
+            # the prompt just filled. Absolute (non-RoPE) position-embedding
+            # families (e.g. GPT2, OPT) size a fixed position-embedding
+            # table to `backbone.max_sequence_length`; requesting a cache
+            # beyond it produces invalid position ids during tracing. When
+            # the backbone defines that attribute, treat it as a hard cap on
+            # how much headroom can safely be added -- this is the same
+            # attribute `LiteRTLMExportSpec.get_cache_config` already treats
+            # as authoritative over the prompt length, so this isn't a new
+            # family-specific heuristic, just reusing that existing signal.
+            prompt_len = numeric_input.shape[-1]
+            # A caller-supplied `prefill_seq_len` is a lower bound on the
+            # cache length regardless of the prompt length -- otherwise the
+            # headroom bump below could compute a `cache_length` smaller
+            # than an already-requested `prefill_seq_len` and trip
+            # `export_to_litertlm`'s own "prefill_seq_len cannot exceed
+            # cache_length" validation.
+            min_required_len = max(
+                prompt_len, export_kwargs.get("prefill_seq_len", 0)
+            )
+            target_cache_length = (
+                min_required_len + _LITERTLM_DECODE_CACHE_HEADROOM
+            )
+            max_supported = getattr(model.backbone, "max_sequence_length", None)
+            if max_supported is not None:
+                target_cache_length = min(target_cache_length, max_supported)
+            if target_cache_length > prompt_len:
+                export_kwargs["cache_length"] = target_cache_length
+                export_kwargs.setdefault("prefill_seq_len", prompt_len)
+        verify_cache_length = export_kwargs.get("cache_length")
+
+        model.export(path, format="litertlm", **export_kwargs)
+
+        self.assertTrue(os.path.exists(path))
+        self.assertGreater(os.path.getsize(path), 0)
+
+        interpreters = self._extract_litertlm_tflite_interpreters(path)
+        self.assertTrue(
+            interpreters,
+            "No TFLite model found in the .litertlm bundle.",
+        )
+
+        all_signatures = {}
+        for interpreter in interpreters:
+            all_signatures.update(interpreter._get_full_signature_list())
+        prefill_sigs = [
+            name for name in all_signatures if name.startswith("prefill")
+        ]
+        self.assertTrue(
+            prefill_sigs,
+            f"No prefill signature found. Signatures: {list(all_signatures)}",
+        )
+        self.assertIn(
+            "decode",
+            all_signatures,
+            f"No decode signature found. Signatures: {list(all_signatures)}",
+        )
+
+        main_interpreter = None
+        for interpreter in interpreters:
+            sigs = interpreter._get_full_signature_list()
+            if any(s.startswith("prefill") for s in sigs) and "decode" in sigs:
+                main_interpreter = interpreter
+                break
+        if main_interpreter is None:
+            main_interpreter = interpreters[0]
+
+        if verify_model_type is not None:
+            llm_metadata = self._parse_litertlm_llm_metadata(path)
+            self.assertIsNotNone(
+                llm_metadata,
+                "LlmMetadata section not found in .litertlm bundle.",
+            )
+            model_type_msg = llm_metadata.llm_model_type
+            actual_type = model_type_msg.WhichOneof("model_type")
+            self.assertEqual(
+                actual_type,
+                verify_model_type,
+                f"Expected LlmModelType '{verify_model_type}', "
+                f"got '{actual_type}'.",
+            )
+
+        if numeric_input is not None:
+            self._verify_litertlm_numerics(
+                model,
+                main_interpreter,
+                numeric_input,
+                atol=atol,
+                rtol=rtol,
+                cache_length=verify_cache_length,
+            )
 
     def _compare_outputs(
         self,

--- a/keras_hub/src/utils/litertlm/adapter.py
+++ b/keras_hub/src/utils/litertlm/adapter.py
@@ -1,0 +1,147 @@
+"""PyTorch adapters for exporting KerasHub CausalLM models to LiteRT-LM."""
+
+import contextlib
+import inspect
+import threading
+
+import torch
+from torch import nn
+
+# Global lock serializing export-time mutations of PyTorch's default device.
+# This keeps _cpu_default_device_scope thread-safe without changing semantics.
+_DEFAULT_DEVICE_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _cpu_default_device_scope():
+    """Temporarily force PyTorch's default device to CPU.
+
+    A module-level lock serializes this scope so concurrent exports (or
+    exports running alongside GPU work) cannot observe a partially-applied
+    default device.
+    """
+    with _DEFAULT_DEVICE_LOCK:
+        original_device = torch.get_default_device()
+        torch.set_default_device("cpu")
+        try:
+            yield
+        finally:
+            torch.set_default_device(original_device)
+
+
+class KerasHubLiteRTAdapter(nn.Module):
+    """Adapter that wraps a KerasHub CausalLM for LiteRT-LM export.
+
+    The adapter exposes `forward_prefill` and `forward_decode` signatures
+    compatible with `litert_torch.signature(...)`:
+
+    Inputs:
+        tokens:       int32 [batch, seq_len]
+        input_pos:    int32 [seq_len]   (position indices)
+        kv_cache_k_0, kv_cache_v_0, ...: per-layer KV caches
+
+    Outputs (prefill):
+        kv_cache_k_0, kv_cache_v_0, ...: updated per-layer KV caches
+        (no logits -- LiteRT-LM extracts last-token logits via decode)
+
+    Outputs (decode):
+        logits:       float [batch, seq_len, vocab_size]
+        kv_cache_k_0, kv_cache_v_0, ...: updated per-layer KV caches
+
+    The adapter delegates to ``export_spec.stack_kv_cache``/
+    ``unstack_kv_cache`` to convert between the flat per-layer k/v tensors
+    and the cache shape ``model.call_with_cache()`` expects for this family.
+    """
+
+    def __init__(
+        self,
+        keras_model,
+        num_layers,
+        cache_length,
+        export_spec,
+    ):
+        super().__init__()
+        self.keras_model = keras_model
+        self.num_layers = num_layers
+        self.cache_length = cache_length
+        self.export_spec = export_spec
+
+        # Cache the call_with_cache signature so we don't re-inspect it on every
+        # forward pass during export tracing.
+        call_params = set(
+            inspect.signature(keras_model.call_with_cache).parameters.keys()
+        )
+        self._call_with_cache_params = call_params
+
+    def forward_prefill(self, tokens, input_pos, **kv_cache):
+        """Prefill step: process the full prompt at the given cache position.
+
+        LiteRT-LM requires prefill to return **only** KV cache tensors
+        (no logits). The runtime extracts the last-token logits internally
+        via a dedicated decode step.
+
+        ``input_pos`` is a 1-D int32 tensor (e.g. ``[0, 1, 2, ...]`` for the
+        first turn, or ``[N, N+1, ...]`` for subsequent turns). The first
+        element is used as the cache-update index so that prefill appends to
+        the existing cache instead of overwriting from position 0.
+        """
+        cache = self.export_spec.stack_kv_cache(kv_cache, self.num_layers)
+        # The first element of input_pos is the start position.
+        cache_update_index = input_pos[0]
+
+        call_kwargs = self._build_call_with_cache_kwargs()
+        return self._call_with_cache(
+            tokens, cache, cache_update_index, call_kwargs, return_logits=False
+        )
+
+    def forward_decode(self, tokens, input_pos, **kv_cache):
+        """Decode step: process a single token at ``input_pos``.
+
+        ``input_pos`` is a scalar int32 tensor (e.g. ``[3]``). It is passed
+        directly as the cache-update index so that the value remains a tensor
+        inside the exported graph and is not baked in as a Python constant.
+        """
+        cache = self.export_spec.stack_kv_cache(kv_cache, self.num_layers)
+        # Squeeze to a 0-D tensor so Keras cache operations receive a scalar.
+        cache_update_index = input_pos.reshape(())
+        call_kwargs = self._build_call_with_cache_kwargs()
+        return self._call_with_cache(
+            tokens, cache, cache_update_index, call_kwargs, return_logits=True
+        )
+
+    def _call_with_cache(
+        self, tokens, cache, cache_update_index, call_kwargs, return_logits
+    ):
+        """Run ``keras_model.call_with_cache`` and return updated KV caches."""
+        # Only Gemma3n forces an override here (a full-length padding mask;
+        # see ``Gemma3nSpec.get_forced_call_with_cache_kwargs``); every other
+        # family is a no-op.
+        call_kwargs.update(
+            self.export_spec.get_forced_call_with_cache_kwargs(
+                tokens, self.cache_length
+            )
+        )
+        logits, _, updated_cache = self.keras_model.call_with_cache(
+            tokens,
+            cache,
+            cache_update_index,
+            **call_kwargs,
+        )
+        # Keras cache-update ops (`slice_update`/`scatter_update`) are
+        # purely functional, so `updated_cache` is already a fresh,
+        # non-aliased tensor -- no `.clone()` needed.
+        outputs = self.export_spec.unstack_kv_cache(
+            updated_cache, self.num_layers
+        )
+        if return_logits:
+            outputs["logits"] = logits
+        return outputs
+
+    def _build_call_with_cache_kwargs(self):
+        """Build kwargs dict for ``call_with_cache`` based on its signature."""
+        params = self._call_with_cache_params
+        values = {
+            "padding_mask": None,
+            "cache_update_mask": None,
+        }
+        return {k: v for k, v in values.items() if k in params}

--- a/keras_hub/src/utils/litertlm/export.py
+++ b/keras_hub/src/utils/litertlm/export.py
@@ -1,0 +1,802 @@
+"""Export KerasHub CausalLM models to LiteRT-LM `.litertlm` bundles."""
+
+import contextlib
+import dataclasses
+import importlib.util
+import os
+import tempfile
+import warnings
+
+import keras
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+from keras_hub.src.tokenizers.sentence_piece_tokenizer import (
+    SentencePieceTokenizer,
+)
+from keras_hub.src.utils.litertlm.model_specs import SamplerConfig
+from keras_hub.src.utils.litertlm.model_specs import resolve_export_spec
+from keras_hub.src.utils.preset_utils import TOKENIZER_ASSET_DIR
+
+# ``litert_torch`` is an optional dependency. Use ``find_spec`` to check for
+# availability without importing it at module level, because importing
+# ``litert_torch`` has the side effect of enabling ``jax_enable_x64``.
+_LITERT_TORCH_AVAILABLE = importlib.util.find_spec("litert_torch") is not None
+
+
+@contextlib.contextmanager
+def _preserve_jax_config_state(name, value=None):
+    """Preserve the JAX config flag ``name`` around ``litert_torch`` usage.
+
+    When ``value`` is given, the flag is pinned to it for the block.
+    """
+    try:
+        import jax
+    except ImportError:
+        jax = None
+        original = None
+    else:
+        original = getattr(jax.config, name)
+    if jax is not None and value is not None:
+        jax.config.update(name, value)
+    try:
+        yield
+    finally:
+        if jax is not None:
+            jax.config.update(name, original)
+
+
+# ``torch`` is optional. Defining the adapter bases conditionally lets the
+# module import cleanly in non-PyTorch environments while still giving
+# ``torch.nn.Module`` semantics when PyTorch is present.
+if torch is not None:
+    _AdapterBase = torch.nn.Module
+else:
+    _AdapterBase = object
+
+
+class _PrefillAdapter(_AdapterBase):
+    """Thin wrapper that exposes ``adapter.forward_prefill`` to litert_torch."""
+
+    def __init__(self, base):
+        super().__init__()
+        self.base = base
+
+    def forward(self, *args, **kwargs):
+        return self.base.forward_prefill(*args, **kwargs)
+
+
+class _DecodeAdapter(_AdapterBase):
+    """Thin wrapper that exposes ``adapter.forward_decode`` to litert_torch."""
+
+    def __init__(self, base):
+        super().__init__()
+        self.base = base
+
+    def forward(self, *args, **kwargs):
+        return self.base.forward_decode(*args, **kwargs)
+
+
+def _validate_export_args(
+    model,
+    path,
+    tokenizer,
+    backend_constraint,
+    prefill_seq_len,
+):
+    """Fail fast on invalid export arguments.
+
+    Importing ``litert_torch`` is deferred to the orchestrator so that the
+    JAX ``jax_enable_x64`` side effect can be kept under one
+    preserve/restore context that covers both import and tracing.
+
+    Returns:
+        A ``(prefill_seq_lens, backend_constraint)`` tuple: the normalized
+        list of prefill sequence lengths, and the normalized (lowercased)
+        ``backend_constraint`` string (or ``None``). Callers must use the
+        returned ``backend_constraint`` -- not the original argument -- so
+        the lowercased value actually reaches ``_assemble_bundle`` /
+        ``builder.add_tflite_model``.
+    """
+    if not path.endswith(".litertlm"):
+        raise ValueError(
+            "LiteRT-LM export requires a filepath ending in `.litertlm`. "
+            f"Received: path={path}"
+        )
+
+    if not hasattr(model, "call_with_cache"):
+        raise ValueError(
+            "LiteRT-LM export requires a model with a `call_with_cache()` "
+            "method."
+        )
+
+    if backend_constraint is not None:
+        if not isinstance(backend_constraint, str):
+            raise ValueError(
+                "`backend_constraint` must be a string or None. "
+                f"Received: {backend_constraint!r}"
+            )
+        backend_constraint = backend_constraint.lower()
+
+    if not _is_sentencepiece_tokenizer(tokenizer):
+        raise ValueError(
+            "LiteRT-LM export supports SentencePiece tokenizers. Received: "
+            f"{type(tokenizer).__module__}.{type(tokenizer).__name__}."
+        )
+
+    # PyTorch is required for tracing and for building sample inputs. Surface
+    # this before the backend check so a JAX/TF caller without torch installed
+    # gets a clear message instead of a raw ``ModuleNotFoundError``.
+    if torch is None:
+        raise ImportError(
+            "LiteRT-LM export requires PyTorch. "
+            "Install it with: pip install torch"
+        )
+
+    # litert_torch only supports the PyTorch Keras backend.
+    if keras.config.backend() != "torch":
+        raise ValueError(
+            "LiteRT-LM export is only supported with the PyTorch backend. "
+            f"Current backend: {keras.config.backend()}."
+        )
+
+    # Now that tokenizer and backend checks are done, require the optional
+    # litert-torch/litert-lm-builder packages for the actual export.
+    if not _LITERT_TORCH_AVAILABLE:
+        raise ImportError(
+            "LiteRT-LM export requires `litert-torch`. "
+            "Install it with: pip install litert-torch"
+        )
+
+    # Validate `backend_constraint` against the builder's enum only after the
+    # availability checks above, so under-supported environments get the
+    # friendly torch/backend/dependency errors first. Allowed values track
+    # `litert_lm_builder.Backend`. The builder also accepts comma-separated
+    # lists; KerasHub deliberately accepts a single backend only.
+    if backend_constraint is not None:
+        litert_lm_builder = _import_litert_lm_builder()
+        valid_backends = {b.value for b in litert_lm_builder.Backend}
+        if backend_constraint not in valid_backends:
+            raise ValueError(
+                f"Invalid backend_constraint: {backend_constraint!r}. "
+                f"Must be one of {sorted(valid_backends)}."
+            )
+
+    # Normalise prefill_seq_len to a sorted list. Cache-length checks are left
+    # to the orchestrator because ``cache_length`` is not known until after
+    # ``spec.get_cache_config`` runs.
+    if prefill_seq_len is None:
+        prefill_seq_lens = None
+    elif isinstance(prefill_seq_len, int):
+        prefill_seq_lens = [prefill_seq_len]
+    elif isinstance(prefill_seq_len, (list, tuple)):
+        if not prefill_seq_len:
+            raise ValueError("`prefill_seq_len` cannot be an empty list.")
+        prefill_seq_lens = sorted(set(prefill_seq_len))
+    else:
+        raise ValueError(
+            "`prefill_seq_len` must be an int or a list of ints. "
+            f"Received: {prefill_seq_len!r}"
+        )
+
+    if prefill_seq_lens is not None:
+        for seq_len in prefill_seq_lens:
+            if not isinstance(seq_len, int) or seq_len <= 0:
+                raise ValueError(
+                    "`prefill_seq_len` values must be positive integers. "
+                    f"Received: {seq_len!r}"
+                )
+
+    return prefill_seq_lens, backend_constraint
+
+
+@dataclasses.dataclass(frozen=True)
+class ExportPlan:
+    """Immutable bundle of per-export-run settings for a single export call.
+
+    ``export_to_litertlm`` computes all of these values once, early in the
+    pipeline (resolving the model-family spec and cache config), then passes
+    a single ``ExportPlan`` to the later pipeline phases (building sample
+    inputs, tracing/converting, assembling the bundle) instead of a long,
+    order-sensitive positional-argument list.
+    """
+
+    spec: object
+    num_layers: int
+    cache_length: int
+    num_kv_heads: int
+    head_dim: int
+    prefill_seq_lens: list
+    dtype: object
+    sampler_config: object | None
+    model_type_overridden: bool
+
+
+def _build_prefill_inputs(plan):
+    """Build a ``{seq_len: sample_inputs}`` map for every prefill bucket."""
+    prefill_inputs_map = {}
+    for seq_len in plan.prefill_seq_lens:
+        prefill_inputs_map[seq_len] = _build_sample_inputs(
+            batch_size=1,
+            seq_len=seq_len,
+            num_layers=plan.num_layers,
+            cache_length=plan.cache_length,
+            num_kv_heads=plan.num_kv_heads,
+            head_dim=plan.head_dim,
+            dtype=plan.dtype,
+            spec=plan.spec,
+        )
+    return prefill_inputs_map
+
+
+def _chain_signatures(litert_torch, signatures, **kwargs):
+    """Chain multiple litert_torch signatures, hiding first/rest asymmetry."""
+    converter = None
+    for sig_name, adapter, sample_kwargs in signatures:
+        if converter is None:
+            converter = litert_torch.signature(
+                sig_name,
+                adapter,
+                sample_kwargs=sample_kwargs,
+                **kwargs,
+            )
+        else:
+            converter = converter.signature(
+                sig_name,
+                adapter,
+                sample_kwargs=sample_kwargs,
+                **kwargs,
+            )
+    return converter
+
+
+def _trace_and_convert(
+    litert_torch,
+    prefill_adapter,
+    decode_adapter,
+    prefill_inputs_map,
+    decode_inputs,
+    plan,
+    **kwargs,
+):
+    """Trace the prefill/decode signatures and convert them to LiteRT."""
+    # Defer torch-specific imports until the backend has been verified as
+    # torch, so that non-torch callers get the friendly backend error.
+    from keras_hub.src.utils.litertlm.traceable_ops import traceable_ops_scope
+
+    with traceable_ops_scope():
+        # Chain one signature per prefill bucket plus the decode signature.
+        signatures = []
+        for seq_len in plan.prefill_seq_lens:
+            sig_name = (
+                "prefill"
+                if len(plan.prefill_seq_lens) == 1
+                else f"prefill_{seq_len}"
+            )
+            signatures.append(
+                (sig_name, prefill_adapter, prefill_inputs_map[seq_len])
+            )
+        signatures.append(("decode", decode_adapter, decode_inputs))
+
+        converter = _chain_signatures(litert_torch, signatures, **kwargs)
+        edge_model = converter.convert(lightweight_conversion=False)
+
+    return edge_model
+
+
+def _assemble_bundle(
+    *,
+    path,
+    temp_dir,
+    tokenizer,
+    backend_constraint,
+    edge_model,
+    plan,
+):
+    """Write TFLite files, bundle the tokenizer, and assemble ``.litertlm``."""
+    prefill_tflite_path = os.path.join(temp_dir, "model.tflite")
+    edge_model.export(prefill_tflite_path)
+
+    tokenizer_path = _materialize_sentencepiece_tokenizer(tokenizer, temp_dir)
+
+    meta_path = os.path.join(temp_dir, "llm_metadata.pb")
+    _build_llm_metadata(
+        plan.spec,
+        tokenizer,
+        plan.cache_length,
+        meta_path,
+        sampler_config=plan.sampler_config,
+        model_type_overridden=plan.model_type_overridden,
+    )
+
+    litert_lm_builder = _import_litert_lm_builder()
+    builder = litert_lm_builder.LitertLmFileBuilder()
+    builder.add_system_metadata(
+        litert_lm_builder.Metadata(
+            key="Authors",
+            value="KerasHub",
+            dtype=litert_lm_builder.DType.STRING,
+        )
+    )
+    builder.add_tflite_model(
+        prefill_tflite_path,
+        litert_lm_builder.TfLiteModelType.PREFILL_DECODE,
+        backend_constraint=backend_constraint,
+    )
+    builder.add_sentencepiece_tokenizer(tokenizer_path)
+    builder.add_llm_metadata(meta_path)
+
+    # Write to a temp file in the same directory as `path` and atomically
+    # rename it into place on success, so a crash mid-build (the bundle can be
+    # large) never leaves a truncated `.litertlm` file at the destination.
+    output_dir = os.path.dirname(os.path.abspath(path)) or "."
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=output_dir,
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".tmp",
+    )
+    try:
+        # `mkstemp` always creates the file 0600. Match the permissions a
+        # plain `open(path, "wb")` would have produced (0666 minus umask) so
+        # switching to an atomic write doesn't silently make bundles
+        # unreadable by other users/services that consumed them before.
+        umask = os.umask(0)
+        os.umask(umask)
+        os.fchmod(tmp_fd, 0o666 & ~umask)
+        with os.fdopen(tmp_fd, "wb") as output_file:
+            builder.build(output_file)
+    except BaseException:
+        os.remove(tmp_path)
+        raise
+    os.replace(tmp_path, path)
+
+    return path
+
+
+def export_to_litertlm(
+    model,
+    path,
+    backend_constraint=None,
+    prefill_seq_len=None,
+    cache_length=None,
+    sampler_config=None,
+    llm_model_type=None,
+    **kwargs,
+):
+    """Export a KerasHub CausalLM model to a LiteRT-LM bundle.
+
+    This exports the model with ``prefill`` and ``decode`` signatures
+    required by the LiteRT-LM executor, bundles the SentencePiece tokenizer,
+    and writes an ``LlmMetadata`` protobuf into the ``.litertlm`` artifact.
+
+    **Bucketing:** ``prefill_seq_len`` accepts either a single ``int`` or a
+    ``list[int]``. When a list is provided (e.g.
+    ``[32, 64, 128, 256, 512, 1024]``), the exporter traces one prefill
+    signature per bucket. At runtime the LiteRT-LM executor dispatches to
+    the smallest bucket that fits the actual prompt, avoiding wasted
+    computation on padding.
+
+    Args:
+        model: ``CausalLM``. The KerasHub model to export, with an attached
+            preprocessor and tokenizer.
+        path: str. Path to save the ``.litertlm`` file.
+        backend_constraint: Optional str. LiteRT-LM backend constraint, such
+            as ``"cpu"`` or ``"gpu"``. Defaults to ``None``.
+        prefill_seq_len: int or list[int]. Sequence length(s) used when
+            tracing the prefill signature(s). Each value must not exceed
+            ``cache_length``. Defaults to ``cache_length`` itself.
+        cache_length: Optional int. The KV-cache length (the model's maximum
+            context window) to trace the export with. If ``None``, this is
+            inferred from ``backbone.max_sequence_length`` when the backbone
+            defines it; most backbones (e.g. Gemma, Llama, Mistral, Qwen) do
+            not, in which case the exporter falls back to
+            ``preprocessor.sequence_length`` and emits a ``UserWarning``,
+            since that value is a tokenization default chosen for training or
+            preprocessing and is not necessarily the model's true maximum
+            context length. Pass this explicitly to avoid the warning and to
+            get a cache length independent of the preprocessor. Defaults to
+            ``None``.
+        sampler_config: Optional
+            ``keras_hub.src.utils.litertlm.model_specs.SamplerConfig``
+            instance. When given, the bundle's ``LlmMetadata.sampler_params``
+            field is populated from it (mirroring litert-torch export_hf's
+            conditional sampler semantics). The only named preset keras-hub
+            ships is ``GREEDY_SAMPLER_CONFIG`` (``top_k=1``), for forcing
+            deterministic greedy generation on-device. Defaults to ``None``,
+            which leaves ``sampler_params`` entirely unset so the runtime
+            chooses its own sampling policy.
+        llm_model_type: Optional str. Explicit ``LlmMetadata.llm_model_type``
+            override for presets that are architecturally identical to another
+            family and so cannot be auto-detected by class, config, or
+            tokenizer -- currently ``"function_gemma"`` (the
+            ``function_gemma_instruct_270m`` preset, which loads as a plain
+            ``Gemma3CausalLM`` but must export as the ``function_gemma`` model
+            type with its function-calling metadata, not as ``gemma3``).
+            Mirrors litert-torch's ``litert_lm_model_type_override``. Defaults
+            to ``None`` (auto-detect the family by class).
+        **kwargs: Additional kwargs forwarded to ``litert_torch`` signature
+            tracing.
+
+    Returns:
+        The output ``path``.
+
+    Raises:
+        ValueError: If the backend is not ``"torch"``, if ``path`` does not
+            end with ``.litertlm``, if the model lacks ``call_with_cache``,
+            if ``backend_constraint`` is invalid, if any
+            ``prefill_seq_len`` exceeds ``cache_length``, if
+            ``sampler_config`` is not a ``SamplerConfig`` instance, if
+            ``llm_model_type`` is not a recognized override, or if the model
+            is a non-exportable MTP draft model (``Gemma4AssistantCausalLM``).
+        ImportError: If ``litert-torch`` or ``litert-lm-builder`` are not
+            installed.
+    """
+    path = os.fspath(path)
+    # Resolve the model-family spec once, up front, and thread it through
+    # the pipeline; `llm_model_type` is an explicit override for presets
+    # indistinguishable by class. Non-exportable models fail fast here.
+    spec = resolve_export_spec(model, llm_model_type=llm_model_type)
+    spec.check_exportable(model)
+    if sampler_config is not None and not isinstance(
+        sampler_config, SamplerConfig
+    ):
+        raise ValueError(
+            "`sampler_config` must be a "
+            "`keras_hub.src.utils.litertlm.model_specs.SamplerConfig` "
+            "instance (e.g. `GREEDY_SAMPLER_CONFIG`). "
+            f"Received: sampler_config={sampler_config!r}."
+        )
+    tokenizer = _get_tokenizer(model)
+    # Use the normalized (lowercased) `backend_constraint` returned by
+    # `_validate_export_args`, not the original argument.
+    prefill_seq_lens, backend_constraint = _validate_export_args(
+        model,
+        path,
+        tokenizer,
+        backend_constraint,
+        prefill_seq_len,
+    )
+
+    # Defer torch-specific adapter imports until after the backend check so
+    # that a JAX/TF caller without torch gets the friendly backend error.
+    from keras_hub.src.utils.litertlm.adapter import KerasHubLiteRTAdapter
+    from keras_hub.src.utils.litertlm.adapter import _cpu_default_device_scope
+
+    # Fail fast on cache structures the adapter cannot build, before any
+    # cache-config derivation or tracing; the spec names the mismatch
+    # (`describe_unsupported_cache_structure`).
+    if spec.cache_structure != "single_stacked":
+        raise ValueError(
+            f"LiteRT-LM export does not support `{type(model).__name__}`: "
+            f"`{type(model.backbone).__name__}` "
+            f"{spec.describe_unsupported_cache_structure()}"
+        )
+
+    cache_cfg = spec.get_cache_config(model, cache_length=cache_length)
+    num_layers = cache_cfg["num_layers"]
+    cache_length = cache_cfg["cache_length"]
+    num_kv_heads = cache_cfg["num_kv_heads"]
+    head_dim = cache_cfg["head_dim"]
+    if cache_cfg["used_preprocessor_fallback"]:
+        warnings.warn(
+            "`cache_length` was not specified and "
+            f"`{type(model.backbone).__name__}` does not define "
+            "`max_sequence_length`. Falling back to "
+            f"`preprocessor.sequence_length` ({cache_length}) as the "
+            "KV-cache length. This is a tokenization default, not "
+            "necessarily the model's true maximum context length. Pass "
+            "`cache_length` explicitly to `export_to_litertlm` / "
+            '`model.export(..., format="litertlm")` to set it directly.',
+            stacklevel=2,
+        )
+
+    # Prefill seq_len values must be validated against the real cache length.
+    if prefill_seq_lens is None:
+        prefill_seq_lens = [cache_length]
+    for seq_len in prefill_seq_lens:
+        if seq_len > cache_length:
+            raise ValueError(
+                f"prefill_seq_len ({seq_len}) cannot exceed "
+                f"cache_length ({cache_length})."
+            )
+
+    dtype = _torch_dtype_from_model(model)
+
+    # Bundle all resolved per-export-run settings into one immutable plan.
+    plan = ExportPlan(
+        spec=spec,
+        num_layers=num_layers,
+        cache_length=cache_length,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        prefill_seq_lens=prefill_seq_lens,
+        dtype=dtype,
+        sampler_config=sampler_config,
+        model_type_overridden=llm_model_type is not None,
+    )
+
+    with _cpu_default_device_scope():
+        prefill_inputs_map = _build_prefill_inputs(plan)
+
+        decode_inputs = _build_sample_inputs(
+            batch_size=1,
+            seq_len=1,
+            num_layers=plan.num_layers,
+            cache_length=plan.cache_length,
+            num_kv_heads=plan.num_kv_heads,
+            head_dim=plan.head_dim,
+            dtype=plan.dtype,
+            spec=plan.spec,
+        )
+
+        adapter = KerasHubLiteRTAdapter(
+            model,
+            plan.num_layers,
+            plan.cache_length,
+            export_spec=spec,
+        )
+        adapter.eval()
+
+        prefill_adapter = _PrefillAdapter(adapter).eval()
+        decode_adapter = _DecodeAdapter(adapter).eval()
+
+        # The JAX bridge defaults to TPU when one is visible; force CPU so
+        # export does not contend with other processes using the TPU.
+        with (
+            _preserve_jax_config_state("jax_enable_x64"),
+            _preserve_jax_config_state("jax_platforms", "cpu"),
+        ):
+            import litert_torch
+
+            # The import above enables ``jax_enable_x64`` only on first
+            # import; the JAX bridge requires x64 for consistent int64
+            # dtypes, so pin it explicitly for the conversion.
+            try:
+                import jax
+
+                jax.config.update("jax_enable_x64", True)
+            except ImportError:
+                pass
+
+            edge_model = _trace_and_convert(
+                litert_torch,
+                prefill_adapter,
+                decode_adapter,
+                prefill_inputs_map,
+                decode_inputs,
+                plan,
+                **kwargs,
+            )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _assemble_bundle(
+            path=path,
+            temp_dir=temp_dir,
+            tokenizer=tokenizer,
+            backend_constraint=backend_constraint,
+            edge_model=edge_model,
+            plan=plan,
+        )
+
+    return path
+
+
+def _build_sample_inputs(
+    batch_size,
+    seq_len,
+    num_layers,
+    cache_length,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    spec,
+):
+    """Create concrete sample tensors for one signature.
+
+    The per-layer KV-cache sample shape is owned by the model family's
+    spec (``spec.get_kv_cache_sample_shape``; see ``cache_layout`` on
+    ``LiteRTLMExportSpec``).
+    """
+    device = "cpu"
+    tokens = torch.zeros(
+        (batch_size, seq_len), dtype=torch.int32, device=device
+    )
+    input_pos = torch.arange(seq_len, dtype=torch.int32, device=device)
+    if seq_len == 1:
+        input_pos = torch.zeros((1,), dtype=torch.int32, device=device)
+    kv_cache = {}
+    shape = spec.get_kv_cache_sample_shape(
+        batch_size, cache_length, num_kv_heads, head_dim
+    )
+    for i in range(num_layers):
+        kv_cache[f"kv_cache_k_{i}"] = torch.zeros(
+            shape, dtype=dtype, device=device
+        )
+        kv_cache[f"kv_cache_v_{i}"] = torch.zeros(
+            shape, dtype=dtype, device=device
+        )
+
+    sample = {
+        "tokens": tokens,
+        "input_pos": input_pos,
+    }
+    sample.update(kv_cache)
+    return sample
+
+
+def _get_tokenizer(model):
+    preprocessor = getattr(model, "preprocessor", None)
+    if preprocessor is None:
+        raise ValueError(
+            "LiteRT-LM export requires an attached preprocessor with a "
+            "tokenizer."
+        )
+    tokenizer = getattr(preprocessor, "tokenizer", None)
+    if tokenizer is None:
+        raise ValueError(
+            "LiteRT-LM export requires an attached tokenizer on the "
+            "preprocessor."
+        )
+    return tokenizer
+
+
+def _is_sentencepiece_tokenizer(tokenizer):
+    """Return ``True`` if *tokenizer* is SentencePiece-compatible."""
+    if isinstance(tokenizer, SentencePieceTokenizer):
+        return True
+    file_assets = set(getattr(tokenizer, "file_assets", []) or [])
+    return "vocabulary.spm" in file_assets
+
+
+def _materialize_sentencepiece_tokenizer(tokenizer, temp_dir):
+    preset_dir = os.path.join(temp_dir, "tokenizer_preset")
+    tokenizer.save_to_preset(preset_dir)
+    tokenizer_path = os.path.join(
+        preset_dir, TOKENIZER_ASSET_DIR, "vocabulary.spm"
+    )
+    if not os.path.exists(tokenizer_path):
+        raise ValueError(
+            "Failed to materialize the SentencePiece tokenizer asset at "
+            f"{tokenizer_path}."
+        )
+    return tokenizer_path
+
+
+def _build_llm_metadata(
+    spec,
+    tokenizer,
+    max_num_tokens,
+    path,
+    sampler_config=None,
+    model_type_overridden=False,
+):
+    """Serialize an ``LlmMetadata`` protobuf to *path*."""
+    # The protobuf lives under an internal-looking subpackage of
+    # ``litert-lm-builder``; import defensively and surface a clear error
+    # if the internal layout changes.
+    try:
+        from litert_lm_builder.runtime.proto import llm_metadata_pb2
+    except ImportError as e:
+        raise ImportError(
+            "LiteRT-LM export requires the metadata protobuf from "
+            "`litert-lm-builder`. The internal module layout appears to have "
+            "changed. Please verify your `litert-lm-builder` installation."
+        ) from e
+
+    meta = llm_metadata_pb2.LlmMetadata()
+
+    start_id = getattr(tokenizer, "start_token_id", None)
+    if start_id is not None:
+        meta.start_token.token_ids.ids.append(int(start_id))
+
+    # The primary EOS (used for packing/training) is always a stop token.
+    stop_token_ids = []
+    end_id = getattr(tokenizer, "end_token_id", None)
+    if end_id is not None:
+        stop_token_ids.append(int(end_id))
+
+    # Add each family's extra chat-turn stop token (e.g. Gemma's
+    # `<end_of_turn>`; see `LiteRTLMExportSpec.get_chat_stop_token_ids`),
+    # de-duplicated against `end_token_id`.
+    for extra_id in spec.get_chat_stop_token_ids(tokenizer):
+        extra_id = int(extra_id)
+        if extra_id not in stop_token_ids:
+            stop_token_ids.append(extra_id)
+
+    for stop_id in stop_token_ids:
+        meta.stop_tokens.add().token_ids.ids.append(stop_id)
+
+    meta.max_num_tokens = int(max_num_tokens)
+
+    getattr(meta.llm_model_type, spec.model_type).SetInParent()
+
+    # Populate function-calling fields (only `FunctionGemmaSpec` overrides
+    # the base no-op). Skipped on an explicit `llm_model_type` override:
+    # litert-torch also skips its model-specific metadata builder then.
+    if not model_type_overridden:
+        spec.populate_function_gemma_metadata(meta)
+
+    # Sampler defaults are written only when the caller passes a
+    # `sampler_config` (mirroring litert-torch's conditional
+    # `sampler_params`); otherwise the runtime picks its own policy.
+    if sampler_config is not None:
+        try:
+            from litert_lm_builder.runtime.proto import sampler_params_pb2
+        except ImportError as e:
+            raise ImportError(
+                "LiteRT-LM export requires the sampler protobuf from "
+                "`litert-lm-builder`. The internal module layout appears to "
+                "have changed. Please verify your `litert-lm-builder` "
+                "installation."
+            ) from e
+
+        sp = meta.sampler_params
+        top_k = sampler_config.top_k
+        if top_k is not None:
+            sp.k = top_k
+        if sampler_config.top_p is not None:
+            sp.p = sampler_config.top_p
+        if sampler_config.temperature is not None:
+            sp.temperature = sampler_config.temperature
+        if sampler_config.seed is not None:
+            sp.seed = sampler_config.seed
+
+        SamplerParameters = sampler_params_pb2.SamplerParameters
+        # `GREEDY` (type 3) is not implemented by litertlm-android 0.13.1 or
+        # the host Python `litert_lm` 0.13.1 runtime. Emit `TOP_K` with k=1
+        # instead, which is functionally equivalent and is implemented.
+        if top_k is not None:
+            sp.type = SamplerParameters.TOP_K
+        else:
+            sp.type = SamplerParameters.TOP_P
+
+    with open(path, "wb") as f:
+        f.write(meta.SerializeToString())
+
+
+def _torch_dtype_from_model(model):
+    """Return a ``torch.dtype`` matching the model's compute dtype."""
+    from keras.src.backend.torch import core as torch_core
+
+    compute_dtype = getattr(model, "compute_dtype", None)
+    if compute_dtype is None:
+        compute_dtype = getattr(model.backbone, "compute_dtype", "float32")
+    # Unwrap DTypePolicy first: `to_torch_dtype` only accepts hashable dtypes.
+    if hasattr(compute_dtype, "name"):
+        compute_dtype = compute_dtype.name
+    if not isinstance(compute_dtype, (str, torch.dtype)):
+        raise ValueError(
+            "The model's `compute_dtype` must be a dtype string, a "
+            "`torch.dtype`, or a Keras `DTypePolicy` for LiteRT-LM export. "
+            f"Received: compute_dtype={compute_dtype!r}"
+        )
+    try:
+        torch_dtype = torch_core.to_torch_dtype(compute_dtype)
+    except ValueError as e:
+        raise ValueError(
+            "The model's `compute_dtype` must map to a PyTorch dtype for "
+            f"LiteRT-LM export. Received: compute_dtype={compute_dtype!r}"
+        ) from e
+    if torch_dtype is torch.bfloat16:
+        warnings.warn(
+            "Exporting with `compute_dtype=bfloat16`. BF16 LiteRT-LM export "
+            "is untested; numeric parity with the Keras model and runtime "
+            "support are not guaranteed. Consider using float32 unless you "
+            "have independently verified BF16 export for this model.",
+            stacklevel=2,
+        )
+    return torch_dtype
+
+
+def _import_litert_lm_builder():
+    try:
+        import litert_lm_builder
+    except ImportError as e:
+        raise ImportError(
+            "LiteRT-LM export requires `litert-lm-builder`. "
+            "Install it with: pip install litert-lm-builder"
+        ) from e
+    return litert_lm_builder

--- a/keras_hub/src/utils/litertlm/export.py
+++ b/keras_hub/src/utils/litertlm/export.py
@@ -3,6 +3,7 @@
 import contextlib
 import dataclasses
 import importlib.util
+import json
 import os
 import tempfile
 import warnings
@@ -14,8 +15,12 @@ try:
 except ImportError:
     torch = None
 
+from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
 from keras_hub.src.tokenizers.sentence_piece_tokenizer import (
     SentencePieceTokenizer,
+)
+from keras_hub.src.utils.litertlm.hf_tokenizer_converter import (
+    materialize_hf_tokenizer_json,
 )
 from keras_hub.src.utils.litertlm.model_specs import SamplerConfig
 from keras_hub.src.utils.litertlm.model_specs import resolve_export_spec
@@ -80,11 +85,108 @@ class _DecodeAdapter(_AdapterBase):
         return self.base.forward_decode(*args, **kwargs)
 
 
+# A cheap sanity check on `hf_tokenizer_path` compatibility, not exact
+# validation: only a large absolute difference AND a >=5x ratio together
+# flag a tokenizer from an entirely different model/family.
+_HF_TOKENIZER_VOCAB_MISMATCH_ABS_THRESHOLD = 300
+_HF_TOKENIZER_VOCAB_MISMATCH_RATIO_THRESHOLD = 5.0
+
+
+def _model_embedding_vocab_size(model):
+    """Return the model's embedding vocabulary size, or ``None`` if unknown.
+
+    Prefers ``backbone.vocabulary_size`` (the constructor argument most
+    backbones store directly, e.g. ``GemmaBackbone``/``LlamaBackbone``/
+    ``GPT2Backbone``); falls back to ``backbone.token_embedding.input_dim``
+    (the actual embedding table size) for backbones that do not expose
+    ``vocabulary_size`` directly.
+    """
+    backbone = getattr(model, "backbone", None)
+    vocab_size = getattr(backbone, "vocabulary_size", None)
+    if vocab_size is not None:
+        return int(vocab_size)
+    token_embedding = getattr(backbone, "token_embedding", None)
+    input_dim = getattr(token_embedding, "input_dim", None)
+    if input_dim is not None:
+        return int(input_dim)
+    return None
+
+
+def _hf_tokenizer_vocab_size(hf_tokenizer_path):
+    """Return the vocab size implied by a HuggingFace ``tokenizer.json``.
+
+    Reads the file directly as JSON (``tokenizer.json`` is plain JSON; this
+    avoids a hard dependency on the ``tokenizers`` library just to sanity
+    check a vocab size) and returns ``max_token_id + 1`` across both the
+    base ``model.vocab`` mapping and any ``added_tokens`` entries (special
+    tokens are often listed separately from the base vocab) -- matching how
+    large the embedding table must be to cover every id the tokenizer can
+    produce. Returns ``None`` if the file cannot be parsed as the expected
+    ``tokenizer.json`` structure.
+    """
+    try:
+        with open(hf_tokenizer_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    model_vocab = (data.get("model") or {}).get("vocab") or {}
+    try:
+        max_id = max(model_vocab.values(), default=-1)
+    except (TypeError, ValueError):
+        return None
+    for token in data.get("added_tokens") or []:
+        token_id = token.get("id")
+        if isinstance(token_id, int):
+            max_id = max(max_id, token_id)
+    if max_id < 0:
+        return None
+    return max_id + 1
+
+
+def _check_hf_tokenizer_vocab_compatible(hf_tokenizer_path, model):
+    """Raise ``ValueError`` if the HF tokenizer's vocab looks incompatible.
+
+    This is a cheap sanity check (see the module-level threshold constants
+    above), not exact validation -- it exists to catch the case of bundling
+    a tokenizer from an entirely different model/family, not to enforce
+    that the tokenizer and model agree token-for-token.
+    """
+    hf_vocab_size = _hf_tokenizer_vocab_size(hf_tokenizer_path)
+    model_vocab_size = _model_embedding_vocab_size(model)
+    if hf_vocab_size is None or not model_vocab_size:
+        # Could not determine one of the two sizes; skip rather than risk a
+        # false positive from an unusual tokenizer.json structure or backbone.
+        return
+    diff = abs(hf_vocab_size - model_vocab_size)
+    ratio = hf_vocab_size / model_vocab_size
+    is_grossly_mismatched = (
+        diff > _HF_TOKENIZER_VOCAB_MISMATCH_ABS_THRESHOLD
+        and (
+            ratio >= _HF_TOKENIZER_VOCAB_MISMATCH_RATIO_THRESHOLD
+            or ratio <= 1 / _HF_TOKENIZER_VOCAB_MISMATCH_RATIO_THRESHOLD
+        )
+    )
+    if is_grossly_mismatched:
+        raise ValueError(
+            "`hf_tokenizer_path` appears incompatible with the model: the "
+            f"tokenizer implies a vocabulary of {hf_vocab_size} tokens "
+            f"(highest token id + 1 across `model.vocab` and "
+            f"`added_tokens` in {hf_tokenizer_path!r}), but the model's "
+            f"embedding table is sized for {model_vocab_size} tokens "
+            f"(`{type(model.backbone).__name__}`). This looks like a "
+            "tokenizer from a different model/family rather than a small "
+            "reserved-token discrepancy -- pass the tokenizer that matches "
+            "this model, or omit `hf_tokenizer_path` to use the model's own "
+            "tokenizer."
+        )
+
+
 def _validate_export_args(
     model,
     path,
     tokenizer,
     backend_constraint,
+    hf_tokenizer_path,
     prefill_seq_len,
 ):
     """Fail fast on invalid export arguments.
@@ -121,9 +223,26 @@ def _validate_export_args(
             )
         backend_constraint = backend_constraint.lower()
 
-    if not _is_sentencepiece_tokenizer(tokenizer):
+    if hf_tokenizer_path is not None:
+        hf_tokenizer_path = os.fspath(hf_tokenizer_path)
+        if not os.path.isfile(hf_tokenizer_path):
+            raise ValueError(
+                "`hf_tokenizer_path` must point to an existing file. "
+                f"Received: {hf_tokenizer_path!r}"
+            )
+        if not hf_tokenizer_path.endswith(".json"):
+            raise ValueError(
+                "`hf_tokenizer_path` must point to a `tokenizer.json` file. "
+                f"Received: {hf_tokenizer_path!r}"
+            )
+        _check_hf_tokenizer_vocab_compatible(hf_tokenizer_path, model)
+    # Any BytePairTokenizer subclass can be converted to HF tokenizer.json.
+    elif not _is_sentencepiece_tokenizer(tokenizer) and not isinstance(
+        tokenizer, BytePairTokenizer
+    ):
         raise ValueError(
-            "LiteRT-LM export supports SentencePiece tokenizers. Received: "
+            "LiteRT-LM export supports SentencePiece tokenizers and any "
+            "BytePairTokenizer subclass. Received: "
             f"{type(tokenizer).__module__}.{type(tokenizer).__name__}."
         )
 
@@ -295,12 +414,23 @@ def _assemble_bundle(
     backend_constraint,
     edge_model,
     plan,
+    hf_tokenizer_path,
 ):
     """Write TFLite files, bundle the tokenizer, and assemble ``.litertlm``."""
     prefill_tflite_path = os.path.join(temp_dir, "model.tflite")
     edge_model.export(prefill_tflite_path)
 
-    tokenizer_path = _materialize_sentencepiece_tokenizer(tokenizer, temp_dir)
+    if hf_tokenizer_path is not None:
+        tokenizer_path = hf_tokenizer_path
+        use_hf_tokenizer = True
+    elif _is_sentencepiece_tokenizer(tokenizer):
+        tokenizer_path = _materialize_sentencepiece_tokenizer(
+            tokenizer, temp_dir
+        )
+        use_hf_tokenizer = False
+    else:
+        tokenizer_path = materialize_hf_tokenizer_json(tokenizer, temp_dir)
+        use_hf_tokenizer = True
 
     meta_path = os.path.join(temp_dir, "llm_metadata.pb")
     _build_llm_metadata(
@@ -326,7 +456,10 @@ def _assemble_bundle(
         litert_lm_builder.TfLiteModelType.PREFILL_DECODE,
         backend_constraint=backend_constraint,
     )
-    builder.add_sentencepiece_tokenizer(tokenizer_path)
+    if use_hf_tokenizer:
+        builder.add_hf_tokenizer(tokenizer_path)
+    else:
+        builder.add_sentencepiece_tokenizer(tokenizer_path)
     builder.add_llm_metadata(meta_path)
 
     # Write to a temp file in the same directory as `path` and atomically
@@ -362,6 +495,7 @@ def export_to_litertlm(
     backend_constraint=None,
     prefill_seq_len=None,
     cache_length=None,
+    hf_tokenizer_path=None,
     sampler_config=None,
     llm_model_type=None,
     **kwargs,
@@ -369,8 +503,10 @@ def export_to_litertlm(
     """Export a KerasHub CausalLM model to a LiteRT-LM bundle.
 
     This exports the model with ``prefill`` and ``decode`` signatures
-    required by the LiteRT-LM executor, bundles the SentencePiece tokenizer,
-    and writes an ``LlmMetadata`` protobuf into the ``.litertlm`` artifact.
+    required by the LiteRT-LM executor, bundles the tokenizer (SentencePiece
+    ``.spm`` for SentencePiece models, or a HuggingFace ``tokenizer.json``
+    produced by auto-converting any ``BytePairTokenizer`` subclass), and
+    writes an ``LlmMetadata`` protobuf into the ``.litertlm`` artifact.
 
     **Bucketing:** ``prefill_seq_len`` accepts either a single ``int`` or a
     ``list[int]``. When a list is provided (e.g.
@@ -399,6 +535,14 @@ def export_to_litertlm(
             context length. Pass this explicitly to avoid the warning and to
             get a cache length independent of the preprocessor. Defaults to
             ``None``.
+        hf_tokenizer_path: Optional str. Path to a HuggingFace
+            ``tokenizer.json`` file to bundle instead of the model's native
+            tokenizer. Use this for BytePair / HuggingFace tokenizers that
+            cannot be materialized as a SentencePiece ``.spm`` file. When
+            provided, the native tokenizer validation is skipped. If ``None``,
+            SentencePiece tokenizers are bundled as ``.spm`` and any
+            ``BytePairTokenizer`` subclass is automatically converted to
+            ``tokenizer.json``. Defaults to ``None``.
         sampler_config: Optional
             ``keras_hub.src.utils.litertlm.model_specs.SamplerConfig``
             instance. When given, the bundle's ``LlmMetadata.sampler_params``
@@ -457,6 +601,7 @@ def export_to_litertlm(
         path,
         tokenizer,
         backend_constraint,
+        hf_tokenizer_path,
         prefill_seq_len,
     )
 
@@ -579,6 +724,7 @@ def export_to_litertlm(
             backend_constraint=backend_constraint,
             edge_model=edge_model,
             plan=plan,
+            hf_tokenizer_path=hf_tokenizer_path,
         )
 
     return path

--- a/keras_hub/src/utils/litertlm/export_test.py
+++ b/keras_hub/src/utils/litertlm/export_test.py
@@ -1,0 +1,465 @@
+import importlib.util
+import os
+import types
+import unittest
+import unittest.mock
+
+import keras
+import numpy as np
+import torch
+
+from keras_hub.src.models.gemma.gemma_backbone import GemmaBackbone
+from keras_hub.src.models.gemma.gemma_causal_lm import GemmaCausalLM
+from keras_hub.src.models.gemma.gemma_causal_lm_preprocessor import (
+    GemmaCausalLMPreprocessor,
+)
+from keras_hub.src.models.gemma.gemma_tokenizer import GemmaTokenizer
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.litertlm import export
+from keras_hub.src.utils.litertlm.adapter import _cpu_default_device_scope
+from keras_hub.src.utils.litertlm.model_specs import GREEDY_SAMPLER_CONFIG
+from keras_hub.src.utils.litertlm.model_specs import SamplerConfig
+
+_LITERT_TORCH_AVAILABLE = importlib.util.find_spec("litert_torch") is not None
+_LITERT_LM_BUILDER_AVAILABLE = (
+    importlib.util.find_spec("litert_lm_builder") is not None
+)
+
+
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "LiteRT-LM export requires the PyTorch backend.",
+)
+@unittest.skipIf(
+    not _LITERT_TORCH_AVAILABLE,
+    "LiteRT-LM export requires `litert-torch`. "
+    "Install it with: pip install litert-torch",
+)
+@unittest.skipIf(
+    not _LITERT_LM_BUILDER_AVAILABLE,
+    "LiteRT-LM export requires `litert-lm-builder`. "
+    "Install it with: pip install litert-lm-builder",
+)
+class TestLiteRTLmExport(TestCase):
+    def setUp(self):
+        super().setUp()
+        proto = os.path.join(self.get_test_data_dir(), "gemma_test_vocab.spm")
+        self.tokenizer = GemmaTokenizer(proto=proto)
+        self.backbone = GemmaBackbone(
+            vocabulary_size=self.tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=32,
+            head_dim=8,
+            intermediate_dim=64,
+            max_sequence_length=8,
+        )
+        self.preprocessor = GemmaCausalLMPreprocessor(
+            tokenizer=self.tokenizer, sequence_length=8
+        )
+        self.model = GemmaCausalLM(
+            backbone=self.backbone, preprocessor=self.preprocessor
+        )
+        self._set_random_weights(self.model)
+
+    def _set_random_weights(self, model, seed=42):
+        rng = np.random.default_rng(seed)
+        weights = model.get_weights()
+        for i in range(len(weights)):
+            weights[i] = rng.random(weights[i].shape).astype(weights[i].dtype)
+        model.set_weights(weights)
+
+    def _assert_kv_cache_close(
+        self, keras_cache, tflite_out, atol, rtol, num_layers
+    ):
+        """Per-layer K/V parity between a Keras cache and TFLite outputs.
+
+        ``num_layers`` is supplied by the caller rather than read off
+        ``keras_cache`` so that a cache built with the wrong layer axis cannot
+        turn the comparison loop into a no-op.
+        """
+        self.assertEqual(keras_cache.shape[1], num_layers)
+        for i in range(num_layers):
+            self.assertAllClose(
+                keras_cache[:, i, 0, ...],
+                tflite_out[f"kv_cache_k_{i}"],
+                atol=atol,
+                rtol=rtol,
+            )
+            self.assertAllClose(
+                keras_cache[:, i, 1, ...],
+                tflite_out[f"kv_cache_v_{i}"],
+                atol=atol,
+                rtol=rtol,
+            )
+
+    def _call_with_cache_no_grad(
+        self, model, tokens, cache, start_index, **kwargs
+    ):
+        """Eager `call_with_cache` under `no_grad`; numpy in, numpy out."""
+        with torch.no_grad():
+            logits, _, cache = model.call_with_cache(
+                torch.from_numpy(tokens),
+                torch.from_numpy(cache),
+                start_index,
+                **kwargs,
+            )
+        return logits.detach().cpu().numpy(), cache.detach().cpu().numpy()
+
+    def test_export_tiny_gemma(self):
+        path = os.path.join(self.get_temp_dir(), "test.litertlm")
+        self.model.export(path, format="litertlm", prefill_seq_len=8)
+
+        self.assertTrue(os.path.exists(path))
+        self.assertGreater(os.path.getsize(path), 0)
+
+    def test_export_with_bucketing(self):
+        """Verify that multiple prefill_seq_len creates multiple signatures."""
+        path = os.path.join(self.get_temp_dir(), "test_buckets.litertlm")
+        self.model.export(
+            path,
+            format="litertlm",
+            prefill_seq_len=[4, 8],
+        )
+
+        self.assertTrue(os.path.exists(path))
+
+        # Extract TFLite from all bucketed interpreters and verify signatures.
+        interpreters = self._extract_litertlm_tflite_interpreters(path)
+        all_signatures = {}
+        for interpreter in interpreters:
+            all_signatures.update(interpreter._get_full_signature_list())
+        signatures = list(all_signatures.keys())
+
+        self.assertIn("prefill_4", signatures)
+        self.assertIn("prefill_8", signatures)
+        self.assertIn("decode", signatures)
+
+    def test_export_outputs_match_keras(self):
+        """Verify that exported TFLite outputs match Keras eager outputs."""
+        # Export
+        litertlm_path = os.path.join(self.get_temp_dir(), "verify.litertlm")
+        self.model.export(litertlm_path, format="litertlm", prefill_seq_len=8)
+
+        # Extract TFLite
+        interpreter = self._extract_litertlm_tflite_interpreters(litertlm_path)[
+            0
+        ]
+
+        B, T, L = 1, 8, 2
+        H = self.backbone.num_key_value_heads
+        D = self.backbone.head_dim
+        tokens_np = (
+            np.arange(1, 1 + T, dtype=np.int32).reshape(B, T)
+            % self.tokenizer.vocabulary_size()
+        )
+        cache_keras = np.zeros((B, L, 2, T, H, D), dtype=np.float32)
+
+        # Keras prefill
+        keras_logits, keras_cache = self._call_with_cache_no_grad(
+            self.model, tokens_np, cache_keras, 0
+        )
+
+        # TFLite prefill
+        prefill_runner = interpreter.get_signature_runner("prefill")
+        prefill_inputs = {
+            "tokens": tokens_np,
+            "input_pos": np.arange(T, dtype=np.int32),
+        }
+        for i in range(L):
+            prefill_inputs[f"kv_cache_k_{i}"] = cache_keras[:, i, 0, ...]
+            prefill_inputs[f"kv_cache_v_{i}"] = cache_keras[:, i, 1, ...]
+        tflite_prefill_out = prefill_runner(**prefill_inputs)
+
+        # Prefill returns only KV caches (no logits) per LiteRT-LM spec.
+        # Logits are verified via the decode step below.
+
+        # Compare prefill KV caches
+        self._assert_kv_cache_close(
+            keras_cache, tflite_prefill_out, atol=1e-4, rtol=1e-4, num_layers=L
+        )
+
+        # Keras decode at position 3
+        decode_pos = 3
+        decode_token = tokens_np[:, decode_pos : decode_pos + 1].copy()
+        keras_logits_dec, keras_cache_dec = self._call_with_cache_no_grad(
+            self.model, decode_token, keras_cache, decode_pos
+        )
+
+        # TFLite decode
+        decode_runner = interpreter.get_signature_runner("decode")
+        decode_inputs = {
+            "tokens": decode_token,
+            "input_pos": np.array([decode_pos], dtype=np.int32),
+        }
+        for i in range(L):
+            decode_inputs[f"kv_cache_k_{i}"] = tflite_prefill_out[
+                f"kv_cache_k_{i}"
+            ]
+            decode_inputs[f"kv_cache_v_{i}"] = tflite_prefill_out[
+                f"kv_cache_v_{i}"
+            ]
+        tflite_dec_out = decode_runner(**decode_inputs)
+
+        # Compare decode logits
+        self.assertAllClose(
+            keras_logits_dec,
+            tflite_dec_out["logits"],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+        # Compare decode KV caches
+        self._assert_kv_cache_close(
+            keras_cache_dec, tflite_dec_out, atol=1e-4, rtol=1e-4, num_layers=L
+        )
+
+    def test_export_with_backend_constraint(self):
+        """Verify export with valid backend_constraints succeeds."""
+        for backend in ("cpu", "gpu", "npu", "gpu_artisan"):
+            with self.subTest(backend=backend):
+                path = os.path.join(
+                    self.get_temp_dir(), f"test_backend_{backend}.litertlm"
+                )
+                self.model.export(
+                    path,
+                    format="litertlm",
+                    prefill_seq_len=8,
+                    backend_constraint=backend,
+                )
+                self.assertTrue(os.path.exists(path))
+
+    def test_export_lowercases_backend_constraint(self):
+        """Verify a mixed-case backend_constraint reaches the builder call
+        already lowercased.
+
+        `_validate_export_args` lowercases `backend_constraint` to validate
+        it, but must also return the normalized value so
+        `export_to_litertlm` threads *that* value through to
+        `_assemble_bundle` / `builder.add_tflite_model`, rather than the
+        original (possibly mixed-case) argument. `litert_lm_builder` itself
+        happens to lowercase `backend_constraint` again before persisting it
+        as metadata, so a real end-to-end bundle read would pass even with
+        the bug (the original argument would still show up lowercased in
+        the file); this spies on the actual call to
+        `LitertLmFileBuilder.add_tflite_model` to check what our own code
+        passes, independent of that downstream normalization.
+        """
+        import litert_lm_builder
+
+        path = os.path.join(self.get_temp_dir(), "test_backend_case.litertlm")
+        original_add_tflite_model = (
+            litert_lm_builder.LitertLmFileBuilder.add_tflite_model
+        )
+        captured_backend_constraints = []
+
+        def _spy_add_tflite_model(self, *args, **kwargs):
+            captured_backend_constraints.append(
+                kwargs.get("backend_constraint")
+            )
+            return original_add_tflite_model(self, *args, **kwargs)
+
+        with unittest.mock.patch.object(
+            litert_lm_builder.LitertLmFileBuilder,
+            "add_tflite_model",
+            _spy_add_tflite_model,
+        ):
+            self.model.export(
+                path,
+                format="litertlm",
+                prefill_seq_len=8,
+                backend_constraint="GPU",
+            )
+
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(captured_backend_constraints)
+        for value in captured_backend_constraints:
+            self.assertEqual(value, "gpu")
+
+    def test_export_invalid_backend_constraint(self):
+        """Verify invalid backend_constraint raises ValueError."""
+        path = os.path.join(
+            self.get_temp_dir(), "test_invalid_backend.litertlm"
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid backend_constraint",
+        ):
+            self.model.export(
+                path,
+                format="litertlm",
+                prefill_seq_len=8,
+                backend_constraint="invalid_backend",
+            )
+
+    def test_export_model_type_metadata(self):
+        """Verify the .litertlm metadata contains the correct model type."""
+        path = os.path.join(self.get_temp_dir(), "test_metadata.litertlm")
+        self.model.export(path, format="litertlm", prefill_seq_len=8)
+
+        llm_metadata = self._parse_litertlm_llm_metadata(path)
+        self.assertIsNotNone(llm_metadata)
+        model_type_msg = llm_metadata.llm_model_type
+        actual_type = model_type_msg.WhichOneof("model_type")
+        self.assertEqual(actual_type, "generic_model")
+
+    def test_export_omits_sampler_params_by_default(self):
+        """No `sampler_config` -> `sampler_params` absent from metadata.
+
+        Mirrors litert-torch export_hf: the field is written only when a
+        caller explicitly requests it. keras-hub ships no default sampler.
+        """
+        path = os.path.join(self.get_temp_dir(), "no_sampler.litertlm")
+        self.model.export(path, format="litertlm", prefill_seq_len=8)
+
+        llm_metadata = self._parse_litertlm_llm_metadata(path)
+        self.assertIsNotNone(llm_metadata)
+        self.assertFalse(
+            llm_metadata.HasField("sampler_params"),
+            "sampler_params must be omitted when no sampler_config is passed.",
+        )
+
+    def test_export_greedy_sampler_config_roundtrip(self):
+        """`GREEDY_SAMPLER_CONFIG` -> TOP_K type + k=1 in re-read metadata.
+
+        We intentionally emit TOP_K instead of GREEDY because litertlm-android
+        0.13.1 and host litert_lm 0.13.1 do not implement sampler type 3
+        (GREEDY). TOP_K with k=1 is functionally equivalent.
+        """
+        from litert_lm_builder.runtime.proto import sampler_params_pb2
+
+        path = os.path.join(self.get_temp_dir(), "greedy_sampler.litertlm")
+        self.model.export(
+            path,
+            format="litertlm",
+            prefill_seq_len=8,
+            sampler_config=GREEDY_SAMPLER_CONFIG,
+        )
+
+        llm_metadata = self._parse_litertlm_llm_metadata(path)
+        self.assertIsNotNone(llm_metadata)
+        self.assertTrue(llm_metadata.HasField("sampler_params"))
+        sp = llm_metadata.sampler_params
+        self.assertEqual(sp.type, sampler_params_pb2.SamplerParameters.TOP_K)
+        self.assertEqual(sp.k, 1)
+
+    def test_sampler_config_validation_and_export_rejects_bad_type(self):
+        """Invalid `SamplerConfig` values and non-config types raise."""
+        # Dataclass-level validation: top_k < 1 is invalid.
+        with self.assertRaises(ValueError):
+            SamplerConfig(top_k=0)
+        # All-None is invalid (would produce an empty sampler_params).
+        with self.assertRaises(ValueError):
+            SamplerConfig()
+        # top_p out of range.
+        with self.assertRaises(ValueError):
+            SamplerConfig(top_p=1.5)
+
+        # Exporter-level guard: a non-SamplerConfig value is rejected before
+        # any tracing/bundling work.
+        path = os.path.join(self.get_temp_dir(), "bad_sampler.litertlm")
+        with self.assertRaises(ValueError):
+            self.model.export(
+                path,
+                format="litertlm",
+                prefill_seq_len=8,
+                sampler_config={"top_k": 1},  # dict, not a SamplerConfig
+            )
+
+    def test_text_only_model_has_no_vision_inputs(self):
+        """Verify text-only models do not expose vision inputs in signatures."""
+        path = os.path.join(self.get_temp_dir(), "test_text_only.litertlm")
+        self.model.export(path, format="litertlm", prefill_seq_len=8)
+
+        interpreters = self._extract_litertlm_tflite_interpreters(path)
+        interpreter = interpreters[0]
+        prefill_sig = interpreter._get_full_signature_list()["prefill"]
+        prefill_inputs = set(prefill_sig["inputs"])
+        self.assertNotIn("images", prefill_inputs)
+        self.assertNotIn("vision_indices", prefill_inputs)
+        self.assertNotIn("vision_mask", prefill_inputs)
+
+
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "LiteRT-LM export is only supported with the PyTorch backend.",
+)
+class TestLiteRTLmAdapterHelpers(TestCase):
+    def test_cpu_default_device_scope_restores_device(self):
+        """_cpu_default_device_scope restores the original default device."""
+        original = torch.get_default_device()
+        with _cpu_default_device_scope():
+            self.assertEqual(torch.get_default_device(), torch.device("cpu"))
+        self.assertEqual(torch.get_default_device(), original)
+
+
+@unittest.skipUnless(
+    keras.config.backend() != "torch",
+    "This test only runs on non-PyTorch backends.",
+)
+class TestLiteRTLmExportBackendChecks(TestCase):
+    def test_export_rejects_non_torch_backend(self):
+        """The exporter raises a clear error on non-PyTorch backends."""
+        if keras.config.backend() == "torch":
+            self.skipTest("This test only runs on non-PyTorch backends.")
+
+        proto = os.path.join(self.get_test_data_dir(), "gemma_test_vocab.spm")
+        tokenizer = GemmaTokenizer(proto=proto)
+        backbone = GemmaBackbone(
+            vocabulary_size=tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=32,
+            head_dim=8,
+            intermediate_dim=64,
+            max_sequence_length=8,
+        )
+        preprocessor = GemmaCausalLMPreprocessor(
+            tokenizer=tokenizer, sequence_length=8
+        )
+        model = GemmaCausalLM(backbone=backbone, preprocessor=preprocessor)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "LiteRT-LM export is only supported with the PyTorch backend",
+        ):
+            model.export(
+                os.path.join(self.get_temp_dir(), "test.litertlm"),
+                format="litertlm",
+                prefill_seq_len=8,
+            )
+
+
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "LiteRT-LM export is only supported with the PyTorch backend.",
+)
+class TestTorchDtypeFromModel(TestCase):
+    def test_resolves_dtype_string(self):
+        """A dtype string resolves to the matching `torch.dtype`."""
+        model = types.SimpleNamespace(compute_dtype="float16")
+        self.assertIs(export._torch_dtype_from_model(model), torch.float16)
+
+    def test_rejects_non_dtype_compute_dtype(self):
+        """A `compute_dtype` that is not a dtype string/`torch.dtype` fails."""
+        model = types.SimpleNamespace(
+            compute_dtype=None,
+            backbone=types.SimpleNamespace(compute_dtype=None),
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "must be a dtype string.*Received: compute_dtype=None",
+        ):
+            export._torch_dtype_from_model(model)
+
+    def test_rejects_unmappable_dtype_string(self):
+        """A dtype string with no PyTorch equivalent gets a LiteRT-LM error."""
+        model = types.SimpleNamespace(compute_dtype="string")
+        with self.assertRaisesRegex(
+            ValueError,
+            "`compute_dtype` must map to a PyTorch dtype",
+        ) as cm:
+            export._torch_dtype_from_model(model)
+        self.assertIsInstance(cm.exception.__cause__, ValueError)

--- a/keras_hub/src/utils/litertlm/export_test.py
+++ b/keras_hub/src/utils/litertlm/export_test.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import os
 import types
 import unittest
@@ -14,9 +15,30 @@ from keras_hub.src.models.gemma.gemma_causal_lm_preprocessor import (
     GemmaCausalLMPreprocessor,
 )
 from keras_hub.src.models.gemma.gemma_tokenizer import GemmaTokenizer
+from keras_hub.src.models.gpt2.gpt2_backbone import GPT2Backbone
+from keras_hub.src.models.gpt2.gpt2_causal_lm import GPT2CausalLM
+from keras_hub.src.models.gpt2.gpt2_causal_lm_preprocessor import (
+    GPT2CausalLMPreprocessor,
+)
+from keras_hub.src.models.gpt2.gpt2_tokenizer import GPT2Tokenizer
+from keras_hub.src.models.llama3.llama3_backbone import Llama3Backbone
+from keras_hub.src.models.llama3.llama3_causal_lm import Llama3CausalLM
+from keras_hub.src.models.llama3.llama3_causal_lm_preprocessor import (
+    Llama3CausalLMPreprocessor,
+)
+from keras_hub.src.models.llama3.llama3_tokenizer import Llama3Tokenizer
+from keras_hub.src.models.qwen3.qwen3_backbone import Qwen3Backbone
+from keras_hub.src.models.qwen3.qwen3_causal_lm import Qwen3CausalLM
+from keras_hub.src.models.qwen3.qwen3_causal_lm_preprocessor import (
+    Qwen3CausalLMPreprocessor,
+)
+from keras_hub.src.models.qwen3.qwen3_tokenizer import Qwen3Tokenizer
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.litertlm import export
 from keras_hub.src.utils.litertlm.adapter import _cpu_default_device_scope
+from keras_hub.src.utils.litertlm.hf_tokenizer_converter import (
+    materialize_hf_tokenizer_json,
+)
 from keras_hub.src.utils.litertlm.model_specs import GREEDY_SAMPLER_CONFIG
 from keras_hub.src.utils.litertlm.model_specs import SamplerConfig
 
@@ -24,6 +46,41 @@ _LITERT_TORCH_AVAILABLE = importlib.util.find_spec("litert_torch") is not None
 _LITERT_LM_BUILDER_AVAILABLE = (
     importlib.util.find_spec("litert_lm_builder") is not None
 )
+
+try:
+    import tokenizers
+except ImportError:
+    tokenizers = None
+
+
+# Content tokens shared by the tiny BPE vocabs in the HF-tokenizer
+# export/roundtrip tests. Tokenizer assertions are exact-id oracles, so
+# this token order is fixed.
+_TINY_BPE_CONTENT_TOKENS = [
+    "h",
+    "i",
+    "Ġ",
+    "Ġh",
+    "e",
+    "l",
+    "o",
+    "w",
+    "r",
+    "d",
+    "t",
+    "s",
+    "a",
+    "b",
+    "ab",
+]
+
+
+def _tiny_bpe_vocab(special_tokens, extra_tokens=("n", "k", "u", "m")):
+    """Tiny BPE vocab: per-family special tokens, then shared content."""
+    tokens = (
+        list(special_tokens) + _TINY_BPE_CONTENT_TOKENS + list(extra_tokens)
+    )
+    return {token: token_id for token_id, token in enumerate(tokens)}
 
 
 @unittest.skipUnless(
@@ -379,6 +436,289 @@ class TestLiteRTLmExport(TestCase):
         self.assertNotIn("images", prefill_inputs)
         self.assertNotIn("vision_indices", prefill_inputs)
         self.assertNotIn("vision_mask", prefill_inputs)
+
+    def test_export_with_hf_tokenizer_path(self):
+        """Verify export with a user-provided HuggingFace tokenizer.json."""
+        try:
+            import litert_lm
+            import tokenizers
+        except ImportError:
+            self.skipTest("This test requires `litert-lm` and `tokenizers`.")
+
+        vocab_size = self.tokenizer.vocabulary_size()
+
+        # Build a tiny HuggingFace BPE tokenizer with the same vocab size.
+        vocab = {
+            "<pad>": 0,
+            "<s>": 1,
+            "</s>": 2,
+            "<unk>": 3,
+        }
+        for i in range(4, vocab_size):
+            vocab[f"tok{i}"] = i
+
+        hf_tokenizer = tokenizers.Tokenizer(
+            tokenizers.models.BPE(vocab=vocab, merges=[])
+        )
+        hf_tokenizer.pre_tokenizer = tokenizers.pre_tokenizers.Whitespace()
+        hf_tokenizer.add_special_tokens(["<pad>", "<s>", "</s>", "<unk>"])
+
+        hf_tokenizer_path = os.path.join(self.get_temp_dir(), "tokenizer.json")
+        hf_tokenizer.save(hf_tokenizer_path)
+
+        path = os.path.join(self.get_temp_dir(), "test_hf_tokenizer.litertlm")
+        self.model.export(
+            path,
+            format="litertlm",
+            prefill_seq_len=8,
+            hf_tokenizer_path=hf_tokenizer_path,
+        )
+
+        self.assertTrue(os.path.exists(path))
+
+        # Smoke-test that the LiteRT-LM runtime can construct an Engine from
+        # the bundle. Full generation requires a real-world HF tokenizer; the
+        # synthetic one above is sufficient to prove `add_hf_tokenizer` was
+        # used and the bundle structure is valid.
+        engine = litert_lm.Engine(
+            path,
+            backend=litert_lm.Backend.CPU(),
+            max_num_tokens=4,
+        )
+        self.assertIsNotNone(engine)
+
+    def test_export_with_hf_tokenizer_path_mismatched_vocab_raises(self):
+        """`hf_tokenizer_path` pointing at a wildly different vocab size
+        must be rejected before any tracing/bundling work happens.
+
+        Uses a bare-bones hand-written ``tokenizer.json`` (rather than a
+        real ``tokenizers.Tokenizer``, as ``test_export_with_hf_tokenizer_path``
+        above does) because the vocab-size sanity check runs during
+        argument validation, before the file would ever be loaded by the
+        `tokenizers` library or `litert_lm_builder`.
+        """
+        model_vocab_size = self.tokenizer.vocabulary_size()
+        # Comfortably past both the absolute-diff and ratio thresholds in
+        # `_check_hf_tokenizer_vocab_compatible`.
+        mismatched_vocab_size = model_vocab_size * 100 + 1000
+        vocab = {f"tok{i}": i for i in range(mismatched_vocab_size)}
+        hf_tokenizer_path = os.path.join(
+            self.get_temp_dir(), "mismatched_tokenizer.json"
+        )
+        with open(hf_tokenizer_path, "w", encoding="utf-8") as f:
+            json.dump({"model": {"vocab": vocab}}, f)
+
+        path = os.path.join(
+            self.get_temp_dir(), "test_mismatched_hf_tokenizer.litertlm"
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "appears incompatible with the model",
+        ):
+            self.model.export(
+                path,
+                format="litertlm",
+                prefill_seq_len=8,
+                hf_tokenizer_path=hf_tokenizer_path,
+            )
+
+    def test_export_gpt2_with_auto_hf_tokenizer(self):
+        """Export a tiny GPT2 model with auto-converted HF tokenizer."""
+        vocab = _tiny_bpe_vocab(["<|endoftext|>"])
+        merges = ["a b"]
+        tokenizer = GPT2Tokenizer(vocabulary=vocab, merges=merges)
+
+        backbone = GPT2Backbone(
+            vocabulary_size=tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_heads=4,
+            hidden_dim=32,
+            intermediate_dim=64,
+            max_sequence_length=8,
+        )
+        preprocessor = GPT2CausalLMPreprocessor(
+            tokenizer=tokenizer, sequence_length=8
+        )
+        model = GPT2CausalLM(backbone=backbone, preprocessor=preprocessor)
+
+        self._set_random_weights(model)
+
+        path = os.path.join(self.get_temp_dir(), "test_gpt2_auto_hf.litertlm")
+        model.export(path, format="litertlm", prefill_seq_len=8)
+        self.assertTrue(os.path.exists(path))
+
+    def test_export_llama3_with_auto_hf_tokenizer(self):
+        """Export a tiny Llama3 model with auto-converted HF tokenizer."""
+        vocab = _tiny_bpe_vocab(
+            [
+                "<|endoftext|>",
+                "<|begin_of_text|>",
+                "<|end_of_text|>",
+                "<|start_header_id|>",
+                "<|end_header_id|>",
+                "<|eot_id|>",
+            ]
+        )
+        merges = ["a b"]
+        tokenizer = Llama3Tokenizer(vocabulary=vocab, merges=merges)
+
+        backbone = Llama3Backbone(
+            vocabulary_size=tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=32,
+            intermediate_dim=64,
+            max_sequence_length=8,
+        )
+        preprocessor = Llama3CausalLMPreprocessor(
+            tokenizer=tokenizer, sequence_length=8
+        )
+        model = Llama3CausalLM(backbone=backbone, preprocessor=preprocessor)
+
+        self._set_random_weights(model)
+
+        path = os.path.join(self.get_temp_dir(), "test_llama3_auto_hf.litertlm")
+        model.export(path, format="litertlm", prefill_seq_len=8)
+        self.assertTrue(os.path.exists(path))
+
+        # Regression coverage for the stop-token fix (see `Llama3Spec` in
+        # model_specs.py): Llama3's chat-turn-stop token `<|eot_id|>` (id 5
+        # in the vocab above) must reach the exported metadata alongside the
+        # primary EOS `<|end_of_text|>` (id 2) -- previously only the
+        # Gemma-specific `<end_of_turn>` literal was checked, so Llama3
+        # never got a chat-stop token beyond its primary (non-chat) EOS.
+        llm_metadata = self._parse_litertlm_llm_metadata(path)
+        self.assertIsNotNone(llm_metadata)
+        stop_token_ids = {
+            stop_token.token_ids.ids[0]
+            for stop_token in llm_metadata.stop_tokens
+        }
+        self.assertIn(2, stop_token_ids)  # <|end_of_text|>
+        self.assertIn(5, stop_token_ids)  # <|eot_id|>
+
+    def test_export_qwen3_with_auto_hf_tokenizer(self):
+        """Export a tiny Qwen3 model with auto-converted HF tokenizer."""
+        vocab = _tiny_bpe_vocab(["<|endoftext|>", "<|im_end|>"])
+        merges = ["a b"]
+        tokenizer = Qwen3Tokenizer(vocabulary=vocab, merges=merges)
+
+        backbone = Qwen3Backbone(
+            vocabulary_size=tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            head_dim=8,
+            hidden_dim=32,
+            intermediate_dim=64,
+            max_sequence_length=8,
+        )
+        preprocessor = Qwen3CausalLMPreprocessor(
+            tokenizer=tokenizer,
+            sequence_length=8,
+            add_start_token=False,
+        )
+        model = Qwen3CausalLM(backbone=backbone, preprocessor=preprocessor)
+
+        self._set_random_weights(model)
+
+        path = os.path.join(self.get_temp_dir(), "test_qwen3_auto_hf.litertlm")
+        model.export(path, format="litertlm", prefill_seq_len=8)
+        self.assertTrue(os.path.exists(path))
+
+
+class TestHfTokenizerVocabCompatibility(TestCase):
+    """Unit tests for the `hf_tokenizer_path` vocab-size sanity check.
+
+    These exercise `_hf_tokenizer_vocab_size` and
+    `_check_hf_tokenizer_vocab_compatible` directly against hand-written
+    `tokenizer.json` fixtures and a minimal fake model, independent of any
+    Keras backend or real KerasHub model -- both helpers are plain
+    JSON/attribute-lookup logic with no tensor operations.
+    """
+
+    def _write_tokenizer_json(self, vocab_size, extra_added_tokens=0):
+        path = os.path.join(self.get_temp_dir(), "tokenizer.json")
+        vocab = {f"tok{i}": i for i in range(vocab_size)}
+        added_tokens = [
+            {"id": vocab_size + i, "content": f"<extra{i}>"}
+            for i in range(extra_added_tokens)
+        ]
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(
+                {"model": {"vocab": vocab}, "added_tokens": added_tokens}, f
+            )
+        return path
+
+    def _fake_model(self, vocabulary_size):
+        backbone = types.SimpleNamespace(vocabulary_size=vocabulary_size)
+        return types.SimpleNamespace(backbone=backbone)
+
+    def test_hf_tokenizer_vocab_size_counts_vocab_and_added_tokens(self):
+        path = self._write_tokenizer_json(vocab_size=20, extra_added_tokens=3)
+        self.assertEqual(export._hf_tokenizer_vocab_size(path), 23)
+
+    def test_check_hf_tokenizer_vocab_compatible_matching_does_not_raise(self):
+        # A handful of reserved/special tokens (well within the "few
+        # hundred" absolute threshold) must not raise.
+        path = self._write_tokenizer_json(vocab_size=1000)
+        model = self._fake_model(vocabulary_size=1000)
+        export._check_hf_tokenizer_vocab_compatible(path, model)
+
+    def test_check_hf_tokenizer_vocab_compatible_mismatch_raises(self):
+        path = self._write_tokenizer_json(vocab_size=50000)
+        model = self._fake_model(vocabulary_size=32)
+        with self.assertRaisesRegex(
+            ValueError, "appears incompatible with the model"
+        ):
+            export._check_hf_tokenizer_vocab_compatible(path, model)
+
+
+@unittest.skipIf(
+    tokenizers is None,
+    "BytePair-to-HF tokenizer roundtrip test requires `tokenizers`.",
+)
+class TestBytePairToHFTokenizer(TestCase):
+    def test_byte_pair_to_hf_tokenizer_roundtrip(self):
+        """Verify converted tokenizer.json round-trips through HF tokenizers."""
+        if keras.config.backend() != "torch":
+            self.skipTest(
+                "BytePair tokenizer roundtrip requires torch backend."
+            )
+
+        vocab = _tiny_bpe_vocab(
+            ["<|endoftext|>"], extra_tokens=["hello", "Ġworld"]
+        )
+        merges = ["a b"]
+        tokenizer = GPT2Tokenizer(vocabulary=vocab, merges=merges)
+
+        hf_tokenizer_path = materialize_hf_tokenizer_json(
+            tokenizer, self.get_temp_dir()
+        )
+        hf_tokenizer = tokenizers.Tokenizer.from_file(hf_tokenizer_path)
+
+        for text in [
+            "hello",
+            "hello world",
+            "hi",
+            "a b",
+            "12345 and 67890",
+        ]:
+            with self.subTest(text=text):
+                keras_ids = list(tokenizer(text))
+                hf_ids = hf_tokenizer.encode(text).ids
+                self.assertEqual(
+                    keras_ids,
+                    hf_ids,
+                    f"Token ids differ for {text!r}",
+                )
+                keras_text = tokenizer.detokenize(keras_ids)
+                hf_text = hf_tokenizer.decode(hf_ids)
+                self.assertEqual(
+                    keras_text,
+                    hf_text,
+                    f"Detokenized text differs for {text!r}",
+                )
 
 
 @unittest.skipUnless(

--- a/keras_hub/src/utils/litertlm/hf_tokenizer_converter.py
+++ b/keras_hub/src/utils/litertlm/hf_tokenizer_converter.py
@@ -1,0 +1,45 @@
+"""Serialize a KerasHub BytePairTokenizer to a HuggingFace tokenizer.json.
+
+Every ``BytePairTokenizer`` already wraps a live ``tokenizers.Tokenizer``
+object (``self._tokenizer``, built in ``_set_vocabulary_and_merges_tokenizers``
+from KerasHub's own vocab/merges and used for every ``encode_batch``/
+``decode_batch``). This module calls ``.to_str()`` on that same object -- it
+is *not* a format conversion and re-derives no token ids, so token identity
+is byte-exact by construction. HF ``tokenizer.json`` is the target because
+the LiteRT-LM runtime accepts only two on-device tokenizer formats
+(SentencePiece and ``HF_Tokenizer_Zlib``); there is no KerasHub-native
+on-device format to emit instead.
+
+This module does not itself import ``tokenizers`` (it only serializes an
+object built elsewhere); the library is used directly only in tests, to
+validate the output.
+"""
+
+import os
+
+from keras_hub.src.tokenizers.byte_pair_tokenizer import BytePairTokenizer
+
+
+def materialize_hf_tokenizer_json(tokenizer, temp_dir):
+    """Convert a KerasHub tokenizer and write ``tokenizer.json`` to disk.
+
+    Relies on the private ``BytePairTokenizer._tokenizer`` attribute and its
+    ``_maybe_initialized_tokenizers`` method.
+
+    Args:
+        tokenizer: A KerasHub ``BytePairTokenizer`` instance.
+        temp_dir: str. Directory where ``tokenizer.json`` will be written.
+
+    Returns:
+        str: Path to the written ``tokenizer.json`` file.
+    """
+    if not isinstance(tokenizer, BytePairTokenizer):
+        raise TypeError(
+            "`materialize_hf_tokenizer_json` expects a BytePairTokenizer "
+            f"instance. Received: {type(tokenizer).__name__}."
+        )
+    tokenizer._maybe_initialized_tokenizers()
+    tokenizer_path = os.path.join(temp_dir, "tokenizer.json")
+    with open(tokenizer_path, "w", encoding="utf-8") as f:
+        f.write(tokenizer._tokenizer.to_str())
+    return tokenizer_path

--- a/keras_hub/src/utils/litertlm/model_specs.py
+++ b/keras_hub/src/utils/litertlm/model_specs.py
@@ -1,0 +1,1103 @@
+"""Model-family export specs for LiteRT-LM export.
+
+``LiteRTLMExportSpec`` centralizes per-family export knowledge. A single
+spec instance is resolved once per export call (see ``resolve_export_spec``)
+from a lazy, ``isinstance``-based registry and threaded through the export
+pipeline and the adapter. The base class itself is the fallback for any
+model family not explicitly registered (``model_type="generic_model"``).
+"""
+
+import dataclasses
+
+
+def _first_attr(obj, *names, default=None):
+    """Return the first non-``None`` attribute from *obj*, or *default*."""
+    if obj is None:
+        return default
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    return default
+
+
+def _get_vision_encoder(backbone):
+    """Return the vision encoder from a backbone, or ``None``."""
+    return _first_attr(backbone, "vision_encoder", "vit_encoder")
+
+
+def _require_patch_size(patch_size, source):
+    """Return *patch_size*, raising an actionable error when it is ``None``.
+
+    Only ``vision_input_style="patch_values"`` families (Gemma4) derive
+    exported shapes from ``patch_size``; the other vision families never read
+    it, so the requirement is gated on that style rather than imposed on
+    every vision encoder.
+
+    Args:
+        patch_size: int or None. The patch size read from the model.
+        source: str. Where *patch_size* was read from, named in the error.
+    """
+    if patch_size is None:
+        raise ValueError(
+            "`patch_size` must be an int for a `patch_values` vision input "
+            "style, which sizes the exported `patch_values` signature and the "
+            "`max_num_patches` metadata from it. "
+            f"Received: patch_size=None (from {source})."
+        )
+    return patch_size
+
+
+# Special token strings used when populating vision/audio metadata.
+_GEMMA3_START_OF_IMAGE_TOKEN = "<start_of_image>"
+_GEMMA3_END_OF_IMAGE_TOKEN = "<end_of_image>"
+_GEMMA4_START_OF_IMAGE_TOKEN = "<|image>"
+_GEMMA4_END_OF_IMAGE_TOKEN = "<image|>"
+_AUDIO_START_TOKEN = "<|audio>"
+_AUDIO_END_TOKEN = "<audio|>"
+
+#: Trace-time frame count for the audio sample inputs; no KerasHub
+#: preprocessor exposes a frames attribute, so this fixes the exported
+#: ``audio_mel`` signature shape.
+_DEFAULT_AUDIO_NUM_FRAMES = 100
+
+# Function-calling ("function_gemma") metadata strings, supplied as
+# literals because keras-hub's Gemma3 tokenizer has no HuggingFace
+# ``special_tokens_map`` carrying them (proto fields shared with Gemma4).
+_FUNCTION_GEMMA_CODE_FENCE_START = "```tool_code"
+_FUNCTION_GEMMA_CODE_FENCE_END = "```"
+_FUNCTION_GEMMA_FUNCTION_RESPONSE_START = "```tool_output"
+_FUNCTION_GEMMA_ESCAPE_TOKEN = "<escape>"
+
+
+@dataclasses.dataclass(frozen=True)
+class SamplerConfig:
+    """Sampler defaults embedded in a LiteRT-LM bundle's ``LlmMetadata``.
+
+    Mirrors the conditional ``sampler_params`` semantics of litert-torch's
+    ``export_hf``: the proto field is only written when a caller explicitly
+    requests it. keras-hub ships no default sampler -- omitting
+    ``sampler_config`` leaves the field unset, letting the runtime pick its
+    own sampling policy.
+
+    Args:
+        top_k: Optional int >= 1. ``top_k == 1`` selects deterministic
+            greedy generation (encoded as ``TOP_K``).
+        top_p: Optional float in (0.0, 1.0].
+        temperature: Optional float >= 0.0.
+        seed: Optional int RNG seed.
+    """
+
+    top_k: int | None = None
+    top_p: float | None = None
+    temperature: float | None = None
+    seed: int | None = None
+
+    def __post_init__(self):
+        if (
+            self.top_k is None
+            and self.top_p is None
+            and self.temperature is None
+        ):
+            raise ValueError(
+                "SamplerConfig requires at least one of `top_k`, `top_p`, or "
+                "`temperature` to be set; an all-None config would produce "
+                "an empty sampler_params. Omit `sampler_config` entirely to "
+                "leave the field unset."
+            )
+        if self.top_k is not None and self.top_k < 1:
+            raise ValueError(
+                "SamplerConfig.top_k must be >= 1. "
+                f"Received: top_k={self.top_k}."
+            )
+        if self.top_p is not None and not (0.0 < self.top_p <= 1.0):
+            raise ValueError(
+                "SamplerConfig.top_p must be in (0.0, 1.0]. "
+                f"Received: top_p={self.top_p}."
+            )
+        if self.temperature is not None and self.temperature < 0.0:
+            raise ValueError(
+                "SamplerConfig.temperature must be >= 0.0. "
+                f"Received: temperature={self.temperature}."
+            )
+
+
+#: Deterministic greedy sampling (``top_k == 1``). The only named sampler
+#: preset keras-hub ships; exercised by the metadata roundtrip test.
+GREEDY_SAMPLER_CONFIG = SamplerConfig(top_k=1)
+
+
+def _single_stacked_support_description():
+    """The shared error tail naming the supported cache structure."""
+    return (
+        "but the LiteRT-LM adapter only supports "
+        '`cache_structure="single_stacked"` (a single stacked '
+        "`[batch, num_layers, 2, cache_length, num_kv_heads, head_dim]` "
+        "KV-cache tensor)."
+    )
+
+
+class LiteRTLMExportSpec:
+    """Default LiteRT-LM export behavior for a model family.
+
+    Also used, unmodified, as the spec for any model family not explicitly
+    registered in ``_EXPORT_SPEC_REGISTRY`` (the ``"generic_model"``
+    fallback). Subclasses customize behavior via the plain class attributes
+    and methods below; plain attributes (not dataclass fields) avoid a
+    dataclass-generated ``__init__`` re-baking the parent's field default
+    over a subclass's override.
+    """
+
+    #: The ``LlmMetadata.llm_model_type`` oneof name for this family.
+    model_type = "generic_model"
+    #: Per-layer KV-cache tensor layout. ``"standard"`` is
+    #: ``[batch, cache_length, num_kv_heads, head_dim]``; ``"gemma3n"`` is
+    #: ``[batch, num_kv_heads, cache_length, head_dim]``.
+    cache_layout = "standard"
+    #: Shape of the ``cache`` argument ``call_with_cache`` expects:
+    #: ``"single_stacked"`` is one stacked KV tensor (what the default
+    #: ``stack_kv_cache`` builds); any other value fails fast in export.
+    cache_structure = "single_stacked"
+    #: How the vision encoder consumes its input: ``"raw_images"`` (a raw
+    #: ``[B, N, H, W, 3]`` tensor; Gemma3, PaliGemma), ``"patch_values"``
+    #: (preprocessed patches; Gemma4), or ``"embedded_pixel_values"``
+    #: (encoder runs inside the backbone; Gemma3n).
+    vision_input_style = "raw_images"
+    #: How the audio encoder consumes its input: ``None`` (no audio),
+    #: ``"embedded_mel"`` (encoder inside the backbone; Gemma3n), or
+    #: ``"standalone_mel"`` (adapter calls ``backbone.audio_encoder``;
+    #: Gemma4).
+    audio_input_style = None
+    #: Whether the vision encoder accepts only a single 4-D image per call,
+    #: so the adapter flattens the ``[B, N, H, W, 3]`` stack (PaliGemma).
+    flatten_image_batch = False
+    #: The end-of-image (EOI) special-token string, or ``None`` if the
+    #: family has none. Consulted only on the separate-vision export path,
+    #: where it controls whether an ``END_OF_VISION`` section is emitted.
+    end_of_vision_token = None
+    #: Whether this family's vision path supports multi-bucket prefill.
+    #: Default ``False``: the bucketing ban in ``export_to_litertlm`` is a
+    #: conservative family-wide default; relaxing it is numerics-gated.
+    allows_vision_bucketing = False
+    #: Whether this family supports the separate-vision-encoder export path.
+    #: ``False`` for families whose encoder runs inside the backbone
+    #: (Gemma3n): there is no separable encoder to export.
+    supports_separate_vision = True
+
+    def get_cache_config(self, model, cache_length=None):
+        """Extract KV-cache dimensions from the model.
+
+        Args:
+            model: ``CausalLM``. The KerasHub model being exported.
+            cache_length: int or None. Explicit cache length; when ``None``,
+                the cache length is inferred from `backbone.max_sequence_length`
+                if the backbone defines it, else from
+                `preprocessor.sequence_length` -- the caller is responsible
+                for warning about this fallback, since the warning needs
+                ``warnings.warn``'s call-site stacklevel to point at the
+                public API, not at this method.
+        """
+        backbone = model.backbone
+        num_layers = _first_attr(backbone, "num_layers", "num_hidden_layers")
+        if num_layers is None:
+            raise ValueError(
+                "Could not determine number of layers from model backbone. "
+                "Expected `backbone.num_layers` or "
+                "`backbone.num_hidden_layers`."
+            )
+
+        used_preprocessor_fallback = False
+        if cache_length is None:
+            cache_length = _first_attr(backbone, "max_sequence_length")
+            if cache_length is None:
+                preprocessor = getattr(model, "preprocessor", None)
+                cache_length = _first_attr(preprocessor, "sequence_length")
+                used_preprocessor_fallback = cache_length is not None
+        if cache_length is None:
+            raise ValueError(
+                "Could not determine cache length from model backbone or "
+                "preprocessor. Please specify `cache_length` or "
+                "`prefill_seq_len`, or ensure the model has "
+                "`max_sequence_length`."
+            )
+
+        num_kv_heads = _first_attr(
+            backbone,
+            "num_key_value_heads",
+            "num_query_heads",
+            "num_heads",
+            "num_attention_heads",
+        )
+        if num_kv_heads is None:
+            raise ValueError(
+                "Could not determine the number of key/value heads from "
+                "model backbone. Expected one of "
+                "`backbone.num_key_value_heads`, `backbone.num_query_heads`, "
+                "`backbone.num_heads`, or `backbone.num_attention_heads`."
+            )
+
+        head_dim = _first_attr(backbone, "head_dim")
+        if head_dim is None:
+            hidden_dim = _first_attr(backbone, "hidden_dim")
+            num_qh = _first_attr(
+                backbone,
+                "num_query_heads",
+                "num_heads",
+                "num_attention_heads",
+            )
+            if hidden_dim is not None and num_qh is not None and num_qh > 0:
+                head_dim = hidden_dim // num_qh
+
+        if head_dim is None:
+            raise ValueError(
+                "Could not determine attention head dimension from model "
+                "attributes. Expected `backbone.head_dim` or both "
+                "`backbone.hidden_dim` and `backbone.num_query_heads`."
+            )
+
+        return {
+            "num_layers": num_layers,
+            "cache_length": cache_length,
+            "num_kv_heads": num_kv_heads,
+            "head_dim": head_dim,
+            "cache_layout": self.cache_layout,
+            "used_preprocessor_fallback": used_preprocessor_fallback,
+        }
+
+    def get_kv_cache_sample_shape(
+        self, batch_size, cache_length, num_kv_heads, head_dim
+    ):
+        """Return the per-layer KV-cache sample shape for this family.
+
+        Used by ``export.py``'s sample-input builder to size the flat
+        ``kv_cache_k_N``/``kv_cache_v_N`` trace inputs. Default: the
+        ``"standard"`` ``cache_layout`` shape, ``[batch, cache_length,
+        num_kv_heads, head_dim]``.
+        """
+        return (batch_size, cache_length, num_kv_heads, head_dim)
+
+    def check_exportable(self, model):
+        """Raise ``ValueError`` if *model* is not exportable at all.
+
+        Called by ``export_to_litertlm`` immediately after spec resolution,
+        before any argument validation or tracing. Default no-op: every
+        registered family is exportable. Non-exportable models (see
+        ``Gemma4AssistantSpec``) override this to fail fast with a
+        family-specific explanation.
+        """
+        del model
+
+    def describe_unsupported_cache_structure(self):
+        """Explain why ``cache_structure`` isn't ``"single_stacked"``.
+
+        Used by ``export_to_litertlm``'s fail-fast check. Default: a
+        generic description naming the actual ``cache_structure`` value and
+        the shape the adapter does support; families with a more specific
+        explanation (e.g. ``Qwen3_5Spec``) override this.
+        """
+        return (
+            f"requires a {self.cache_structure!r} cache structure, "
+            f"{_single_stacked_support_description()} "
+            "Support for this cache structure is not yet implemented."
+        )
+
+    def get_vision_config(self, model):
+        """Return vision metadata if *model* has a vision encoder, else
+        ``None``."""
+        backbone = getattr(model, "backbone", None)
+        if backbone is None:
+            return None
+        vision_encoder = _get_vision_encoder(backbone)
+        if vision_encoder is None:
+            return None
+        preprocessor = getattr(model, "preprocessor", None)
+        max_images = self.get_max_images_per_prompt(preprocessor)
+
+        image_size = getattr(backbone, "image_size", None)
+        if image_size is None:
+            # Gemma3n does not set backbone.image_size; read the
+            # preprocessor image converter, then the encoder config.
+            image_converter = getattr(preprocessor, "image_converter", None)
+            if image_converter is not None:
+                image_size = getattr(image_converter, "image_size", None)
+            if image_size is None:
+                vision_encoder_config = getattr(
+                    backbone, "vision_encoder_config", {}
+                )
+                image_shape = vision_encoder_config.get("image_shape")
+                if image_shape is not None:
+                    image_size = image_shape[0]
+        if image_size is None:
+            raise ValueError(
+                "Could not determine vision image size. Searched "
+                "`backbone.image_size`, "
+                "`preprocessor.image_converter.image_size`, and "
+                "`backbone.vision_encoder_config.image_shape[0]`."
+            )
+        # Image converters may report a (height, width) tuple; use the
+        # height (downstream assumes a square image).
+        if isinstance(image_size, (list, tuple)):
+            image_size = image_size[0]
+
+        num_vision_tokens_per_image = getattr(
+            backbone, "num_vision_tokens_per_image", None
+        )
+        if num_vision_tokens_per_image is None:
+            # PaliGemma exposes the count as ``image_sequence_length``.
+            num_vision_tokens_per_image = getattr(
+                backbone, "image_sequence_length", None
+            )
+        if num_vision_tokens_per_image is None and preprocessor is not None:
+            # Gemma3/Gemma3n expose the count on the preprocessor.
+            num_vision_tokens_per_image = getattr(
+                preprocessor, "num_vision_tokens_per_image", None
+            )
+        if num_vision_tokens_per_image is None:
+            raise ValueError(
+                "Could not determine `num_vision_tokens_per_image`. "
+                "Searched `backbone.num_vision_tokens_per_image`, "
+                "`backbone.image_sequence_length`, and "
+                "`preprocessor.num_vision_tokens_per_image`."
+            )
+        num_vision_tokens = num_vision_tokens_per_image * max_images
+        patch_size = getattr(vision_encoder, "patch_size", None)
+        if self.vision_input_style == "patch_values":
+            patch_size = _require_patch_size(
+                patch_size, f"`{type(vision_encoder).__name__}.patch_size`"
+            )
+        pool_size = getattr(vision_encoder, "pool_size", None)
+        return {
+            "max_images_per_prompt": max_images,
+            "image_size": image_size,
+            "num_vision_tokens": num_vision_tokens,
+            "num_vision_tokens_per_image": num_vision_tokens_per_image,
+            "patch_size": patch_size,
+            "pool_size": pool_size,
+        }
+
+    def get_audio_config(self, model):
+        """Return audio metadata if *model* has an audio encoder, else
+        ``None``."""
+        backbone = getattr(model, "backbone", None)
+        if backbone is None:
+            return None
+        audio_encoder = getattr(backbone, "audio_encoder", None)
+        if audio_encoder is None:
+            return None
+        preprocessor = getattr(model, "preprocessor", None)
+        max_clips = getattr(preprocessor, "max_audio_clips_per_prompt", None)
+        if max_clips is None:
+            # Gemma3n names this attribute ``max_audios_per_prompt``.
+            max_clips = getattr(preprocessor, "max_audios_per_prompt", None)
+        if max_clips is None:
+            raise ValueError(
+                "Could not determine `max_clips_per_prompt`. Searched "
+                "`preprocessor.max_audio_clips_per_prompt` and "
+                "`preprocessor.max_audios_per_prompt`."
+            )
+        # Trace-time frame count for the audio sample inputs: no KerasHub
+        # preprocessor exposes a frames attribute, so this fixes the
+        # exported `audio_mel` signature shape.
+        num_frames = _DEFAULT_AUDIO_NUM_FRAMES
+        num_audio_tokens_per_clip = getattr(
+            backbone, "num_audio_tokens_per_clip", None
+        )
+        if num_audio_tokens_per_clip is None and preprocessor is not None:
+            # Gemma3n names this attribute ``num_audio_tokens_per_audio``.
+            num_audio_tokens_per_clip = getattr(
+                preprocessor, "num_audio_tokens_per_audio", None
+            )
+        if num_audio_tokens_per_clip is None:
+            raise ValueError(
+                "Could not determine `num_audio_tokens_per_clip`. Searched "
+                "`backbone.num_audio_tokens_per_clip` and "
+                "`preprocessor.num_audio_tokens_per_audio`."
+            )
+        num_audio_tokens = num_audio_tokens_per_clip * max_clips
+        audio_input_feat_size = getattr(
+            preprocessor, "audio_input_feat_size", None
+        )
+        if audio_input_feat_size is None and preprocessor is not None:
+            audio_converter = getattr(preprocessor, "audio_converter", None)
+            if audio_converter is not None:
+                audio_input_feat_size = getattr(
+                    audio_converter, "feature_size", None
+                )
+        if audio_input_feat_size is None:
+            raise ValueError(
+                "Could not determine `audio_input_feat_size`. Searched "
+                "`preprocessor.audio_input_feat_size` and "
+                "`preprocessor.audio_converter.feature_size`."
+            )
+        return {
+            "max_clips_per_prompt": max_clips,
+            "num_frames": num_frames,
+            "num_audio_tokens": num_audio_tokens,
+            "audio_input_feat_size": audio_input_feat_size,
+        }
+
+    def get_vision_output_dim(self, vision_encoder):
+        """Return the projected vision feature dimension."""
+        dim = getattr(vision_encoder, "output_dim", None)
+        if dim is None:
+            # PaliGemma's ViT names the projected dimension ``num_classes``.
+            dim = getattr(vision_encoder, "num_classes", None)
+        return dim
+
+    def get_max_images_per_prompt(self, preprocessor):
+        """Return the max images the runtime may pass per prompt.
+
+        Read from ``preprocessor.max_images_per_prompt``. A missing
+        attribute is only valid for single-image families
+        (``flatten_image_batch=True``, e.g. PaliGemma); on a multi-image
+        family it is a misconfiguration and must not silently default to 1.
+        """
+        max_images = getattr(preprocessor, "max_images_per_prompt", None)
+        if max_images is not None:
+            return max_images
+        if self.flatten_image_batch:
+            return 1
+        raise ValueError(
+            f"{type(self).__name__} declares flatten_image_batch=False "
+            "(multi-image family) but its preprocessor has no "
+            "`max_images_per_prompt` attribute, so the number of images per "
+            "prompt cannot be determined. Set `max_images_per_prompt` on the "
+            "preprocessor, or (for a genuinely single-image family) set "
+            "`flatten_image_batch = True` on the spec."
+        )
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        """Populate vision-related fields in the ``LlmMetadata`` protobuf.
+
+        Default: no-op. Text-only families and families without a dedicated
+        ``LlmModelType`` vision subtype populate nothing.
+        """
+        del meta, vision_cfg
+
+    def populate_audio_metadata(self, meta, audio_cfg):
+        """Populate audio-related fields in the ``LlmMetadata`` protobuf.
+
+        Default: no-op (see ``populate_vision_metadata``).
+        """
+        del meta, audio_cfg
+
+    def populate_function_gemma_metadata(self, meta):
+        """Populate function-calling fields in the ``LlmMetadata`` protobuf.
+
+        Default: no-op; only ``FunctionGemmaSpec`` overrides this. Called by
+        ``_build_llm_metadata`` except when ``llm_model_type`` was an
+        explicit caller override (mirroring litert-torch, which skips its
+        model-specific metadata builder on override).
+        """
+        del meta
+
+    def reshape_separate_vision_embeddings(
+        self, img_embeddings, tokens, preprocessor
+    ):
+        """Reshape ``mm_embedding`` for the separate-vision-encoder path.
+
+        Default: no reshape needed. Only Gemma4 interleaves image
+        embeddings with a ``(batch, num_images, tokens_per_image,
+        hidden_dim)`` shape that must be restored after the separate
+        vision-encoder/adapter models flatten to
+        ``(batch * num_images, ...)``.
+        """
+        del tokens, preprocessor
+        return img_embeddings
+
+    def get_forced_call_with_cache_kwargs(self, tokens, cache_length):
+        """Return kwargs to force/override on every ``call_with_cache`` call.
+
+        Default: none. Only Gemma3n needs this, to force a full-length
+        padding mask (see ``Gemma3nSpec``).
+        """
+        del tokens, cache_length
+        return {}
+
+    # Converting between the flat signature tensors and the family's
+    # ``call_with_cache`` cache shape is per-family behavior, so it lives on
+    # the spec (a hybrid-cache family overrides these, not the adapter).
+
+    def stack_kv_cache(self, kv_cache, num_layers):
+        """Stack flat ``kv_cache_k_N``/``kv_cache_v_N`` tensors into the
+        cache format ``call_with_cache`` expects for this family.
+
+        Default: a single ``[batch, num_layers, 2, cache_length,
+        num_kv_heads, head_dim]`` tensor. ``torch.stack`` always allocates
+        a fresh contiguous tensor, so the result never aliases the input
+        buffers and no ``.clone()`` is needed. Torch is imported locally:
+        this method is only called after the torch backend is verified.
+        """
+        import torch
+
+        k_list = [kv_cache[f"kv_cache_k_{i}"] for i in range(num_layers)]
+        v_list = [kv_cache[f"kv_cache_v_{i}"] for i in range(num_layers)]
+        k_stack = torch.stack(k_list, dim=1)
+        v_stack = torch.stack(v_list, dim=1)
+        return torch.stack([k_stack, v_stack], dim=2)
+
+    def unstack_kv_cache(self, cache, num_layers):
+        """Split the cache ``call_with_cache`` returned back into per-layer
+        ``kv_cache_k_N``/``kv_cache_v_N`` output tensors, inverting
+        ``stack_kv_cache``.
+
+        Each per-layer tensor is a view into ``cache``, which
+        ``call_with_cache`` already returns freshly allocated (Keras's
+        cache-update ops are purely functional), and ``torch.export``'s
+        functionalization materializes graph-output views into independent
+        buffers -- so no ``.clone()`` is needed.
+        """
+        outputs = {}
+        for i in range(num_layers):
+            outputs[f"kv_cache_k_{i}"] = cache[:, i, 0, ...]
+            outputs[f"kv_cache_v_{i}"] = cache[:, i, 1, ...]
+        return outputs
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        """Return extra chat-turn-boundary stop token ids for this family.
+
+        ``_build_llm_metadata`` always adds ``tokenizer.end_token_id`` as a
+        stop token; families that mark the end of a *chat turn* with a
+        distinct second token (Gemma's ``<end_of_turn>``, Llama3's
+        ``<|eot_id|>``) override this so on-device chat generation can stop
+        at turn boundaries. Default: none. Returned ids need not be
+        disjoint from ``end_token_id``; the caller de-duplicates.
+        """
+        del tokenizer
+        return []
+
+    def get_end_of_vision_token_ids(self, tokenizer):
+        """Return this family's end-of-image token id(s), or ``None``.
+
+        Used only by the separate-vision-encoder export path to decide
+        whether to bundle an ``END_OF_VISION`` model. Returns ``None`` --
+        never a wrong, unk-resolved id -- when the family declares no EOI
+        token or the tokenizer cannot resolve it, so the caller skips the
+        section instead of bundling an incorrect embedding.
+        """
+        if self.end_of_vision_token is None:
+            return None
+        token_id = _lookup_token_id(tokenizer, self.end_of_vision_token)
+        return [token_id] if token_id is not None else None
+
+
+def _lookup_token_id(tokenizer, token_str):
+    """Return the id for *token_str* in *tokenizer*'s vocab, or ``None``.
+
+    Only looks up when the tokenizer exposes ``token_to_id``, and swallows
+    the specific lookup-failure exceptions so a missing special token does
+    not abort export. Also treats a lookup that resolves to the tokenizer's
+    unk id as "not present", since some tokenizers map unknown lookups to
+    the unk id instead of raising.
+    """
+    if not hasattr(tokenizer, "token_to_id"):
+        return None
+    try:
+        token_id = tokenizer.token_to_id(token_str)
+    except (KeyError, ValueError):
+        return None
+    if token_id is None:
+        return None
+    unk_id = getattr(tokenizer, "_unk_token_id", None)
+    if token_id == unk_id:
+        return None
+    return token_id
+
+
+def _gemma_family_chat_stop_token_ids(tokenizer):
+    """Return ``[<end_of_turn> id]`` if present in *tokenizer*'s vocab.
+
+    ``<end_of_turn>`` is an optional chat-turn-stop token shared by the
+    Gemma family of SentencePiece tokenizers (Gemma, Gemma3, Gemma3n,
+    Gemma4, PaliGemma), distinct from ``tokenizer.end_token_id``.
+    """
+    token_id = _lookup_token_id(tokenizer, "<end_of_turn>")
+    return [token_id] if token_id is not None else []
+
+
+class GemmaSpec(LiteRTLMExportSpec):
+    """Base Gemma (Gemma/Gemma2) family.
+
+    There is no dedicated ``LlmModelType`` subtype for base Gemma, so
+    ``model_type`` stays ``"generic_model"``. Provides the Gemma-family
+    ``<end_of_turn>`` chat-stop-token convention shared by every Gemma*
+    spec below (all subclass this instead of ``LiteRTLMExportSpec``).
+    """
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        return _gemma_family_chat_stop_token_ids(tokenizer)
+
+
+class Gemma3Spec(GemmaSpec):
+    model_type = "gemma3"
+    #: Same string as ``LlmModelType.gemma3.end_of_image_token``.
+    end_of_vision_token = _GEMMA3_END_OF_IMAGE_TOKEN
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        _populate_gemma3_family_vision_metadata(
+            meta, self.model_type, vision_cfg
+        )
+
+
+class FunctionGemmaSpec(Gemma3Spec):
+    """The ``function_gemma_instruct_270m`` preset.
+
+    Architecturally identical to Gemma3 -- it loads as a plain
+    ``Gemma3CausalLM`` -- so it cannot be distinguished by ``isinstance``
+    or config. It is reached via the explicit
+    ``llm_model_type="function_gemma"`` override (mirroring litert-torch's
+    ``litert_lm_model_type_override``) or by tokenizer auto-detection
+    (``_is_function_gemma``). ``model_type = "function_gemma"`` maps it to
+    the ``FunctionGemma`` proto instead of ``gemma3``, preserving the
+    function-calling metadata a plain Gemma3 export would silently drop.
+
+    Deliberately NOT registered in ``_EXPORT_SPEC_REGISTRY``: an
+    ``isinstance`` entry would shadow ``Gemma3Spec`` for *every* Gemma3
+    model.
+    """
+
+    model_type = "function_gemma"
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        # The ``FunctionGemma`` proto has no image fields, so the gemma3-
+        # family vision population inherited from ``Gemma3Spec`` must not run.
+        del meta, vision_cfg
+
+    def populate_function_gemma_metadata(self, meta):
+        """Populate the ``FunctionGemma`` function-calling proto fields.
+
+        Mirrors litert-torch's Gemma4 metadata builder
+        (``export_hf/model_ext/gemma4/metadata_builder.py``), whose
+        function-calling field block ``FunctionGemma`` shares (proto fields
+        5-14). ``constraint_mode`` is left at its proto default, as
+        litert-torch leaves it.
+        """
+        subtype = meta.llm_model_type.function_gemma
+        subtype.code_fence_start = _FUNCTION_GEMMA_CODE_FENCE_START
+        subtype.code_fence_end = _FUNCTION_GEMMA_CODE_FENCE_END
+        subtype.open_quote = _FUNCTION_GEMMA_ESCAPE_TOKEN
+        subtype.close_quote = _FUNCTION_GEMMA_ESCAPE_TOKEN
+        subtype.function_response_start = (
+            _FUNCTION_GEMMA_FUNCTION_RESPONSE_START
+        )
+        subtype.use_template_for_fc_format = True
+
+
+class Gemma3nSpec(GemmaSpec):
+    model_type = "gemma3n"
+    cache_layout = "gemma3n"
+    vision_input_style = "embedded_pixel_values"
+    audio_input_style = "embedded_mel"
+    #: The encoder runs inside the backbone; no standalone encoder to pack.
+    supports_separate_vision = False
+
+    def get_kv_cache_sample_shape(
+        self, batch_size, cache_length, num_kv_heads, head_dim
+    ):
+        """Return Gemma3n's per-layer KV-cache sample shape.
+
+        Gemma3n's ``cache_layout`` transposes the standard shape to
+        ``[batch, num_kv_heads, cache_length, head_dim]``.
+        """
+        return (batch_size, num_kv_heads, cache_length, head_dim)
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        # The gemma3n subtype carries the same image-token fields as gemma3.
+        _populate_gemma3_family_vision_metadata(
+            meta, self.model_type, vision_cfg
+        )
+
+    def populate_audio_metadata(self, meta, audio_cfg):
+        del audio_cfg
+        # Deliberately Gemma4's audio token strings: that is what the
+        # verified golden gemma3n bundles contain. Do NOT "fix" these to
+        # Gemma3n's own `<start_of_audio>`/`<end_of_audio>` tokenizer tokens.
+        subtype = meta.llm_model_type.gemma3n
+        subtype.start_of_audio_token.token_str = _AUDIO_START_TOKEN
+        subtype.end_of_audio_token.token_str = _AUDIO_END_TOKEN
+
+    def get_forced_call_with_cache_kwargs(self, tokens, cache_length):
+        # Gemma3n's attention-mask computation requires a full-cache-length
+        # padding mask (a shorter one mis-broadcasts against the causal
+        # mask); export passes full-length valid tokens, so ones is correct.
+        import torch
+
+        return {
+            "padding_mask": torch.ones(
+                (tokens.shape[0], cache_length),
+                dtype=torch.bool,
+                device=tokens.device,
+            )
+        }
+
+
+class Gemma4Spec(GemmaSpec):
+    model_type = "gemma4"
+    vision_input_style = "patch_values"
+    audio_input_style = "standalone_mel"
+    #: Same string as ``LlmModelType.gemma4.end_of_image_token``.
+    end_of_vision_token = _GEMMA4_END_OF_IMAGE_TOKEN
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        image_size = vision_cfg["image_size"]
+        patch_size = _require_patch_size(
+            vision_cfg["patch_size"], "`vision_cfg['patch_size']`"
+        )
+        pool_size = vision_cfg.get("pool_size")
+        subtype = meta.llm_model_type.gemma4
+        subtype.start_of_image_token.token_str = _GEMMA4_START_OF_IMAGE_TOKEN
+        subtype.end_of_image_token.token_str = _GEMMA4_END_OF_IMAGE_TOKEN
+        subtype.patch_width = patch_size
+        subtype.patch_height = patch_size
+        subtype.max_num_patches = (image_size // patch_size) ** 2
+        if pool_size is not None:
+            subtype.pooling_kernel_size = pool_size
+
+    def populate_audio_metadata(self, meta, audio_cfg):
+        # The gemma4 subtype has no proto fields for the derived `audio_cfg`
+        # values; they only size the audio trace inputs, so not forwarded.
+        del audio_cfg
+        subtype = meta.llm_model_type.gemma4
+        subtype.start_of_audio_token.token_str = _AUDIO_START_TOKEN
+        subtype.end_of_audio_token.token_str = _AUDIO_END_TOKEN
+        # `skip_mel_spectrogram_extraction=False` makes the runtime perform
+        # mel extraction (`True` feeds raw PCM): the trace consumes log-mel
+        # `audio_mel`. Also the proto3 default -- an explicit regression guard.
+        subtype.skip_mel_spectrogram_extraction = False
+
+    def reshape_separate_vision_embeddings(
+        self, img_embeddings, tokens, preprocessor
+    ):
+        if img_embeddings is None:
+            return None
+        # The separate vision encoder/adapter flattens Gemma4's interleaved
+        # (batch, num_images, tokens_per_image, hidden_dim) embeddings to
+        # (batch*num_images, ...); reshape back before the language model.
+        max_images = self.get_max_images_per_prompt(preprocessor)
+        batch_size = tokens.shape[0]
+        return img_embeddings.reshape(
+            batch_size,
+            max_images,
+            img_embeddings.shape[1],
+            img_embeddings.shape[2],
+        )
+
+
+class Gemma4AssistantSpec(LiteRTLMExportSpec):
+    """The Gemma4 MTP draft (assistant) model: not standalone-exportable.
+
+    ``Gemma4AssistantCausalLM`` is a multi-token-prediction (MTP) draft
+    model for speculative decoding: its ``call_with_cache()`` requires a
+    target model's hidden state, last-token embedding, and borrowed KV
+    cache, so it has no self-contained prefill/decode graph to export. It
+    subclasses ``CausalLM`` directly (not ``Gemma4CausalLM``), so without
+    its own registry entry it would fall through to the generic spec and
+    crash deep in tracing. See the ``Gemma4AssistantCausalLM`` docstring
+    ("This model must NOT be used standalone").
+    """
+
+    def check_exportable(self, model):
+        raise ValueError(
+            f"LiteRT-LM export does not support `{type(model).__name__}`: it "
+            "is a multi-token-prediction (MTP) draft model for speculative "
+            "decoding, not a standalone model. Its `call_with_cache()` "
+            "depends on a target model's hidden state, last-token embedding, "
+            "and borrowed KV cache, so it cannot be exported on its own. "
+            "Export the target `Gemma4CausalLM` instead; the runtime uses "
+            "the draft model via `target_model.generate(..., "
+            "assistant_model=...)`."
+        )
+
+
+class PaliGemmaSpec(GemmaSpec):
+    """PaliGemma has no dedicated ``LlmModelType`` vision subtype today.
+
+    Registered explicitly (rather than relying on the ``LiteRTLMExportSpec``
+    fallback) purely for discoverability, so its lack of special-cased
+    behavior is a documented decision rather than an omission. Subclasses
+    ``GemmaSpec`` (not ``LiteRTLMExportSpec`` directly) since PaliGemma uses
+    a Gemma tokenizer and shares the same ``<end_of_turn>`` convention.
+    """
+
+    #: PaliGemma's ViT accepts one image at a time (4-D input).
+    flatten_image_batch = True
+
+    # `end_of_vision_token` stays `None`: PaliGemma defines no end-of-image
+    # special token, so separate-vision emits no `END_OF_VISION` section.
+    # `populate_vision_metadata` stays the base no-op for the same reason as
+    # the missing subtype: there are no proto fields to populate.
+
+
+class Llama3Spec(LiteRTLMExportSpec):
+    """Llama3's chat template ends a turn with ``<|eot_id|>``.
+
+    ``Llama3Tokenizer`` registers both ``<|end_of_text|>`` (the primary EOS,
+    ``end_token_id``) and ``<|eot_id|>`` (as the secondary ``end_token2``)
+    because checkpoints have no config indicating the true stop token.
+    Without this override, ``<|eot_id|>`` never reaches the exported
+    metadata, so on-device chat generation cannot stop at a turn boundary.
+    """
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        eot_id = getattr(tokenizer, "end_token2_id", None)
+        return [eot_id] if eot_id is not None else []
+
+
+class Phi3Spec(LiteRTLMExportSpec):
+    """Phi-3's chat template ends every turn with ``<|end|>``.
+
+    ``<|end|>`` is distinct from the primary EOS ``<|endoftext|>`` (what
+    ``Phi3Tokenizer`` registers as ``end_token``), so it never reaches the
+    exported metadata without this override. It is an ordinary special
+    token in the vocab, so look it up by string and return ``[]`` when it
+    is absent (base/non-instruct vocabularies).
+    """
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        token_id = _lookup_token_id(tokenizer, "<|end|>")
+        return [token_id] if token_id is not None else []
+
+
+# These keep the `LiteRTLMExportSpec` default (EOS-only): Mistral/Mixtral
+# end turns with the primary EOS `</s>`; base Llama, GPT2, Bloom, GPT-NeoX
+# and OPT are base LMs with no second chat-turn token in their tokenizers.
+
+
+def _qwen_family_chat_stop_token_ids(tokenizer):
+    """Return ``[<|im_end|> id]`` if present in *tokenizer*'s vocab.
+
+    ``<|im_end|>`` is the ChatML chat-turn-stop token shared by the Qwen
+    families (Qwen3 and pre-Qwen3 Qwen/Qwen-MoE alike).
+    """
+    token_id = _lookup_token_id(tokenizer, "<|im_end|>")
+    return [token_id] if token_id is not None else []
+
+
+class Qwen3FamilySpec(LiteRTLMExportSpec):
+    """Qwen3, Qwen3-MoE, and Qwen3.5 all map to the "qwen3" oneof."""
+
+    model_type = "qwen3"
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        # Qwen3's `<|im_end|>` is already `tokenizer.end_token_id`; surfaced
+        # explicitly (`_build_llm_metadata` de-duplicates).
+        return _qwen_family_chat_stop_token_ids(tokenizer)
+
+
+class Qwen3_5Spec(Qwen3FamilySpec):
+    """Qwen3.5 spec: maps to "qwen3" but its hybrid cache is unsupported.
+
+    Qwen3.5's hybrid full-attention/linear-attention decoder layers need a
+    dual cache (``Qwen3_5CausalLM.call_with_cache`` expects a ``(kv_cache,
+    conv_cache, recurrent_cache)`` tuple) that the LiteRT-LM adapter's
+    single stacked-KV-tensor cache format cannot represent yet.
+    """
+
+    cache_structure = "hybrid"
+
+    def describe_unsupported_cache_structure(self):
+        return (
+            "requires a 'hybrid' cache structure: Qwen3.5's hybrid "
+            "full_attention/linear_attention layers use a dual cache "
+            "structure (`call_with_cache` expects a `(kv_cache, conv_cache, "
+            "recurrent_cache)` tuple, since linear-attention layers need a "
+            "convolutional/recurrent state that a stacked KV tensor cannot "
+            f"represent), {_single_stacked_support_description()} "
+            "Support for hybrid cache structures is not yet implemented."
+        )
+
+
+class Qwen2p5FamilySpec(LiteRTLMExportSpec):
+    """Qwen and Qwen-MoE (pre-Qwen3 architecture) map to "qwen2p5"."""
+
+    model_type = "qwen2p5"
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        # Qwen 2.5 registers `<|endoftext|>` as `end_token`, but ChatML
+        # checkpoints may still carry `<|im_end|>`; add it when present.
+        return _qwen_family_chat_stop_token_ids(tokenizer)
+
+
+def _populate_gemma3_family_vision_metadata(meta, model_type, vision_cfg):
+    """Shared image-token metadata population for gemma3 and gemma3n."""
+    image_size = vision_cfg["image_size"]
+    subtype = getattr(meta.llm_model_type, model_type)
+    subtype.start_of_image_token.token_str = _GEMMA3_START_OF_IMAGE_TOKEN
+    subtype.end_of_image_token.token_str = _GEMMA3_END_OF_IMAGE_TOKEN
+    subtype.image_tensor_height = image_size
+    subtype.image_tensor_width = image_size
+
+
+# (module_path, class_name, spec_factory), imported lazily inside
+# ``resolve_export_spec`` to avoid heavy top-level dependencies.
+_EXPORT_SPEC_REGISTRY = (
+    (
+        "keras_hub.src.models.gemma4.gemma4_causal_lm",
+        "Gemma4CausalLM",
+        Gemma4Spec,
+    ),
+    # MTP draft model, not standalone-exportable: registered so
+    # `check_exportable` fails fast instead of tracing the generic path.
+    (
+        "keras_hub.src.models.gemma4.gemma4_assistant_causal_lm",
+        "Gemma4AssistantCausalLM",
+        Gemma4AssistantSpec,
+    ),
+    (
+        "keras_hub.src.models.gemma3n.gemma3n_causal_lm",
+        "Gemma3nCausalLM",
+        Gemma3nSpec,
+    ),
+    (
+        "keras_hub.src.models.gemma3.gemma3_causal_lm",
+        "Gemma3CausalLM",
+        Gemma3Spec,
+    ),
+    (
+        "keras_hub.src.models.pali_gemma.pali_gemma_causal_lm",
+        "PaliGemmaCausalLM",
+        PaliGemmaSpec,
+    ),
+    # Registered (despite no dedicated ``LlmModelType`` subtype) so base
+    # Gemma gets the shared Gemma-family ``<end_of_turn>`` behavior.
+    (
+        "keras_hub.src.models.gemma.gemma_causal_lm",
+        "GemmaCausalLM",
+        GemmaSpec,
+    ),
+    (
+        "keras_hub.src.models.qwen3_moe.qwen3_moe_causal_lm",
+        "Qwen3MoeCausalLM",
+        Qwen3FamilySpec,
+    ),
+    (
+        "keras_hub.src.models.qwen3.qwen3_causal_lm",
+        "Qwen3CausalLM",
+        Qwen3FamilySpec,
+    ),
+    # NOTE: no dedicated "qwen3_5" LlmModelType field; maps to "qwen3". Own
+    # spec class because its hybrid cache is not yet supported.
+    (
+        "keras_hub.src.models.qwen3_5.qwen3_5_causal_lm",
+        "Qwen3_5CausalLM",
+        Qwen3_5Spec,
+    ),
+    (
+        "keras_hub.src.models.qwen_moe.qwen_moe_causal_lm",
+        "QwenMoeCausalLM",
+        Qwen2p5FamilySpec,
+    ),
+    (
+        "keras_hub.src.models.qwen.qwen_causal_lm",
+        "QwenCausalLM",
+        Qwen2p5FamilySpec,
+    ),
+    # Llama3CausalLM subclasses LlamaCausalLM, so its entry must come first
+    # (first match wins) to get ``Llama3Spec``'s ``<|eot_id|>`` override.
+    (
+        "keras_hub.src.models.llama3.llama3_causal_lm",
+        "Llama3CausalLM",
+        Llama3Spec,
+    ),
+    # NOTE: no dedicated "llama" LlmModelType field; map to generic_model
+    # (the default -- explicit for greppability). No chat-stop token needed.
+    (
+        "keras_hub.src.models.llama.llama_causal_lm",
+        "LlamaCausalLM",
+        LiteRTLMExportSpec,
+    ),
+    (
+        "keras_hub.src.models.phi3.phi3_causal_lm",
+        "Phi3CausalLM",
+        Phi3Spec,
+    ),
+)
+
+# Deferred chat-stop-token cases, all left EOS-only: SmolLM3 (keras-hub's
+# tokenizer does not register `<|im_end|>`), GPT-OSS (harmony stop-token
+# semantics not encoded in keras-hub), Falcon (`falcon_causal_lm_test.py`
+# xfail).
+
+
+# Explicit model-type overrides for presets architecturally identical to
+# another family (see ``FunctionGemmaSpec``), keyed by ``llm_model_type``.
+# NOT in ``_EXPORT_SPEC_REGISTRY``: an entry would shadow the look-alike.
+_MODEL_TYPE_OVERRIDE_SPECS = {
+    "function_gemma": FunctionGemmaSpec,
+}
+
+
+def _is_function_gemma(model):
+    """Detect the ``function_gemma_instruct_270m`` preset by tokenizer tokens.
+
+    The preset loads as a plain ``Gemma3CausalLM`` (architecturally identical
+    to Gemma3), but its ``Gemma3Tokenizer`` vocabulary contains the
+    function-calling special tokens ``<start_function_call>`` and
+    ``<end_function_call>``. Plain Gemma3 presets do not.
+
+    We must verify the token round-trips, because some tokenizers map
+    out-of-vocabulary strings to a fixed ``<unk>`` id instead of raising.
+    """
+    try:
+        tokenizer = model.preprocessor.tokenizer
+        token_id = tokenizer.token_to_id("<start_function_call>")
+        return tokenizer.id_to_token(token_id) == "<start_function_call>"
+    except (AttributeError, ValueError, KeyError, TypeError):
+        return False
+
+
+def _resolve_export_spec_by_class(model):
+    """Return the spec ``_EXPORT_SPEC_REGISTRY`` maps *model*'s class to."""
+    # function_gemma loads as a plain Gemma3CausalLM but is distinguished by
+    # function-calling special tokens in its tokenizer. Check before the
+    # registry so it does not fall through to Gemma3Spec.
+    if _is_function_gemma(model):
+        return FunctionGemmaSpec()
+    for module_path, class_name, spec_factory in _EXPORT_SPEC_REGISTRY:
+        # Modules are imported lazily so importing this module stays cheap;
+        # all entries are first-party and must import cleanly -- an
+        # ImportError here is a real bug and must surface, not be skipped.
+        module = __import__(module_path, fromlist=[class_name])
+        cls = getattr(module, class_name)
+        if isinstance(model, cls):
+            return spec_factory()
+
+    return LiteRTLMExportSpec()
+
+
+def resolve_export_spec(model, llm_model_type=None):
+    """Return the ``LiteRTLMExportSpec`` for *model*.
+
+    If *llm_model_type* is given, it is an explicit caller override that
+    selects a spec by ``LlmMetadata.llm_model_type`` name for presets that are
+    architecturally indistinguishable from another family (e.g.
+    ``function_gemma``, which loads as a plain ``Gemma3CausalLM``); see
+    ``_MODEL_TYPE_OVERRIDE_SPECS``. Otherwise the spec is resolved by
+    ``isinstance`` checks against ``_EXPORT_SPEC_REGISTRY`` (in registration
+    order, first match wins, to avoid mis-identifying user-defined
+    subclasses). Unrecognized models get the default ``LiteRTLMExportSpec()``
+    (``model_type="generic_model"``, ``cache_layout="standard"``).
+
+    Raises:
+        ValueError: If *llm_model_type* is not a recognized override, or if it
+            is used on a model whose class is not exportable at all (the
+            override selects exported metadata, not exportability).
+    """
+    if llm_model_type is not None:
+        try:
+            override_spec_factory = _MODEL_TYPE_OVERRIDE_SPECS[llm_model_type]
+        except KeyError:
+            raise ValueError(
+                f"Unknown `llm_model_type` override {llm_model_type!r}. "
+                "Supported overrides: "
+                f"{sorted(_MODEL_TYPE_OVERRIDE_SPECS)}. Omit the argument to "
+                "auto-detect the model family by class."
+            )
+        # Exportability is a property of the model class, not of the requested
+        # metadata subtype, so the gate runs on the class-resolved spec: an
+        # override must not smuggle a non-exportable model past it. The other
+        # branch returns that same class-resolved spec, so the caller's own
+        # `check_exportable` call covers it.
+        _resolve_export_spec_by_class(model).check_exportable(model)
+        return override_spec_factory()
+    return _resolve_export_spec_by_class(model)

--- a/keras_hub/src/utils/litertlm/model_specs_test.py
+++ b/keras_hub/src/utils/litertlm/model_specs_test.py
@@ -1,0 +1,737 @@
+import importlib
+import types
+
+from keras_hub.src.models.gemma.gemma_backbone import GemmaBackbone
+from keras_hub.src.models.gemma.gemma_causal_lm import GemmaCausalLM
+from keras_hub.src.models.gemma3.gemma3_backbone import Gemma3Backbone
+from keras_hub.src.models.gemma3.gemma3_causal_lm import Gemma3CausalLM
+from keras_hub.src.models.gemma4.gemma4_assistant_causal_lm import (
+    Gemma4AssistantCausalLM,
+)
+from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.models.llama.llama_backbone import LlamaBackbone
+from keras_hub.src.models.llama.llama_causal_lm import LlamaCausalLM
+from keras_hub.src.models.llama3.llama3_backbone import Llama3Backbone
+from keras_hub.src.models.llama3.llama3_causal_lm import Llama3CausalLM
+from keras_hub.src.models.phi3.phi3_backbone import Phi3Backbone
+from keras_hub.src.models.phi3.phi3_causal_lm import Phi3CausalLM
+from keras_hub.src.models.qwen.qwen_backbone import QwenBackbone
+from keras_hub.src.models.qwen.qwen_causal_lm import QwenCausalLM
+from keras_hub.src.models.qwen3.qwen3_backbone import Qwen3Backbone
+from keras_hub.src.models.qwen3.qwen3_causal_lm import Qwen3CausalLM
+from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
+from keras_hub.src.models.qwen3_5.qwen3_5_causal_lm import Qwen3_5CausalLM
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.litertlm.model_specs import _EXPORT_SPEC_REGISTRY
+from keras_hub.src.utils.litertlm.model_specs import FunctionGemmaSpec
+from keras_hub.src.utils.litertlm.model_specs import Gemma3nSpec
+from keras_hub.src.utils.litertlm.model_specs import Gemma3Spec
+from keras_hub.src.utils.litertlm.model_specs import Gemma4AssistantSpec
+from keras_hub.src.utils.litertlm.model_specs import Gemma4Spec
+from keras_hub.src.utils.litertlm.model_specs import GemmaSpec
+from keras_hub.src.utils.litertlm.model_specs import LiteRTLMExportSpec
+from keras_hub.src.utils.litertlm.model_specs import Llama3Spec
+from keras_hub.src.utils.litertlm.model_specs import PaliGemmaSpec
+from keras_hub.src.utils.litertlm.model_specs import Phi3Spec
+from keras_hub.src.utils.litertlm.model_specs import Qwen2p5FamilySpec
+from keras_hub.src.utils.litertlm.model_specs import Qwen3_5Spec
+from keras_hub.src.utils.litertlm.model_specs import Qwen3FamilySpec
+from keras_hub.src.utils.litertlm.model_specs import resolve_export_spec
+
+
+class ExportSpecRegistryIntegrityTest(TestCase):
+    """Walk `_EXPORT_SPEC_REGISTRY` and verify every entry actually resolves.
+
+    Deliberately has no torch/litert_torch dependency and no backend
+    requirement: it only imports plain Keras model-definition modules (which
+    build fine under any Keras backend) plus `model_specs.py` itself (which
+    has no external imports at all).
+    """
+
+    def test_every_registry_entry_imports_and_resolves(self):
+        """Every `(module_path, class_name, spec_factory)` entry must import.
+
+        `resolve_export_spec` deliberately swallows `ImportError` per entry
+        so an unavailable optional model class doesn't break resolution for
+        every other family -- but that means a typo'd `module_path` or
+        `class_name` would silently and permanently fall back to the base
+        spec, with no test noticing. Import each entry directly here (not
+        through `resolve_export_spec`), so a broken entry fails loudly.
+        """
+        self.assertTrue(_EXPORT_SPEC_REGISTRY, "Registry must not be empty.")
+        for module_path, class_name, spec_factory in _EXPORT_SPEC_REGISTRY:
+            with self.subTest(module_path=module_path, class_name=class_name):
+                module = importlib.import_module(module_path)
+                self.assertTrue(
+                    hasattr(module, class_name),
+                    f"{module_path!r} has no attribute {class_name!r} -- "
+                    "check for a typo in _EXPORT_SPEC_REGISTRY.",
+                )
+                cls = getattr(module, class_name)
+                self.assertTrue(
+                    isinstance(cls, type),
+                    f"{module_path}.{class_name} is not a class.",
+                )
+                spec = spec_factory()
+                self.assertIsInstance(spec, LiteRTLMExportSpec)
+
+    # Tiny, randomly-initialized instances, matching the pattern every
+    # `*_causal_lm_test.py` in this repo already uses for cheap model
+    # construction. `resolve_export_spec` only performs `isinstance` checks,
+    # so no preprocessor or real weights are needed.
+
+    def _tiny_llama(self):
+        backbone = LlamaBackbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return LlamaCausalLM(backbone=backbone)
+
+    def _tiny_llama3(self):
+        backbone = Llama3Backbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return Llama3CausalLM(backbone=backbone)
+
+    def _tiny_phi3(self):
+        backbone = Phi3Backbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return Phi3CausalLM(backbone=backbone)
+
+    def _tiny_gemma(self):
+        backbone = GemmaBackbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=4,
+            intermediate_dim=16,
+        )
+        return GemmaCausalLM(backbone=backbone)
+
+    def _tiny_gemma3(self):
+        # Text-only Gemma3 (`vision_encoder=None`); `resolve_export_spec` only
+        # does `isinstance`, so no preprocessor or real weights are needed.
+        backbone = Gemma3Backbone(
+            vocabulary_size=10,
+            image_size=16,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=4,
+            intermediate_dim=16,
+            vision_encoder=None,
+        )
+        # `Gemma3CausalLM` requires `preprocessor`, but `resolve_export_spec`
+        # only does an `isinstance` check, so a null preprocessor is fine.
+        return Gemma3CausalLM(preprocessor=None, backbone=backbone)
+
+    def _tiny_gemma4_assistant(self):
+        # Mirrors the tiny config in `gemma4_assistant_causal_lm_test.py`.
+        backbone = Gemma4Backbone(
+            vocabulary_size=256,
+            num_layers=4,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+            head_dim=4,
+            global_head_dim=8,
+            image_size=16,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+        )
+        return Gemma4AssistantCausalLM(
+            preprocessor=None,
+            backbone=backbone,
+            backbone_hidden_size=16,
+            num_centroids=4,
+            centroid_intermediate_top_k=2,
+            use_ordered_embeddings=True,
+        )
+
+    def _tiny_qwen(self):
+        backbone = QwenBackbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return QwenCausalLM(backbone=backbone)
+
+    def _tiny_qwen3(self):
+        backbone = Qwen3Backbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=4,
+            intermediate_dim=16,
+        )
+        return Qwen3CausalLM(backbone=backbone)
+
+    def _tiny_qwen3_5(self):
+        backbone = Qwen3_5Backbone(
+            vocabulary_size=10,
+            num_layers=2,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=8,
+            intermediate_dim=16,
+            layer_types=["linear_attention", "full_attention"],
+            partial_rotary_factor=0.25,
+            linear_num_key_heads=1,
+            linear_num_value_heads=2,
+            linear_key_head_dim=4,
+            linear_value_head_dim=4,
+            linear_conv_kernel_dim=4,
+        )
+        return Qwen3_5CausalLM(backbone=backbone)
+
+    def test_llama_resolves_to_base_generic_spec(self):
+        """Llama is explicitly registered but maps to the base spec/class
+        (see the `LlamaCausalLM` entry's NOTE in `_EXPORT_SPEC_REGISTRY`)."""
+        spec = resolve_export_spec(self._tiny_llama())
+        self.assertIs(type(spec), LiteRTLMExportSpec)
+        self.assertEqual(spec.model_type, "generic_model")
+        self.assertEqual(spec.cache_structure, "single_stacked")
+
+    def test_qwen_resolves_to_qwen2p5_family_spec(self):
+        spec = resolve_export_spec(self._tiny_qwen())
+        self.assertIsInstance(spec, Qwen2p5FamilySpec)
+        self.assertEqual(spec.model_type, "qwen2p5")
+
+    def test_qwen3_resolves_to_qwen3_family_spec(self):
+        spec = resolve_export_spec(self._tiny_qwen3())
+        self.assertIsInstance(spec, Qwen3FamilySpec)
+        self.assertNotIsInstance(spec, Qwen3_5Spec)
+        self.assertEqual(spec.model_type, "qwen3")
+        self.assertEqual(spec.cache_structure, "single_stacked")
+
+    def test_qwen3_5_resolves_to_hybrid_cache_spec(self):
+        """Regression coverage for the `cache_structure` fix: Qwen3.5 must
+        resolve to its own `Qwen3_5Spec` (not the shared `Qwen3FamilySpec`
+        every other Qwen3-family model uses), so `export_to_litertlm`'s
+        `cache_structure` fail-fast check actually fires for it.
+
+        This is deliberately not a duplicate of
+        `test_litertlm_model_type_detection` in `qwen3_5_causal_lm_test.py`:
+        that test only checks `model_type` and requires the torch backend;
+        this one also checks spec class identity and `cache_structure`, and
+        needs neither torch nor any litertlm dependency.
+        """
+        spec = resolve_export_spec(self._tiny_qwen3_5())
+        self.assertIsInstance(spec, Qwen3_5Spec)
+        self.assertEqual(spec.model_type, "qwen3")
+        self.assertEqual(spec.cache_structure, "hybrid")
+
+    def test_gemma_resolves_to_gemma_spec(self):
+        """Base Gemma has no dedicated `LlmModelType` subtype, but must still
+        resolve to `GemmaSpec` (not the plain `LiteRTLMExportSpec` fallback)
+        to get the shared Gemma-family `<end_of_turn>` chat-stop-token
+        behavior."""
+        spec = resolve_export_spec(self._tiny_gemma())
+        self.assertIsInstance(spec, GemmaSpec)
+        self.assertEqual(spec.model_type, "generic_model")
+
+    def test_gemma3_resolves_to_gemma3_spec_by_default(self):
+        """A plain Gemma3 (no override) resolves to `Gemma3Spec` -- the
+        regression guard that the `function_gemma` override never leaks into
+        ordinary Gemma3 exports."""
+        spec = resolve_export_spec(self._tiny_gemma3())
+        self.assertIsInstance(spec, Gemma3Spec)
+        self.assertNotIsInstance(spec, FunctionGemmaSpec)
+        self.assertEqual(spec.model_type, "gemma3")
+
+    def test_function_gemma_override_resolves_to_function_gemma_spec(self):
+        """The explicit `llm_model_type="function_gemma"` override selects
+        `FunctionGemmaSpec` (`model_type="function_gemma"`), even though the
+        model is a plain `Gemma3CausalLM` that would otherwise resolve to
+        `Gemma3Spec`."""
+        model = self._tiny_gemma3()
+        self.assertEqual(resolve_export_spec(model).model_type, "gemma3")
+        spec = resolve_export_spec(model, llm_model_type="function_gemma")
+        self.assertIsInstance(spec, FunctionGemmaSpec)
+        self.assertEqual(spec.model_type, "function_gemma")
+
+    def test_function_gemma_spec_not_in_isinstance_registry(self):
+        """`FunctionGemmaSpec` must NOT be in `_EXPORT_SPEC_REGISTRY`: an
+        `isinstance` entry would shadow `Gemma3Spec` for every Gemma3 model."""
+        self.assertNotIn(
+            FunctionGemmaSpec, [f for _, _, f in _EXPORT_SPEC_REGISTRY]
+        )
+
+    def test_function_gemma_auto_detected_by_tokenizer_tokens(self):
+        """A `Gemma3CausalLM` whose tokenizer exposes function-calling special
+        tokens (`<start_function_call>`) auto-resolves to `FunctionGemmaSpec`
+        even without an explicit `llm_model_type` override."""
+
+        class MockTokenizer:
+            def token_to_id(self, token):
+                if token == "<start_function_call>":
+                    return 48
+                return -1
+
+            def id_to_token(self, token_id):
+                if token_id == 48:
+                    return "<start_function_call>"
+                return "<unk>"
+
+        class MockPreprocessor:
+            tokenizer = MockTokenizer()
+
+        model = self._tiny_gemma3()
+        model.preprocessor = MockPreprocessor()
+        spec = resolve_export_spec(model)
+        self.assertIsInstance(spec, FunctionGemmaSpec)
+        self.assertEqual(spec.model_type, "function_gemma")
+
+    def test_unknown_llm_model_type_override_raises(self):
+        """An unrecognized `llm_model_type` override is a hard error, not a
+        silent fall-through to isinstance resolution."""
+        model = self._tiny_gemma3()
+        with self.assertRaisesRegex(ValueError, "Unknown `llm_model_type`"):
+            resolve_export_spec(model, llm_model_type="not_a_real_type")
+
+    def test_llama3_resolves_to_llama3_spec(self):
+        """`Llama3CausalLM` is a subclass of `LlamaCausalLM`; it must resolve
+        to `Llama3Spec` (registered earlier in `_EXPORT_SPEC_REGISTRY`), not
+        fall through to the plain `LlamaCausalLM` entry."""
+        spec = resolve_export_spec(self._tiny_llama3())
+        self.assertIsInstance(spec, Llama3Spec)
+        self.assertEqual(spec.model_type, "generic_model")
+
+    def test_phi3_causal_lm_resolves_to_phi3_spec(self):
+        """`Phi3CausalLM` must resolve to `Phi3Spec` (not fall through to
+        the plain `LiteRTLMExportSpec` default), so its `<|end|>`
+        chat-stop-token override actually fires."""
+        spec = resolve_export_spec(self._tiny_phi3())
+        self.assertIsInstance(spec, Phi3Spec)
+        self.assertEqual(spec.model_type, "generic_model")
+
+    def test_gemma4_assistant_check_exportable_raises(self):
+        """`Gemma4AssistantCausalLM` resolves to `Gemma4AssistantSpec`, whose
+        `check_exportable` fails fast with the MTP-draft explanation instead
+        of letting the model fall through to the generic spec and crash in
+        tracing. The base-class gate is a no-op for ordinary models."""
+        model = self._tiny_gemma4_assistant()
+        spec = resolve_export_spec(model)
+        self.assertIs(type(spec), Gemma4AssistantSpec)
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not support `Gemma4AssistantCausalLM`.*"
+            "multi-token-prediction",
+        ):
+            spec.check_exportable(model)
+        self.assertIsNone(
+            LiteRTLMExportSpec().check_exportable(self._tiny_llama())
+        )
+
+    def test_llm_model_type_override_cannot_bypass_check_exportable(self):
+        """`llm_model_type` selects exported metadata, never exportability.
+
+        The override resolves a spec by name instead of by class, so it must
+        not be usable to route a non-exportable model (an MTP draft model) to
+        an exportable family's spec and slip past `check_exportable`."""
+        model = self._tiny_gemma4_assistant()
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not support `Gemma4AssistantCausalLM`.*"
+            "multi-token-prediction",
+        ):
+            resolve_export_spec(model, llm_model_type="function_gemma")
+
+    # Dependency-free checks of `get_chat_stop_token_ids` against small fake
+    # tokenizer objects -- no real KerasHub tokenizer or torch/litert
+    # dependency needed, since the method only calls `token_to_id`/reads
+    # plain attributes.
+
+    def test_gemma_spec_chat_stop_token_ids_looks_up_end_of_turn(self):
+        vocab = {"<end_of_turn>": 7}
+        tokenizer = types.SimpleNamespace(
+            token_to_id=vocab.__getitem__, _unk_token_id=0
+        )
+        self.assertEqual(GemmaSpec().get_chat_stop_token_ids(tokenizer), [7])
+
+    def test_gemma_spec_chat_stop_token_ids_absent_returns_empty(self):
+        tokenizer = types.SimpleNamespace(
+            token_to_id=lambda token: (_ for _ in ()).throw(KeyError(token))
+        )
+        self.assertEqual(GemmaSpec().get_chat_stop_token_ids(tokenizer), [])
+
+    def test_llama3_spec_chat_stop_token_ids_uses_end_token2_id(self):
+        """`Llama3Tokenizer` stores `<|eot_id|>` as `end_token2_id` (see the
+        "Hack" comment in `llama3_tokenizer.py`), not via `token_to_id`
+        lookup -- `Llama3Spec` must read that attribute directly."""
+        tokenizer = types.SimpleNamespace(end_token2_id=5)
+        self.assertEqual(Llama3Spec().get_chat_stop_token_ids(tokenizer), [5])
+
+    def test_llama3_spec_chat_stop_token_ids_absent_returns_empty(self):
+        """Base Llama (no `end_token2` hack) has no `end_token2_id`
+        attribute at all."""
+        tokenizer = types.SimpleNamespace()
+        self.assertEqual(Llama3Spec().get_chat_stop_token_ids(tokenizer), [])
+
+    def test_qwen3_family_spec_chat_stop_token_ids_looks_up_im_end(self):
+        """Qwen3's `<|im_end|>` is already `tokenizer.end_token_id`; this
+        override documents that intentionally rather than leaving it as an
+        accident of `end_token_id`'s value (`_build_llm_metadata`
+        deduplicates the two)."""
+        vocab = {"<|im_end|>": 3}
+        tokenizer = types.SimpleNamespace(
+            token_to_id=vocab.__getitem__, _unk_token_id=0
+        )
+        self.assertEqual(
+            Qwen3FamilySpec().get_chat_stop_token_ids(tokenizer), [3]
+        )
+
+    def test_qwen2p5_family_spec_chat_stop_token_ids_absent_by_default(self):
+        """Base Qwen (2.5) tokenizers use `<|endoftext|>`, not `<|im_end|>`;
+        the override must not invent a token that isn't in vocab."""
+        tokenizer = types.SimpleNamespace(
+            token_to_id=lambda token: (_ for _ in ()).throw(KeyError(token))
+        )
+        self.assertEqual(
+            Qwen2p5FamilySpec().get_chat_stop_token_ids(tokenizer), []
+        )
+
+    def test_phi3_spec_chat_stop_token_ids_looks_up_end(self):
+        """Phi-3's chat template ends each turn with `<|end|>` (distinct
+        from the `<|endoftext|>` EOS); the override must surface it.
+        `<|end|>` is an ordinary special token looked up by string, not a
+        named tokenizer attribute."""
+        vocab = {"<|end|>": 18}
+        tokenizer = types.SimpleNamespace(
+            token_to_id=vocab.__getitem__, _unk_token_id=0
+        )
+        self.assertEqual(Phi3Spec().get_chat_stop_token_ids(tokenizer), [18])
+
+    def test_phi3_spec_chat_stop_token_ids_absent_returns_empty(self):
+        """Base/non-instruct Phi-3 vocabularies without `<|end|>` get no
+        chat-stop token; the override must not invent one."""
+        tokenizer = types.SimpleNamespace(
+            token_to_id=lambda token: (_ for _ in ()).throw(KeyError(token))
+        )
+        self.assertEqual(Phi3Spec().get_chat_stop_token_ids(tokenizer), [])
+
+    def test_base_spec_describes_unsupported_cache_structure_generically(self):
+        """The default `describe_unsupported_cache_structure` must name the
+        actual mismatched `cache_structure` value generically, without any
+        family-specific (e.g. Qwen3.5) text -- that lives on the family's
+        own spec (see `Qwen3_5Spec`'s override) instead of leaking into the
+        shared/generic path."""
+
+        class _CustomHybridSpec(LiteRTLMExportSpec):
+            cache_structure = "custom_hybrid"
+
+        message = _CustomHybridSpec().describe_unsupported_cache_structure()
+        self.assertIn("custom_hybrid", message)
+        self.assertIn("single_stacked", message)
+        self.assertNotIn("Qwen3.5", message)
+        self.assertNotIn("Qwen", message)
+
+    def test_qwen3_5_spec_describes_hybrid_cache_specifically(self):
+        message = Qwen3_5Spec().describe_unsupported_cache_structure()
+        self.assertIn("hybrid full_attention/linear_attention", message)
+
+    # Every audio-capable family must declare an `audio_input_style`
+    # matching how its encoder consumes input.
+
+    def test_audio_capable_specs_declare_audio_input_style(self):
+        """Gemma3n and Gemma4 are the only audio-capable families; each must
+        declare a concrete `audio_input_style` matching how its audio encoder
+        consumes input (embedded-in-backbone vs standalone in-trace)."""
+        self.assertEqual(Gemma3nSpec().audio_input_style, "embedded_mel")
+        self.assertEqual(Gemma4Spec().audio_input_style, "standalone_mel")
+
+    def test_non_audio_specs_have_no_audio_input_style(self):
+        """The base spec and non-audio families default to `None`, so the
+        registry test's audio-capability signal stays a clean non-None
+        check."""
+        self.assertIsNone(LiteRTLMExportSpec().audio_input_style)
+        self.assertIsNone(GemmaSpec().audio_input_style)
+        self.assertIsNone(Gemma3Spec().audio_input_style)
+        self.assertIsNone(PaliGemmaSpec().audio_input_style)
+
+    def test_gemma3n_audio_metadata_pins_gemma4_token_strings(self):
+        """Gemma3n's audio metadata deliberately uses Gemma4's token strings
+        (golden reference bundles); regression-guard against deriving them
+        from Gemma3n's own `<start_of_audio>`/`<end_of_audio>` tokens."""
+        meta = types.SimpleNamespace(
+            llm_model_type=types.SimpleNamespace(
+                gemma3n=types.SimpleNamespace(
+                    start_of_audio_token=types.SimpleNamespace(token_str=""),
+                    end_of_audio_token=types.SimpleNamespace(token_str=""),
+                )
+            )
+        )
+        Gemma3nSpec().populate_audio_metadata(meta, None)
+        self.assertEqual(
+            meta.llm_model_type.gemma3n.start_of_audio_token.token_str,
+            "<|audio>",
+        )
+        self.assertEqual(
+            meta.llm_model_type.gemma3n.end_of_audio_token.token_str,
+            "<audio|>",
+        )
+
+    # The gemma3-family image-token population belongs to the subtypes that
+    # actually have those proto fields; every other Gemma-family spec must
+    # leave `LlmMetadata` untouched.
+
+    def _fake_vision_meta(self, subtype_name=None):
+        llm_model_type = types.SimpleNamespace()
+        subtype = None
+        if subtype_name is not None:
+            subtype = types.SimpleNamespace(
+                start_of_image_token=types.SimpleNamespace(token_str=""),
+                end_of_image_token=types.SimpleNamespace(token_str=""),
+                image_tensor_height=0,
+                image_tensor_width=0,
+            )
+            setattr(llm_model_type, subtype_name, subtype)
+        return types.SimpleNamespace(llm_model_type=llm_model_type), subtype
+
+    def test_gemma3_family_populates_image_token_metadata(self):
+        for spec_cls, subtype_name in (
+            (Gemma3Spec, "gemma3"),
+            (Gemma3nSpec, "gemma3n"),
+        ):
+            with self.subTest(subtype=subtype_name):
+                meta, subtype = self._fake_vision_meta(subtype_name)
+                spec_cls().populate_vision_metadata(meta, {"image_size": 48})
+                self.assertEqual(
+                    subtype.start_of_image_token.token_str, "<start_of_image>"
+                )
+                self.assertEqual(
+                    subtype.end_of_image_token.token_str, "<end_of_image>"
+                )
+                self.assertEqual(subtype.image_tensor_height, 48)
+                self.assertEqual(subtype.image_tensor_width, 48)
+
+    def test_specs_without_image_proto_fields_populate_nothing(self):
+        """These families map to a `LlmModelType` subtype with no image fields
+        (`generic_model`, `function_gemma`), or have no dedicated vision
+        subtype at all (PaliGemma), so populating gemma3-family image metadata
+        would be an `AttributeError` on the real protobuf. Their
+        `populate_vision_metadata` must be a strict no-op, touching nothing on
+        `meta`."""
+        for spec_cls in (
+            LiteRTLMExportSpec,
+            GemmaSpec,
+            FunctionGemmaSpec,
+            PaliGemmaSpec,
+        ):
+            with self.subTest(spec=spec_cls.__name__):
+                meta, _ = self._fake_vision_meta()
+                self.assertIsNone(
+                    spec_cls().populate_vision_metadata(
+                        meta, {"image_size": 48}
+                    )
+                )
+                self.assertEqual(vars(meta.llm_model_type), {})
+
+    def test_single_image_family_declares_flatten_image_batch(self):
+        """PaliGemma's ViT is 4-D-only; its spec must declare
+        flatten_image_batch=True so the adapter flattens the batched images
+        stack before calling it."""
+        self.assertTrue(PaliGemmaSpec().flatten_image_batch)
+
+    def test_multi_image_families_do_not_flatten(self):
+        """Every other vision family accepts the batched stack (or does not
+        run the encoder standalone), so flatten_image_batch stays False."""
+        self.assertFalse(LiteRTLMExportSpec().flatten_image_batch)
+        self.assertFalse(Gemma3Spec().flatten_image_batch)
+        self.assertFalse(Gemma3nSpec().flatten_image_batch)
+        self.assertFalse(Gemma4Spec().flatten_image_batch)
+
+    def test_max_images_reads_preprocessor_attribute(self):
+        pre = types.SimpleNamespace(max_images_per_prompt=4)
+        self.assertEqual(Gemma4Spec().get_max_images_per_prompt(pre), 4)
+
+    def test_max_images_single_image_family_defaults_to_one(self):
+        """PaliGemma's preprocessor has no max_images_per_prompt; because it
+        declares flatten_image_batch=True, resolving to 1 is legitimate."""
+        pre = types.SimpleNamespace()  # no max_images_per_prompt attribute
+        self.assertEqual(PaliGemmaSpec().get_max_images_per_prompt(pre), 1)
+
+    def test_max_images_missing_on_multi_image_family_raises(self):
+        """A multi-image (flatten_image_batch=False) family with no
+        max_images_per_prompt is a misconfiguration -- must raise, not
+        silently default to 1."""
+        pre = types.SimpleNamespace()  # no max_images_per_prompt attribute
+        with self.assertRaisesRegex(ValueError, "flatten_image_batch=False"):
+            Gemma4Spec().get_max_images_per_prompt(pre)
+
+    # `get_vision_config` / `get_audio_config` only read plain attributes, so
+    # these guard tests drive them with small fakes instead of real backbones.
+
+    def _fake_vision_model(self, **encoder_attrs):
+        vision_encoder = types.SimpleNamespace(**encoder_attrs)
+        backbone = types.SimpleNamespace(
+            vision_encoder=vision_encoder,
+            image_size=32,
+            num_vision_tokens_per_image=4,
+        )
+        return types.SimpleNamespace(
+            backbone=backbone,
+            preprocessor=types.SimpleNamespace(max_images_per_prompt=2),
+        )
+
+    def _fake_audio_model(self, **preprocessor_attrs):
+        return types.SimpleNamespace(
+            backbone=types.SimpleNamespace(audio_encoder=object()),
+            preprocessor=types.SimpleNamespace(**preprocessor_attrs),
+        )
+
+    def test_patch_values_family_requires_patch_size(self):
+        """Gemma4 derives its exported `patch_values` signature and
+        `max_num_patches` from `patch_size`, so a vision encoder that does not
+        declare one is a misconfiguration -- it must raise rather than fall
+        back to an invented default patch geometry."""
+        model = self._fake_vision_model()  # no patch_size attribute
+        with self.assertRaisesRegex(ValueError, "patch_size=None"):
+            Gemma4Spec().get_vision_config(model)
+
+    def test_non_patch_values_family_tolerates_missing_patch_size(self):
+        """Only `patch_values` families consume `patch_size`. Gemma3n feeds
+        `embedded_pixel_values` and no keras-hub Gemma3n preset can supply a
+        `patch_size`, so a missing one must resolve to None, not raise."""
+        model = self._fake_vision_model()  # no patch_size attribute
+        vision_cfg = Gemma3nSpec().get_vision_config(model)
+        self.assertIsNone(vision_cfg["patch_size"])
+        self.assertEqual(vision_cfg["num_vision_tokens"], 8)
+
+    def test_patch_size_is_read_from_the_vision_encoder(self):
+        model = self._fake_vision_model(patch_size=8, pool_size=2)
+        vision_cfg = Gemma4Spec().get_vision_config(model)
+        self.assertEqual(vision_cfg["patch_size"], 8)
+        self.assertEqual(vision_cfg["pool_size"], 2)
+
+    def test_gemma4_vision_metadata_rejects_missing_patch_size(self):
+        """`Gemma4Spec.populate_vision_metadata` computes `max_num_patches`
+        from `patch_size`; a None must produce the same actionable error as
+        `get_vision_config`, not a `TypeError` from the arithmetic."""
+        meta = types.SimpleNamespace(llm_model_type=types.SimpleNamespace())
+        with self.assertRaisesRegex(ValueError, "patch_size=None"):
+            Gemma4Spec().populate_vision_metadata(
+                meta, {"image_size": 32, "patch_size": None}
+            )
+
+    def test_missing_max_clips_per_prompt_raises(self):
+        model = self._fake_audio_model(
+            num_audio_tokens_per_audio=3, audio_input_feat_size=16
+        )
+        with self.assertRaisesRegex(
+            ValueError, "Could not determine `max_clips_per_prompt`"
+        ):
+            Gemma3nSpec().get_audio_config(model)
+
+    def test_missing_num_audio_tokens_per_clip_raises(self):
+        model = self._fake_audio_model(
+            max_audios_per_prompt=2, audio_input_feat_size=16
+        )
+        with self.assertRaisesRegex(
+            ValueError, "Could not determine `num_audio_tokens_per_clip`"
+        ):
+            Gemma3nSpec().get_audio_config(model)
+
+    def test_missing_audio_input_feat_size_raises(self):
+        model = self._fake_audio_model(
+            max_audios_per_prompt=2, num_audio_tokens_per_audio=3
+        )
+        with self.assertRaisesRegex(
+            ValueError, "Could not determine `audio_input_feat_size`"
+        ):
+            Gemma3nSpec().get_audio_config(model)
+
+    def test_audio_config_resolves_from_preprocessor_attributes(self):
+        """The happy path for the three guards above: with every attribute
+        present the config resolves, so each guard test is failing on the one
+        attribute it drops rather than on an incomplete fake."""
+        model = self._fake_audio_model(
+            max_audios_per_prompt=2,
+            num_audio_tokens_per_audio=3,
+            audio_input_feat_size=16,
+        )
+        audio_cfg = Gemma3nSpec().get_audio_config(model)
+        self.assertEqual(audio_cfg["max_clips_per_prompt"], 2)
+        self.assertEqual(audio_cfg["num_audio_tokens"], 6)
+        self.assertEqual(audio_cfg["audio_input_feat_size"], 16)
+
+    # These tests lock the family-wide default (False) so a per-family
+    # relaxation is a deliberate, visible one-line override.
+
+    def test_all_vision_families_disallow_bucketing_by_default(self):
+        """Every vision-capable family inherits allows_vision_bucketing=False,
+        so the family-wide bucketing ban stays in force until a family is
+        explicitly, deliberately relaxed with a numerics-gated override."""
+        self.assertFalse(Gemma3Spec().allows_vision_bucketing)
+        self.assertFalse(Gemma3nSpec().allows_vision_bucketing)
+        self.assertFalse(Gemma4Spec().allows_vision_bucketing)
+        self.assertFalse(PaliGemmaSpec().allows_vision_bucketing)
+
+    def test_base_and_text_specs_default_disallow_vision_bucketing(self):
+        """The base spec and text-only families also default to False. The
+        flag is only consulted when `get_vision_config` returns non-None (see
+        `export.py`'s `has_vision` guard), so text-only families keep full
+        bucketing support regardless of this value; the default is asserted
+        here for completeness and to document the base-class contract."""
+        self.assertFalse(LiteRTLMExportSpec().allows_vision_bucketing)
+        self.assertFalse(GemmaSpec().allows_vision_bucketing)
+
+    # These tests lock the {baked, separate} support matrix so a change is
+    # deliberate.
+
+    def test_vision_families_declare_supports_separate_vision(self):
+        """Every vision-capable family declares supports_separate_vision
+        explicitly, and its value matches the current support matrix: Gemma3,
+        Gemma4 and PaliGemma support the separate path; Gemma3n (encoder
+        inside the backbone) does not."""
+        self.assertTrue(Gemma3Spec().supports_separate_vision)
+        self.assertTrue(Gemma4Spec().supports_separate_vision)
+        self.assertTrue(PaliGemmaSpec().supports_separate_vision)
+        self.assertFalse(Gemma3nSpec().supports_separate_vision)
+
+    def test_embedded_vision_family_disallows_separate_vision(self):
+        """The `supports_separate_vision=False` families are exactly the
+        `embedded_pixel_values` ones (encoder runs in-backbone). Lock the two
+        facts together so the flag can't drift away from the input style it
+        summarizes."""
+        for spec in (Gemma3nSpec(),):
+            self.assertEqual(spec.vision_input_style, "embedded_pixel_values")
+            self.assertFalse(spec.supports_separate_vision)
+
+    def test_base_and_text_specs_default_support_separate_vision(self):
+        """The base spec and text-only families inherit the permissive
+        default (True). The flag is only consulted when `get_vision_config`
+        returns non-None (see export.py's `has_vision` guard), so its value on
+        text-only families is inert; asserted here for the base-class
+        contract, matching the allows_vision_bucketing default test above."""
+        self.assertTrue(LiteRTLMExportSpec().supports_separate_vision)
+        self.assertTrue(GemmaSpec().supports_separate_vision)

--- a/keras_hub/src/utils/litertlm/traceable_ops.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops.py
@@ -1,0 +1,472 @@
+"""Traceable replacements for Keras torch-backend ops used during export.
+
+``torch.export`` (used by ``litert_torch`` to trace KerasHub models for
+LiteRT-LM) cannot lower every op that Keras's torch backend produces --
+some introduce fused ATen ops, runtime assertions, or unbacked symbolic
+shapes that ``litert_torch`` cannot translate to TFLite. This module holds
+self-contained, drop-in replacements for the handful of ops that need this
+treatment (``one_hot``, ``repeat``, ``slice``, ``take``, ``scatter_update``,
+``dot_product_attention``, ``amax``), plus context managers that
+temporarily monkeypatch Keras's torch backend to use them. This has no
+relationship to ``KerasHubLiteRTAdapter`` beyond being a dependency used
+while tracing it -- it is a standalone "make these ops traceable" shim
+library.
+"""
+
+import contextlib
+import unittest.mock
+
+import numpy as np
+import torch
+from keras.src import backend
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import nn as torch_backend_nn
+from keras.src.backend.torch import numpy as torch_backend_numpy
+
+
+def _make_scope(module, attr, replacement):
+    """Build a context manager that patches ``module.attr`` to *replacement*."""
+
+    @contextlib.contextmanager
+    def _scope():
+        with unittest.mock.patch.object(module, attr, replacement):
+            yield
+
+    return _scope
+
+
+def _normalize_start_indices(start_indices):
+    """Convert ``start_indices`` to a list preserving tensor elements."""
+    if isinstance(start_indices, (list, tuple)):
+        return list(start_indices)
+    start_indices = torch_core.convert_to_tensor(start_indices, dtype="int64")
+    if start_indices.ndim != 1:
+        raise ValueError(
+            "`start_indices` must be a 1-D tensor or a list/tuple of ints. "
+            f"Received shape: {tuple(start_indices.shape)}."
+        )
+    return list(start_indices.reshape(-1).unbind())
+
+
+def _patched_slice(inputs, start_indices, shape):
+    """Traceable replacement for Keras torch-backend ``slice``."""
+    inputs = torch_core.convert_to_tensor(inputs)
+
+    starts = _normalize_start_indices(start_indices)
+
+    if isinstance(shape, (list, tuple)):
+        lengths = list(shape)
+    else:
+        shape = torch_core.convert_to_tensor(shape, dtype="int64")
+        lengths = list(shape.reshape(-1).unbind())
+
+    def _is_dynamic(value):
+        # ``torch.SymInt`` values are not plain Python ints and require
+        # tensor-based slicing to avoid data-dependent guards.
+        return isinstance(value, torch.Tensor) or isinstance(
+            value, torch.SymInt
+        )
+
+    # Dimensions whose start or length is dynamic.
+    dynamic_dims = [
+        dim
+        for dim, (start, length) in enumerate(zip(starts, lengths))
+        if _is_dynamic(start) or _is_dynamic(length)
+    ]
+
+    # No dynamic values -> use Python slice objects directly.
+    if len(dynamic_dims) == 0:
+        slices = tuple(
+            slice(start, start + length)
+            for start, length in zip(starts, lengths)
+        )
+        return inputs[slices]
+
+    # Single dynamic dimension -> build indices with ``torch.arange`` and
+    # use ``index_select``. This keeps the output shape symbolic and avoids
+    # unbacked symbols that ``torch.export`` cannot resolve.
+    if len(dynamic_dims) == 1:
+        dim = dynamic_dims[0]
+        start = starts[dim]
+        if not isinstance(start, torch.Tensor):
+            start = torch_core.convert_to_tensor(
+                start, dtype="int32", device=inputs.device
+            )
+        start = start.reshape(())
+        length = lengths[dim]
+
+        indices = torch.arange(length, dtype=torch.int32, device=inputs.device)
+        indices = indices + start
+        result = torch.index_select(inputs, dim, indices)
+
+        # Apply static slicing for the remaining dimensions.
+        for d, (s, l) in enumerate(zip(starts, lengths)):
+            if d != dim and (s != 0 or l != result.shape[d]):
+                result = torch.narrow(result, d, s, l)
+        return result
+
+    # Multiple dynamic dimensions are not supported for LiteRT-LM export
+    # because ``torch.export`` cannot resolve the resulting unbacked
+    # symbols. Fail fast with an actionable message instead of falling
+    # back to the original implementation and producing a cryptic export
+    # error.
+    raise NotImplementedError(
+        "Slicing with multiple dynamic dimensions is not supported for "
+        "LiteRT-LM export. Received dynamic dims "
+        f"{dynamic_dims}. Consider materializing start/length values as "
+        "static ints or simplifying the slice operation."
+    )
+
+
+_traceable_slice_scope = _make_scope(torch_core, "slice", _patched_slice)
+
+
+def _traceable_dot_product_attention(
+    query,
+    key,
+    value,
+    bias=None,
+    mask=None,
+    scale=None,
+    is_causal=False,
+    flash_attention=None,
+    attn_logits_soft_cap=None,
+):
+    """Traceable replacement for Keras torch-backend ``dot_product_attention``.
+
+    ``torch.nn.functional.scaled_dot_product_attention`` lowers to the
+    composite ``aten.scaled_dot_product_attention`` op (torch 2.12 under
+    ``torch.export``), which ``litert_torch`` cannot translate to TFLite.
+    This implementation expands
+    attention to a plain ``matmul`` + ``softmax`` + ``matmul`` sequence that
+    ``litert_torch`` handles well.
+
+    The function mirrors Keras's ``dot_product_attention`` signature and shape
+    convention: inputs are ``[batch, seq_len, num_heads, head_dim]`` and the
+    output is returned in the same layout.
+
+    Unlike the original Keras torch-backend op, this implementation does
+    **not** internally broadcast mismatched query/key-value head counts for
+    grouped-query attention. Every current KerasHub attention layer that
+    calls ``dot_product_attention`` (e.g. ``LlamaAttention``,
+    ``GemmaAttention``) already repeats the key/value heads up to the query
+    head count before calling it, so this is not a behavior change in
+    practice -- but a caller relying on the original op's implicit GQA
+    broadcast would get silently wrong (shape-broadcast) results here.
+
+    Two further divergences from the original op: ``bias`` and ``mask`` are
+    applied additively instead of raising when both are passed, and input
+    ranks are not validated. No exported family passes ``bias``, so neither
+    path is exercised during export.
+    """
+    del flash_attention  # Fused flash attention is not exportable.
+
+    query = torch_core.convert_to_tensor(query)
+    key = torch_core.convert_to_tensor(key)
+    value = torch_core.convert_to_tensor(value)
+
+    compute_dtype = backend.result_type(query.dtype, key.dtype, value.dtype)
+    query = torch_core.cast(query, compute_dtype)
+    key = torch_core.cast(key, compute_dtype)
+    value = torch_core.cast(value, compute_dtype)
+
+    if scale is None:
+        scale = float(query.shape[-1]) ** -0.5
+    scale = torch_core.convert_to_tensor(scale, dtype=compute_dtype)
+
+    if mask is not None:
+        mask = torch_core.convert_to_tensor(mask, dtype="bool")
+        if is_causal:
+            q_len, kv_len = query.shape[1], key.shape[1]
+            causal_mask = torch.tril(
+                torch.ones(
+                    (q_len, kv_len), dtype=torch.bool, device=mask.device
+                )
+            )
+            mask = torch.logical_and(mask, causal_mask)
+        is_causal = False
+    elif is_causal:
+        q_len, kv_len = query.shape[1], key.shape[1]
+        mask = torch.tril(
+            torch.ones((q_len, kv_len), dtype=torch.bool, device=query.device)
+        )
+
+    # Move heads to the batch dimension to match SDPA's score layout
+    # [batch, num_heads, seq_len, head_dim].
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+
+    scores = torch.matmul(query, key.transpose(-2, -1)) * scale
+
+    if bias is not None:
+        scores = scores + torch_core.convert_to_tensor(
+            bias, dtype=compute_dtype
+        )
+
+    if mask is not None:
+        large_neg = torch.tensor(
+            torch.finfo(scores.dtype).min,
+            dtype=scores.dtype,
+            device=scores.device,
+        )
+        scores = torch.where(mask, scores, large_neg)
+
+    if attn_logits_soft_cap is not None:
+        cap = torch_core.convert_to_tensor(
+            attn_logits_soft_cap, dtype=compute_dtype
+        )
+        scores = torch.tanh(scores / cap) * cap
+
+    attn = torch.softmax(scores, dim=-1)
+    output = torch.matmul(attn, value)
+    return output.transpose(1, 2)
+
+
+_traceable_dot_product_attention_scope = _make_scope(
+    torch_backend_nn, "dot_product_attention", _traceable_dot_product_attention
+)
+
+
+def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
+    """Traceable replacement for Keras torch-backend ``one_hot``.
+
+    ``torch.nn.functional.one_hot`` inserts runtime assertions that class
+    values are non-negative. Under ``torch.export`` these become
+    ``aten._assert_async.msg`` ops, which ``litert_torch`` cannot lower.
+
+    This implementation uses equality against ``torch.arange``, which produces
+    the same result for non-negative indices and does not introduce
+    unlowerable assertions. Negative indices are preserved as all-zero vectors,
+    matching the original behavior.
+
+    Integer tensors are kept in int32 so the exported MLIR remains compatible
+    with ``litert_torch``'s i32-based TFLite lowering.
+    """
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with torch backend")
+    x = torch_core.convert_to_tensor(x, dtype=torch.int32)
+    x_clamped = torch.clamp(x, min=0)
+    output = x_clamped.unsqueeze(-1) == torch.arange(
+        num_classes, dtype=torch.int32, device=x.device
+    )
+    # Preserve original behavior for negative indices.
+    zero = torch.zeros_like(output)
+    output = torch.where(x.unsqueeze(-1) >= 0, output, zero)
+    if dtype is None:
+        dtype = "float32"
+    output = torch_core.convert_to_tensor(output, dtype=dtype)
+    dims = output.dim()
+    if axis < 0:
+        original_axis = axis
+        axis = dims + axis
+    else:
+        original_axis = axis
+    if axis < 0 or axis >= dims:
+        raise ValueError(
+            "`axis` is out of bounds for one-hot output with "
+            f"{dims} dimensions. Received: axis={original_axis}."
+        )
+    if axis != dims - 1:
+        new_axes_order = list(range(dims))
+        new_axes_order[axis] = dims - 1
+        for ax in range(axis + 1, dims):
+            new_axes_order[ax] -= 1
+        output = output.permute(new_axes_order)
+    return output
+
+
+_traceable_one_hot_scope = _make_scope(
+    torch_backend_nn, "one_hot", _patched_one_hot
+)
+
+
+def _patched_take(x, indices, axis=None):
+    """Patch Keras torch-backend ``take`` to keep embedding indices as int32.
+
+    The default implementation casts integer indices to int64 before calling
+    ``torch.nn.functional.embedding``. ``litert_torch``'s TFLite embedding
+    lowering expects int32 indices consistent with the traced function
+    signature, so we keep indices in int32 for the embedding-lookup case.
+
+    ``axis=None`` means "take from the flattened input" (matching
+    ``numpy``/``jax`` semantics), so the input must be flattened *before*
+    negative indices are wrapped -- wrapping against
+    ``x.shape[0]`` (the first, unflattened dimension) is only correct when
+    ``x`` is already 1-D. Flattening first and then computing ``x_dim`` as
+    the flattened length keeps this correct for multi-dimensional ``x``
+    (e.g. ``take(x_3x4, -1, axis=None)`` must resolve to the last of the 12
+    flattened elements, not wrap against the first dimension's size of 3).
+    """
+    x = torch_core.convert_to_tensor(x)
+    indices = torch_core.convert_to_tensor(indices, dtype=torch.int32)
+    if axis is None:
+        x = torch.reshape(x, (-1,))
+        axis = 0
+    x_dim = x.shape[axis]
+    indices = torch.where(
+        indices < 0,
+        indices + x_dim,
+        indices,
+    )
+    if x.ndim == 2 and axis == 0:
+        # ``F.embedding`` documents a float ``weight`` (embedding table),
+        # but empirically accepts int32/int64/bool ``x`` as a plain gather,
+        # both eagerly and under ``torch.export`` -- no dtype guard needed.
+        return torch.nn.functional.embedding(indices, x)
+    axis = torch_backend_numpy.canonicalize_axis(axis, x.ndim)
+    shape = x.shape[:axis] + indices.shape + x.shape[axis + 1 :]
+    indices = indices.ravel()
+    out = torch.index_select(x, dim=axis, index=indices).squeeze(axis)
+    return out.reshape(shape)
+
+
+_traceable_take_scope = _make_scope(torch_backend_numpy, "take", _patched_take)
+
+
+_SCATTER_UPDATE_REDUCTION_OPS = {
+    "max": torch.maximum,
+    "min": torch.minimum,
+    "mul": lambda a, b: a * b,
+}
+
+
+def _patched_scatter_update(inputs, indices, updates, reduction=None):
+    """Patch Keras torch-backend ``scatter_update`` to keep indices int32.
+
+    The default implementation casts indices to int64. ``litert_torch``'s
+    TFLite scatter lowering expects int32 indices, so we keep them in int32
+    during export.
+    """
+    inputs = torch_core.convert_to_tensor(inputs)
+    indices = torch_core.convert_to_tensor(indices, dtype=torch.int32)
+    updates = torch_core.convert_to_tensor(updates, dtype=inputs.dtype)
+    indices = torch.transpose(indices, 0, 1)
+    idx = tuple(indices)
+
+    outputs = torch.clone(inputs)
+    if reduction is None:
+        outputs[idx] = updates
+    elif reduction == "add":
+        outputs.index_put_(idx, updates, accumulate=True)
+    elif reduction in _SCATTER_UPDATE_REDUCTION_OPS:
+        op_fn = _SCATTER_UPDATE_REDUCTION_OPS[reduction]
+        indices_t = indices.T
+        for i in range(indices_t.shape[0]):
+            idx_i = tuple(indices_t[i])
+            outputs[idx_i] = op_fn(outputs[idx_i], updates[i])
+    else:
+        raise ValueError(f"Unsupported reduction: {reduction}")
+    return outputs
+
+
+_traceable_scatter_update_scope = _make_scope(
+    torch_core, "scatter_update", _patched_scatter_update
+)
+
+
+def _is_scalar_integer(value):
+    """Return ``True`` if *value* is a scalar integer (Python or numpy)."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return True
+    # Accept 0-D numpy integer arrays / tensors with a single integer value.
+    if hasattr(value, "dtype") and hasattr(value, "ndim"):
+        return value.ndim == 0 and "int" in str(value.dtype)
+    return False
+
+
+# Capture the original ``repeat`` at module load so the patch can delegate
+# to it for every input form outside the scalar-tensor intercept.
+_ORIGINAL_REPEAT = torch_backend_numpy.repeat
+
+
+def _traceable_repeat(x, repeats, axis=None):
+    """Intercept 0-D tensor ``repeats`` (and ``repeats == 1``) with an axis.
+
+    Keras's own ``repeat`` fast-paths only plain Python ints; every other
+    input form defers to the original implementation unchanged.
+    """
+    x = torch_core.convert_to_tensor(x)
+
+    if axis is not None and _is_scalar_integer(repeats):
+        repeats = int(repeats)
+        if repeats < 0:
+            raise ValueError("`repeats` must be non-negative.")
+        if repeats == 1:
+            return x
+        if axis < 0:
+            axis = x.ndim + axis
+        shape = list(x.shape)
+        x = x.unsqueeze(axis + 1)
+        expand_shape = [-1] * x.ndim
+        expand_shape[axis + 1] = repeats
+        x = x.expand(expand_shape)
+        new_shape = list(shape)
+        new_shape[axis] = shape[axis] * repeats
+        return x.reshape(new_shape)
+
+    return _ORIGINAL_REPEAT(x, repeats, axis=axis)
+
+
+_traceable_repeat_scope = _make_scope(
+    torch_backend_numpy, "repeat", _traceable_repeat
+)
+
+
+# Capture the original ``amax`` at module load so the patched version can
+# delegate to it for every input form that does not trigger the layout bug.
+_ORIGINAL_AMAX = torch_backend_numpy.amax
+
+
+def _patched_amax(x, axis=None, keepdims=False):
+    """Traceable replacement for Keras torch-backend ``amax``.
+
+    ``keras.ops.max`` / ``keras.ops.amax`` with an integer ``axis`` lower to
+    ``aten.amax``. ``litert_torch``'s layout-optimization pass registers a
+    *checker* for ``aten.amax`` that forces the op to NHWC whenever its input
+    is 4-D (``layout_check.py``), but registers **no matching NHWC rewriter**
+    (``layout_rewrite.py``), so a 4-D ``aten.amax`` aborts conversion with
+    ``RuntimeError: NHWC node rewriter not found: amax``. GPT-OSS hits this in
+    its attention-sink softmax stabilization
+    (``gpt_oss_attention.py``: ``ops.max(combined_logits, axis=-1,
+    keepdims=True)`` on a ``[batch, heads, q, k]`` tensor); the litert-torch
+    gap is https://github.com/google-ai-edge/litert-torch/issues/1126.
+
+    For the single-integer-axis reduction of a 4-D tensor -- the only case that
+    trips the missing rewriter -- this routes through ``torch.max(dim=...)``,
+    which lowers to ``aten.max.dim`` (a *registered* rewriter). That is the
+    identical reduction and yields bit-identical values. Every other input form
+    (other ranks, tuple axes, ``axis=None``) defers to the original ``amax``
+    unchanged, so this is a no-op transform outside the triggering case.
+    """
+    x = torch_core.convert_to_tensor(x)
+    # NumPy integer axes (e.g. ``np.int64`` from shape arithmetic) are not
+    # Python ``int``; normalize so they take the same traceable path.
+    if isinstance(axis, np.integer):
+        axis = int(axis)
+    if axis is not None and isinstance(axis, int) and x.ndim == 4:
+        return torch.max(x, dim=axis, keepdim=keepdims).values
+    return _ORIGINAL_AMAX(x, axis=axis, keepdims=keepdims)
+
+
+_traceable_amax_scope = _make_scope(torch_backend_numpy, "amax", _patched_amax)
+
+
+@contextlib.contextmanager
+def traceable_ops_scope():
+    """Enter every traceable-op patch scope at once.
+
+    Combines the seven individual patch scopes (slice, dot_product_attention,
+    one_hot, repeat, take, scatter_update, amax) into a single context
+    manager via ``contextlib.ExitStack``, so callers open one scope instead of
+    nesting seven ``with`` statements.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(_traceable_slice_scope())
+        stack.enter_context(_traceable_dot_product_attention_scope())
+        stack.enter_context(_traceable_one_hot_scope())
+        stack.enter_context(_traceable_repeat_scope())
+        stack.enter_context(_traceable_take_scope())
+        stack.enter_context(_traceable_scatter_update_scope())
+        stack.enter_context(_traceable_amax_scope())
+        yield

--- a/keras_hub/src/utils/litertlm/traceable_ops_test.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops_test.py
@@ -1,0 +1,390 @@
+import unittest
+import unittest.mock
+
+import keras
+import numpy as np
+import torch
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import nn as torch_backend_nn
+from keras.src.backend.torch import numpy as torch_backend_numpy
+
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.litertlm import traceable_ops
+
+
+def _to_np(x):
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return np.asarray(x)
+
+
+# Parity-only: patched ops are called directly on eager tensors (no
+# torch.export) and checked against the original Keras implementations.
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "The litertlm traceable-op patches only exist for the PyTorch backend.",
+)
+class TraceableOpsParityTest(TestCase):
+    def test_one_hot_matches_original(self):
+        cases = [
+            ([0, 1, 2, 3], 5, -1, "float32"),
+            ([0, 1, 2, 3], 5, 0, "float32"),
+            ([[0, 1], [2, 3]], 4, -1, "float32"),
+            ([[0, 1], [2, 3]], 4, 1, "float32"),
+            ([[0, 1], [2, 3]], 4, 2, "int32"),
+            ([-1, 0, 2], 4, -1, "float32"),  # negative-index handling
+        ]
+        for x, num_classes, axis, dtype in cases:
+            with self.subTest(x=x, num_classes=num_classes, axis=axis):
+                x_t = torch.tensor(x, dtype=torch.int32)
+                original = torch_backend_nn.one_hot(
+                    x_t, num_classes, axis=axis, dtype=dtype
+                )
+                patched = traceable_ops._patched_one_hot(
+                    x_t, num_classes, axis=axis, dtype=dtype
+                )
+                self.assertEqual(tuple(original.shape), tuple(patched.shape))
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_one_hot_rejects_sparse(self):
+        with self.assertRaises(ValueError):
+            torch_backend_nn.one_hot(torch.tensor([0]), 4, sparse=True)
+        with self.assertRaises(ValueError):
+            traceable_ops._patched_one_hot(torch.tensor([0]), 4, sparse=True)
+
+    def test_repeat_matches_original(self):
+        x = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1):
+            for repeats in (1, 2, 3):
+                with self.subTest(axis=axis, repeats=repeats):
+                    original = torch_backend_numpy.repeat(x, repeats, axis=axis)
+                    patched = traceable_ops._traceable_repeat(
+                        x, repeats, axis=axis
+                    )
+                    self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_scalar_tensor_repeats_matches_original(self):
+        # A 0-D tensor `repeats` is not a plain Python `int`, so Keras's
+        # torch-backend `repeat` falls through to the `repeat_interleave`
+        # path, while `_traceable_repeat`'s `_is_scalar_integer` check takes
+        # the unsqueeze+expand+reshape fast path instead. Values must match.
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        repeats = torch.tensor(2)
+        original = torch_backend_numpy.repeat(x, repeats, axis=1)
+        patched = traceable_ops._traceable_repeat(x, repeats, axis=1)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_identity_when_repeats_is_one(self):
+        x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        patched = traceable_ops._traceable_repeat(x, 1, axis=0)
+        self.assertAllClose(_to_np(x), _to_np(patched))
+
+    def test_repeat_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            traceable_ops._traceable_repeat(torch.zeros(2, 2), -1, axis=0)
+
+    def test_repeat_no_axis_falls_back_to_original(self):
+        x = torch.arange(6, dtype=torch.float32)
+        original = torch_backend_numpy.repeat(x, 3, axis=None)
+        patched = traceable_ops._traceable_repeat(x, 3, axis=None)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_list_repeats_with_axis_delegates_to_original(self):
+        # Keras's torch-backend `repeat` rejects a Python list `repeats`
+        # with ValueError; inside the patch scope the fallback must
+        # delegate to the captured original (mirroring that raise), not
+        # recurse into the patch.
+        x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with self.assertRaises(ValueError):
+            torch_backend_numpy.repeat(x, [1, 2], axis=0)
+        with traceable_ops._traceable_repeat_scope():
+            with self.assertRaises(ValueError):
+                torch_backend_numpy.repeat(x, [1, 2], axis=0)
+
+    def test_slice_static_matches_original(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        original = torch_core.slice(x, [1, 1, 0], [2, 2, 5])
+        patched = patched_slice(x, [1, 1, 0], [2, 2, 5])
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_single_dynamic_dim_matches_original(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        for start in range(0, 3):
+            with self.subTest(start=start):
+                start_t = torch.tensor(start)
+                original = torch_core.slice(x, [start, 0, 0], [1, 4, 5])
+                patched = patched_slice(x, [start_t, 0, 0], [1, 4, 5])
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_dynamic_middle_dim_matches_original(self):
+        # Regression check for the KV-cache read pattern used by
+        # `KerasHubLiteRTAdapter`: slicing along a non-leading axis with a
+        # dynamic start while the surrounding axes are fully covered.
+        x = torch.arange(2 * 4 * 5, dtype=torch.float32).reshape(2, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        for start in range(0, 3):
+            with self.subTest(start=start):
+                start_t = torch.tensor(start)
+                original = torch_core.slice(x, [0, start, 0], [2, 1, 5])
+                patched = patched_slice(x, [0, start_t, 0], [2, 1, 5])
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_multiple_dynamic_dims_raises(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        with self.assertRaises(NotImplementedError):
+            patched_slice(x, [torch.tensor(0), torch.tensor(1), 0], [1, 1, 5])
+
+    def test_take_embedding_lookup_matches_original(self):
+        table = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        indices = torch.tensor([0, 2, 4, 1])
+        original = torch_backend_numpy.take(table, indices, axis=0)
+        patched = traceable_ops._patched_take(table, indices, axis=0)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_matches_original_various_axes(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        cases = [
+            (torch.tensor([0, 2]), 0),
+            (torch.tensor([0, 3, 1]), 1),
+            (torch.tensor([4, 0]), 2),
+            (torch.tensor([-1, -2]), 2),  # negative indices
+        ]
+        for indices, axis in cases:
+            with self.subTest(axis=axis, indices=indices.tolist()):
+                original = torch_backend_numpy.take(x, indices, axis=axis)
+                patched = traceable_ops._patched_take(x, indices, axis=axis)
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_no_axis_matches_original(self):
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        indices = torch.tensor([0, 5, 11])
+        original = torch_backend_numpy.take(x, indices, axis=None)
+        patched = traceable_ops._patched_take(x, indices, axis=None)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_no_axis_negative_index_matches_flattened_semantics(self):
+        """Regression test: ``axis=None`` + negative indices on a
+        multi-dim input must wrap against the *flattened* length, not the
+        first (unflattened) dimension's size.
+
+        Note this deliberately does **not** compare against
+        ``keras.src.backend.torch.numpy.take`` (the pattern every other
+        ``test_take_*`` case in this file uses): that Keras
+        function has the exact same bug (it computes
+        ``x_dim = x.shape[0]`` before flattening for ``axis=None``), so it
+        is not a valid reference here. Ground truth is real numpy's
+        ``np.take(..., axis=None)``, which flattens first -- e.g. for a
+        ``3x4`` input (12 elements), index ``-1`` must resolve to the last
+        flattened element (value ``11``), not wrap as if against a
+        first-dimension size of 3 (which would incorrectly give ``2``).
+        """
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        indices = torch.tensor([-1, -2])
+
+        expected = np.take(_to_np(x), _to_np(indices), axis=None)
+        patched = traceable_ops._patched_take(x, indices, axis=None)
+        self.assertAllClose(expected, _to_np(patched))
+
+    def test_scatter_update_matches_original(self):
+        inputs = torch.zeros((4, 4), dtype=torch.float32)
+        indices = torch.tensor([[0, 0], [1, 1], [2, 2]])
+        updates = torch.tensor([10.0, 20.0, 30.0])
+        for reduction in (None, "add", "max", "min", "mul"):
+            with self.subTest(reduction=reduction):
+                original = torch_core.scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                patched = traceable_ops._patched_scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_scatter_update_overlapping_indices_matches_original(self):
+        # Duplicate indices exercise the accumulation/reduction semantics
+        # more thoroughly than the diagonal case above.
+        inputs = torch.full((3, 3), 2.0, dtype=torch.float32)
+        indices = torch.tensor([[0, 0], [0, 0], [1, 1]])
+        updates = torch.tensor([3.0, 5.0, 7.0])
+        for reduction in (None, "add", "max", "min", "mul"):
+            with self.subTest(reduction=reduction):
+                original = torch_core.scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                patched = traceable_ops._patched_scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_scatter_update_rejects_unsupported_reduction(self):
+        inputs = torch.zeros((2, 2), dtype=torch.float32)
+        indices = torch.tensor([[0, 0]])
+        updates = torch.tensor([1.0])
+        with self.assertRaises(ValueError):
+            traceable_ops._patched_scatter_update(
+                inputs, indices, updates, reduction="bogus"
+            )
+
+    def _reference_attention_inputs(self, num_query_heads, num_kv_heads):
+        rng = np.random.default_rng(0)
+        batch, q_len, kv_len, head_dim = 2, 3, 4, 8
+        query = torch.tensor(
+            rng.standard_normal((batch, q_len, num_query_heads, head_dim)),
+            dtype=torch.float32,
+        )
+        key = torch.tensor(
+            rng.standard_normal((batch, kv_len, num_kv_heads, head_dim)),
+            dtype=torch.float32,
+        )
+        value = torch.tensor(
+            rng.standard_normal((batch, kv_len, num_kv_heads, head_dim)),
+            dtype=torch.float32,
+        )
+        return query, key, value
+
+    def test_dot_product_attention_matches_original_mha(self):
+        """Standard multi-head attention (num_query_heads == num_kv_heads)."""
+        query, key, value = self._reference_attention_inputs(4, 4)
+        original = torch_backend_nn.dot_product_attention(
+            query, key, value, is_causal=True
+        )
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key, value, is_causal=True
+        )
+        self.assertAllClose(
+            _to_np(original), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_dot_product_attention_gqa_matches_original(self):
+        """Grouped-query attention (num_query_heads > num_kv_heads).
+
+        This is the head configuration used by every tiny test model in
+        ``export_test.py`` (e.g. ``num_query_heads=4,
+        num_key_value_heads=1``). The original Keras torch-backend op
+        internally repeats the key/value heads to match the query heads;
+        this checks that the traceable replacement -- which does a plain
+        batched matmul with no explicit GQA broadcast -- still matches, i.e.
+        that its caller must pre-broadcast key/value to the query head count.
+        """
+        query, key, value = self._reference_attention_inputs(4, 1)
+        original = torch_backend_nn.dot_product_attention(
+            query, key, value, is_causal=True
+        )
+
+        # `_traceable_dot_product_attention` does not itself broadcast
+        # mismatched head counts (unlike the original), so the caller must
+        # repeat key/value to the query head count first, exactly as
+        # `GemmaAttention._compute_attention`'s non-fused path (used on CPU)
+        # does via a manual einsum reshape rather than relying on this op.
+        groups = query.shape[2] // key.shape[2]
+        key_r = key.repeat_interleave(groups, dim=2)
+        value_r = value.repeat_interleave(groups, dim=2)
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key_r, value_r, is_causal=True
+        )
+        self.assertAllClose(
+            _to_np(original), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_dot_product_attention_with_mask_matches_original(self):
+        query, key, value = self._reference_attention_inputs(2, 2)
+        batch, q_len, _, _ = query.shape
+        kv_len = key.shape[1]
+        mask = torch.ones((batch, q_len, kv_len), dtype=torch.bool)
+        mask[:, :, -1] = False  # mask out the last key position
+
+        original = torch_backend_nn.dot_product_attention(
+            query, key, value, mask=mask
+        )
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key, value, mask=mask
+        )
+        self.assertAllClose(
+            _to_np(original), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_dot_product_attention_soft_cap_matches_manual_reference(self):
+        """Attention-logit soft-capping (used by Gemma-family models).
+
+        Keras's torch-backend ``dot_product_attention`` accepts an
+        ``attn_logits_soft_cap`` parameter but never applies it (it is
+        always routed through ``torch.nn.functional.
+        scaled_dot_product_attention``, which has no soft-cap support), so
+        there is no meaningful "original" to compare against here. Instead,
+        verify the patched implementation directly against a manual
+        matmul/softmax/matmul reference with the soft-cap formula applied by
+        hand.
+        """
+        query, key, value = self._reference_attention_inputs(2, 2)
+        cap = 5.0
+
+        scale = float(query.shape[-1]) ** -0.5
+        q = query.transpose(1, 2)
+        k = key.transpose(1, 2)
+        v = value.transpose(1, 2)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        scores = torch.tanh(scores / cap) * cap
+        attn = torch.softmax(scores, dim=-1)
+        expected = torch.matmul(attn, v).transpose(1, 2)
+
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key, value, attn_logits_soft_cap=cap
+        )
+        self.assertAllClose(
+            _to_np(expected), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_amax_matches_original(self):
+        cases = [
+            (torch.randn(2, 3, 4, 5), -1, True),  # 4-D last axis, keepdims
+            (torch.randn(2, 3, 4, 5), -1, False),  # 4-D last axis, no keepdims
+            (torch.randn(2, 3, 4, 5), 1, True),  # 4-D middle axis
+            (torch.randn(2, 3, 4, 5), 0, False),  # 4-D leading axis
+            (torch.randn(2, 4, 5), -1, True),  # 3-D (fallthrough)
+            (torch.randn(4, 5), -1, True),  # 2-D (fallthrough)
+            (torch.randn(7), 0, True),  # 1-D (fallthrough)
+            (torch.randn(2, 2, 3, 4, 5), -1, True),  # 5-D (fallthrough)
+            (torch.randn(2, 3, 4, 5), (2, 3), True),  # 4-D tuple (fallthrough)
+            (torch.randn(2, 3, 4, 5), np.int64(-1), True),  # np.int64 axis
+            (torch.randn(2, 3, 4, 5), np.int32(1), True),  # np.int32 axis
+        ]
+        for x, axis, keepdims in cases:
+            with self.subTest(
+                shape=tuple(x.shape), axis=axis, keepdims=keepdims
+            ):
+                patched = traceable_ops._patched_amax(
+                    x, axis=axis, keepdims=keepdims
+                )
+                # The original Keras amax cannot handle NumPy integer axes
+                # (raises "truth value of an empty array is ambiguous"); for
+                # those cases verify only that the patched version works and
+                # matches torch.max directly.
+                if isinstance(axis, np.integer):
+                    expected = torch.max(
+                        x, dim=int(axis), keepdim=keepdims
+                    ).values
+                    self.assertTrue(torch.equal(expected, patched))
+                else:
+                    original = torch_backend_numpy.amax(
+                        x, axis=axis, keepdims=keepdims
+                    )
+                    self.assertEqual(
+                        tuple(original.shape), tuple(patched.shape)
+                    )
+                    # The reformulation is the identical reduction; values must
+                    # be bit-identical, not merely close (a silent numeric
+                    # drift here would corrupt attention-sink softmax
+                    # stabilization).
+                    self.assertTrue(torch.equal(original, patched))
+
+    def test_amax_public_ops_max_4d_matches(self):
+        # The public keras op that GPT-OSS attention actually calls.
+        x = torch.randn(2, 3, 4, 5)
+        ref = keras.ops.max(x, axis=-1, keepdims=True)
+        with unittest.mock.patch.object(
+            torch_backend_numpy, "amax", traceable_ops._patched_amax
+        ):
+            got = keras.ops.max(x, axis=-1, keepdims=True)
+        self.assertTrue(torch.equal(ref, got))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,16 @@ dependencies = [
     "tensorflow-text;platform_system != 'Windows'",
 ]
 
+[project.optional-dependencies]
+# LiteRT-LM export (`CausalLM.export(..., format="litertlm")`) is only
+# supported with the PyTorch backend; keras_hub's litertlm export code
+# already guards its usage at runtime via `importlib.util.find_spec`, so this
+# is an opt-in extra rather than an unconditional dependency.
+litertlm = [
+    "litert-torch>=0.9.0",
+    "litert-lm-builder>=0.11.0",
+]
+
 [project.urls]
 Home = "https://keras.io/keras_hub/"
 Repository = "https://github.com/keras-team/keras/keras_hub"

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -10,4 +10,9 @@ torchvision==0.22.1+cu126
 # Jax cpu-only version.
 jax[cpu]
 
+# LiteRT (for torch-backend TFLite export and LiteRT-LM testing). Only
+# meaningful with the PyTorch backend above.
+litert-torch>=0.9.0
+litert-lm-builder>=0.11.0
+
 -r requirements-common.txt


### PR DESCRIPTION
Part of tracking issue https://github.com/keras-team/keras-hub/issues/2880 (LiteRT-LM Export Stacked PRs).

**Stacked Order**: Slice 20 of 28
**Predecessor PR**: #2920 (Test Harness: Enable Export Tests (First 8 Models))
**Successor PR**: #2901 (Unsupported Models Declaration)
**Exact Incremental Stat**: `8 files changed, 101 insertions(+)`

### What Changed & Technical Rationale
Enables shared LiteRT-LM export tests across the remaining 8 causal LM model families (mixtral, opt, phi3, qwen, qwen3, qwen3_moe, qwen_moe, smollm3).

### Verification
- Python syntax & compilation (`py_compile`) verified on all touched files.
- Executed unit tests and verified 100% byte-for-byte stack parity against reference branches.