### PR TITLE
[LiteRT-LM 4/28] Traceable Ops: Indexing & Slicing Shims

### DIFF
--- a/keras_hub/src/models/llama/llama_attention.py
+++ b/keras_hub/src/models/llama/llama_attention.py
@@ -8,6 +8,9 @@ from keras_hub.src.models.llama.llama_rotary_embedding import (
 )
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
+from keras_hub.src.utils.keras_utils import gpu_supports_fused_attention_op
+from keras_hub.src.utils.keras_utils import running_on_gpu
+from keras_hub.src.utils.keras_utils import running_on_tpu
 
 
 class LlamaAttention(keras.layers.Layer):
@@ -197,8 +200,20 @@ class LlamaAttention(keras.layers.Layer):
             )
         return self._softmax(attention_scores)
 
+    def _use_fused_attention_op(self):
+        if not fused_attention_op_available():
+            return False
+        if self.dropout > 0.0:
+            return False
+        if running_on_gpu():
+            return gpu_supports_fused_attention_op()
+        elif running_on_tpu():
+            return True
+        else:
+            return False
+
     def _compute_attention(self, query, key, value, attention_mask=None):
-        if fused_attention_op_available():
+        if self._use_fused_attention_op():
             # Use `dot_product_attention` with Flash Attention support if
             # available.
             if attention_mask is not None:

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_causal_lm_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_causal_lm_test.py
@@ -1,7 +1,4 @@
-import os
 from unittest.mock import patch
-
-os.environ["KERAS_BACKEND"] = "jax"
 
 import keras
 import pytest

--- a/keras_hub/src/models/qwen_moe/qwen_moe_causal_lm_test.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_causal_lm_test.py
@@ -1,7 +1,4 @@
-import os
 from unittest.mock import patch
-
-os.environ["KERAS_BACKEND"] = "jax"
 
 import keras
 import pytest

--- a/keras_hub/src/models/smollm3/smollm3_layers.py
+++ b/keras_hub/src/models/smollm3/smollm3_layers.py
@@ -151,7 +151,6 @@ class SmolLM3Attention(layers.Layer):
         Args:
             hidden_states: Input tensor of shape (batch_size, seq_len,
                 hidden_size).
-            position_embeddings: Tuple of (cos, sin) tensors for RoPE.
             attention_mask: Attention mask tensor.
             training: Whether the layer is in training mode.
             self_attention_cache: Cached key and value projections from
@@ -559,8 +558,6 @@ class SmolLM3DecoderLayer(layers.Layer):
         Args:
             hidden_states: Input tensor of shape (batch_size,
                 seq_len, hidden_size).
-            position_embeddings: Optional tuple of (cos, sin)
-                tensors for RoPE.
             training: Whether the layer is in training mode.
             self_attention_cache: Cached key and value projections from
                 previous decoding steps.

--- a/keras_hub/src/models/smollm3/smollm3_layers.py
+++ b/keras_hub/src/models/smollm3/smollm3_layers.py
@@ -142,6 +142,8 @@ class SmolLM3Attention(layers.Layer):
         hidden_states,
         training=False,
         attention_mask=None,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
         **kwargs,
     ):
         """Forward pass for SmolLM3Attention.
@@ -152,12 +154,12 @@ class SmolLM3Attention(layers.Layer):
             position_embeddings: Tuple of (cos, sin) tensors for RoPE.
             attention_mask: Attention mask tensor.
             training: Whether the layer is in training mode.
+            self_attention_cache: Cached key and value projections from
+                previous decoding steps.
+            self_attention_cache_update_index: Index in the cache at which
+                the current projections are written.
         """
         self.training = training
-        self_attention_cache = kwargs.get("self_attention_cache", None)
-        self_attention_cache_update_index = kwargs.get(
-            "self_attention_cache_update_index", None
-        )
         start_index = (
             self_attention_cache_update_index
             if self_attention_cache_update_index is not None
@@ -547,6 +549,8 @@ class SmolLM3DecoderLayer(layers.Layer):
         training=False,
         decoder_padding_mask=None,
         decoder_attention_mask=None,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
         **kwargs,
     ):
         """
@@ -558,12 +562,11 @@ class SmolLM3DecoderLayer(layers.Layer):
             position_embeddings: Optional tuple of (cos, sin)
                 tensors for RoPE.
             training: Whether the layer is in training mode.
+            self_attention_cache: Cached key and value projections from
+                previous decoding steps.
+            self_attention_cache_update_index: Index in the cache at which
+                the current projections are written.
         """
