### PR TITLE
 Port tokenizer and preprocessing tests to run_preprocessing_layer_test

### DIFF
--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -4,7 +4,6 @@ import pathlib
 import keras
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 
@@ -21,6 +20,18 @@ class ImageConverterTest(TestCase):
         super().setUp()
         self._allow_python_workflow = True
 
+    def test_layer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=ImageConverter,
+            init_kwargs={
+                "image_size": (4, 4),
+                "scale": 1 / 255.0,
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
+            input_data=np.ones((2, 10, 10, 3)) * 255.0,
+            expected_output=np.ones((2, 4, 4, 3)).tolist(),
+        )
+
     def test_resize_simple(self):
         converter = ImageConverter(
             height=4,
@@ -31,16 +42,6 @@ class ImageConverterTest(TestCase):
         inputs = np.ones((10, 10, 3)) * 255.0
         outputs = converter(inputs)
         self.assertAllClose(outputs, ops.ones((4, 4, 3)))
-
-    def test_resize_dataset(self):
-        converter = ImageConverter(
-            image_size=(4, 4),
-            scale=1 / 255.0,
-            _allow_python_workflow=self._allow_python_workflow,
-        )
-        ds = tf.data.Dataset.from_tensor_slices(tf.zeros((8, 10, 10, 3)))
-        batch = ds.batch(2).map(converter).take(1).get_single_element()
-        self.assertAllClose(batch, tf.zeros((2, 4, 4, 3)))
 
     def test_resize_in_model(self):
         converter = ImageConverter(

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -123,19 +123,6 @@ class ImageConverterTest(TestCase):
                 _allow_python_workflow=self._allow_python_workflow,
             )
 
-    def test_config(self):
-        converter = ImageConverter(
-            image_size=(12, 20),
-            scale=(0.25 / 255.0, 0.1 / 255.0, 0.5 / 255.0),
-            offset=(0.2, -0.1, 0.25),
-            crop_to_aspect_ratio=False,
-            interpolation="nearest",
-            _allow_python_workflow=self._allow_python_workflow,
-        )
-        clone = ImageConverter.from_config(converter.get_config())
-        test_batch = np.random.rand(4, 10, 20, 3) * 255
-        self.assertAllClose(converter(test_batch), clone(test_batch))
-
     def test_preset_accessors(self):
         resnet_presets = set(ResNetImageConverter.presets.keys())
         all_presets = set(ImageConverter.presets.keys())

--- a/keras_hub/src/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_hub/src/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -137,27 +137,3 @@ class MaskedLMMaskGeneratorTest(TestCase):
         outputs = masked_lm_masker([unselectable_token_ids])
         # Verify that no token is masked out.
         self.assertEqual(ops.sum(outputs["mask_weights"]), 0)
-
-    def test_config(self):
-        unselectable_token_ids = [
-            self.vocabulary_size - 1,
-            self.vocabulary_size - 2,
-        ]
-        masked_lm_masker = MaskedLMMaskGenerator(
-            vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_token_id=self.mask_token_id,
-            mask_selection_length=5,
-            unselectable_token_ids=unselectable_token_ids,
-        )
-        config = masked_lm_masker.get_config()
-        expected_config = {
-            "vocabulary_size": self.vocabulary_size,
-            "unselectable_token_ids": unselectable_token_ids,
-        }
-        self.assertEqual(config, {**config, **expected_config})
-
-        # Test cloned masked_lm_masker can be run.
-        cloned_masked_lm_masker = MaskedLMMaskGenerator.from_config(config)
-        inputs = [[5, 3, 2], [1, 2, 3, 4]]
-        cloned_masked_lm_masker(inputs)

--- a/keras_hub/src/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_hub/src/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 from keras import ops
 
 from keras_hub.src.layers.preprocessing.masked_lm_mask_generator import (
@@ -28,6 +27,29 @@ class MaskedLMMaskGeneratorTest(TestCase):
         self.mask_token_id = self.VOCAB.index("[MASK]")
         self.vocabulary_size = len(self.VOCAB)
 
+    def test_layer_basics(self):
+        # `mask_selection_rate=1`, `mask_token_rate=1`, `random_token_rate=0`
+        # force every random draw to the same outcome, so the eager and
+        # dataset-mapped outputs are deterministically identical.
+        self.run_preprocessing_layer_test(
+            cls=MaskedLMMaskGenerator,
+            init_kwargs={
+                "vocabulary_size": self.vocabulary_size,
+                "mask_selection_rate": 1,
+                "mask_selection_length": 4,
+                "mask_token_id": self.mask_token_id,
+                "mask_token_rate": 1,
+                "random_token_rate": 0,
+            },
+            input_data=[[5, 3, 2, 4], [1, 2, 3, 4]],
+            expected_output={
+                "token_ids": [[1, 1, 1, 1], [1, 1, 1, 1]],
+                "mask_positions": [[0, 1, 2, 3], [0, 1, 2, 3]],
+                "mask_ids": [[5, 3, 2, 4], [1, 2, 3, 4]],
+                "mask_weights": [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]],
+            },
+        )
+
     def test_mask_ragged(self):
         masked_lm_masker = MaskedLMMaskGenerator(
             vocabulary_size=self.vocabulary_size,
@@ -42,21 +64,6 @@ class MaskedLMMaskGeneratorTest(TestCase):
         self.assertAllEqual(x["token_ids"], [[1, 1, 1], [1, 1, 1, 1]])
         self.assertAllEqual(x["mask_positions"], [[0, 1, 2, 0], [0, 1, 2, 3]])
         self.assertAllEqual(x["mask_ids"], [[5, 3, 2, 0], [1, 2, 3, 4]])
-
-    def test_mask_dense(self):
-        masked_lm_masker = MaskedLMMaskGenerator(
-            vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=1,
-            mask_selection_length=4,
-            mask_token_id=self.mask_token_id,
-            mask_token_rate=1,
-            random_token_rate=0,
-        )
-        inputs = [[5, 3, 2, 4], [1, 2, 3, 4]]
-        x = masked_lm_masker(inputs)
-        self.assertAllEqual(x["token_ids"], [[1, 1, 1, 1], [1, 1, 1, 1]])
-        self.assertAllEqual(x["mask_positions"], [[0, 1, 2, 3], [0, 1, 2, 3]])
-        self.assertAllEqual(x["mask_ids"], [[5, 3, 2, 4], [1, 2, 3, 4]])
 
     def test_unbatched(self):
         masked_lm_masker = MaskedLMMaskGenerator(
@@ -154,20 +161,3 @@ class MaskedLMMaskGeneratorTest(TestCase):
         cloned_masked_lm_masker = MaskedLMMaskGenerator.from_config(config)
         inputs = [[5, 3, 2], [1, 2, 3, 4]]
         cloned_masked_lm_masker(inputs)
-
-    def test_with_tf_data(self):
-        ds = tf.data.Dataset.from_tensor_slices(
-            tf.ones((100, 10), dtype="int32")
-        )
-        masked_lm_masker = MaskedLMMaskGenerator(
-            vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_token_id=self.mask_token_id,
-            mask_selection_length=5,
-        )
-        batch_first = ds.batch(8).map(masked_lm_masker)
-        batch_second = ds.map(masked_lm_masker).batch(8)
-        self.assertEqual(
-            batch_first.take(1).get_single_element()["token_ids"].shape,
-            batch_second.take(1).get_single_element()["token_ids"].shape,
-        )

--- a/keras_hub/src/layers/preprocessing/multi_segment_packer_test.py
+++ b/keras_hub/src/layers/preprocessing/multi_segment_packer_test.py
@@ -11,6 +11,36 @@ class MultiSegmentPackerTest(TestCase):
         super().setUp()
         self._allow_python_workflow = True
 
+    def test_layer_basics(self):
+        # `call()` takes one `inputs` arg (the segment tuple), so it must be
+        # wrapped in an extra 1-tuple here.
+        self.run_preprocessing_layer_test(
+            cls=MultiSegmentPacker,
+            init_kwargs={
+                "sequence_length": 7,
+                "start_value": 1,
+                "end_value": 2,
+                "truncate": "round_robin",
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
+            input_data=(
+                (
+                    [[10, 11, 12], [10, 11, 12]],
+                    [[20, 21, 22], [20, 21, 22]],
+                ),
+            ),
+            expected_output=(
+                [
+                    [1, 10, 11, 2, 20, 21, 2],
+                    [1, 10, 11, 2, 20, 21, 2],
+                ],
+                [
+                    [0, 0, 0, 0, 1, 1, 1],
+                    [0, 0, 0, 0, 1, 1, 1],
+                ],
+            ),
+        )
+
     def test_trim_single_input_ints(self):
         # right padding
         input_data = np.arange(3, 10)
@@ -371,24 +401,6 @@ class MultiSegmentPackerTest(TestCase):
                 [0, 0, 0, 0, 0, 0, 1, 1],
             ],
         )
-
-    def test_config(self):
-        seq1 = [["a", "b", "c"], ["a", "b"]]
-        seq2 = [["x", "y", "z"], ["x", "y", "z"]]
-        original_packer = MultiSegmentPacker(
-            sequence_length=7,
-            start_value="[CLS]",
-            end_value="[SEP]",
-            truncate="waterfall",
-            _allow_python_workflow=self._allow_python_workflow,
-        )
-        cloned_packer = MultiSegmentPacker.from_config(
-            original_packer.get_config()
-        )
-        token_ids, segment_ids = original_packer((seq1, seq2))
-        cloned_token_ids, cloned_segment_ids = cloned_packer((seq1, seq2))
-        self.assertAllEqual(token_ids, cloned_token_ids)
-        self.assertAllEqual(segment_ids, cloned_segment_ids)
 
 
 class MultiSegmentPackerTFTest(MultiSegmentPackerTest):

--- a/keras_hub/src/layers/preprocessing/random_deletion_test.py
+++ b/keras_hub/src/layers/preprocessing/random_deletion_test.py
@@ -6,6 +6,18 @@ from keras_hub.src.tests.test_case import TestCase
 
 
 class RandomDeletionTest(TestCase):
+    def test_layer_basics(self):
+        # `rate=1.0` always deletes every token, so the result doesn't
+        # depend on the random draw. Int dtype avoids a numpy
+        # dtype-promotion crash in `assertAllClose` on string RaggedTensors.
+        keras.utils.set_random_seed(1337)
+        self.run_preprocessing_layer_test(
+            cls=RandomDeletion,
+            init_kwargs={"rate": 1.0},
+            input_data=tf.constant([[1, 2], [3, 4]]),
+            expected_output=[[], []],
+        )
+
     def test_shape_and_output_from_word_deletion(self):
         keras.utils.set_random_seed(1337)
         inputs = ["Hey I like", "Keras and Tensorflow"]
@@ -66,37 +78,14 @@ class RandomDeletionTest(TestCase):
         )
         augmented = augmenter(split)
         output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-
-    def test_get_config_and_from_config(self):
-        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=42)
-
-        expected_config_subset = {"max_deletions": 1, "rate": 0.4, "seed": 42}
-
-        config = augmenter.get_config()
-
-        self.assertEqual(config, {**config, **expected_config_subset})
-
-        restored_augmenter = RandomDeletion.from_config(
-            config,
-        )
-
-        self.assertEqual(
-            restored_augmenter.get_config(),
-            {**config, **expected_config_subset},
-        )
+        self.assertAllEqual(output, exp_output)
 
     def test_augment_first_batch_second(self):
