### PR TITLE
Fix incorrect hardcoding of `training` argument in Qwen model creation.

### DIFF
--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_backbone.py
@@ -111,7 +111,6 @@ class Qwen3MoeBackbone(Backbone):
         sliding_window_size=32768,
         router_aux_loss_coefficient=0.001,
         mlp_only_layers=None,
-        training=None,
         **kwargs,
     ):
         # === Layers ===
@@ -171,9 +170,7 @@ class Qwen3MoeBackbone(Backbone):
         )
         x = self.token_embedding(token_id_input)
         for transformer_layer in self.transformer_layers:
-            x = transformer_layer(
-                x, decoder_padding_mask=padding_mask_input, training=training
-            )
+            x = transformer_layer(x, decoder_padding_mask=padding_mask_input)
         sequence_output = self.layer_norm(x)
         super().__init__(
             inputs={

--- a/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_backbone.py
@@ -118,7 +118,6 @@ class QwenMoeBackbone(Backbone):
         output_router_logits=False,
         router_aux_loss_coefficient=0.001,
         mlp_only_layers=[],
-        training=None,
         **kwargs,
     ):
         # === Layers ===
@@ -172,9 +171,7 @@ class QwenMoeBackbone(Backbone):
         )
         x = self.token_embedding(token_id_input)
         for transformer_layer in self.transformer_layers:
-            x = transformer_layer(
-                x, decoder_padding_mask=padding_mask_input, training=training
-            )
+            x = transformer_layer(x, decoder_padding_mask=padding_mask_input)
         sequence_output = self.layer_norm(x)
         super().__init__(
             inputs={


### PR DESCRIPTION
`QwenMoeBackbone` and `Qwen3MoeBackbone` had a `training` argument in their `__init__` that was forwarded to the `QwenMoeTransformerDecoder` during functional model creation. Previously, this was ignored because some ad-hoc `Functional` model behavior would override the `training` argument.

With this fix in Keras Core https://github.com/keras-team/keras/pull/23364 the `training` argument in functional model creation is now honored.

This was however not the intended behavior for Qwen, the `training` argument is expected to be propagated normally from the model invocation.

- Removed the `training` argument in `__init__`
- Removed the `training` argument passed to `QwenMoeTransformerDecoder` during functional model construction

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