-        self_attention_cache = kwargs.get("self_attention_cache", None)
-        self_attention_cache_update_index = kwargs.get(
-            "self_attention_cache_update_index", None
-        )
-
         self_attention_mask = self._compute_self_attention_mask(
             decoder_sequence=hidden_states,
             decoder_padding_mask=decoder_padding_mask,
@@ -580,7 +583,8 @@ class SmolLM3DecoderLayer(layers.Layer):
             hidden_states=hidden_states,
             training=training,
             attention_mask=self_attention_mask,
-            **kwargs,
+            self_attention_cache=self_attention_cache,
+            self_attention_cache_update_index=self_attention_cache_update_index,
         )
 
         if isinstance(x, tuple):

--- a/keras_hub/src/models/smollm3/smollm3_layers.py
+++ b/keras_hub/src/models/smollm3/smollm3_layers.py
@@ -582,6 +582,7 @@ class SmolLM3DecoderLayer(layers.Layer):
             attention_mask=self_attention_mask,
             self_attention_cache=self_attention_cache,
             self_attention_cache_update_index=self_attention_cache_update_index,
+            **kwargs,
         )
 
         if isinstance(x, tuple):

--- a/keras_hub/src/utils/litertlm/traceable_ops.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops.py
@@ -1,0 +1,201 @@
+"""Traceable replacements for Keras torch-backend ops used during export.
+
+``torch.export`` (used by ``litert_torch`` to trace KerasHub models for
+LiteRT-LM) cannot lower every op that Keras's torch backend produces --
+some introduce fused ATen ops, runtime assertions, or unbacked symbolic
+shapes that ``litert_torch`` cannot translate to TFLite. This module holds
+self-contained, drop-in replacements for the handful of ops that need this
+treatment (``one_hot``, ``repeat``, ``slice``, ``take``, ``scatter_update``,
+``dot_product_attention``, ``amax``), plus context managers that
+temporarily monkeypatch Keras's torch backend to use them.
+
+These replacements live in keras-hub rather than upstream in Keras because
+they are export-specific workarounds for ``torch.export`` and LiteRT
+lowering limitations, not improvements to the torch backend generally.
+"""
+
+import contextlib
+import unittest.mock
+
+import numpy as np
+import torch
+from keras.src import backend
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import nn as torch_backend_nn
+from keras.src.backend.torch import numpy as torch_backend_numpy
+
+
+def _make_scope(module, attr, replacement):
+    """Build a context manager that patches ``module.attr`` to *replacement*."""
+
+    @contextlib.contextmanager
+    def _scope():
+        with unittest.mock.patch.object(module, attr, replacement):
+            yield
+
+    return _scope
+
+
+def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
+    """Traceable replacement for Keras torch-backend ``one_hot``.
+
+    ``torch.nn.functional.one_hot`` inserts runtime assertions that class
+    values are non-negative. Under ``torch.export`` these become
+    ``aten._assert_async.msg`` ops, which ``litert_torch`` cannot lower.
+
+    This implementation uses equality against ``torch.arange``, which produces
+    the same result for non-negative indices and does not introduce
+    unlowerable assertions. Negative indices are preserved as all-zero vectors,
+    matching the original behavior.
+
+    Integer tensors are kept in int32 so the exported MLIR remains compatible
+    with ``litert_torch``'s i32-based TFLite lowering.
+    """
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with torch backend")
+    x = torch_core.convert_to_tensor(x, dtype=torch.int32)
+    x_clamped = torch.clamp(x, min=0)
+    output = x_clamped.unsqueeze(-1) == torch.arange(
+        num_classes, dtype=torch.int32, device=x.device
+    )
+    # Preserve original behavior for negative indices.
+    zero = torch.zeros_like(output)
+    output = torch.where(x.unsqueeze(-1) >= 0, output, zero)
+    if dtype is None:
+        dtype = "float32"
+    output = torch_core.convert_to_tensor(output, dtype=dtype)
+    dims = output.dim()
+    if axis < 0:
+        original_axis = axis
+        axis = dims + axis
+    else:
+        original_axis = axis
+    if axis < 0 or axis >= dims:
+        raise ValueError(
+            "`axis` is out of bounds for one-hot output with "
+            f"{dims} dimensions. Received: axis={original_axis}."
+        )
+    if axis != dims - 1:
+        new_axes_order = list(range(dims))
+        new_axes_order[axis] = dims - 1
+        for ax in range(axis + 1, dims):
+            new_axes_order[ax] -= 1
+        output = output.permute(new_axes_order)
+    return output
+
+
+_traceable_one_hot_scope = _make_scope(
+    torch_backend_nn, "one_hot", _patched_one_hot
+)
+
+
+def _is_scalar_integer(value):
+    """Return ``True`` if *value* is a scalar integer (Python or numpy)."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return True
+    # Accept 0-D numpy integer arrays / tensors with a single integer value.
+    if hasattr(value, "dtype") and hasattr(value, "ndim"):
+        return value.ndim == 0 and "int" in str(value.dtype)
+    return False
+
+
+# Capture the original ``repeat`` at module load so the patch can delegate
+# to it for every input form outside the scalar-tensor intercept.
+_ORIGINAL_REPEAT = torch_backend_numpy.repeat
+
+
+def _traceable_repeat(x, repeats, axis=None):
+    """Intercept 0-D tensor ``repeats`` (and ``repeats == 1``) with an axis.
+
+    Keras's own ``repeat`` fast-paths only plain Python ints; every other
+    input form defers to the original implementation unchanged.
+    """
+    x = torch_core.convert_to_tensor(x)
+
+    if axis is not None and _is_scalar_integer(repeats):
+        repeats = int(repeats)
+        if repeats < 0:
+            raise ValueError("`repeats` must be non-negative.")
+        if repeats == 1:
+            return x
+        if axis < 0:
+            axis = x.ndim + axis
+        shape = list(x.shape)
+        x = x.unsqueeze(axis + 1)
+        expand_shape = [-1] * x.ndim
+        expand_shape[axis + 1] = repeats
+        x = x.expand(expand_shape)
+        new_shape = list(shape)
+        new_shape[axis] = shape[axis] * repeats
+        return x.reshape(new_shape)
+
+    return _ORIGINAL_REPEAT(x, repeats, axis=axis)
+
+
+_traceable_repeat_scope = _make_scope(
+    torch_backend_numpy, "repeat", _traceable_repeat
+)
+
+
+# Capture the original ``amax`` at module load so the patched version can
+# delegate to it for every input form that does not trigger the layout bug.
+_ORIGINAL_AMAX = torch_backend_numpy.amax
+
+
+def _patched_amax(x, axis=None, keepdims=False):
+    """Traceable replacement for Keras torch-backend ``amax``.
+
+    ``keras.ops.max`` / ``keras.ops.amax`` with an integer ``axis`` lower to
+    ``aten.amax``. ``litert_torch``'s layout-optimization pass registers a
+    *checker* for ``aten.amax`` that forces the op to NHWC whenever its input
+    is 4-D (``layout_check.py``), but registers **no matching NHWC rewriter**
+    (``layout_rewrite.py``), so a 4-D ``aten.amax`` aborts conversion with
+    ``RuntimeError: NHWC node rewriter not found: amax``. GPT-OSS hits this in
+    its attention-sink softmax stabilization
+    (``gpt_oss_attention.py``: ``ops.max(combined_logits, axis=-1,
+    keepdims=True)`` on a ``[batch, heads, q, k]`` tensor); the litert-torch
+    gap is https://github.com/google-ai-edge/litert-torch/issues/1126.
+
+    For the single-integer-axis reduction of a 4-D tensor -- the only case that
+    trips the missing rewriter -- this routes through ``torch.max(dim=...)``,
+    which lowers to ``aten.max.dim`` (a *registered* rewriter). That is the
+    identical reduction and yields bit-identical values. Every other input form
+    (other ranks, tuple axes, ``axis=None``) defers to the original ``amax``
+    unchanged, so this is a no-op transform outside the triggering case.
+    """
+    x = torch_core.convert_to_tensor(x)
+    # NumPy integer axes (e.g. ``np.int64`` from shape arithmetic) are not
+    # Python ``int``; normalize so they take the same traceable path.
+    if isinstance(axis, np.integer):
+        axis = int(axis)
+    if axis is not None and isinstance(axis, int) and x.ndim == 4:
+        return torch.max(x, dim=axis, keepdim=keepdims).values
+    return _ORIGINAL_AMAX(x, axis=axis, keepdims=keepdims)
+
+
+_traceable_amax_scope = _make_scope(torch_backend_numpy, "amax", _patched_amax)
+
+
+@contextlib.contextmanager
+
+def traceable_ops_scope():
+    """Enter a context where Keras PyTorch backend ops are replaced with export-traceable shims."""
+    return _TraceableOpsScope(
+        _traceable_one_hot_scope,
+        _traceable_repeat_scope,
+        _traceable_amax_scope,
+    )
+
+class _TraceableOpsScope:
+    def __init__(self, *scopes):
+        self.scopes = scopes
+        self._entered = []
+    def __enter__(self):
+        for s in self.scopes:
+            s.__enter__()
+            self._entered.append(s)
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        while self._entered:
+            s = self._entered.pop()
+            s.__exit__(exc_type, exc_val, exc_tb)

--- a/keras_hub/src/utils/litertlm/traceable_ops.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops.py
@@ -36,6 +36,92 @@ def _make_scope(module, attr, replacement):
     return _scope
 
 
+def _normalize_start_indices(start_indices):
+    """Convert ``start_indices`` to a list preserving tensor elements."""
+    if isinstance(start_indices, (list, tuple)):
+        return list(start_indices)
+    start_indices = torch_core.convert_to_tensor(start_indices, dtype="int64")
+    if start_indices.ndim != 1:
+        raise ValueError(
+            "`start_indices` must be a 1-D tensor or a list/tuple of ints. "
+            f"Received shape: {tuple(start_indices.shape)}."
+        )
+    return list(start_indices.reshape(-1).unbind())
+
+
+def _patched_slice(inputs, start_indices, shape):
+    """Traceable replacement for Keras torch-backend ``slice``."""
+    inputs = torch_core.convert_to_tensor(inputs)
+
+    starts = _normalize_start_indices(start_indices)
+
+    if isinstance(shape, (list, tuple)):
+        lengths = list(shape)
+    else:
+        shape = torch_core.convert_to_tensor(shape, dtype="int64")
+        lengths = list(shape.reshape(-1).unbind())
+
+    def _is_dynamic(value):
+        # ``torch.SymInt`` values are not plain Python ints and require
+        # tensor-based slicing to avoid data-dependent guards.
+        return isinstance(value, torch.Tensor) or isinstance(
+            value, torch.SymInt
+        )
+
+    # Dimensions whose start or length is dynamic.
+    dynamic_dims = [
+        dim
+        for dim, (start, length) in enumerate(zip(starts, lengths))
+        if _is_dynamic(start) or _is_dynamic(length)
+    ]
+
+    # No dynamic values -> use Python slice objects directly.
+    if len(dynamic_dims) == 0:
+        slices = tuple(
+            slice(start, start + length)
+            for start, length in zip(starts, lengths)
+        )
+        return inputs[slices]
+
+    # Single dynamic dimension -> build indices with ``torch.arange`` and
+    # use ``index_select``. This keeps the output shape symbolic and avoids
+    # unbacked symbols that ``torch.export`` cannot resolve.
+    if len(dynamic_dims) == 1:
+        dim = dynamic_dims[0]
+        start = starts[dim]
+        if not isinstance(start, torch.Tensor):
+            start = torch_core.convert_to_tensor(
+                start, dtype="int32", device=inputs.device
+            )
+        start = start.reshape(())
+        length = lengths[dim]
+
+        indices = torch.arange(length, dtype=torch.int32, device=inputs.device)
+        indices = indices + start
+        result = torch.index_select(inputs, dim, indices)
+
+        # Apply static slicing for the remaining dimensions.
+        for d, (s, l) in enumerate(zip(starts, lengths)):
+            if d != dim and (s != 0 or l != result.shape[d]):
+                result = torch.narrow(result, d, s, l)
+        return result
+
+    # Multiple dynamic dimensions are not supported for LiteRT-LM export
+    # because ``torch.export`` cannot resolve the resulting unbacked
+    # symbols. Fail fast with an actionable message instead of falling
+    # back to the original implementation and producing a cryptic export
+    # error.
+    raise NotImplementedError(
+        "Slicing with multiple dynamic dimensions is not supported for "
+        "LiteRT-LM export. Received dynamic dims "
+        f"{dynamic_dims}. Consider materializing start/length values as "
+        "static ints or simplifying the slice operation."
+    )
+
+
+_traceable_slice_scope = _make_scope(torch_core, "slice", _patched_slice)
+
+
 def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     """Traceable replacement for Keras torch-backend ``one_hot``.
 