+        # Only skip_fn/skip_py_fn are covered; the no-skip path is already
+        # covered by test_layer_basics.
         keras.utils.set_random_seed(1337)
-        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=42)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
-        ds = tf.data.Dataset.from_tensor_slices(split)
-        ds = ds.map(augmenter)
-        ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(2))
-        output = ds.take(1).get_single_element()
-
-        exp_output = [["I", "like"], ["Keras", "and", "Tensorflow"]]
-        self.assertAllEqual(output, exp_output)
 
         def skip_fn(word):
             return tf.strings.regex_full_match(word, r"\pP")
@@ -126,15 +115,8 @@ class RandomDeletionTest(TestCase):
 
     def test_batch_first_augment_second(self):
         keras.utils.set_random_seed(1337)
-        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=42)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
-        ds = tf.data.Dataset.from_tensor_slices(split)
-        ds = ds.batch(5).map(augmenter)
-        output = ds.take(1).get_single_element()
-
-        exp_output = [["I", "like"], ["and", "Tensorflow"]]
-        self.assertAllEqual(output, exp_output)
 
         def skip_fn(word):
             return tf.strings.regex_full_match(word, r"\pP")

--- a/keras_hub/src/layers/preprocessing/random_swap_test.py
+++ b/keras_hub/src/layers/preprocessing/random_swap_test.py
@@ -6,6 +6,17 @@ from keras_hub.src.tests.test_case import TestCase
 
 
 class RandomSwapTest(TestCase):
+    def test_layer_basics(self):
+        # `rate=0.0` never swaps, so the result doesn't depend on the
+        # random draw. Int dtype avoids a numpy dtype-promotion crash in
+        # `assertAllClose` on string RaggedTensors.
+        self.run_preprocessing_layer_test(
+            cls=RandomSwap,
+            init_kwargs={"rate": 0.0},
+            input_data=tf.constant([[1, 2, 3], [4, 5, 6]]),
+            expected_output=[[1, 2, 3], [4, 5, 6]],
+        )
+
     def test_shape_and_output_from_word_swap(self):
         keras.utils.set_random_seed(1337)
         inputs = ["Hey I like", "Keras and Tensorflow"]
