### PR TITLE
Fix `MultiSegmentPacker` Python path to forward `sequence_length`, `add_start_value`, and `add_end_value` to trimming

### DIFF
--- a/keras_hub/src/layers/preprocessing/multi_segment_packer.py
+++ b/keras_hub/src/layers/preprocessing/multi_segment_packer.py
@@ -474,6 +474,9 @@ class MultiSegmentPacker(PreprocessingLayer):
         add_start_value=True,
         add_end_value=True,
     ):
+        if sequence_length is not None:
+            sequence_length = int(sequence_length)
+
         def _get_type(inputs):
             if self.start_value:
                 return type(self.start_value[0])

--- a/keras_hub/src/layers/preprocessing/multi_segment_packer.py
+++ b/keras_hub/src/layers/preprocessing/multi_segment_packer.py
@@ -406,21 +406,28 @@ class MultiSegmentPacker(PreprocessingLayer):
                     remaining_budget = 0
         return trimmed_segments
 
-    def _trim_inputs_python(self, inputs):
+    def _trim_inputs_python(
+        self,
+        inputs,
+        sequence_length=None,
+        add_start_value=True,
+        add_end_value=True,
+    ):
         """Trim inputs to desired length."""
+        sequence_length = sequence_length or self.sequence_length
         num_segments = len(inputs)
         num_special_tokens = (
-            len(self.start_value)
+            (len(self.start_value) if add_start_value else 0)
             + (num_segments - 1) * len(self.sep_value)
-            + len(self.end_value)
+            + (len(self.end_value) if add_end_value else 0)
         )
         if self.truncate == "round_robin":
             return self._trim_inputs_round_robin_python(
-                self.sequence_length - num_special_tokens, inputs
+                sequence_length - num_special_tokens, inputs
             )
         elif self.truncate == "waterfall":
             return self._trim_inputs_waterfall_python(
-                self.sequence_length - num_special_tokens, inputs
+                sequence_length - num_special_tokens, inputs
             )
         else:
             raise ValueError("Unsupported truncate: %s" % self.truncate)
@@ -503,7 +510,12 @@ class MultiSegmentPacker(PreprocessingLayer):
         inputs, batched = self._canonicalize_inputs_python(inputs)
         input_type = _get_type(inputs)
 
-        segments = self._trim_inputs_python(inputs)
+        segments = self._trim_inputs_python(
+            inputs,
+            sequence_length=sequence_length,
+            add_start_value=add_start_value,
+            add_end_value=add_end_value,
+        )
         token_ids, segment_ids = self._combine_inputs_python(
             segments,
             add_start_value=add_start_value,

--- a/keras_hub/src/layers/preprocessing/multi_segment_packer_test.py
+++ b/keras_hub/src/layers/preprocessing/multi_segment_packer_test.py
@@ -390,6 +390,64 @@ class MultiSegmentPackerTest(TestCase):
         self.assertAllEqual(token_ids, cloned_token_ids)
         self.assertAllEqual(segment_ids, cloned_segment_ids)
 
+    def test_sequence_length_override(self):
+        """Caller-supplied sequence_length should override init value."""
+        seq1 = [1, 2, 3, 4, 5]
+        seq2 = [6, 7, 8, 9, 10]
+        packer = MultiSegmentPacker(
+            sequence_length=8,
+            start_value=101,
+            end_value=102,
+            pad_value=0,
+            sep_value=[],
+            _allow_python_workflow=self._allow_python_workflow,
+        )
+        # Call with sequence_length=12 (overriding init value of 8).
+        # Budget = 12 - 1(start) - 1(end) = 10 → all tokens fit.
+        token_ids, segment_ids = packer((seq1, seq2), sequence_length=12)
+        self.assertAllEqual(
+            token_ids,
+            [101, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 102],
+        )
+
+    def test_no_start_token(self):
+        """add_start_value=False should not reserve space for start token."""
+        seq1 = [1, 2, 3, 4]
+        seq2 = [5, 6, 7, 8]
+        packer = MultiSegmentPacker(
+            sequence_length=7,
+            start_value=101,
+            end_value=102,
+            pad_value=0,
+            sep_value=[],
+            _allow_python_workflow=self._allow_python_workflow,
+        )
+        # With add_start_value=False:
+        # Budget = 7 - 0(no start) - 1(end) = 6, round_robin → 3+3.
+        # Output: [1,2,3, 5,6,7, 102]
+        token_ids, segment_ids = packer((seq1, seq2), add_start_value=False)
+        self.assertAllEqual(token_ids, [1, 2, 3, 5, 6, 7, 102])
+        self.assertAllEqual(segment_ids, [0, 0, 0, 1, 1, 1, 1])
+
+    def test_no_end_token(self):
+        """add_end_value=False should not reserve space for end token."""
+        seq1 = [1, 2, 3, 4]
+        seq2 = [5, 6, 7, 8]
+        packer = MultiSegmentPacker(
+            sequence_length=7,
+            start_value=101,
+            end_value=102,
+            pad_value=0,
+            sep_value=[],
+            _allow_python_workflow=self._allow_python_workflow,
+        )
+        # With add_end_value=False:
+        # Budget = 7 - 1(start) - 0(no end) = 6, round_robin → 3+3.
+        # Output: [101, 1,2,3, 5,6,7]
+        token_ids, segment_ids = packer((seq1, seq2), add_end_value=False)
+        self.assertAllEqual(token_ids, [101, 1, 2, 3, 5, 6, 7])
+        self.assertAllEqual(segment_ids, [0, 0, 0, 0, 1, 1, 1])
+
 
 class MultiSegmentPackerTFTest(MultiSegmentPackerTest):
     """Set `_allow_python_workflow=False` to test TF execution."""


### PR DESCRIPTION
## Description of the change

## Problem

`MultiSegmentPacker._call_python()` does not forward `sequence_length`, `add_start_value`, or `add_end_value` to `_trim_inputs_python()`, causing the Python and TF execution paths to produce different results.

- **`sequence_length`**: The Python path always trims using `self.sequence_length` (set at init), ignoring the caller-supplied override.
- **`add_start_value` / `add_end_value`**: The Python path always reserves space for both start and end tokens in the trimming budget, even when they are disabled.

The TF path (`_trim_inputs_tf`) already handles all three parameters correctly.

## Fix

- Added `sequence_length`, `add_start_value`, `add_end_value` parameters to `_trim_inputs_python()`, mirroring `_trim_inputs_tf()`.
- Updated `_call_python()` to forward these parameters to `_trim_inputs_python()`.


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook

[Verification gist before and after ](https://colab.sandbox.google.com/gist/laxmareddyp/d302aff0f0f4cc3e36a4382363f01a3f/multisegmentpacker-issue.ipynb)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