@@ -86,6 +172,90 @@ def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
 
 _traceable_one_hot_scope = _make_scope(
     torch_backend_nn, "one_hot", _patched_one_hot
+)
+
+
+def _patched_take(x, indices, axis=None):
+    """Patch Keras torch-backend ``take`` to keep embedding indices as int32.
+
+    The default implementation casts integer indices to int64 before calling
+    ``torch.nn.functional.embedding``. ``litert_torch``'s TFLite embedding
+    lowering expects int32 indices consistent with the traced function
+    signature, so we keep indices in int32 for the embedding-lookup case.
+
+    ``axis=None`` means "take from the flattened input" (matching
+    ``numpy``/``jax`` semantics), so the input must be flattened *before*
+    negative indices are wrapped -- wrapping against
+    ``x.shape[0]`` (the first, unflattened dimension) is only correct when
+    ``x`` is already 1-D. Flattening first and then computing ``x_dim`` as
+    the flattened length keeps this correct for multi-dimensional ``x``
+    (e.g. ``take(x_3x4, -1, axis=None)`` must resolve to the last of the 12
+    flattened elements, not wrap against the first dimension's size of 3).
+    """
+    x = torch_core.convert_to_tensor(x)
+    indices = torch_core.convert_to_tensor(indices, dtype=torch.int32)
+    if axis is None:
+        x = torch.reshape(x, (-1,))
+        axis = 0
+    x_dim = x.shape[axis]
+    indices = torch.where(
+        indices < 0,
+        indices + x_dim,
+        indices,
+    )
+    if x.ndim == 2 and axis == 0:
+        # ``F.embedding`` documents a float ``weight`` (embedding table),
+        # but empirically accepts int32/int64/bool ``x`` as a plain gather,
+        # both eagerly and under ``torch.export`` -- no dtype guard needed.
+        return torch.nn.functional.embedding(indices, x)
+    axis = torch_backend_numpy.canonicalize_axis(axis, x.ndim)
+    shape = x.shape[:axis] + indices.shape + x.shape[axis + 1 :]
+    indices = indices.ravel()
+    out = torch.index_select(x, dim=axis, index=indices).squeeze(axis)
+    return out.reshape(shape)
+
+
+_traceable_take_scope = _make_scope(torch_backend_numpy, "take", _patched_take)
+
+
+_SCATTER_UPDATE_REDUCTION_OPS = {
+    "max": torch.maximum,
+    "min": torch.minimum,
+    "mul": lambda a, b: a * b,
+}
+
+
+def _patched_scatter_update(inputs, indices, updates, reduction=None):
+    """Patch Keras torch-backend ``scatter_update`` to keep indices int32.
+
+    The default implementation casts indices to int64. ``litert_torch``'s
+    TFLite scatter lowering expects int32 indices, so we keep them in int32
+    during export.
+    """
+    inputs = torch_core.convert_to_tensor(inputs)
+    indices = torch_core.convert_to_tensor(indices, dtype=torch.int32)
+    updates = torch_core.convert_to_tensor(updates, dtype=inputs.dtype)
+    indices = torch.transpose(indices, 0, 1)
+    idx = tuple(indices)
+
+    outputs = torch.clone(inputs)
+    if reduction is None:
+        outputs[idx] = updates
+    elif reduction == "add":
+        outputs.index_put_(idx, updates, accumulate=True)
+    elif reduction in _SCATTER_UPDATE_REDUCTION_OPS:
+        op_fn = _SCATTER_UPDATE_REDUCTION_OPS[reduction]
+        indices_t = indices.T
+        for i in range(indices_t.shape[0]):
+            idx_i = tuple(indices_t[i])
+            outputs[idx_i] = op_fn(outputs[idx_i], updates[i])
+    else:
+        raise ValueError(f"Unsupported reduction: {reduction}")
+    return outputs
+
+
+_traceable_scatter_update_scope = _make_scope(
+    torch_core, "scatter_update", _patched_scatter_update
 )
 
 