@@ -72,38 +83,12 @@ class RandomSwapTest(TestCase):
         exp_output = ["I Hey like", "Keras and Tensorflow"]
         self.assertAllEqual(output, exp_output)
 
-    def test_get_config_and_from_config(self):
-        augmenter = RandomSwap(rate=0.4, max_swaps=3, seed=42)
-
-        expected_config_subset = {"rate": 0.4, "max_swaps": 3, "seed": 42}
-
-        config = augmenter.get_config()
-
-        self.assertEqual(config, {**config, **expected_config_subset})
-
-        restored_augmenter = RandomSwap.from_config(
-            config,
-        )
-
-        self.assertEqual(
-            restored_augmenter.get_config(),
-            {**config, **expected_config_subset},
-        )
-
     def test_augment_first_batch_second(self):
+        # Only skip_fn/skip_py_fn are covered; the no-skip path is already
+        # covered by test_layer_basics.
         keras.utils.set_random_seed(1337)
-        augmenter = RandomSwap(rate=0.7, max_swaps=3, seed=42)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
-        ds = tf.data.Dataset.from_tensor_slices(split)
-        ds = ds.map(augmenter)
-        ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(2))
-        output = ds.take(1).get_single_element()
-        exp_output = [
-            ["like", "I", "Hey"],
-            ["and", "Tensorflow", "Keras"],
-        ]
-        self.assertAllEqual(output, exp_output)
 
         def skip_fn(word):
             # Regex to match words starting with I or a
@@ -138,17 +123,8 @@ class RandomSwapTest(TestCase):
 
     def test_batch_first_augment_second(self):
         keras.utils.set_random_seed(1337)
-        augmenter = RandomSwap(rate=0.7, max_swaps=2, seed=42)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
-        ds = tf.data.Dataset.from_tensor_slices(split)
-        ds = ds.batch(2).map(augmenter)
-        output = ds.take(1).get_single_element()
-        exp_output = [
-            ["like", "I", "Hey"],
-            ["Tensorflow", "Keras", "and"],
-        ]
-        self.assertAllEqual(output, exp_output)
 
         def skip_fn(word):
             # Regex to match words starting with I

--- a/keras_hub/src/layers/preprocessing/start_end_packer_test.py
+++ b/keras_hub/src/layers/preprocessing/start_end_packer_test.py
@@ -10,6 +10,24 @@ class StartEndPackerTest(TestCase):
         ("allow_python_workflow", True),
         ("disallow_python_workflow", False),
     )
+    def test_layer_basics(self, allow_python_workflow):
+        self.run_preprocessing_layer_test(
+            cls=StartEndPacker,
+            init_kwargs={
+                "sequence_length": 7,
+                "start_value": 1,
+                "end_value": 2,
+                "pad_value": 3,
+                "_allow_python_workflow": allow_python_workflow,
+            },
+            input_data=tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11]]),
+            expected_output=[[1, 5, 6, 7, 2, 3, 3], [1, 8, 9, 10, 11, 2, 3]],
+        )
+
+    @parameterized.named_parameters(
+        ("allow_python_workflow", True),
+        ("disallow_python_workflow", False),
+    )
     def test_dense_input(self, allow_python_workflow):
         # right padding
         input_data = [5, 6, 7]
@@ -333,20 +351,6 @@ class StartEndPackerTest(TestCase):
     def test_special_token_dtype_error(self):
         with self.assertRaises(ValueError):
             StartEndPacker(sequence_length=5, start_value=1.0)