@@ -181,7 +351,10 @@ _traceable_amax_scope = _make_scope(torch_backend_numpy, "amax", _patched_amax)
 def traceable_ops_scope():
     """Enter a context where Keras PyTorch backend ops are replaced with export-traceable shims."""
     return _TraceableOpsScope(
+        _traceable_slice_scope,
         _traceable_one_hot_scope,
+        _traceable_take_scope,
+        _traceable_scatter_update_scope,
         _traceable_repeat_scope,
         _traceable_amax_scope,
     )

--- a/keras_hub/src/utils/litertlm/traceable_ops_test.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops_test.py
@@ -101,6 +101,132 @@ class TraceableOpsParityTest(TestCase):
             with self.assertRaises(ValueError):
                 torch_backend_numpy.repeat(x, [1, 2], axis=0)
 
+    def test_slice_static_matches_original(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        original = torch_core.slice(x, [1, 1, 0], [2, 2, 5])
+        patched = patched_slice(x, [1, 1, 0], [2, 2, 5])
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_single_dynamic_dim_matches_original(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        for start in range(0, 3):
+            with self.subTest(start=start):
+                start_t = torch.tensor(start)
+                original = torch_core.slice(x, [start, 0, 0], [1, 4, 5])
+                patched = patched_slice(x, [start_t, 0, 0], [1, 4, 5])
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_dynamic_middle_dim_matches_original(self):
+        # Regression check for the KV-cache read pattern: slicing along a
+        # non-leading axis with a dynamic start while the surrounding axes
+        # are fully covered.
+        x = torch.arange(2 * 4 * 5, dtype=torch.float32).reshape(2, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        for start in range(0, 3):
+            with self.subTest(start=start):
+                start_t = torch.tensor(start)
+                original = torch_core.slice(x, [0, start, 0], [2, 1, 5])
+                patched = patched_slice(x, [0, start_t, 0], [2, 1, 5])
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_multiple_dynamic_dims_raises(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        with self.assertRaises(NotImplementedError):
+            patched_slice(x, [torch.tensor(0), torch.tensor(1), 0], [1, 1, 5])
+
+    def test_take_embedding_lookup_matches_original(self):
+        table = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        indices = torch.tensor([0, 2, 4, 1])
+        original = torch_backend_numpy.take(table, indices, axis=0)
+        patched = traceable_ops._patched_take(table, indices, axis=0)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_matches_original_various_axes(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        cases = [
+            (torch.tensor([0, 2]), 0),
+            (torch.tensor([0, 3, 1]), 1),
+            (torch.tensor([4, 0]), 2),
+            (torch.tensor([-1, -2]), 2),  # negative indices
+        ]
+        for indices, axis in cases:
+            with self.subTest(axis=axis, indices=indices.tolist()):
+                original = torch_backend_numpy.take(x, indices, axis=axis)
+                patched = traceable_ops._patched_take(x, indices, axis=axis)
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_no_axis_matches_original(self):
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        indices = torch.tensor([0, 5, 11])
+        original = torch_backend_numpy.take(x, indices, axis=None)
+        patched = traceable_ops._patched_take(x, indices, axis=None)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_no_axis_negative_index_matches_flattened_semantics(self):
+        """Regression test: ``axis=None`` + negative indices on a
+        multi-dim input must wrap against the *flattened* length, not the
+        first (unflattened) dimension's size.
+
+        Note this deliberately does **not** compare against
+        ``keras.src.backend.torch.numpy.take`` (the pattern every other
+        ``test_take_*`` case in this file uses): that Keras
+        function has the exact same bug (it computes
+        ``x_dim = x.shape[0]`` before flattening for ``axis=None``), so it
+        is not a valid reference here. Ground truth is real numpy's
+        ``np.take(..., axis=None)``, which flattens first -- e.g. for a
+        ``3x4`` input (12 elements), index ``-1`` must resolve to the last
+        flattened element (value ``11``), not wrap as if against a
+        first-dimension size of 3 (which would incorrectly give ``2``).
+        """
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        indices = torch.tensor([-1, -2])
+
+        expected = np.take(_to_np(x), _to_np(indices), axis=None)
+        patched = traceable_ops._patched_take(x, indices, axis=None)
+        self.assertAllClose(expected, _to_np(patched))
+
+    def test_scatter_update_matches_original(self):
+        inputs = torch.zeros((4, 4), dtype=torch.float32)
+        indices = torch.tensor([[0, 0], [1, 1], [2, 2]])
+        updates = torch.tensor([10.0, 20.0, 30.0])
+        for reduction in (None, "add", "max", "min", "mul"):
+            with self.subTest(reduction=reduction):
+                original = torch_core.scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                patched = traceable_ops._patched_scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_scatter_update_overlapping_indices_matches_original(self):
+        # Duplicate indices exercise the accumulation/reduction semantics
+        # more thoroughly than the diagonal case above.
+        inputs = torch.full((3, 3), 2.0, dtype=torch.float32)
+        indices = torch.tensor([[0, 0], [0, 0], [1, 1]])
+        updates = torch.tensor([3.0, 5.0, 7.0])
+        for reduction in (None, "add", "max", "min", "mul"):
+            with self.subTest(reduction=reduction):
+                original = torch_core.scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                patched = traceable_ops._patched_scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_scatter_update_rejects_unsupported_reduction(self):
+        inputs = torch.zeros((2, 2), dtype=torch.float32)
+        indices = torch.tensor([[0, 0]])
+        updates = torch.tensor([1.0])
+        with self.assertRaises(ValueError):
+            traceable_ops._patched_scatter_update(
+                inputs, indices, updates, reduction="bogus"
+            )
+
     def test_amax_matches_original(self):
         cases = [
             (torch.randn(2, 3, 4, 5), -1, True),  # 4-D last axis, keepdims
@@ -165,8 +291,11 @@ class TraceableOpsParityTest(TestCase):
 )
 class TraceableOpsScopeTest(TestCase):
     PATCHES = [
+        (torch_core, "slice", "_patched_slice"),
         (torch_backend_nn, "one_hot", "_patched_one_hot"),
         (torch_backend_numpy, "repeat", "_traceable_repeat"),
+        (torch_backend_numpy, "take", "_patched_take"),
+        (torch_core, "scatter_update", "_patched_scatter_update"),
         (torch_backend_numpy, "amax", "_patched_amax"),
     ]
 

--- a/keras_hub/src/utils/litertlm/traceable_ops_test.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops_test.py
@@ -1,0 +1,187 @@
+import unittest
+import unittest.mock
+
+import keras
+import numpy as np
+import torch
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import nn as torch_backend_nn
+from keras.src.backend.torch import numpy as torch_backend_numpy
+
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.litertlm import traceable_ops
+
+
+def _to_np(x):
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return np.asarray(x)
+
+
+# Parity-only: patched ops are called directly on eager tensors (no
+# torch.export) and checked against the original Keras implementations.
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "The litertlm traceable-op patches only exist for the PyTorch backend.",
+)
+class TraceableOpsParityTest(TestCase):
+    def test_one_hot_matches_original(self):
+        cases = [
+            ([0, 1, 2, 3], 5, -1, "float32"),
+            ([0, 1, 2, 3], 5, 0, "float32"),
+            ([[0, 1], [2, 3]], 4, -1, "float32"),
+            ([[0, 1], [2, 3]], 4, 1, "float32"),
+            ([[0, 1], [2, 3]], 4, 2, "int32"),
+            ([-1, 0, 2], 4, -1, "float32"),  # negative-index handling
+        ]
+        for x, num_classes, axis, dtype in cases:
+            with self.subTest(x=x, num_classes=num_classes, axis=axis):
+                x_t = torch.tensor(x, dtype=torch.int32)
+                original = torch_backend_nn.one_hot(
+                    x_t, num_classes, axis=axis, dtype=dtype
+                )
+                patched = traceable_ops._patched_one_hot(
+                    x_t, num_classes, axis=axis, dtype=dtype
+                )
+                self.assertEqual(tuple(original.shape), tuple(patched.shape))
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_one_hot_rejects_sparse(self):
+        with self.assertRaises(ValueError):
+            torch_backend_nn.one_hot(torch.tensor([0]), 4, sparse=True)
+        with self.assertRaises(ValueError):
+            traceable_ops._patched_one_hot(torch.tensor([0]), 4, sparse=True)
+
+    def test_repeat_matches_original(self):
+        x = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1):
+            for repeats in (1, 2, 3):
+                with self.subTest(axis=axis, repeats=repeats):
+                    original = torch_backend_numpy.repeat(x, repeats, axis=axis)
+                    patched = traceable_ops._traceable_repeat(
+                        x, repeats, axis=axis
+                    )
+                    self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_scalar_tensor_repeats_matches_original(self):
+        # A 0-D tensor `repeats` is not a plain Python `int`, so Keras's
+        # torch-backend `repeat` falls through to the `repeat_interleave`
+        # path, while `_traceable_repeat`'s `_is_scalar_integer` check takes
+        # the unsqueeze+expand+reshape fast path instead. Values must match.
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        repeats = torch.tensor(2)
+        original = torch_backend_numpy.repeat(x, repeats, axis=1)
+        patched = traceable_ops._traceable_repeat(x, repeats, axis=1)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_identity_when_repeats_is_one(self):
+        x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        patched = traceable_ops._traceable_repeat(x, 1, axis=0)
+        self.assertAllClose(_to_np(x), _to_np(patched))
+
+    def test_repeat_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            traceable_ops._traceable_repeat(torch.zeros(2, 2), -1, axis=0)
+
+    def test_repeat_no_axis_falls_back_to_original(self):
+        x = torch.arange(6, dtype=torch.float32)
+        original = torch_backend_numpy.repeat(x, 3, axis=None)
+        patched = traceable_ops._traceable_repeat(x, 3, axis=None)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_list_repeats_with_axis_delegates_to_original(self):
+        # Keras's torch-backend `repeat` rejects a Python list `repeats`
+        # with ValueError; inside the patch scope the fallback must
+        # delegate to the captured original (mirroring that raise), not
+        # recurse into the patch.
+        x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with self.assertRaises(ValueError):
+            torch_backend_numpy.repeat(x, [1, 2], axis=0)
+        with traceable_ops._traceable_repeat_scope():
+            with self.assertRaises(ValueError):
+                torch_backend_numpy.repeat(x, [1, 2], axis=0)
+
+    def test_amax_matches_original(self):
+        cases = [
+            (torch.randn(2, 3, 4, 5), -1, True),  # 4-D last axis, keepdims
+            (torch.randn(2, 3, 4, 5), -1, False),  # 4-D last axis, no keepdims
+            (torch.randn(2, 3, 4, 5), 1, True),  # 4-D middle axis
+            (torch.randn(2, 3, 4, 5), 0, False),  # 4-D leading axis
+            (torch.randn(2, 4, 5), -1, True),  # 3-D (fallthrough)
+            (torch.randn(4, 5), -1, True),  # 2-D (fallthrough)
+            (torch.randn(7), 0, True),  # 1-D (fallthrough)
+            (torch.randn(2, 2, 3, 4, 5), -1, True),  # 5-D (fallthrough)
+            (torch.randn(2, 3, 4, 5), (2, 3), True),  # 4-D tuple (fallthrough)
+            (torch.randn(2, 3, 4, 5), np.int64(-1), True),  # np.int64 axis
+            (torch.randn(2, 3, 4, 5), np.int32(1), True),  # np.int32 axis
+        ]
+        for x, axis, keepdims in cases:
+            with self.subTest(
+                shape=tuple(x.shape), axis=axis, keepdims=keepdims
+            ):
+                patched = traceable_ops._patched_amax(
+                    x, axis=axis, keepdims=keepdims
+                )
+                # The original Keras amax cannot handle NumPy integer axes
+                # (raises "truth value of an empty array is ambiguous"); for
+                # those cases verify only that the patched version works and
+                # matches torch.max directly.
+                if isinstance(axis, np.integer):
+                    expected = torch.max(
+                        x, dim=int(axis), keepdim=keepdims
+                    ).values
+                    self.assertTrue(torch.equal(expected, patched))
+                else:
+                    original = torch_backend_numpy.amax(
+                        x, axis=axis, keepdims=keepdims
+                    )
+                    self.assertEqual(
+                        tuple(original.shape), tuple(patched.shape)
+                    )
+                    # The reformulation is the identical reduction; values must
+                    # be bit-identical, not merely close (a silent numeric
+                    # drift here would corrupt attention-sink softmax
+                    # stabilization).
+                    self.assertTrue(torch.equal(original, patched))
+
+    def test_amax_public_ops_max_4d_matches(self):
+        # The public keras op that GPT-OSS attention actually calls.
+        x = torch.randn(2, 3, 4, 5)
+        ref = keras.ops.max(x, axis=-1, keepdims=True)
+        with unittest.mock.patch.object(
+            torch_backend_numpy, "amax", traceable_ops._patched_amax
+        ):
+            got = keras.ops.max(x, axis=-1, keepdims=True)
+        self.assertTrue(torch.equal(ref, got))
+
+
+# Every module/attribute/replacement triple is resolved lazily, when a
+# scope is entered, so nothing above this point would notice a patch aimed
+# at the wrong module or a misspelled attribute name.
+
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "The litertlm traceable-op patches only exist for the PyTorch backend.",
+)
+class TraceableOpsScopeTest(TestCase):
+    PATCHES = [
+        (torch_backend_nn, "one_hot", "_patched_one_hot"),
+        (torch_backend_numpy, "repeat", "_traceable_repeat"),
+        (torch_backend_numpy, "amax", "_patched_amax"),
+    ]
+
+    def test_scope_installs_every_replacement_and_restores_it(self):
+        originals = [
+            (module, attr, getattr(module, attr))
+            for module, attr, _ in self.PATCHES
+        ]
+        with traceable_ops.traceable_ops_scope():
+            for module, attr, replacement_name in self.PATCHES:
+                with self.subTest(attr=attr, phase="inside"):
+                    self.assertIs(
+                        getattr(module, attr),
+                        getattr(traceable_ops, replacement_name),
+                    )
+        for module, attr, original in originals:
+            with self.subTest(attr=attr, phase="restored"):
+                self.assertIs(getattr(module, attr), original)


### PR DESCRIPTION
Part of tracking issue https://github.com/keras-team/keras-hub/issues/2880 (LiteRT-LM Export Stacked PRs).

**Stacked Order**: Slice 4 of 28
**Predecessor PR**: #2908 (Traceable Ops: Core Scope Manager & Basic Shims)
**Successor PR**: #2894 (Traceable Ops: Attention Shim & Full Parity)
**Exact Incremental Stat**: `2 files changed, 298 insertions(+)`

### What Changed & Technical Rationale
Adds export-traceable indexing and slicing replacement shims (slice, take, scatter_update) to the ops scope.

### Verification
- Python syntax & compilation (`py_compile`) verified on all touched files.
- Executed unit tests and verified 100% byte-for-byte stack parity against reference branches.