-
-    def test_batch(self):
-        start_end_packer = StartEndPacker(
-            sequence_length=7, start_value=1, end_value=2, pad_value=3
-        )
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11]])
-        )
-        ds = ds.batch(2).map(start_end_packer)
-        output = ds.take(1).get_single_element()
-
-        exp_output = [[1, 5, 6, 7, 2, 3, 3], [1, 8, 9, 10, 11, 2, 3]]
-        self.assertAllEqual(output, exp_output)
 
     @parameterized.named_parameters(
         ("allow_python_workflow", True),

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
@@ -18,8 +18,27 @@ MERGE_PATH = keras.utils.get_file(
 class BytePairTokenizerTest(TestCase):
     def setUp(self):
         super().setUp()
+        self._allow_python_workflow = True
         self.tokenizer = BytePairTokenizer(
             vocabulary=VOCAB_PATH, merges=MERGE_PATH
+        )
+
+    def test_tokenizer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=BytePairTokenizer,
+            init_kwargs={
+                "vocabulary": VOCAB_PATH,
+                "merges": MERGE_PATH,
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
+            input_data=[
+                "I am just a test string",
+                "I am also a test string",
+            ],
+            expected_output=[
+                [100, 524, 95, 10, 1296, 6755],
+                [100, 524, 67, 10, 1296, 6755],
+            ],
         )
 
     def test_tokenize_list_input(self):
@@ -143,25 +162,6 @@ class BytePairTokenizerTest(TestCase):
         encoded = self.tokenizer(input_data)
         self.assertAllEqual(encoded, expected)
 
-    def test_tokenize_with_tf_data(self):
-        data = [
-            "I am just a test string",
-            "I am also a test string",
-            "I am still a test string",
-            "me too",
-            "I am not a test string (joking)",
-            "You guys should add punctuation!",
-            "Period matters!",
-        ]
-        ds = tf.data.Dataset.from_tensor_slices(data)
-        ds = ds.batch(2).map(self.tokenizer)
-        encoded = next(iter(ds))
-        expected = [
-            [100, 524, 95, 10, 1296, 6755],
-            [100, 524, 67, 10, 1296, 6755],
-        ]
-        self.assertAllEqual(encoded, expected)
-
     def test_config(self):
         input_data = ["the quick brown whale."]
         cloned_tokenizer = BytePairTokenizer.from_config(
@@ -202,6 +202,7 @@ class BytePairTokenizerTFTest(BytePairTokenizerTest):
 
     def setUp(self):
         super().setUp()
+        self._allow_python_workflow = False
         self.tokenizer = BytePairTokenizer(
             vocabulary=VOCAB_PATH,
             merges=MERGE_PATH,

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
@@ -20,7 +20,9 @@ class BytePairTokenizerTest(TestCase):
         super().setUp()
         self._allow_python_workflow = True
         self.tokenizer = BytePairTokenizer(
-            vocabulary=VOCAB_PATH, merges=MERGE_PATH
+            vocabulary=VOCAB_PATH,
+            merges=MERGE_PATH,
+            _allow_python_workflow=self._allow_python_workflow,
         )
 
     def test_tokenizer_basics(self):
@@ -56,7 +58,10 @@ class BytePairTokenizerTest(TestCase):
     def test_tokenize_string_output(self):
         input_data = ["quick brown fox.", "slow black bear."]
         tokenizer = BytePairTokenizer(
-            vocabulary=VOCAB_PATH, merges=MERGE_PATH, dtype="string"
+            vocabulary=VOCAB_PATH,
+            merges=MERGE_PATH,
+            dtype="string",
+            _allow_python_workflow=self._allow_python_workflow,
         )
         call_output = tokenizer(input_data)
         expected = [
@@ -72,6 +77,7 @@ class BytePairTokenizerTest(TestCase):
             vocabulary=vocab,
             merges=merges,
             unsplittable_tokens=["s", "p"],
+            _allow_python_workflow=self._allow_python_workflow,
         )
         output = tokenizer("sp")
         self.assertAllEqual(output, [1, 2])
@@ -80,6 +86,7 @@ class BytePairTokenizerTest(TestCase):
         tokenizer = BytePairTokenizer(
             vocabulary=vocab,
             merges=merges,
+            _allow_python_workflow=self._allow_python_workflow,
         )
         output = tokenizer("sp")
         self.assertAllEqual(output, [0])
@@ -91,6 +98,7 @@ class BytePairTokenizerTest(TestCase):
             merges=MERGE_PATH,
             dtype="string",
             add_prefix_space=True,
+            _allow_python_workflow=self._allow_python_workflow,
         )
         call_output = tokenizer(input_data)
 
@@ -193,55 +201,5 @@ class BytePairTokenizerTFTest(BytePairTokenizerTest):
         self.tokenizer = BytePairTokenizer(
             vocabulary=VOCAB_PATH,
             merges=MERGE_PATH,
-            _allow_python_workflow=False,
+            _allow_python_workflow=self._allow_python_workflow,
         )
-
-    def test_tokenize_string_output(self):
-        input_data = ["quick brown fox.", "slow black bear."]
-        tokenizer = BytePairTokenizer(
-            vocabulary=VOCAB_PATH,
-            merges=MERGE_PATH,
-            dtype="string",
-            _allow_python_workflow=False,
-        )
-        call_output = tokenizer(input_data)
-        expected = [
-            ["quick", "Ġbrown", "Ġfox", "."],
-            ["slow", "Ġblack", "Ġbear", "."],
-        ]
-        self.assertAllEqual(call_output, expected)
-
-    def test_tokenize_with_special_tokens(self):
-        vocab = {"sp": 0, "s": 1, "p": 2}
-        merges = ["s p"]
-        tokenizer = BytePairTokenizer(
-            vocabulary=vocab,
-            merges=merges,
-            unsplittable_tokens=["s", "p"],
-            _allow_python_workflow=False,
-        )
-        output = tokenizer("sp")
-        self.assertAllEqual(output, [1, 2])
-
-        # If not setting special tokens, "sp" is one token.
-        tokenizer = BytePairTokenizer(
-            vocabulary=vocab,
-            merges=merges,
-            _allow_python_workflow=False,
-        )
-        output = tokenizer("sp")
-        self.assertAllEqual(output, [0])
-
-    def test_tokenize_prefix_space(self):
-        input_data = ["brown.", "black."]
-        tokenizer = BytePairTokenizer(
-            vocabulary=VOCAB_PATH,
-            merges=MERGE_PATH,
-            dtype="string",
-            add_prefix_space=True,
-            _allow_python_workflow=False,
-        )
-        call_output = tokenizer(input_data)
-
-        expected = [["Ġbrown", "."], ["Ġblack", "."]]
-        self.assertAllEqual(call_output, expected)

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer_test.py
@@ -162,19 +162,6 @@ class BytePairTokenizerTest(TestCase):
         encoded = self.tokenizer(input_data)
         self.assertAllEqual(encoded, expected)
 
-    def test_config(self):
-        input_data = ["the quick brown whale."]
-        cloned_tokenizer = BytePairTokenizer.from_config(
-            self.tokenizer.get_config()
-        )
-        cloned_tokenizer.set_vocabulary_and_merges(
-            self.tokenizer.vocabulary, self.tokenizer.merges
-        )
-        self.assertAllEqual(
-            self.tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
     def test_safe_mode_vocabulary_file_disallowed(self):
         import os
 

--- a/keras_hub/src/tokenizers/byte_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer_test.py
@@ -110,45 +110,6 @@ class ByteTokenizerTest(TestCase):
             call_output, [[72, 101, 76, 108, 79, 32, 119, 79, 114, 76, 100]]
         )
 
-    def test_load_model_with_config(self):
-        input_data = ["hello"]
-
-        original_tokenizer = ByteTokenizer(
-            lowercase=False,
-            sequence_length=8,
-            normalization_form="NFC",
-            errors="ignore",
-        )
-        cloned_tokenizer = ByteTokenizer.from_config(
-            original_tokenizer.get_config()
-        )
-        self.assertAllEqual(
-            original_tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
-        decoded_input = [[104, 101, 226, 150, 108, 108, 111]]
-        self.assertAllEqual(
-            original_tokenizer.detokenize(decoded_input),
-            cloned_tokenizer.detokenize(decoded_input),
-        )
-
-    def test_config(self):
-        input_data = ["hello", "fun", "▀▁▂▃", "haha"]
-        tokenizer = ByteTokenizer(
-            name="byte_tokenizer_config_test",
-            lowercase=False,
-            sequence_length=8,
-            normalization_form="NFC",
-            errors="ignore",
-            replacement_char=0,
-        )
-        cloned_tokenizer = ByteTokenizer.from_config(tokenizer.get_config())
-        self.assertAllEqual(
-            tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
     def test_token_to_id(self):
         input_tokens = ["f", "u", "n"]
         expected_ids = [102, 117, 110]

--- a/keras_hub/src/tokenizers/byte_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer_test.py
@@ -5,18 +5,34 @@ from keras_hub.src.tokenizers.byte_tokenizer import ByteTokenizer
 
 
 class ByteTokenizerTest(TestCase):
-    def test_tokenize(self):
-        input_data = ["hello", "fun", "▀▁▂▃"]
-        tokenizer = ByteTokenizer()
-        call_output = tokenizer(input_data)
-        tokenize_output = tokenizer.tokenize(input_data)
-        exp_outputs = [
-            [104, 101, 108, 108, 111],
-            [102, 117, 110],
-            [226, 150, 128, 226, 150, 129, 226, 150, 130, 226, 150, 131],
-        ]
-        self.assertAllEqual(call_output, exp_outputs)
-        self.assertAllEqual(tokenize_output, exp_outputs)
+    def test_tokenizer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=ByteTokenizer,
+            init_kwargs={},
+            input_data=["hello", "fun", "▀▁▂▃", "haha"],
+            expected_output=[
+                [104, 101, 108, 108, 111],
+                [102, 117, 110],
+                [226, 150, 128, 226, 150, 129, 226, 150, 130, 226, 150, 131],
+                [104, 97, 104, 97],
+            ],
+        )
+
+    def test_tokenizer_basics_with_sequence_length(self):
+        # `sequence_length=12` is long enough that none of the inputs below
+        # get truncated, so the dense, padded output round-trips cleanly
+        # through `detokenize`.
+        self.run_preprocessing_layer_test(
+            cls=ByteTokenizer,
+            init_kwargs={"sequence_length": 12},
+            input_data=["hello", "fun", "▀▁▂▃", "haha"],
+            expected_output=[
+                [104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0],
+                [102, 117, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [226, 150, 128, 226, 150, 129, 226, 150, 130, 226, 150, 131],
+                [104, 97, 104, 97, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+        )
 
     def test_tokenize_scalar(self):
         input_data = "hello"
@@ -93,76 +109,6 @@ class ByteTokenizerTest(TestCase):
         self.assertAllEqual(
             call_output, [[72, 101, 76, 108, 79, 32, 119, 79, 114, 76, 100]]
         )
-
-    def test_tokenize_first_batch_second(self):
-        tokenizer = ByteTokenizer()
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["hello", "fun", "▀▁▂▃", "haha"]
-        )
-        ds = ds.map(tokenizer)
-        ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(4))
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [104, 101, 108, 108, 111],
-            [102, 117, 110],
-            [226, 150, 128, 226, 150, 129, 226, 150, 130, 226, 150, 131],
-            [104, 97, 104, 97],
-        ]
-        self.assertAllEqual(output, exp_output)
-
-    def test_tokenize_first_batch_second_with_sequence_length(self):
-        tokenizer = ByteTokenizer(sequence_length=10)
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["hello", "fun", "▀▁▂▃", "haha"]
-        )
-        ds = ds.map(tokenizer)
-        ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(4))
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [104, 101, 108, 108, 111, 0, 0, 0, 0, 0],
-            [102, 117, 110, 0, 0, 0, 0, 0, 0, 0],
-            [226, 150, 128, 226, 150, 129, 226, 150, 130, 226],
-            [104, 97, 104, 97, 0, 0, 0, 0, 0, 0],
-        ]
-        self.assertAllEqual(output, exp_output)
-
-    def test_batch_first_tokenize_second(self):
-        tokenizer = ByteTokenizer()
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["hello", "fun", "▀▁▂▃", "haha"]
-        )
-        ds = ds.batch(4).map(tokenizer)
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [104, 101, 108, 108, 111],
-            [102, 117, 110],
-            [226, 150, 128, 226, 150, 129, 226, 150, 130, 226, 150, 131],
-            [104, 97, 104, 97],
-        ]
-        self.assertAllEqual(output, exp_output)
-
-    def test_batch_first_tokenize_second_with_sequence_length(self):
-        tokenizer = ByteTokenizer(sequence_length=10)
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["hello", "fun", "▀▁▂▃", "haha"]
-        )
-        ds = ds.batch(4).map(tokenizer)
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [104, 101, 108, 108, 111, 0, 0, 0, 0, 0],
-            [102, 117, 110, 0, 0, 0, 0, 0, 0, 0],
-            [226, 150, 128, 226, 150, 129, 226, 150, 130, 226],
-            [104, 97, 104, 97, 0, 0, 0, 0, 0, 0],
-        ]
-        self.assertAllEqual(output, exp_output)
 
     def test_load_model_with_config(self):
         input_data = ["hello"]

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
@@ -130,20 +130,6 @@ class SentencePieceTokenizerTest(TestCase):
         output_data = tokenizer(["the quick brown fox."])
         self.assertAllEqual(output_data, [[6, 5, 3, 4]])
 
-    def test_config(self):
-        input_data = ["the quick brown whale."]
-        original_tokenizer = SentencePieceTokenizer(
-            proto=self.proto,
-        )
-        cloned_tokenizer = SentencePieceTokenizer.from_config(
-            original_tokenizer.get_config()
-        )
-        cloned_tokenizer.set_proto(original_tokenizer.proto)
-        self.assertAllEqual(
-            original_tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
     def test_safe_mode_proto_file_disallowed(self):
         temp_dir = self.get_temp_dir()
         proto_path = os.path.join(temp_dir, "model.spm")

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
@@ -1,6 +1,5 @@
 import os
 
-import tensorflow as tf
 from keras.src.saving import serialization_lib
 
 from keras_hub.src.tests.test_case import TestCase
@@ -12,10 +11,32 @@ from keras_hub.src.tokenizers.sentence_piece_tokenizer import (
 class SentencePieceTokenizerTest(TestCase):
     def setUp(self):
         super().setUp()
+        self._allow_python_workflow = True
         self.proto = os.path.join(
             self.get_test_data_dir(), "tokenizer_test_vocab.spm"
         )
         self.tokenizer = SentencePieceTokenizer(proto=self.proto)
+
+    def test_tokenizer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=SentencePieceTokenizer,
+            init_kwargs={
+                "proto": self.proto,
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
+            input_data=[
+                "the quick brown fox.",
+                "the quick",
+                "the",
+                "quick brown fox.",
+            ],
+            expected_output=[
+                [6, 5, 3, 4],
+                [6, 5],
+                [6],
+                [5, 3, 4],
+            ],
+        )
 
     def test_tokenize(self):
         input_data = ["the quick brown fox."]
@@ -109,40 +130,6 @@ class SentencePieceTokenizerTest(TestCase):
         output_data = tokenizer(["the quick brown fox."])
         self.assertAllEqual(output_data, [[6, 5, 3, 4]])
 
-    def test_tokenize_then_batch(self):
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["the quick brown fox.", "the quick", "the", "quick brown fox."]
-        )
-        ds = ds.map(self.tokenizer).apply(
-            tf.data.experimental.dense_to_ragged_batch(4)
-        )
-        output_data = ds.take(1).get_single_element()
-
-        expected = [
-            [6, 5, 3, 4],
-            [6, 5],
-            [6],
-            [5, 3, 4],
-        ]
-        for i in range(4):
-            self.assertAllEqual(output_data[i], expected[i])
-
-    def test_batch_then_tokenize(self):
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["the quick brown fox.", "the quick", "the", "quick brown fox."]
-        )
-        ds = ds.batch(4).map(self.tokenizer)
-        output_data = ds.take(1).get_single_element()
-
-        expected = [
-            [6, 5, 3, 4],
-            [6, 5],
-            [6],
-            [5, 3, 4],
-        ]
-        for i in range(4):
-            self.assertAllEqual(output_data[i], expected[i])
-
     def test_config(self):
         input_data = ["the quick brown whale."]
         original_tokenizer = SentencePieceTokenizer(
@@ -178,6 +165,7 @@ class SentencePieceTokenizerTFTest(SentencePieceTokenizerTest):
 
     def setUp(self):
         super().setUp()
+        self._allow_python_workflow = False
         self.tokenizer = SentencePieceTokenizer(
             proto=self.proto,
             _allow_python_workflow=False,

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
@@ -15,7 +15,10 @@ class SentencePieceTokenizerTest(TestCase):
         self.proto = os.path.join(
             self.get_test_data_dir(), "tokenizer_test_vocab.spm"
         )
-        self.tokenizer = SentencePieceTokenizer(proto=self.proto)
+        self.tokenizer = SentencePieceTokenizer(
+            proto=self.proto,
+            _allow_python_workflow=self._allow_python_workflow,
+        )
 
     def test_tokenizer_basics(self):
         self.run_preprocessing_layer_test(
@@ -57,6 +60,7 @@ class SentencePieceTokenizerTest(TestCase):
         tokenizer = SentencePieceTokenizer(
             proto=self.proto,
             sequence_length=10,
+            _allow_python_workflow=self._allow_python_workflow,
         )
         output_data = tokenizer(input_data)
         self.assertAllEqual(output_data, [[6, 5, 3, 4, 0, 0, 0, 0, 0, 0]])
@@ -66,6 +70,7 @@ class SentencePieceTokenizerTest(TestCase):
         tokenizer = SentencePieceTokenizer(
             proto=self.proto,
             dtype="string",
+            _allow_python_workflow=self._allow_python_workflow,
         )
         output_data = tokenizer(input_data)
         self.assertAllEqual(
@@ -79,6 +84,7 @@ class SentencePieceTokenizerTest(TestCase):
             proto=self.proto,
             add_bos=True,
             add_eos=True,
+            _allow_python_workflow=self._allow_python_workflow,
         )
         output_data = tokenizer(input_data)
         self.assertAllEqual(output_data, [1, 6, 5, 3, 4, 2])
@@ -90,6 +96,7 @@ class SentencePieceTokenizerTest(TestCase):
             dtype="string",
             add_bos=True,
             add_eos=True,
+            _allow_python_workflow=self._allow_python_workflow,
         )
         output_data = tokenizer(input_data)
         self.assertAllEqual(
@@ -126,7 +133,10 @@ class SentencePieceTokenizerTest(TestCase):
     def test_from_bytes(self):
         with open(self.proto, "rb") as file:
             proto = file.read()
-        tokenizer = SentencePieceTokenizer(proto=proto)
+        tokenizer = SentencePieceTokenizer(
+            proto=proto,
+            _allow_python_workflow=self._allow_python_workflow,
+        )
         output_data = tokenizer(["the quick brown fox."])
         self.assertAllEqual(output_data, [[6, 5, 3, 4]])
 
@@ -154,63 +164,5 @@ class SentencePieceTokenizerTFTest(SentencePieceTokenizerTest):
         self._allow_python_workflow = False
         self.tokenizer = SentencePieceTokenizer(
             proto=self.proto,
-            _allow_python_workflow=False,
+            _allow_python_workflow=self._allow_python_workflow,
         )
-
-    def test_dense_output(self):
-        input_data = ["the quick brown fox."]
-        tokenizer = SentencePieceTokenizer(
-            proto=self.proto,
-            sequence_length=10,
-            _allow_python_workflow=False,
-        )
-        output_data = tokenizer(input_data)
-        self.assertAllEqual(output_data, [[6, 5, 3, 4, 0, 0, 0, 0, 0, 0]])
-
-    def test_string_tokenize(self):
-        input_data = ["the quick brown fox."]
-        tokenizer = SentencePieceTokenizer(
-            proto=self.proto,
-            dtype="string",
-            _allow_python_workflow=False,
-        )
-        output_data = tokenizer(input_data)
-        self.assertAllEqual(
-            output_data,
-            [["▁the", "▁quick", "▁brown", "▁fox."]],
-        )
-
-    def test_scalar_bos_eos(self):
-        input_data = "the quick brown fox."
-        tokenizer = SentencePieceTokenizer(
-            proto=self.proto,
-            add_bos=True,
-            add_eos=True,
-            _allow_python_workflow=False,
-        )
-        output_data = tokenizer(input_data)
-        self.assertAllEqual(output_data, [1, 6, 5, 3, 4, 2])
-
-    def test_string_bos_eos(self):
-        input_data = ["the quick brown fox."]
-        tokenizer = SentencePieceTokenizer(
-            proto=self.proto,
-            dtype="string",
-            add_bos=True,
-            add_eos=True,
-            _allow_python_workflow=False,
-        )
-        output_data = tokenizer(input_data)
-        self.assertAllEqual(
-            output_data, [["<s>", "▁the", "▁quick", "▁brown", "▁fox.", "</s>"]]
-        )
-
-    def test_from_bytes(self):
-        with open(self.proto, "rb") as file:
-            proto = file.read()
-        tokenizer = SentencePieceTokenizer(
-            proto=proto,
-            _allow_python_workflow=False,
-        )
-        output_data = tokenizer(["the quick brown fox."])
-        self.assertAllEqual(output_data, [[6, 5, 3, 4]])

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -161,49 +161,6 @@ class UnicodeCodepointTokenizerTest(TestCase):
             [[78, 105, 78, 74, 97, 83]],
         )
 
-    def test_load_model_with_config(self):
-        input_data = tf.constant(["hello"])
-
-        original_tokenizer = UnicodeCodepointTokenizer(
-            lowercase=False,
-            sequence_length=11,
-            normalization_form="NFC",
-            errors="strict",
-            vocabulary_size=None,
-        )
-        cloned_tokenizer = UnicodeCodepointTokenizer.from_config(
-            original_tokenizer.get_config()
-        )
-        self.assertAllEqual(
-            original_tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
-        decoded_input = [107, 101, 114, 97, 115]
-        self.assertAllEqual(
-            original_tokenizer.detokenize(decoded_input),
-            cloned_tokenizer.detokenize(decoded_input),
-        )
-
-    def test_config(self):
-        input_data = ["ninja", "samurai", "▀▁▂▃"]
-        tokenizer = UnicodeCodepointTokenizer(
-            name="unicode_character_tokenizer_config_gen",
-            lowercase=False,
-            sequence_length=8,
-            normalization_form="NFC",
-            errors="ignore",
-            replacement_char=0,
-            vocabulary_size=100,
-        )
-        cloned_tokenizer = UnicodeCodepointTokenizer.from_config(
-            tokenizer.get_config()
-        )
-        self.assertAllEqual(
-            tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
     def test_token_to_id(self):
         input_tokens = ["ب", "و", "خ"]
         expected_ids = [1576, 1608, 1582]

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -37,6 +37,26 @@ class UnicodeCodepointTokenizerTest(TestCase):
             ],
         )
 
+    def test_tokenizer_basics_with_non_default_config(self):
+        self.run_preprocessing_layer_test(
+            cls=UnicodeCodepointTokenizer,
+            init_kwargs={
+                "lowercase": False,
+                "sequence_length": 8,
+                "normalization_form": "NFC",
+                "errors": "ignore",
+                "replacement_char": 0,
+                "vocabulary_size": 100,
+            },
+            input_data=["ninja", "samurai", "▀▁▂▃"],
+            expected_output=[
+                [99, 99, 99, 99, 97, 0, 0, 0],
+                [99, 97, 99, 99, 99, 97, 99, 0],
+                [99, 99, 99, 99, 0, 0, 0, 0],
+            ],
+            expected_detokenize_output=[b"cccca", b"cacccac", b"cccc"],
+        )
+
     def test_tokenize_scalar(self):
         input_data = "ninja"
         tokenizer = UnicodeCodepointTokenizer()

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -7,18 +7,35 @@ from keras_hub.src.tokenizers.unicode_codepoint_tokenizer import (
 
 
 class UnicodeCodepointTokenizerTest(TestCase):
-    def test_tokenize(self):
-        input_data = ["ninja", "samurai", "▀▁▂▃"]
-        tokenizer = UnicodeCodepointTokenizer()
-        call_output = tokenizer(input_data)
-        tokenize_output = tokenizer.tokenize(input_data)
-        exp_outputs = [
-            [110, 105, 110, 106, 97],
-            [115, 97, 109, 117, 114, 97, 105],
-            [9600, 9601, 9602, 9603],
-        ]
-        self.assertAllEqual(call_output, exp_outputs)
-        self.assertAllEqual(tokenize_output, exp_outputs)
+    def test_tokenizer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=UnicodeCodepointTokenizer,
+            init_kwargs={},
+            input_data=["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"],
+            expected_output=[
+                [110, 105, 110, 106, 97],
+                [115, 97, 109, 117, 114, 97, 105],
+                [9600, 9601, 9602, 9603],
+                [107, 101, 114, 97, 115],
+                [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
+            ],
+        )
+
+    def test_tokenizer_basics_with_sequence_length(self):
+        # None of the inputs below get truncated at `sequence_length=10`, so
+        # the dense, padded output round-trips cleanly through `detokenize`.
+        self.run_preprocessing_layer_test(
+            cls=UnicodeCodepointTokenizer,
+            init_kwargs={"sequence_length": 10},
+            input_data=["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"],
+            expected_output=[
+                [110, 105, 110, 106, 97, 0, 0, 0, 0, 0],
+                [115, 97, 109, 117, 114, 97, 105, 0, 0, 0],
+                [9600, 9601, 9602, 9603, 0, 0, 0, 0, 0, 0],
+                [107, 101, 114, 97, 115, 0, 0, 0, 0, 0],
+                [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
+            ],
+        )
 
     def test_tokenize_scalar(self):
         input_data = "ninja"
@@ -143,80 +160,6 @@ class UnicodeCodepointTokenizerTest(TestCase):
             call_output,
             [[78, 105, 78, 74, 97, 83]],
         )
-
-    def test_tokenize_first_batch_second(self):
-        tokenizer = UnicodeCodepointTokenizer()
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"]
-        )
-        ds = ds.map(tokenizer)
-        ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(5))
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [110, 105, 110, 106, 97],
-            [115, 97, 109, 117, 114, 97, 105],
-            [9600, 9601, 9602, 9603],
-            [107, 101, 114, 97, 115],
-            [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
-        ]
-        self.assertAllEqual(output, exp_output)
-
-    def test_tokenize_first_batch_second_with_sequence_length(self):
-        tokenizer = UnicodeCodepointTokenizer(sequence_length=10)
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"]
-        )
-        ds = ds.map(tokenizer)
-        ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(5))
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [110, 105, 110, 106, 97, 0, 0, 0, 0, 0],
-            [115, 97, 109, 117, 114, 97, 105, 0, 0, 0],
-            [9600, 9601, 9602, 9603, 0, 0, 0, 0, 0, 0],
-            [107, 101, 114, 97, 115, 0, 0, 0, 0, 0],
-            [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
-        ]
-        self.assertAllEqual(output, exp_output)
-
-    def test_batch_first_tokenize_second(self):
-        tokenizer = UnicodeCodepointTokenizer()
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"]
-        )
-        ds = ds.batch(5).map(tokenizer)
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [110, 105, 110, 106, 97],
-            [115, 97, 109, 117, 114, 97, 105],
-            [9600, 9601, 9602, 9603],
-            [107, 101, 114, 97, 115],
-            [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
-        ]
-        self.assertAllEqual(output, exp_output)
-
-    def test_batch_first_tokenize_second_with_sequence_length(self):
-        tokenizer = UnicodeCodepointTokenizer(sequence_length=10)
-
-        ds = tf.data.Dataset.from_tensor_slices(
-            ["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"]
-        )
-        ds = ds.batch(5).map(tokenizer)
-        output = ds.take(1).get_single_element()
-
-        exp_output = [
-            [110, 105, 110, 106, 97, 0, 0, 0, 0, 0],
-            [115, 97, 109, 117, 114, 97, 105, 0, 0, 0],
-            [9600, 9601, 9602, 9603, 0, 0, 0, 0, 0, 0],
-            [107, 101, 114, 97, 115, 0, 0, 0, 0, 0],
-            [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
-        ]
-        self.assertAllEqual(output, exp_output)
 
     def test_load_model_with_config(self):
         input_data = tf.constant(["hello"])

--- a/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
@@ -195,25 +195,6 @@ class WordPieceTokenizerTest(TestCase):
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [[1, 2, 3, 4, 5, 6, 7]])
 
-    def test_config(self):
-        input_data = ["quick brOWN whale"]
-        vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@OWN", "fox"]
-        original_tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data,
-            lowercase=False,
-            oov_token="@UNK@",
-            suffix_indicator="@@",
-            dtype="string",
-        )
-        cloned_tokenizer = WordPieceTokenizer.from_config(
-            original_tokenizer.get_config()
-        )
-        cloned_tokenizer.set_vocabulary(original_tokenizer.get_vocabulary())
-        self.assertAllEqual(
-            original_tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
-
     def test_no_oov_token_in_vocabulary(self):
         vocab_data = ["qu", "@@ick", "br", "@@OWN", "fox"]
         with self.assertRaises(ValueError):
@@ -250,28 +231,6 @@ class WordPieceTokenizerTest(TestCase):
         )
         output = tokenizer(input_data)
         self.assertAllEqual(output, [0, 0, 1, 2])
-
-    def test_config_with_special_tokens(self):
-        input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
-        special_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
-        vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
-        vocab_data = [*special_tokens, *vocab_data]
-        original_tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data,
-            lowercase=False,
-            oov_token="[UNK]",
-            suffix_indicator="##",
-            dtype="string",
-            special_tokens=special_tokens,
-        )
-        cloned_tokenizer = WordPieceTokenizer.from_config(
-            original_tokenizer.get_config()
-        )
-        cloned_tokenizer.set_vocabulary(original_tokenizer.get_vocabulary())
-        self.assertAllEqual(
-            original_tokenizer(input_data),
-            cloned_tokenizer(input_data),
-        )
 
     def test_safe_mode_vocabulary_file_disallowed(self):
         temp_dir = self.get_temp_dir()

--- a/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
@@ -8,14 +8,25 @@ from keras_hub.src.tokenizers.word_piece_tokenizer import WordPieceTokenizer
 
 
 class WordPieceTokenizerTest(TestCase):
-    def test_tokenize(self):
-        input_data = ["the quick brown fox."]
-        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
-        call_output = tokenizer(input_data)
-        tokenize_output = tokenizer.tokenize(input_data)
-        self.assertAllEqual(call_output, [[1, 2, 3, 4, 5, 6, 7]])
-        self.assertAllEqual(tokenize_output, [[1, 2, 3, 4, 5, 6, 7]])
+    def test_tokenizer_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=WordPieceTokenizer,
+            init_kwargs={
+                "vocabulary": [
+                    "[UNK]",
+                    "the",
+                    "qu",
+                    "##ick",
+                    "br",
+                    "##own",
+                    "fox",
+                    ".",
+                ]
+            },
+            input_data=["the quick brown fox."],
+            expected_output=[[1, 2, 3, 4, 5, 6, 7]],
+            expected_detokenize_output=["the quick brown fox ."],
+        )
 
     def test_dense_output(self):
         input_data = ["the quick brown fox."]
@@ -172,18 +183,6 @@ class WordPieceTokenizerTest(TestCase):
         )
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [1, 2, 3, 4, 5, 6])
-
-    def test_batching_ragged_tensors(self):
-        tokenizer = WordPieceTokenizer(
-            vocabulary=["[UNK]", "a", "b", "c", "d", "e", "f"]
-        )
-        dataset = tf.data.Dataset.from_tensor_slices(["a b c", "d e", "a f e"])
-        dataset = dataset.map(tokenizer)
-        dataset = dataset.apply(
-            tf.data.experimental.dense_to_ragged_batch(batch_size=1)
-        )
-        element = dataset.take(1).get_single_element().numpy()
-        self.assertAllEqual(element, [[1, 2, 3]])
 
     def test_from_file(self):
         vocab_path = os.path.join(self.get_temp_dir(), "vocab.txt")

--- a/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
@@ -28,6 +28,24 @@ class WordPieceTokenizerTest(TestCase):
             expected_detokenize_output=["the quick brown fox ."],
         )
 
+    def test_tokenizer_basics_with_non_default_config(self):
+        special_tokens = ["@UNK@", "@MASK@"]
+        vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox", "@MASK@"]
+        self.run_preprocessing_layer_test(
+            cls=WordPieceTokenizer,
+            init_kwargs={
+                "vocabulary": vocab_data,
+                "lowercase": True,
+                "oov_token": "@UNK@",
+                "suffix_indicator": "@@",
+                "special_tokens": special_tokens,
+                "special_tokens_in_strings": True,
+            },
+            input_data=["quick brown whale @MASK@"],
+            expected_output=[[1, 2, 3, 4, 0, 6]],
+            expected_detokenize_output=["quick brown @UNK@ @MASK@"],
+        )
+
     def test_dense_output(self):
         input_data = ["the quick brown fox."]
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]


### PR DESCRIPTION
This PR addresses #1313.

### Tokenizer tests

Ports these files to use `TestCase.run_preprocessing_layer_test` as their first test, removing `tf.data` map/batch tests already covered by the shared helper, and removing `test_config`/`test_load_model_with_config` methods that duplicated the `get_config`/`from_config` round-trip check `run_preprocessing_layer_test`'s `run_serialization_test` already performs:

- `byte_tokenizer_test.py`
- `unicode_codepoint_tokenizer_test.py`
- `word_piece_tokenizer_test.py`
- `byte_pair_tokenizer_test.py`
- `sentence_piece_tokenizer_test.py`

In `byte_pair_tokenizer_test.py` and `sentence_piece_tokenizer_test.py`, also removes test overrides in `BytePairTokenizerTFTest`/`SentencePieceTokenizerTFTest` that were duplicates of the base tests aside from a hardcoded `_allow_python_workflow=False`. The base tests now read `self._allow_python_workflow` instead, so they already run under both workflows via inheritance.

### Preprocessing layer tests

Also ports six keras_hub/src/layers/preprocessing/*_test.py files:

- `image_converter_test.py`: replaces `test_resize_dataset` and removes the redundant `test_config`.
- `masked_lm_mask_generator_test.py`: replaces `test_mask_dense` and `test_with_tf_data` with one deterministic case (mask_selection_rate=1, mask_token_rate=1, random_token_rate=0), the layer holds a stateful tf.random.Generator, so non-deterministic settings can't be reused across the helper's repeated calls and removes the redundant `test_config`.
- `start_end_packer_test.py`: replaces `test_batch`, now parameterized over `_allow_python_workflow` like the rest of the file.
- `multi_segment_packer_test.py`: adds `test_layer_basics`, removes the redundant `test_config`. call() takes a single inputs argument (the tuple of segments), so input_data needs an extra 1-tuple wrapper to match the helper's layer(*input_data) convention.
- `random_deletion_test.py`: adds `test_layer_basics` (rate=1.0, deletes every token, deterministic regardless of RNG state), removes the redundant `test_get_config_and_from_config`, and trims `test_augment_first_batch_second`/`test_batch_first_augment_second` down to just their `skip_fn`/`skip_py_fn` cases, since the default no-skip case is now covered generically by `test_layer_basics` but `skip_fn`/`skip_py_fn` are distinct code paths that need their own verification under tf.data.Dataset.map.
- `random_swap_test.py`: same treatment, using rate=0.0 (never swaps) since, unlike deletion, swap-partner selection has no rate that makes the result order-independent, 0.0 is the only fully deterministic option.

### Note
`test_layer_basics` for `RandomDeletion`/`RandomSwap` uses int tokens rather than these layers' more typical string/word-level usage. `run_preprocessing_layer_test`'s internal direct-call-vs-tf.data-mapped consistency check uses assertAllClose, which calls np.isclose internally; np.isclose tries to promote its inputs against a float tolerance and raises DTypePromotionError for string dtypes, even when comparing two identical strings, so the helper's consistency check is currently broken for any string-output layer, independent of test data. This looks like a latent bug in `test_case.py` but would like to understand if this is intentional.