### PR TITLE
[LiteRT-LM 9/28] Model Specs: Gemma Vision & Audio Metadata

### DIFF
--- a/keras_hub/src/models/llama/llama_attention.py
+++ b/keras_hub/src/models/llama/llama_attention.py
@@ -8,6 +8,9 @@ from keras_hub.src.models.llama.llama_rotary_embedding import (
 )
 from keras_hub.src.utils.keras_utils import clone_initializer
 from keras_hub.src.utils.keras_utils import fused_attention_op_available
+from keras_hub.src.utils.keras_utils import gpu_supports_fused_attention_op
+from keras_hub.src.utils.keras_utils import running_on_gpu
+from keras_hub.src.utils.keras_utils import running_on_tpu
 
 
 class LlamaAttention(keras.layers.Layer):
@@ -197,8 +200,20 @@ class LlamaAttention(keras.layers.Layer):
             )
         return self._softmax(attention_scores)
 
+    def _use_fused_attention_op(self):
+        if not fused_attention_op_available():
+            return False
+        if self.dropout > 0.0:
+            return False
+        if running_on_gpu():
+            return gpu_supports_fused_attention_op()
+        elif running_on_tpu():
+            return True
+        else:
+            return False
+
     def _compute_attention(self, query, key, value, attention_mask=None):
-        if fused_attention_op_available():
+        if self._use_fused_attention_op():
             # Use `dot_product_attention` with Flash Attention support if
             # available.
             if attention_mask is not None:

--- a/keras_hub/src/models/qwen3_moe/qwen3_moe_causal_lm_test.py
+++ b/keras_hub/src/models/qwen3_moe/qwen3_moe_causal_lm_test.py
@@ -1,7 +1,4 @@
-import os
 from unittest.mock import patch
-
-os.environ["KERAS_BACKEND"] = "jax"
 
 import keras
 import pytest

--- a/keras_hub/src/models/qwen_moe/qwen_moe_causal_lm_test.py
+++ b/keras_hub/src/models/qwen_moe/qwen_moe_causal_lm_test.py
@@ -1,7 +1,4 @@
-import os
 from unittest.mock import patch
-
-os.environ["KERAS_BACKEND"] = "jax"
 
 import keras
 import pytest

--- a/keras_hub/src/models/smollm3/smollm3_layers.py
+++ b/keras_hub/src/models/smollm3/smollm3_layers.py
@@ -151,7 +151,6 @@ class SmolLM3Attention(layers.Layer):
         Args:
             hidden_states: Input tensor of shape (batch_size, seq_len,
                 hidden_size).
-            position_embeddings: Tuple of (cos, sin) tensors for RoPE.
             attention_mask: Attention mask tensor.
             training: Whether the layer is in training mode.
             self_attention_cache: Cached key and value projections from
@@ -559,8 +558,6 @@ class SmolLM3DecoderLayer(layers.Layer):
         Args:
             hidden_states: Input tensor of shape (batch_size,
                 seq_len, hidden_size).
-            position_embeddings: Optional tuple of (cos, sin)
-                tensors for RoPE.
             training: Whether the layer is in training mode.
             self_attention_cache: Cached key and value projections from
                 previous decoding steps.

--- a/keras_hub/src/models/smollm3/smollm3_layers.py
+++ b/keras_hub/src/models/smollm3/smollm3_layers.py
@@ -142,6 +142,8 @@ class SmolLM3Attention(layers.Layer):
         hidden_states,
         training=False,
         attention_mask=None,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
         **kwargs,
     ):
         """Forward pass for SmolLM3Attention.
@@ -152,12 +154,12 @@ class SmolLM3Attention(layers.Layer):
             position_embeddings: Tuple of (cos, sin) tensors for RoPE.
             attention_mask: Attention mask tensor.
             training: Whether the layer is in training mode.
+            self_attention_cache: Cached key and value projections from
+                previous decoding steps.
+            self_attention_cache_update_index: Index in the cache at which
+                the current projections are written.
         """
         self.training = training
-        self_attention_cache = kwargs.get("self_attention_cache", None)
-        self_attention_cache_update_index = kwargs.get(
-            "self_attention_cache_update_index", None
-        )
         start_index = (
             self_attention_cache_update_index
             if self_attention_cache_update_index is not None
@@ -547,6 +549,8 @@ class SmolLM3DecoderLayer(layers.Layer):
         training=False,
         decoder_padding_mask=None,
         decoder_attention_mask=None,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
         **kwargs,
     ):
         """
@@ -558,12 +562,11 @@ class SmolLM3DecoderLayer(layers.Layer):
             position_embeddings: Optional tuple of (cos, sin)
                 tensors for RoPE.
             training: Whether the layer is in training mode.
+            self_attention_cache: Cached key and value projections from
+                previous decoding steps.
+            self_attention_cache_update_index: Index in the cache at which
+                the current projections are written.
         """
-        self_attention_cache = kwargs.get("self_attention_cache", None)
-        self_attention_cache_update_index = kwargs.get(
-            "self_attention_cache_update_index", None
-        )
-
         self_attention_mask = self._compute_self_attention_mask(
             decoder_sequence=hidden_states,
             decoder_padding_mask=decoder_padding_mask,
@@ -580,7 +583,8 @@ class SmolLM3DecoderLayer(layers.Layer):
             hidden_states=hidden_states,
             training=training,
             attention_mask=self_attention_mask,
-            **kwargs,
+            self_attention_cache=self_attention_cache,
+            self_attention_cache_update_index=self_attention_cache_update_index,
         )
 
         if isinstance(x, tuple):

--- a/keras_hub/src/models/smollm3/smollm3_layers.py
+++ b/keras_hub/src/models/smollm3/smollm3_layers.py
@@ -582,6 +582,7 @@ class SmolLM3DecoderLayer(layers.Layer):
             attention_mask=self_attention_mask,
             self_attention_cache=self_attention_cache,
             self_attention_cache_update_index=self_attention_cache_update_index,
+            **kwargs,
         )
 
         if isinstance(x, tuple):

--- a/keras_hub/src/utils/litertlm/model_specs.py
+++ b/keras_hub/src/utils/litertlm/model_specs.py
@@ -616,6 +616,61 @@ class Phi3Spec(LiteRTLMExportSpec):
 # and OPT are base LMs with no second chat-turn token in their tokenizers.
 
 
+def _qwen_family_chat_stop_token_ids(tokenizer):
+    """Return ``[<|im_end|> id]`` if present in *tokenizer*'s vocab.
+
+    ``<|im_end|>`` is the ChatML chat-turn-stop token shared by the Qwen
+    families (Qwen3 and pre-Qwen3 Qwen/Qwen-MoE alike).
+    """
+    token_id = _lookup_token_id(tokenizer, "<|im_end|>")
+    return [token_id] if token_id is not None else []
+
+
+class Qwen3FamilySpec(LiteRTLMExportSpec):
+    """Qwen3, Qwen3-MoE, and Qwen3.5 all map to the "qwen3" oneof."""
+
+    model_type = "qwen3"
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        # Qwen3's `<|im_end|>` is already `tokenizer.end_token_id`; surfaced
+        # explicitly (`_build_llm_metadata` de-duplicates).
+        return _qwen_family_chat_stop_token_ids(tokenizer)
+
+
+class Qwen3_5Spec(Qwen3FamilySpec):
+    """Qwen3.5 spec: maps to "qwen3" but its hybrid cache is unsupported.
+
+    Qwen3.5's hybrid full-attention/linear-attention decoder layers need a
+    dual cache (``Qwen3_5CausalLM.call_with_cache`` expects a ``(kv_cache,
+    conv_cache, recurrent_cache)`` tuple) that the LiteRT-LM adapter's
+    single stacked-KV-tensor cache format cannot represent yet.
+    """
+
+    cache_structure = "hybrid"
+
+    def describe_unsupported_cache_structure(self):
+        return (
+            "requires a 'hybrid' cache structure: Qwen3.5's hybrid "
+            "full_attention/linear_attention layers use a dual cache "
+            "structure (`call_with_cache` expects a `(kv_cache, conv_cache, "
+            "recurrent_cache)` tuple, since linear-attention layers need a "
+            "convolutional/recurrent state that a stacked KV tensor cannot "
+            f"represent), {_single_stacked_support_description()} "
+            "Support for hybrid cache structures is not yet implemented."
+        )
+
+
+class Qwen2p5FamilySpec(LiteRTLMExportSpec):
+    """Qwen and Qwen-MoE (pre-Qwen3 architecture) map to "qwen2p5"."""
+
+    model_type = "qwen2p5"
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        # Qwen 2.5 registers `<|endoftext|>` as `end_token`, but ChatML
+        # checkpoints may still carry `<|im_end|>`; add it when present.
+        return _qwen_family_chat_stop_token_ids(tokenizer)
+
+
 def _populate_gemma3_family_vision_metadata(meta, model_type, vision_cfg):
     """Shared image-token metadata population for gemma3 and gemma3n."""
     image_size = vision_cfg["image_size"]
@@ -629,6 +684,9 @@ def _populate_gemma3_family_vision_metadata(meta, model_type, vision_cfg):
 # (module_path, class_name, spec_factory), imported lazily inside
 # ``resolve_export_spec`` to avoid heavy top-level dependencies.
 _EXPORT_SPEC_REGISTRY = (
+    ("keras_hub.src.models.qwen3_5.qwen3_5_causal_lm", "Qwen3_5CausalLM", Qwen3_5Spec),
+    ("keras_hub.src.models.qwen3.qwen3_causal_lm", "Qwen3CausalLM", Qwen3FamilySpec),
+    ("keras_hub.src.models.qwen2_5.qwen2_5_causal_lm", "Qwen2_5CausalLM", Qwen2p5FamilySpec),
     ("keras_hub.src.models.llama3.llama3_causal_lm", "Llama3CausalLM", Llama3Spec),
     ("keras_hub.src.models.phi3.phi3_causal_lm", "Phi3CausalLM", Phi3Spec),
 )

--- a/keras_hub/src/utils/litertlm/model_specs.py
+++ b/keras_hub/src/utils/litertlm/model_specs.py
@@ -1,0 +1,713 @@
+"""Model-family export specs for LiteRT-LM export.
+
+``LiteRTLMExportSpec`` centralizes per-family export knowledge. A single
+spec instance is resolved once per export call (see ``resolve_export_spec``)
+from a lazy, ``isinstance``-based registry and threaded through the export
+pipeline and the adapter. The base class itself is the fallback for any
+model family not explicitly registered (``model_type="generic_model"``).
+"""
+
+import dataclasses
+
+
+def _first_attr(obj, *names, default=None):
+    """Return the first non-``None`` attribute from *obj*, or *default*."""
+    if obj is None:
+        return default
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    return default
+
+
+def _get_vision_encoder(backbone):
+    """Return the vision encoder from a backbone, or ``None``."""
+    return _first_attr(backbone, "vision_encoder", "vit_encoder")
+
+
+def _require_patch_size(patch_size, source):
+    """Return *patch_size*, raising an actionable error when it is ``None``.
+
+    Only ``vision_input_style="patch_values"`` families (Gemma4) derive
+    exported shapes from ``patch_size``; the other vision families never read
+    it, so the requirement is gated on that style rather than imposed on
+    every vision encoder.
+
+    Args:
+        patch_size: int or None. The patch size read from the model.
+        source: str. Where *patch_size* was read from, named in the error.
+    """
+    if patch_size is None:
+        raise ValueError(
+            "`patch_size` must be an int for a `patch_values` vision input "
+            "style, which sizes the exported `patch_values` signature and the "
+            "`max_num_patches` metadata from it. "
+            f"Received: patch_size=None (from {source})."
+        )
+    return patch_size
+
+
+# Special token strings used when populating vision/audio metadata.
+_GEMMA3_START_OF_IMAGE_TOKEN = "<start_of_image>"
+_GEMMA3_END_OF_IMAGE_TOKEN = "<end_of_image>"
+_GEMMA4_START_OF_IMAGE_TOKEN = "<|image>"
+_GEMMA4_END_OF_IMAGE_TOKEN = "<image|>"
+_AUDIO_START_TOKEN = "<|audio>"
+_AUDIO_END_TOKEN = "<audio|>"
+
+#: Trace-time frame count for the audio sample inputs; no KerasHub
+#: preprocessor exposes a frames attribute, so this fixes the exported
+#: ``audio_mel`` signature shape.
+_DEFAULT_AUDIO_NUM_FRAMES = 100
+
+# Function-calling ("function_gemma") metadata strings, supplied as
+# literals because keras-hub's Gemma3 tokenizer has no HuggingFace
+# ``special_tokens_map`` carrying them (proto fields shared with Gemma4).
+_FUNCTION_GEMMA_CODE_FENCE_START = "```tool_code"
+_FUNCTION_GEMMA_CODE_FENCE_END = "```"
+_FUNCTION_GEMMA_FUNCTION_RESPONSE_START = "```tool_output"
+_FUNCTION_GEMMA_ESCAPE_TOKEN = "<escape>"
+
+
+@dataclasses.dataclass(frozen=True)
+class SamplerConfig:
+    """Sampler defaults embedded in a LiteRT-LM bundle's ``LlmMetadata``.
+
+    Mirrors the conditional ``sampler_params`` semantics of litert-torch's
+    ``export_hf``: the proto field is only written when a caller explicitly
+    requests it. keras-hub ships no default sampler -- omitting
+    ``sampler_config`` leaves the field unset, letting the runtime pick its
+    own sampling policy.
+
+    Args:
+        top_k: Optional int >= 1. ``top_k == 1`` selects deterministic
+            greedy generation (encoded as ``TOP_K``).
+        top_p: Optional float in (0.0, 1.0].
+        temperature: Optional float >= 0.0.
+        seed: Optional int RNG seed.
+    """
+
+    top_k: int | None = None
+    top_p: float | None = None
+    temperature: float | None = None
+    seed: int | None = None
+
+    def __post_init__(self):
+        if (
+            self.top_k is None
+            and self.top_p is None
+            and self.temperature is None
+        ):
+            raise ValueError(
+                "SamplerConfig requires at least one of `top_k`, `top_p`, or "
+                "`temperature` to be set; an all-None config would produce "
+                "an empty sampler_params. Omit `sampler_config` entirely to "
+                "leave the field unset."
+            )
+        if self.top_k is not None and self.top_k < 1:
+            raise ValueError(
+                "SamplerConfig.top_k must be >= 1. "
+                f"Received: top_k={self.top_k}."
+            )
+        if self.top_p is not None and not (0.0 < self.top_p <= 1.0):
+            raise ValueError(
+                "SamplerConfig.top_p must be in (0.0, 1.0]. "
+                f"Received: top_p={self.top_p}."
+            )
+        if self.temperature is not None and self.temperature < 0.0:
+            raise ValueError(
+                "SamplerConfig.temperature must be >= 0.0. "
+                f"Received: temperature={self.temperature}."
+            )
+
+
+#: Deterministic greedy sampling (``top_k == 1``). The only named sampler
+#: preset keras-hub ships; exercised by the metadata roundtrip test.
+GREEDY_SAMPLER_CONFIG = SamplerConfig(top_k=1)
+
+
+def _single_stacked_support_description():
+    """The shared error tail naming the supported cache structure."""
+    return (
+        "but the LiteRT-LM adapter only supports "
+        '`cache_structure="single_stacked"` (a single stacked '
+        "`[batch, num_layers, 2, cache_length, num_kv_heads, head_dim]` "
+        "KV-cache tensor)."
+    )
+
+
+class LiteRTLMExportSpec:
+    """Default LiteRT-LM export behavior for a model family.
+
+    Also used, unmodified, as the spec for any model family not explicitly
+    registered in ``_EXPORT_SPEC_REGISTRY`` (the ``"generic_model"``
+    fallback). Subclasses customize behavior via the plain class attributes
+    and methods below; plain attributes (not dataclass fields) avoid a
+    dataclass-generated ``__init__`` re-baking the parent's field default
+    over a subclass's override.
+    """
+
+    #: The ``LlmMetadata.llm_model_type`` oneof name for this family.
+    model_type = "generic_model"
+    #: Per-layer KV-cache tensor layout. ``"standard"`` is
+    #: ``[batch, cache_length, num_kv_heads, head_dim]``; ``"gemma3n"`` is
+    #: ``[batch, num_kv_heads, cache_length, head_dim]``.
+    cache_layout = "standard"
+    #: Shape of the ``cache`` argument ``call_with_cache`` expects:
+    #: ``"single_stacked"`` is one stacked KV tensor (what the default
+    #: ``stack_kv_cache`` builds); any other value fails fast in export.
+    cache_structure = "single_stacked"
+    #: How the vision encoder consumes its input: ``"raw_images"`` (a raw
+    #: ``[B, N, H, W, 3]`` tensor; Gemma3, PaliGemma), ``"patch_values"``
+    #: (preprocessed patches; Gemma4), or ``"embedded_pixel_values"``
+    #: (encoder runs inside the backbone; Gemma3n).
+    vision_input_style = "raw_images"
+    #: How the audio encoder consumes its input: ``None`` (no audio),
+    #: ``"embedded_mel"`` (encoder inside the backbone; Gemma3n), or
+    #: ``"standalone_mel"`` (adapter calls ``backbone.audio_encoder``;
+    #: Gemma4).
+    audio_input_style = None
+    #: Whether the vision encoder accepts only a single 4-D image per call,
+    #: so the adapter flattens the ``[B, N, H, W, 3]`` stack (PaliGemma).
+    flatten_image_batch = False
+    #: The end-of-image (EOI) special-token string, or ``None`` if the
+    #: family has none. Consulted only on the separate-vision export path,
+    #: where it controls whether an ``END_OF_VISION`` section is emitted.
+    end_of_vision_token = None
+    #: Whether this family's vision path supports multi-bucket prefill.
+    #: Default ``False``: the bucketing ban in ``export_to_litertlm`` is a
+    #: conservative family-wide default; relaxing it is numerics-gated.
+    allows_vision_bucketing = False
+    #: Whether this family supports the separate-vision-encoder export path.
+    #: ``False`` for families whose encoder runs inside the backbone
+    #: (Gemma3n): there is no separable encoder to export.
+    supports_separate_vision = True
+
+    def get_cache_config(self, model, cache_length=None):
+        """Extract KV-cache dimensions from the model.
+
+        Args:
+            model: ``CausalLM``. The KerasHub model being exported.
+            cache_length: int or None. Explicit cache length; when ``None``,
+                the cache length is inferred from `backbone.max_sequence_length`
+                if the backbone defines it, else from
+                `preprocessor.sequence_length` -- the caller is responsible
+                for warning about this fallback, since the warning needs
+                ``warnings.warn``'s call-site stacklevel to point at the
+                public API, not at this method.
+        """
+        backbone = model.backbone
+        num_layers = _first_attr(backbone, "num_layers", "num_hidden_layers")
+        if num_layers is None:
+            raise ValueError(
+                "Could not determine number of layers from model backbone. "
+                "Expected `backbone.num_layers` or "
+                "`backbone.num_hidden_layers`."
+            )
+
+        used_preprocessor_fallback = False
+        if cache_length is None:
+            cache_length = _first_attr(backbone, "max_sequence_length")
+            if cache_length is None:
+                preprocessor = getattr(model, "preprocessor", None)
+                cache_length = _first_attr(preprocessor, "sequence_length")
+                used_preprocessor_fallback = cache_length is not None
+        if cache_length is None:
+            raise ValueError(
+                "Could not determine cache length from model backbone or "
+                "preprocessor. Please specify `cache_length` or "
+                "`prefill_seq_len`, or ensure the model has "
+                "`max_sequence_length`."
+            )
+
+        num_kv_heads = _first_attr(
+            backbone,
+            "num_key_value_heads",
+            "num_query_heads",
+            "num_heads",
+            "num_attention_heads",
+        )
+        if num_kv_heads is None:
+            raise ValueError(
+                "Could not determine the number of key/value heads from "
+                "model backbone. Expected one of "
+                "`backbone.num_key_value_heads`, `backbone.num_query_heads`, "
+                "`backbone.num_heads`, or `backbone.num_attention_heads`."
+            )
+
+        head_dim = _first_attr(backbone, "head_dim")
+        if head_dim is None:
+            hidden_dim = _first_attr(backbone, "hidden_dim")
+            num_qh = _first_attr(
+                backbone,
+                "num_query_heads",
+                "num_heads",
+                "num_attention_heads",
+            )
+            if hidden_dim is not None and num_qh is not None and num_qh > 0:
+                head_dim = hidden_dim // num_qh
+
+        if head_dim is None:
+            raise ValueError(
+                "Could not determine attention head dimension from model "
+                "attributes. Expected `backbone.head_dim` or both "
+                "`backbone.hidden_dim` and `backbone.num_query_heads`."
+            )
+
+        return {
+            "num_layers": num_layers,
+            "cache_length": cache_length,
+            "num_kv_heads": num_kv_heads,
+            "head_dim": head_dim,
+            "cache_layout": self.cache_layout,
+            "used_preprocessor_fallback": used_preprocessor_fallback,
+        }
+
+    def get_kv_cache_sample_shape(
+        self, batch_size, cache_length, num_kv_heads, head_dim
+    ):
+        """Return the per-layer KV-cache sample shape for this family.
+
+        Used by ``export.py``'s sample-input builder to size the flat
+        ``kv_cache_k_N``/``kv_cache_v_N`` trace inputs. Default: the
+        ``"standard"`` ``cache_layout`` shape, ``[batch, cache_length,
+        num_kv_heads, head_dim]``.
+        """
+        return (batch_size, cache_length, num_kv_heads, head_dim)
+
+    def check_exportable(self, model):
+        """Raise ``ValueError`` if *model* is not exportable at all.
+
+        Called by ``export_to_litertlm`` immediately after spec resolution,
+        before any argument validation or tracing. Default no-op: every
+        registered family is exportable. Non-exportable models (see
+        ``Gemma4AssistantSpec``) override this to fail fast with a
+        family-specific explanation.
+        """
+        del model
+
+    def describe_unsupported_cache_structure(self):
+        """Explain why ``cache_structure`` isn't ``"single_stacked"``.
+
+        Used by ``export_to_litertlm``'s fail-fast check. Default: a
+        generic description naming the actual ``cache_structure`` value and
+        the shape the adapter does support; families with a more specific
+        explanation (e.g. ``Qwen3_5Spec``) override this.
+        """
+        return (
+            f"requires a {self.cache_structure!r} cache structure, "
+            f"{_single_stacked_support_description()} "
+            "Support for this cache structure is not yet implemented."
+        )
+
+    def get_vision_config(self, model):
+        """Return vision metadata if *model* has a vision encoder, else
+        ``None``."""
+        backbone = getattr(model, "backbone", None)
+        if backbone is None:
+            return None
+        vision_encoder = _get_vision_encoder(backbone)
+        if vision_encoder is None:
+            return None
+        preprocessor = getattr(model, "preprocessor", None)
+        max_images = self.get_max_images_per_prompt(preprocessor)
+
+        image_size = getattr(backbone, "image_size", None)
+        if image_size is None:
+            # Gemma3n does not set backbone.image_size; read the
+            # preprocessor image converter, then the encoder config.
+            image_converter = getattr(preprocessor, "image_converter", None)
+            if image_converter is not None:
+                image_size = getattr(image_converter, "image_size", None)
+            if image_size is None:
+                vision_encoder_config = getattr(
+                    backbone, "vision_encoder_config", {}
+                )
+                image_shape = vision_encoder_config.get("image_shape")
+                if image_shape is not None:
+                    image_size = image_shape[0]
+        if image_size is None:
+            raise ValueError(
+                "Could not determine vision image size. Searched "
+                "`backbone.image_size`, "
+                "`preprocessor.image_converter.image_size`, and "
+                "`backbone.vision_encoder_config.image_shape[0]`."
+            )
+        # Image converters may report a (height, width) tuple; use the
+        # height (downstream assumes a square image).
+        if isinstance(image_size, (list, tuple)):
+            image_size = image_size[0]
+
+        num_vision_tokens_per_image = getattr(
+            backbone, "num_vision_tokens_per_image", None
+        )
+        if num_vision_tokens_per_image is None:
+            # PaliGemma exposes the count as ``image_sequence_length``.
+            num_vision_tokens_per_image = getattr(
+                backbone, "image_sequence_length", None
+            )
+        if num_vision_tokens_per_image is None and preprocessor is not None:
+            # Gemma3/Gemma3n expose the count on the preprocessor.
+            num_vision_tokens_per_image = getattr(
+                preprocessor, "num_vision_tokens_per_image", None
+            )
+        if num_vision_tokens_per_image is None:
+            raise ValueError(
+                "Could not determine `num_vision_tokens_per_image`. "
+                "Searched `backbone.num_vision_tokens_per_image`, "
+                "`backbone.image_sequence_length`, and "
+                "`preprocessor.num_vision_tokens_per_image`."
+            )
+        num_vision_tokens = num_vision_tokens_per_image * max_images
+        patch_size = getattr(vision_encoder, "patch_size", None)
+        if self.vision_input_style == "patch_values":
+            patch_size = _require_patch_size(
+                patch_size, f"`{type(vision_encoder).__name__}.patch_size`"
+            )
+        pool_size = getattr(vision_encoder, "pool_size", None)
+        return {
+            "max_images_per_prompt": max_images,
+            "image_size": image_size,
+            "num_vision_tokens": num_vision_tokens,
+            "num_vision_tokens_per_image": num_vision_tokens_per_image,
+            "patch_size": patch_size,
+            "pool_size": pool_size,
+        }
+
+    def get_audio_config(self, model):
+        """Return audio metadata if *model* has an audio encoder, else
+        ``None``."""
+        backbone = getattr(model, "backbone", None)
+        if backbone is None:
+            return None
+        audio_encoder = getattr(backbone, "audio_encoder", None)
+        if audio_encoder is None:
+            return None
+        preprocessor = getattr(model, "preprocessor", None)
+        max_clips = getattr(preprocessor, "max_audio_clips_per_prompt", None)
+        if max_clips is None:
+            # Gemma3n names this attribute ``max_audios_per_prompt``.
+            max_clips = getattr(preprocessor, "max_audios_per_prompt", None)
+        if max_clips is None:
+            raise ValueError(
+                "Could not determine `max_clips_per_prompt`. Searched "
+                "`preprocessor.max_audio_clips_per_prompt` and "
+                "`preprocessor.max_audios_per_prompt`."
+            )
+        # Trace-time frame count for the audio sample inputs: no KerasHub
+        # preprocessor exposes a frames attribute, so this fixes the
+        # exported `audio_mel` signature shape.
+        num_frames = _DEFAULT_AUDIO_NUM_FRAMES
+        num_audio_tokens_per_clip = getattr(
+            backbone, "num_audio_tokens_per_clip", None
+        )
+        if num_audio_tokens_per_clip is None and preprocessor is not None:
+            # Gemma3n names this attribute ``num_audio_tokens_per_audio``.
+            num_audio_tokens_per_clip = getattr(
+                preprocessor, "num_audio_tokens_per_audio", None
+            )
+        if num_audio_tokens_per_clip is None:
+            raise ValueError(
+                "Could not determine `num_audio_tokens_per_clip`. Searched "
+                "`backbone.num_audio_tokens_per_clip` and "
+                "`preprocessor.num_audio_tokens_per_audio`."
+            )
+        num_audio_tokens = num_audio_tokens_per_clip * max_clips
+        audio_input_feat_size = getattr(
+            preprocessor, "audio_input_feat_size", None
+        )
+        if audio_input_feat_size is None and preprocessor is not None:
+            audio_converter = getattr(preprocessor, "audio_converter", None)
+            if audio_converter is not None:
+                audio_input_feat_size = getattr(
+                    audio_converter, "feature_size", None
+                )
+        if audio_input_feat_size is None:
+            raise ValueError(
+                "Could not determine `audio_input_feat_size`. Searched "
+                "`preprocessor.audio_input_feat_size` and "
+                "`preprocessor.audio_converter.feature_size`."
+            )
+        return {
+            "max_clips_per_prompt": max_clips,
+            "num_frames": num_frames,
+            "num_audio_tokens": num_audio_tokens,
+            "audio_input_feat_size": audio_input_feat_size,
+        }
+
+    def get_vision_output_dim(self, vision_encoder):
+        """Return the projected vision feature dimension."""
+        dim = getattr(vision_encoder, "output_dim", None)
+        if dim is None:
+            # PaliGemma's ViT names the projected dimension ``num_classes``.
+            dim = getattr(vision_encoder, "num_classes", None)
+        return dim
+
+    def get_max_images_per_prompt(self, preprocessor):
+        """Return the max images the runtime may pass per prompt.
+
+        Read from ``preprocessor.max_images_per_prompt``. A missing
+        attribute is only valid for single-image families
+        (``flatten_image_batch=True``, e.g. PaliGemma); on a multi-image
+        family it is a misconfiguration and must not silently default to 1.
+        """
+        max_images = getattr(preprocessor, "max_images_per_prompt", None)
+        if max_images is not None:
+            return max_images
+        if self.flatten_image_batch:
+            return 1
+        raise ValueError(
+            f"{type(self).__name__} declares flatten_image_batch=False "
+            "(multi-image family) but its preprocessor has no "
+            "`max_images_per_prompt` attribute, so the number of images per "
+            "prompt cannot be determined. Set `max_images_per_prompt` on the "
+            "preprocessor, or (for a genuinely single-image family) set "
+            "`flatten_image_batch = True` on the spec."
+        )
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        """Populate vision-related fields in the ``LlmMetadata`` protobuf.
+
+        Default: no-op. Text-only families and families without a dedicated
+        ``LlmModelType`` vision subtype populate nothing.
+        """
+        del meta, vision_cfg
+
+    def populate_audio_metadata(self, meta, audio_cfg):
+        """Populate audio-related fields in the ``LlmMetadata`` protobuf.
+
+        Default: no-op (see ``populate_vision_metadata``).
+        """
+        del meta, audio_cfg
+
+    def populate_function_gemma_metadata(self, meta):
+        """Populate function-calling fields in the ``LlmMetadata`` protobuf.
+
+        Default: no-op; only ``FunctionGemmaSpec`` overrides this. Called by
+        ``_build_llm_metadata`` except when ``llm_model_type`` was an
+        explicit caller override (mirroring litert-torch, which skips its
+        model-specific metadata builder on override).
+        """
+        del meta
+
+    def reshape_separate_vision_embeddings(
+        self, img_embeddings, tokens, preprocessor
+    ):
+        """Reshape ``mm_embedding`` for the separate-vision-encoder path.
+
+        Default: no reshape needed. Only Gemma4 interleaves image
+        embeddings with a ``(batch, num_images, tokens_per_image,
+        hidden_dim)`` shape that must be restored after the separate
+        vision-encoder/adapter models flatten to
+        ``(batch * num_images, ...)``.
+        """
+        del tokens, preprocessor
+        return img_embeddings
+
+    def get_forced_call_with_cache_kwargs(self, tokens, cache_length):
+        """Return kwargs to force/override on every ``call_with_cache`` call.
+
+        Default: none. Only Gemma3n needs this, to force a full-length
+        padding mask (see ``Gemma3nSpec``).
+        """
+        del tokens, cache_length
+        return {}
+
+    # Converting between the flat signature tensors and the family's
+    # ``call_with_cache`` cache shape is per-family behavior, so it lives on
+    # the spec (a hybrid-cache family overrides these, not the adapter).
+
+    def stack_kv_cache(self, kv_cache, num_layers):
+        """Stack flat ``kv_cache_k_N``/``kv_cache_v_N`` tensors into the
+        cache format ``call_with_cache`` expects for this family.
+
+        Default: a single ``[batch, num_layers, 2, cache_length,
+        num_kv_heads, head_dim]`` tensor. ``torch.stack`` always allocates
+        a fresh contiguous tensor, so the result never aliases the input
+        buffers and no ``.clone()`` is needed. Torch is imported locally:
+        this method is only called after the torch backend is verified.
+        """
+        import torch
+
+        k_list = [kv_cache[f"kv_cache_k_{i}"] for i in range(num_layers)]
+        v_list = [kv_cache[f"kv_cache_v_{i}"] for i in range(num_layers)]
+        k_stack = torch.stack(k_list, dim=1)
+        v_stack = torch.stack(v_list, dim=1)
+        return torch.stack([k_stack, v_stack], dim=2)
+
+    def unstack_kv_cache(self, cache, num_layers):
+        """Split the cache ``call_with_cache`` returned back into per-layer
+        ``kv_cache_k_N``/``kv_cache_v_N`` output tensors, inverting
+        ``stack_kv_cache``.
+
+        Each per-layer tensor is a view into ``cache``, which
+        ``call_with_cache`` already returns freshly allocated (Keras's
+        cache-update ops are purely functional), and ``torch.export``'s
+        functionalization materializes graph-output views into independent
+        buffers -- so no ``.clone()`` is needed.
+        """
+        outputs = {}
+        for i in range(num_layers):
+            outputs[f"kv_cache_k_{i}"] = cache[:, i, 0, ...]
+            outputs[f"kv_cache_v_{i}"] = cache[:, i, 1, ...]
+        return outputs
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        """Return extra chat-turn-boundary stop token ids for this family.
+
+        ``_build_llm_metadata`` always adds ``tokenizer.end_token_id`` as a
+        stop token; families that mark the end of a *chat turn* with a
+        distinct second token (Gemma's ``<end_of_turn>``, Llama3's
+        ``<|eot_id|>``) override this so on-device chat generation can stop
+        at turn boundaries. Default: none. Returned ids need not be
+        disjoint from ``end_token_id``; the caller de-duplicates.
+        """
+        del tokenizer
+        return []
+
+    def get_end_of_vision_token_ids(self, tokenizer):
+        """Return this family's end-of-image token id(s), or ``None``.
+
+        Used only by the separate-vision-encoder export path to decide
+        whether to bundle an ``END_OF_VISION`` model. Returns ``None`` --
+        never a wrong, unk-resolved id -- when the family declares no EOI
+        token or the tokenizer cannot resolve it, so the caller skips the
+        section instead of bundling an incorrect embedding.
+        """
+        if self.end_of_vision_token is None:
+            return None
+        token_id = _lookup_token_id(tokenizer, self.end_of_vision_token)
+        return [token_id] if token_id is not None else None
+
+
+class Llama3Spec(LiteRTLMExportSpec):
+    """Llama3's chat template ends a turn with ``<|eot_id|>``.
+
+    ``Llama3Tokenizer`` registers both ``<|end_of_text|>`` (the primary EOS,
+    ``end_token_id``) and ``<|eot_id|>`` (as the secondary ``end_token2``)
+    because checkpoints have no config indicating the true stop token.
+    Without this override, ``<|eot_id|>`` never reaches the exported
+    metadata, so on-device chat generation cannot stop at a turn boundary.
+    """
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        eot_id = getattr(tokenizer, "end_token2_id", None)
+        return [eot_id] if eot_id is not None else []
+
+
+class Phi3Spec(LiteRTLMExportSpec):
+    """Phi-3's chat template ends every turn with ``<|end|>``.
+
+    ``<|end|>`` is distinct from the primary EOS ``<|endoftext|>`` (what
+    ``Phi3Tokenizer`` registers as ``end_token``), so it never reaches the
+    exported metadata without this override. It is an ordinary special
+    token in the vocab, so look it up by string and return ``[]`` when it
+    is absent (base/non-instruct vocabularies).
+    """
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        token_id = _lookup_token_id(tokenizer, "<|end|>")
+        return [token_id] if token_id is not None else []
+
+
+# These keep the `LiteRTLMExportSpec` default (EOS-only): Mistral/Mixtral
+# end turns with the primary EOS `</s>`; base Llama, GPT2, Bloom, GPT-NeoX
+# and OPT are base LMs with no second chat-turn token in their tokenizers.
+
+
+def _populate_gemma3_family_vision_metadata(meta, model_type, vision_cfg):
+    """Shared image-token metadata population for gemma3 and gemma3n."""
+    image_size = vision_cfg["image_size"]
+    subtype = getattr(meta.llm_model_type, model_type)
+    subtype.start_of_image_token.token_str = _GEMMA3_START_OF_IMAGE_TOKEN
+    subtype.end_of_image_token.token_str = _GEMMA3_END_OF_IMAGE_TOKEN
+    subtype.image_tensor_height = image_size
+    subtype.image_tensor_width = image_size
+
+
+# (module_path, class_name, spec_factory), imported lazily inside
+# ``resolve_export_spec`` to avoid heavy top-level dependencies.
+_EXPORT_SPEC_REGISTRY = (
+    ("keras_hub.src.models.llama3.llama3_causal_lm", "Llama3CausalLM", Llama3Spec),
+    ("keras_hub.src.models.phi3.phi3_causal_lm", "Phi3CausalLM", Phi3Spec),
+)
+_MODEL_TYPE_OVERRIDE_SPECS = {
+    "function_gemma": FunctionGemmaSpec,
+}
+
+
+def _is_function_gemma(model):
+    """Detect the ``function_gemma_instruct_270m`` preset by tokenizer tokens.
+
+    The preset loads as a plain ``Gemma3CausalLM`` (architecturally identical
+    to Gemma3), but its ``Gemma3Tokenizer`` vocabulary contains the
+    function-calling special tokens ``<start_function_call>`` and
+    ``<end_function_call>``. Plain Gemma3 presets do not.
+
+    We must verify the token round-trips, because some tokenizers map
+    out-of-vocabulary strings to a fixed ``<unk>`` id instead of raising.
+    """
+    try:
+        tokenizer = model.preprocessor.tokenizer
+        token_id = tokenizer.token_to_id("<start_function_call>")
+        return tokenizer.id_to_token(token_id) == "<start_function_call>"
+    except (AttributeError, ValueError, KeyError, TypeError):
+        return False
+
+
+def _resolve_export_spec_by_class(model):
+    """Return the spec ``_EXPORT_SPEC_REGISTRY`` maps *model*'s class to."""
+    # function_gemma loads as a plain Gemma3CausalLM but is distinguished by
+    # function-calling special tokens in its tokenizer. Check before the
+    # registry so it does not fall through to Gemma3Spec.
+    if _is_function_gemma(model):
+        return FunctionGemmaSpec()
+    for module_path, class_name, spec_factory in _EXPORT_SPEC_REGISTRY:
+        # Modules are imported lazily so importing this module stays cheap;
+        # all entries are first-party and must import cleanly -- an
+        # ImportError here is a real bug and must surface, not be skipped.
+        module = __import__(module_path, fromlist=[class_name])
+        cls = getattr(module, class_name)
+        if isinstance(model, cls):
+            return spec_factory()
+
+    return LiteRTLMExportSpec()
+
+
+def resolve_export_spec(model, llm_model_type=None):
+    """Return the ``LiteRTLMExportSpec`` for *model*.
+
+    If *llm_model_type* is given, it is an explicit caller override that
+    selects a spec by ``LlmMetadata.llm_model_type`` name for presets that are
+    architecturally indistinguishable from another family (e.g.
+    ``function_gemma``, which loads as a plain ``Gemma3CausalLM``); see
+    ``_MODEL_TYPE_OVERRIDE_SPECS``. Otherwise the spec is resolved by
+    ``isinstance`` checks against ``_EXPORT_SPEC_REGISTRY`` (in registration
+    order, first match wins, to avoid mis-identifying user-defined
+    subclasses). Unrecognized models get the default ``LiteRTLMExportSpec()``
+    (``model_type="generic_model"``, ``cache_layout="standard"``).
+
+    Raises:
+        ValueError: If *llm_model_type* is not a recognized override, or if it
+            is used on a model whose class is not exportable at all (the
+            override selects exported metadata, not exportability).
+    """
+    if llm_model_type is not None:
+        try:
+            override_spec_factory = _MODEL_TYPE_OVERRIDE_SPECS[llm_model_type]
+        except KeyError:
+            raise ValueError(
+                f"Unknown `llm_model_type` override {llm_model_type!r}. "
+                "Supported overrides: "
+                f"{sorted(_MODEL_TYPE_OVERRIDE_SPECS)}. Omit the argument to "
+                "auto-detect the model family by class."
+            )
+        # Exportability is a property of the model class, not of the requested
+        # metadata subtype, so the gate runs on the class-resolved spec: an
+        # override must not smuggle a non-exportable model past it. The other
+        # branch returns that same class-resolved spec, so the caller's own
+        # `check_exportable` call covers it.
+        _resolve_export_spec_by_class(model).check_exportable(model)
+        return override_spec_factory()
+    return _resolve_export_spec_by_class(model)

--- a/keras_hub/src/utils/litertlm/model_specs.py
+++ b/keras_hub/src/utils/litertlm/model_specs.py
@@ -683,6 +683,132 @@ class FunctionGemmaSpec(Gemma3Spec):
         subtype.use_template_for_fc_format = True
 
 
+class Gemma3nSpec(GemmaSpec):
+    model_type = "gemma3n"
+    cache_layout = "gemma3n"
+    vision_input_style = "embedded_pixel_values"
+    audio_input_style = "embedded_mel"
+    #: The encoder runs inside the backbone; no standalone encoder to pack.
+    supports_separate_vision = False
+
+    def get_kv_cache_sample_shape(
+        self, batch_size, cache_length, num_kv_heads, head_dim
+    ):
+        """Return Gemma3n's per-layer KV-cache sample shape.
+
+        Gemma3n's ``cache_layout`` transposes the standard shape to
+        ``[batch, num_kv_heads, cache_length, head_dim]``.
+        """
+        return (batch_size, num_kv_heads, cache_length, head_dim)
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        # The gemma3n subtype carries the same image-token fields as gemma3.
+        _populate_gemma3_family_vision_metadata(
+            meta, self.model_type, vision_cfg
+        )
+
+    def populate_audio_metadata(self, meta, audio_cfg):
+        del audio_cfg
+        # Deliberately Gemma4's audio token strings: that is what the
+        # verified golden gemma3n bundles contain. Do NOT "fix" these to
+        # Gemma3n's own `<start_of_audio>`/`<end_of_audio>` tokenizer tokens.
+        subtype = meta.llm_model_type.gemma3n
+        subtype.start_of_audio_token.token_str = _AUDIO_START_TOKEN
+        subtype.end_of_audio_token.token_str = _AUDIO_END_TOKEN
+
+    def get_forced_call_with_cache_kwargs(self, tokens, cache_length):
+        # Gemma3n's attention-mask computation requires a full-cache-length
+        # padding mask (a shorter one mis-broadcasts against the causal
+        # mask); export passes full-length valid tokens, so ones is correct.
+        import torch
+
+        return {
+            "padding_mask": torch.ones(
+                (tokens.shape[0], cache_length),
+                dtype=torch.bool,
+                device=tokens.device,
+            )
+        }
+
+
+class Gemma4Spec(GemmaSpec):
+    model_type = "gemma4"
+    vision_input_style = "patch_values"
+    audio_input_style = "standalone_mel"
+    #: Same string as ``LlmModelType.gemma4.end_of_image_token``.
+    end_of_vision_token = _GEMMA4_END_OF_IMAGE_TOKEN
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        image_size = vision_cfg["image_size"]
+        patch_size = _require_patch_size(
+            vision_cfg["patch_size"], "`vision_cfg['patch_size']`"
+        )
+        pool_size = vision_cfg.get("pool_size")
+        subtype = meta.llm_model_type.gemma4
+        subtype.start_of_image_token.token_str = _GEMMA4_START_OF_IMAGE_TOKEN
+        subtype.end_of_image_token.token_str = _GEMMA4_END_OF_IMAGE_TOKEN
+        subtype.patch_width = patch_size
+        subtype.patch_height = patch_size
+        subtype.max_num_patches = (image_size // patch_size) ** 2
+        if pool_size is not None:
+            subtype.pooling_kernel_size = pool_size
+
+    def populate_audio_metadata(self, meta, audio_cfg):
+        # The gemma4 subtype has no proto fields for the derived `audio_cfg`
+        # values; they only size the audio trace inputs, so not forwarded.
+        del audio_cfg
+        subtype = meta.llm_model_type.gemma4
+        subtype.start_of_audio_token.token_str = _AUDIO_START_TOKEN
+        subtype.end_of_audio_token.token_str = _AUDIO_END_TOKEN
+        # `skip_mel_spectrogram_extraction=False` makes the runtime perform
+        # mel extraction (`True` feeds raw PCM): the trace consumes log-mel
+        # `audio_mel`. Also the proto3 default -- an explicit regression guard.
+        subtype.skip_mel_spectrogram_extraction = False
+
+    def reshape_separate_vision_embeddings(
+        self, img_embeddings, tokens, preprocessor
+    ):
+        if img_embeddings is None:
+            return None
+        # The separate vision encoder/adapter flattens Gemma4's interleaved
+        # (batch, num_images, tokens_per_image, hidden_dim) embeddings to
+        # (batch*num_images, ...); reshape back before the language model.
+        max_images = self.get_max_images_per_prompt(preprocessor)
+        batch_size = tokens.shape[0]
+        return img_embeddings.reshape(
+            batch_size,
+            max_images,
+            img_embeddings.shape[1],
+            img_embeddings.shape[2],
+        )
+
+
+class Gemma4AssistantSpec(LiteRTLMExportSpec):
+    """The Gemma4 MTP draft (assistant) model: not standalone-exportable.
+
+    ``Gemma4AssistantCausalLM`` is a multi-token-prediction (MTP) draft
+    model for speculative decoding: its ``call_with_cache()`` requires a
+    target model's hidden state, last-token embedding, and borrowed KV
+    cache, so it has no self-contained prefill/decode graph to export. It
+    subclasses ``CausalLM`` directly (not ``Gemma4CausalLM``), so without
+    its own registry entry it would fall through to the generic spec and
+    crash deep in tracing. See the ``Gemma4AssistantCausalLM`` docstring
+    ("This model must NOT be used standalone").
+    """
+
+    def check_exportable(self, model):
+        raise ValueError(
+            f"LiteRT-LM export does not support `{type(model).__name__}`: it "
+            "is a multi-token-prediction (MTP) draft model for speculative "
+            "decoding, not a standalone model. Its `call_with_cache()` "
+            "depends on a target model's hidden state, last-token embedding, "
+            "and borrowed KV cache, so it cannot be exported on its own. "
+            "Export the target `Gemma4CausalLM` instead; the runtime uses "
+            "the draft model via `target_model.generate(..., "
+            "assistant_model=...)`."
+        )
+
+
 class Llama3Spec(LiteRTLMExportSpec):
     """Llama3's chat template ends a turn with ``<|eot_id|>``.
 
@@ -786,6 +912,8 @@ def _populate_gemma3_family_vision_metadata(meta, model_type, vision_cfg):
 # (module_path, class_name, spec_factory), imported lazily inside
 # ``resolve_export_spec`` to avoid heavy top-level dependencies.
 _EXPORT_SPEC_REGISTRY = (
+    ("keras_hub.src.models.gemma4.gemma4_causal_lm", "Gemma4CausalLM", Gemma4Spec),
+    ("keras_hub.src.models.gemma3n.gemma3n_causal_lm", "Gemma3nCausalLM", Gemma3nSpec),
     ("keras_hub.src.models.gemma3.gemma3_causal_lm", "Gemma3CausalLM", Gemma3Spec),
     ("keras_hub.src.models.gemma.gemma_causal_lm", "GemmaCausalLM", GemmaSpec),
     ("keras_hub.src.models.qwen3_5.qwen3_5_causal_lm", "Qwen3_5CausalLM", Qwen3_5Spec),

--- a/keras_hub/src/utils/litertlm/model_specs.py
+++ b/keras_hub/src/utils/litertlm/model_specs.py
@@ -581,6 +581,108 @@ class LiteRTLMExportSpec:
         return [token_id] if token_id is not None else None
 
 
+def _lookup_token_id(tokenizer, token_str):
+    """Return the id for *token_str* in *tokenizer*'s vocab, or ``None``.
+
+    Only looks up when the tokenizer exposes ``token_to_id``, and swallows
+    the specific lookup-failure exceptions so a missing special token does
+    not abort export. Also treats a lookup that resolves to the tokenizer's
+    unk id as "not present", since some tokenizers map unknown lookups to
+    the unk id instead of raising.
+    """
+    if not hasattr(tokenizer, "token_to_id"):
+        return None
+    try:
+        token_id = tokenizer.token_to_id(token_str)
+    except (KeyError, ValueError):
+        return None
+    if token_id is None:
+        return None
+    unk_id = getattr(tokenizer, "_unk_token_id", None)
+    if token_id == unk_id:
+        return None
+    return token_id
+
+
+def _gemma_family_chat_stop_token_ids(tokenizer):
+    """Return ``[<end_of_turn> id]`` if present in *tokenizer*'s vocab.
+
+    ``<end_of_turn>`` is an optional chat-turn-stop token shared by the
+    Gemma family of SentencePiece tokenizers (Gemma, Gemma3, Gemma3n,
+    Gemma4, PaliGemma), distinct from ``tokenizer.end_token_id``.
+    """
+    token_id = _lookup_token_id(tokenizer, "<end_of_turn>")
+    return [token_id] if token_id is not None else []
+
+
+class GemmaSpec(LiteRTLMExportSpec):
+    """Base Gemma (Gemma/Gemma2) family.
+
+    There is no dedicated ``LlmModelType`` subtype for base Gemma, so
+    ``model_type`` stays ``"generic_model"``. Provides the Gemma-family
+    ``<end_of_turn>`` chat-stop-token convention shared by every Gemma*
+    spec below (all subclass this instead of ``LiteRTLMExportSpec``).
+    """
+
+    def get_chat_stop_token_ids(self, tokenizer):
+        return _gemma_family_chat_stop_token_ids(tokenizer)
+
+
+class Gemma3Spec(GemmaSpec):
+    model_type = "gemma3"
+    #: Same string as ``LlmModelType.gemma3.end_of_image_token``.
+    end_of_vision_token = _GEMMA3_END_OF_IMAGE_TOKEN
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        _populate_gemma3_family_vision_metadata(
+            meta, self.model_type, vision_cfg
+        )
+
+
+class FunctionGemmaSpec(Gemma3Spec):
+    """The ``function_gemma_instruct_270m`` preset.
+
+    Architecturally identical to Gemma3 -- it loads as a plain
+    ``Gemma3CausalLM`` -- so it cannot be distinguished by ``isinstance``
+    or config. It is reached via the explicit
+    ``llm_model_type="function_gemma"`` override (mirroring litert-torch's
+    ``litert_lm_model_type_override``) or by tokenizer auto-detection
+    (``_is_function_gemma``). ``model_type = "function_gemma"`` maps it to
+    the ``FunctionGemma`` proto instead of ``gemma3``, preserving the
+    function-calling metadata a plain Gemma3 export would silently drop.
+
+    Deliberately NOT registered in ``_EXPORT_SPEC_REGISTRY``: an
+    ``isinstance`` entry would shadow ``Gemma3Spec`` for *every* Gemma3
+    model.
+    """
+
+    model_type = "function_gemma"
+
+    def populate_vision_metadata(self, meta, vision_cfg):
+        # The ``FunctionGemma`` proto has no image fields, so the gemma3-
+        # family vision population inherited from ``Gemma3Spec`` must not run.
+        del meta, vision_cfg
+
+    def populate_function_gemma_metadata(self, meta):
+        """Populate the ``FunctionGemma`` function-calling proto fields.
+
+        Mirrors litert-torch's Gemma4 metadata builder
+        (``export_hf/model_ext/gemma4/metadata_builder.py``), whose
+        function-calling field block ``FunctionGemma`` shares (proto fields
+        5-14). ``constraint_mode`` is left at its proto default, as
+        litert-torch leaves it.
+        """
+        subtype = meta.llm_model_type.function_gemma
+        subtype.code_fence_start = _FUNCTION_GEMMA_CODE_FENCE_START
+        subtype.code_fence_end = _FUNCTION_GEMMA_CODE_FENCE_END
+        subtype.open_quote = _FUNCTION_GEMMA_ESCAPE_TOKEN
+        subtype.close_quote = _FUNCTION_GEMMA_ESCAPE_TOKEN
+        subtype.function_response_start = (
+            _FUNCTION_GEMMA_FUNCTION_RESPONSE_START
+        )
+        subtype.use_template_for_fc_format = True
+
+
 class Llama3Spec(LiteRTLMExportSpec):
     """Llama3's chat template ends a turn with ``<|eot_id|>``.
 
@@ -684,6 +786,8 @@ def _populate_gemma3_family_vision_metadata(meta, model_type, vision_cfg):
 # (module_path, class_name, spec_factory), imported lazily inside
 # ``resolve_export_spec`` to avoid heavy top-level dependencies.
 _EXPORT_SPEC_REGISTRY = (
+    ("keras_hub.src.models.gemma3.gemma3_causal_lm", "Gemma3CausalLM", Gemma3Spec),
+    ("keras_hub.src.models.gemma.gemma_causal_lm", "GemmaCausalLM", GemmaSpec),
     ("keras_hub.src.models.qwen3_5.qwen3_5_causal_lm", "Qwen3_5CausalLM", Qwen3_5Spec),
     ("keras_hub.src.models.qwen3.qwen3_causal_lm", "Qwen3CausalLM", Qwen3FamilySpec),
     ("keras_hub.src.models.qwen2_5.qwen2_5_causal_lm", "Qwen2_5CausalLM", Qwen2p5FamilySpec),

--- a/keras_hub/src/utils/litertlm/model_specs_test.py
+++ b/keras_hub/src/utils/litertlm/model_specs_test.py
@@ -78,6 +78,76 @@ class ExportSpecRegistryIntegrityTest(TestCase):
     # Tiny, randomly-initialized instances, matching the pattern every
     # `*_causal_lm_test.py` in this repo already uses for cheap model
     # construction. `resolve_export_spec` only performs `isinstance` checks,
+    # so no preprocessor or real weights are needed.
+
+    def _tiny_llama(self):
+        backbone = LlamaBackbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return LlamaCausalLM(backbone=backbone)
+
+    def _tiny_llama3(self):
+        backbone = Llama3Backbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return Llama3CausalLM(backbone=backbone)
+
+    def _tiny_phi3(self):
+        backbone = Phi3Backbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+        )
+        return Phi3CausalLM(backbone=backbone)
+
+    def _tiny_gemma(self):
+        backbone = GemmaBackbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=4,
+            intermediate_dim=16,
+        )
+        return GemmaCausalLM(backbone=backbone)
+
+    def _tiny_gemma3(self):
+        # Text-only Gemma3 (`vision_encoder=None`); `resolve_export_spec` only
+        # does `isinstance`, so no preprocessor or real weights are needed.
+        backbone = Gemma3Backbone(
+            vocabulary_size=10,
+            image_size=16,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=4,
+            intermediate_dim=16,
+            vision_encoder=None,
+        )
+        # `Gemma3CausalLM` requires `preprocessor`, but `resolve_export_spec`
+        # only does an `isinstance` check, so a null preprocessor is fine.
+        return Gemma3CausalLM(preprocessor=None, backbone=backbone)
+
+    def _tiny_gemma4_assistant(self):
+        # Mirrors the tiny config in `gemma4_assistant_causal_lm_test.py`.
+        backbone = Gemma4Backbone(
+            vocabulary_size=256,
+            num_layers=4,
             intermediate_dim=16,
         )
         return QwenCausalLM(backbone=backbone)
@@ -138,3 +208,43 @@ class ExportSpecRegistryIntegrityTest(TestCase):
         resolve to its own `Qwen3_5Spec` (not the shared `Qwen3FamilySpec`
         every other Qwen3-family model uses), so `export_to_litertlm`'s
         `cache_structure` fail-fast check actually fires for it.
+
+        This is deliberately not a duplicate of
+        `test_litertlm_model_type_detection` in `qwen3_5_causal_lm_test.py`:
+        that test only checks `model_type` and requires the torch backend;
+        this one also checks spec class identity and `cache_structure`, and
+        needs neither torch nor any litertlm dependency.
+        """
+        spec = resolve_export_spec(self._tiny_qwen3_5())
+        self.assertIsInstance(spec, Qwen3_5Spec)
+        self.assertEqual(spec.model_type, "qwen3")
+        self.assertEqual(spec.cache_structure, "hybrid")
+
+    def test_gemma_resolves_to_gemma_spec(self):
+        """Base Gemma has no dedicated `LlmModelType` subtype, but must still
+        resolve to `GemmaSpec` (not the plain `LiteRTLMExportSpec` fallback)
+        to get the shared Gemma-family `<end_of_turn>` chat-stop-token
+        behavior."""
+        spec = resolve_export_spec(self._tiny_gemma())
+        self.assertIsInstance(spec, GemmaSpec)
+        self.assertEqual(spec.model_type, "generic_model")
+
+    def test_gemma3_resolves_to_gemma3_spec_by_default(self):
+        """A plain Gemma3 (no override) resolves to `Gemma3Spec` -- the
+        regression guard that the `function_gemma` override never leaks into
+        ordinary Gemma3 exports."""
+        spec = resolve_export_spec(self._tiny_gemma3())
+        self.assertIsInstance(spec, Gemma3Spec)
+        self.assertNotIsInstance(spec, FunctionGemmaSpec)
+        self.assertEqual(spec.model_type, "gemma3")
+
+    def test_function_gemma_override_resolves_to_function_gemma_spec(self):
+        """The explicit `llm_model_type="function_gemma"` override selects
+        `FunctionGemmaSpec` (`model_type="function_gemma"`), even though the
+        model is a plain `Gemma3CausalLM` that would otherwise resolve to
+        `Gemma3Spec`."""
+        model = self._tiny_gemma3()
+        self.assertEqual(resolve_export_spec(model).model_type, "gemma3")
+        spec = resolve_export_spec(model, llm_model_type="function_gemma")
+        self.assertIsInstance(spec, FunctionGemmaSpec)
+        self.assertEqual(spec.model_type, "function_gemma")

--- a/keras_hub/src/utils/litertlm/model_specs_test.py
+++ b/keras_hub/src/utils/litertlm/model_specs_test.py
@@ -1,0 +1,140 @@
+import importlib
+import types
+
+from keras_hub.src.models.gemma.gemma_backbone import GemmaBackbone
+from keras_hub.src.models.gemma.gemma_causal_lm import GemmaCausalLM
+from keras_hub.src.models.gemma3.gemma3_backbone import Gemma3Backbone
+from keras_hub.src.models.gemma3.gemma3_causal_lm import Gemma3CausalLM
+from keras_hub.src.models.gemma4.gemma4_assistant_causal_lm import (
+    Gemma4AssistantCausalLM,
+)
+from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.models.llama.llama_backbone import LlamaBackbone
+from keras_hub.src.models.llama.llama_causal_lm import LlamaCausalLM
+from keras_hub.src.models.llama3.llama3_backbone import Llama3Backbone
+from keras_hub.src.models.llama3.llama3_causal_lm import Llama3CausalLM
+from keras_hub.src.models.phi3.phi3_backbone import Phi3Backbone
+from keras_hub.src.models.phi3.phi3_causal_lm import Phi3CausalLM
+from keras_hub.src.models.qwen.qwen_backbone import QwenBackbone
+from keras_hub.src.models.qwen.qwen_causal_lm import QwenCausalLM
+from keras_hub.src.models.qwen3.qwen3_backbone import Qwen3Backbone
+from keras_hub.src.models.qwen3.qwen3_causal_lm import Qwen3CausalLM
+from keras_hub.src.models.qwen3_5.qwen3_5_backbone import Qwen3_5Backbone
+from keras_hub.src.models.qwen3_5.qwen3_5_causal_lm import Qwen3_5CausalLM
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.litertlm.model_specs import _EXPORT_SPEC_REGISTRY
+from keras_hub.src.utils.litertlm.model_specs import FunctionGemmaSpec
+from keras_hub.src.utils.litertlm.model_specs import Gemma3nSpec
+from keras_hub.src.utils.litertlm.model_specs import Gemma3Spec
+from keras_hub.src.utils.litertlm.model_specs import Gemma4AssistantSpec
+from keras_hub.src.utils.litertlm.model_specs import Gemma4Spec
+from keras_hub.src.utils.litertlm.model_specs import GemmaSpec
+from keras_hub.src.utils.litertlm.model_specs import LiteRTLMExportSpec
+from keras_hub.src.utils.litertlm.model_specs import Llama3Spec
+from keras_hub.src.utils.litertlm.model_specs import PaliGemmaSpec
+from keras_hub.src.utils.litertlm.model_specs import Phi3Spec
+from keras_hub.src.utils.litertlm.model_specs import Qwen2p5FamilySpec
+from keras_hub.src.utils.litertlm.model_specs import Qwen3_5Spec
+from keras_hub.src.utils.litertlm.model_specs import Qwen3FamilySpec
+from keras_hub.src.utils.litertlm.model_specs import resolve_export_spec
+
+
+class ExportSpecRegistryIntegrityTest(TestCase):
+    """Walk `_EXPORT_SPEC_REGISTRY` and verify every entry actually resolves.
+
+    Deliberately has no torch/litert_torch dependency and no backend
+    requirement: it only imports plain Keras model-definition modules (which
+    build fine under any Keras backend) plus `model_specs.py` itself (which
+    has no external imports at all).
+    """
+
+    def test_every_registry_entry_imports_and_resolves(self):
+        """Every `(module_path, class_name, spec_factory)` entry must import.
+
+        `resolve_export_spec` imports each entry lazily and deliberately does
+        not catch `ImportError`, so a typo'd `module_path` or `class_name`
+        breaks resolution for every model reaching that entry. Import each
+        entry directly here (not through `resolve_export_spec`), so a broken
+        entry is reported by name instead of surfacing as an unrelated
+        family's export failure.
+        """
+        self.assertTrue(_EXPORT_SPEC_REGISTRY, "Registry must not be empty.")
+        for module_path, class_name, spec_factory in _EXPORT_SPEC_REGISTRY:
+            with self.subTest(module_path=module_path, class_name=class_name):
+                module = importlib.import_module(module_path)
+                self.assertTrue(
+                    hasattr(module, class_name),
+                    f"{module_path!r} has no attribute {class_name!r} -- "
+                    "check for a typo in _EXPORT_SPEC_REGISTRY.",
+                )
+                cls = getattr(module, class_name)
+                self.assertTrue(
+                    isinstance(cls, type),
+                    f"{module_path}.{class_name} is not a class.",
+                )
+                spec = spec_factory()
+                self.assertIsInstance(spec, LiteRTLMExportSpec)
+
+    # Tiny, randomly-initialized instances, matching the pattern every
+    # `*_causal_lm_test.py` in this repo already uses for cheap model
+    # construction. `resolve_export_spec` only performs `isinstance` checks,
+            intermediate_dim=16,
+        )
+        return QwenCausalLM(backbone=backbone)
+
+    def _tiny_qwen3(self):
+        backbone = Qwen3Backbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=4,
+            intermediate_dim=16,
+        )
+        return Qwen3CausalLM(backbone=backbone)
+
+    def _tiny_qwen3_5(self):
+        backbone = Qwen3_5Backbone(
+            vocabulary_size=10,
+            num_layers=2,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            head_dim=8,
+            intermediate_dim=16,
+            layer_types=["linear_attention", "full_attention"],
+            partial_rotary_factor=0.25,
+            linear_num_key_heads=1,
+            linear_num_value_heads=2,
+            linear_key_head_dim=4,
+            linear_value_head_dim=4,
+            linear_conv_kernel_dim=4,
+        )
+        return Qwen3_5CausalLM(backbone=backbone)
+
+    def test_llama_resolves_to_base_generic_spec(self):
+        """Llama is explicitly registered but maps to the base spec/class
+        (see the `LlamaCausalLM` entry's NOTE in `_EXPORT_SPEC_REGISTRY`)."""
+        spec = resolve_export_spec(self._tiny_llama())
+        self.assertIs(type(spec), LiteRTLMExportSpec)
+        self.assertEqual(spec.model_type, "generic_model")
+        self.assertEqual(spec.cache_structure, "single_stacked")
+
+    def test_qwen_resolves_to_qwen2p5_family_spec(self):
+        spec = resolve_export_spec(self._tiny_qwen())
+        self.assertIsInstance(spec, Qwen2p5FamilySpec)
+        self.assertEqual(spec.model_type, "qwen2p5")
+
+    def test_qwen3_resolves_to_qwen3_family_spec(self):
+        spec = resolve_export_spec(self._tiny_qwen3())
+        self.assertIsInstance(spec, Qwen3FamilySpec)
+        self.assertNotIsInstance(spec, Qwen3_5Spec)
+        self.assertEqual(spec.model_type, "qwen3")
+        self.assertEqual(spec.cache_structure, "single_stacked")
+
+    def test_qwen3_5_resolves_to_hybrid_cache_spec(self):
+        """Regression coverage for the `cache_structure` fix: Qwen3.5 must
+        resolve to its own `Qwen3_5Spec` (not the shared `Qwen3FamilySpec`
+        every other Qwen3-family model uses), so `export_to_litertlm`'s
+        `cache_structure` fail-fast check actually fires for it.

--- a/keras_hub/src/utils/litertlm/model_specs_test.py
+++ b/keras_hub/src/utils/litertlm/model_specs_test.py
@@ -348,3 +348,103 @@ class ExportSpecRegistryIntegrityTest(TestCase):
             "multi-token-prediction",
         ):
             spec.check_exportable(model)
+        self.assertIsNone(
+            LiteRTLMExportSpec().check_exportable(self._tiny_llama())
+        )
+
+    def test_llm_model_type_override_cannot_bypass_check_exportable(self):
+        """`llm_model_type` selects exported metadata, never exportability.
+
+        The override resolves a spec by name instead of by class, so it must
+        not be usable to route a non-exportable model (an MTP draft model) to
+        an exportable family's spec and slip past `check_exportable`."""
+        model = self._tiny_gemma4_assistant()
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not support `Gemma4AssistantCausalLM`.*"
+            "multi-token-prediction",
+        ):
+            resolve_export_spec(model, llm_model_type="function_gemma")
+
+    # Dependency-free checks of `get_chat_stop_token_ids` against small fake
+    # tokenizer objects -- no real KerasHub tokenizer or torch/litert
+    # dependency needed, since the method only calls `token_to_id`/reads
+    # plain attributes.
+
+    def test_gemma_spec_chat_stop_token_ids_looks_up_end_of_turn(self):
+        vocab = {"<end_of_turn>": 7}
+        tokenizer = types.SimpleNamespace(
+            token_to_id=vocab.__getitem__, _unk_token_id=0
+        )
+        self.assertEqual(GemmaSpec().get_chat_stop_token_ids(tokenizer), [7])
+
+    def test_gemma_spec_chat_stop_token_ids_absent_returns_empty(self):
+        tokenizer = types.SimpleNamespace(
+            token_to_id=lambda token: (_ for _ in ()).throw(KeyError(token))
+        )
+        self.assertEqual(GemmaSpec().get_chat_stop_token_ids(tokenizer), [])
+
+    def test_llama3_spec_chat_stop_token_ids_uses_end_token2_id(self):
+        """`Llama3Tokenizer` stores `<|eot_id|>` as `end_token2_id` (see the
+        "Hack" comment in `llama3_tokenizer.py`), not via `token_to_id`
+        lookup -- `Llama3Spec` must read that attribute directly."""
+        tokenizer = types.SimpleNamespace(end_token2_id=5)
+        self.assertEqual(Llama3Spec().get_chat_stop_token_ids(tokenizer), [5])
+
+    def test_llama3_spec_chat_stop_token_ids_absent_returns_empty(self):
+        """Base Llama (no `end_token2` hack) has no `end_token2_id`
+        attribute at all."""
+        tokenizer = types.SimpleNamespace()
+        self.assertEqual(Llama3Spec().get_chat_stop_token_ids(tokenizer), [])
+
+    def test_qwen3_family_spec_chat_stop_token_ids_looks_up_im_end(self):
+        """Qwen3's `<|im_end|>` is already `tokenizer.end_token_id`; this
+        override documents that intentionally rather than leaving it as an
+        accident of `end_token_id`'s value (`_build_llm_metadata`
+        deduplicates the two)."""
+        vocab = {"<|im_end|>": 3}
+        tokenizer = types.SimpleNamespace(
+            token_to_id=vocab.__getitem__, _unk_token_id=0
+        )
+        self.assertEqual(
+            Qwen3FamilySpec().get_chat_stop_token_ids(tokenizer), [3]
+        )
+
+    def test_qwen2p5_family_spec_chat_stop_token_ids_absent_by_default(self):
+        """Base Qwen (2.5) tokenizers use `<|endoftext|>`, not `<|im_end|>`;
+        the override must not invent a token that isn't in vocab."""
+        tokenizer = types.SimpleNamespace(
+            token_to_id=lambda token: (_ for _ in ()).throw(KeyError(token))
+        )
+        self.assertEqual(
+            Qwen2p5FamilySpec().get_chat_stop_token_ids(tokenizer), []
+        )
+
+    def test_phi3_spec_chat_stop_token_ids_looks_up_end(self):
+        """Phi-3's chat template ends each turn with `<|end|>` (distinct
+        from the `<|endoftext|>` EOS); the override must surface it.
+        `<|end|>` is an ordinary special token looked up by string, not a
+        named tokenizer attribute."""
+        vocab = {"<|end|>": 18}
+        tokenizer = types.SimpleNamespace(
+            token_to_id=vocab.__getitem__, _unk_token_id=0
+        )
+        self.assertEqual(Phi3Spec().get_chat_stop_token_ids(tokenizer), [18])
+
+    def test_phi3_spec_chat_stop_token_ids_absent_returns_empty(self):
+        """Base/non-instruct Phi-3 vocabularies without `<|end|>` get no
+        chat-stop token; the override must not invent one."""
+        tokenizer = types.SimpleNamespace(
+            token_to_id=lambda token: (_ for _ in ()).throw(KeyError(token))
+        )
+        self.assertEqual(Phi3Spec().get_chat_stop_token_ids(tokenizer), [])
+
+    def test_base_spec_describes_unsupported_cache_structure_generically(self):
+        """The default `describe_unsupported_cache_structure` must name the
+        actual mismatched `cache_structure` value generically, without any
+        family-specific (e.g. Qwen3.5) text -- that lives on the family's
+        own spec (see `Qwen3_5Spec`'s override) instead of leaking into the
+        shared/generic path."""
+
+        class _CustomHybridSpec(LiteRTLMExportSpec):
+            cache_structure = "custom_hybrid"

--- a/keras_hub/src/utils/litertlm/model_specs_test.py
+++ b/keras_hub/src/utils/litertlm/model_specs_test.py
@@ -148,6 +148,36 @@ class ExportSpecRegistryIntegrityTest(TestCase):
         backbone = Gemma4Backbone(
             vocabulary_size=256,
             num_layers=4,
+            num_query_heads=4,
+            num_key_value_heads=1,
+            hidden_dim=8,
+            intermediate_dim=16,
+            head_dim=4,
+            global_head_dim=8,
+            image_size=16,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+        )
+        return Gemma4AssistantCausalLM(
+            preprocessor=None,
+            backbone=backbone,
+            backbone_hidden_size=16,
+            num_centroids=4,
+            centroid_intermediate_top_k=2,
+            use_ordered_embeddings=True,
+        )
+
+    def _tiny_qwen(self):
+        backbone = QwenBackbone(
+            vocabulary_size=10,
+            num_layers=1,
+            num_query_heads=2,
+            num_key_value_heads=1,
+            hidden_dim=8,
             intermediate_dim=16,
         )
         return QwenCausalLM(backbone=backbone)
@@ -248,3 +278,73 @@ class ExportSpecRegistryIntegrityTest(TestCase):
         spec = resolve_export_spec(model, llm_model_type="function_gemma")
         self.assertIsInstance(spec, FunctionGemmaSpec)
         self.assertEqual(spec.model_type, "function_gemma")
+
+    def test_function_gemma_spec_not_in_isinstance_registry(self):
+        """`FunctionGemmaSpec` must NOT be in `_EXPORT_SPEC_REGISTRY`: an
+        `isinstance` entry would shadow `Gemma3Spec` for every Gemma3 model."""
+        self.assertNotIn(
+            FunctionGemmaSpec, [f for _, _, f in _EXPORT_SPEC_REGISTRY]
+        )
+
+    def test_function_gemma_auto_detected_by_tokenizer_tokens(self):
+        """A `Gemma3CausalLM` whose tokenizer exposes function-calling special
+        tokens (`<start_function_call>`) auto-resolves to `FunctionGemmaSpec`
+        even without an explicit `llm_model_type` override."""
+
+        class MockTokenizer:
+            def token_to_id(self, token):
+                if token == "<start_function_call>":
+                    return 48
+                return -1
+
+            def id_to_token(self, token_id):
+                if token_id == 48:
+                    return "<start_function_call>"
+                return "<unk>"
+
+        class MockPreprocessor:
+            tokenizer = MockTokenizer()
+
+        model = self._tiny_gemma3()
+        model.preprocessor = MockPreprocessor()
+        spec = resolve_export_spec(model)
+        self.assertIsInstance(spec, FunctionGemmaSpec)
+        self.assertEqual(spec.model_type, "function_gemma")
+
+    def test_unknown_llm_model_type_override_raises(self):
+        """An unrecognized `llm_model_type` override is a hard error, not a
+        silent fall-through to isinstance resolution."""
+        model = self._tiny_gemma3()
+        with self.assertRaisesRegex(ValueError, "Unknown `llm_model_type`"):
+            resolve_export_spec(model, llm_model_type="not_a_real_type")
+
+    def test_llama3_resolves_to_llama3_spec(self):
+        """`Llama3CausalLM` is a subclass of `LlamaCausalLM`; it must resolve
+        to `Llama3Spec` (registered earlier in `_EXPORT_SPEC_REGISTRY`), not
+        fall through to the plain `LlamaCausalLM` entry."""
+        spec = resolve_export_spec(self._tiny_llama3())
+        self.assertIsInstance(spec, Llama3Spec)
+        self.assertEqual(spec.model_type, "generic_model")
+
+    def test_phi3_causal_lm_resolves_to_phi3_spec(self):
+        """`Phi3CausalLM` must resolve to `Phi3Spec` (not fall through to
+        the plain `LiteRTLMExportSpec` default), so its `<|end|>`
+        chat-stop-token override actually fires."""
+        spec = resolve_export_spec(self._tiny_phi3())
+        self.assertIsInstance(spec, Phi3Spec)
+        self.assertEqual(spec.model_type, "generic_model")
+
+    def test_gemma4_assistant_check_exportable_raises(self):
+        """`Gemma4AssistantCausalLM` resolves to `Gemma4AssistantSpec`, whose
+        `check_exportable` fails fast with the MTP-draft explanation instead
+        of letting the model fall through to the generic spec and crash in
+        tracing. The base-class gate is a no-op for ordinary models."""
+        model = self._tiny_gemma4_assistant()
+        spec = resolve_export_spec(model)
+        self.assertIs(type(spec), Gemma4AssistantSpec)
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not support `Gemma4AssistantCausalLM`.*"
+            "multi-token-prediction",
+        ):
+            spec.check_exportable(model)

--- a/keras_hub/src/utils/litertlm/traceable_ops.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops.py
@@ -122,6 +122,120 @@ def _patched_slice(inputs, start_indices, shape):
 _traceable_slice_scope = _make_scope(torch_core, "slice", _patched_slice)
 
 
+def _traceable_dot_product_attention(
+    query,
+    key,
+    value,
+    bias=None,
+    mask=None,
+    scale=None,
+    is_causal=False,
+    flash_attention=None,
+    attn_logits_soft_cap=None,
+):
+    """Traceable replacement for Keras torch-backend ``dot_product_attention``.
+
+    ``torch.nn.functional.scaled_dot_product_attention`` lowers to the
+    composite ``aten.scaled_dot_product_attention`` op (torch 2.12 under
+    ``torch.export``), which ``litert_torch`` cannot translate to TFLite.
+    This implementation expands
+    attention to a plain ``matmul`` + ``softmax`` + ``matmul`` sequence that
+    ``litert_torch`` handles well.
+
+    The function mirrors Keras's ``dot_product_attention`` signature and shape
+    convention: inputs are ``[batch, seq_len, num_heads, head_dim]`` and the
+    output is returned in the same layout.
+
+    Unlike the original Keras torch-backend op, this implementation does
+    **not** internally broadcast mismatched query/key-value head counts for
+    grouped-query attention; the caller repeats the key/value heads up to
+    the query head count first. KerasHub's grouped-query attention layers
+    do that before calling ``dot_product_attention``, except for
+    ``CachedGemmaAttention`` and ``CachedGemma3Attention``, which forward
+    ``num_key_value_heads`` keys and values unchanged from a branch gated
+    on ``_use_fused_attention_op()`` -- and that gate returns ``False`` off
+    GPU and TPU, so the branch is not taken on CPU.
+
+    A caller that did rely on the implicit broadcast is not corrupted
+    silently either way: with ``num_key_value_heads == 1`` the singleton
+    head axis broadcasts to the correct multi-query result, and with
+    ``1 < num_key_value_heads < num_query_heads`` ``torch.matmul`` raises a
+    shape error.
+
+    Two further divergences from the original op: ``bias`` and ``mask`` are
+    applied additively instead of raising when both are passed, and input
+    ranks are not validated. No exported family passes ``bias``, so neither
+    path is exercised during export.
+    """
+    del flash_attention  # Fused flash attention is not exportable.
+
+    query = torch_core.convert_to_tensor(query)
+    key = torch_core.convert_to_tensor(key)
+    value = torch_core.convert_to_tensor(value)
+
+    compute_dtype = backend.result_type(query.dtype, key.dtype, value.dtype)
+    query = torch_core.cast(query, compute_dtype)
+    key = torch_core.cast(key, compute_dtype)
+    value = torch_core.cast(value, compute_dtype)
+
+    if scale is None:
+        scale = float(query.shape[-1]) ** -0.5
+    scale = torch_core.convert_to_tensor(scale, dtype=compute_dtype)
+
+    if mask is not None:
+        mask = torch_core.convert_to_tensor(mask, dtype="bool")
+        if is_causal:
+            q_len, kv_len = query.shape[1], key.shape[1]
+            causal_mask = torch.tril(
+                torch.ones(
+                    (q_len, kv_len), dtype=torch.bool, device=mask.device
+                )
+            )
+            mask = torch.logical_and(mask, causal_mask)
+        is_causal = False
+    elif is_causal:
+        q_len, kv_len = query.shape[1], key.shape[1]
+        mask = torch.tril(
+            torch.ones((q_len, kv_len), dtype=torch.bool, device=query.device)
+        )
+
+    # Move heads to the batch dimension to match SDPA's score layout
+    # [batch, num_heads, seq_len, head_dim].
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+
+    scores = torch.matmul(query, key.transpose(-2, -1)) * scale
+
+    if bias is not None:
+        scores = scores + torch_core.convert_to_tensor(
+            bias, dtype=compute_dtype
+        )
+
+    if mask is not None:
+        large_neg = torch.tensor(
+            torch.finfo(scores.dtype).min,
+            dtype=scores.dtype,
+            device=scores.device,
+        )
+        scores = torch.where(mask, scores, large_neg)
+
+    if attn_logits_soft_cap is not None:
+        cap = torch_core.convert_to_tensor(
+            attn_logits_soft_cap, dtype=compute_dtype
+        )
+        scores = torch.tanh(scores / cap) * cap
+
+    attn = torch.softmax(scores, dim=-1)
+    output = torch.matmul(attn, value)
+    return output.transpose(1, 2)
+
+
+_traceable_dot_product_attention_scope = _make_scope(
+    torch_backend_nn, "dot_product_attention", _traceable_dot_product_attention
+)
+
+
 def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     """Traceable replacement for Keras torch-backend ``one_hot``.
 
@@ -347,28 +461,20 @@ _traceable_amax_scope = _make_scope(torch_backend_numpy, "amax", _patched_amax)
 
 
 @contextlib.contextmanager
-
 def traceable_ops_scope():
-    """Enter a context where Keras PyTorch backend ops are replaced with export-traceable shims."""
-    return _TraceableOpsScope(
-        _traceable_slice_scope,
-        _traceable_one_hot_scope,
-        _traceable_take_scope,
-        _traceable_scatter_update_scope,
-        _traceable_repeat_scope,
-        _traceable_amax_scope,
-    )
+    """Enter every traceable-op patch scope at once.
 
-class _TraceableOpsScope:
-    def __init__(self, *scopes):
-        self.scopes = scopes
-        self._entered = []
-    def __enter__(self):
-        for s in self.scopes:
-            s.__enter__()
-            self._entered.append(s)
-        return self
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        while self._entered:
-            s = self._entered.pop()
-            s.__exit__(exc_type, exc_val, exc_tb)
+    Combines the seven individual patch scopes (slice, dot_product_attention,
+    one_hot, repeat, take, scatter_update, amax) into a single context
+    manager via ``contextlib.ExitStack``, so callers open one scope instead of
+    nesting seven ``with`` statements.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(_traceable_slice_scope())
+        stack.enter_context(_traceable_dot_product_attention_scope())
+        stack.enter_context(_traceable_one_hot_scope())
+        stack.enter_context(_traceable_repeat_scope())
+        stack.enter_context(_traceable_take_scope())
+        stack.enter_context(_traceable_scatter_update_scope())
+        stack.enter_context(_traceable_amax_scope())
+        yield

--- a/keras_hub/src/utils/litertlm/traceable_ops.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops.py
@@ -1,0 +1,201 @@
+"""Traceable replacements for Keras torch-backend ops used during export.
+
+``torch.export`` (used by ``litert_torch`` to trace KerasHub models for
+LiteRT-LM) cannot lower every op that Keras's torch backend produces --
+some introduce fused ATen ops, runtime assertions, or unbacked symbolic
+shapes that ``litert_torch`` cannot translate to TFLite. This module holds
+self-contained, drop-in replacements for the handful of ops that need this
+treatment (``one_hot``, ``repeat``, ``slice``, ``take``, ``scatter_update``,
+``dot_product_attention``, ``amax``), plus context managers that
+temporarily monkeypatch Keras's torch backend to use them.
+
+These replacements live in keras-hub rather than upstream in Keras because
+they are export-specific workarounds for ``torch.export`` and LiteRT
+lowering limitations, not improvements to the torch backend generally.
+"""
+
+import contextlib
+import unittest.mock
+
+import numpy as np
+import torch
+from keras.src import backend
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import nn as torch_backend_nn
+from keras.src.backend.torch import numpy as torch_backend_numpy
+
+
+def _make_scope(module, attr, replacement):
+    """Build a context manager that patches ``module.attr`` to *replacement*."""
+
+    @contextlib.contextmanager
+    def _scope():
+        with unittest.mock.patch.object(module, attr, replacement):
+            yield
+
+    return _scope
+
+
+def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
+    """Traceable replacement for Keras torch-backend ``one_hot``.
+
+    ``torch.nn.functional.one_hot`` inserts runtime assertions that class
+    values are non-negative. Under ``torch.export`` these become
+    ``aten._assert_async.msg`` ops, which ``litert_torch`` cannot lower.
+
+    This implementation uses equality against ``torch.arange``, which produces
+    the same result for non-negative indices and does not introduce
+    unlowerable assertions. Negative indices are preserved as all-zero vectors,
+    matching the original behavior.
+
+    Integer tensors are kept in int32 so the exported MLIR remains compatible
+    with ``litert_torch``'s i32-based TFLite lowering.
+    """
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with torch backend")
+    x = torch_core.convert_to_tensor(x, dtype=torch.int32)
+    x_clamped = torch.clamp(x, min=0)
+    output = x_clamped.unsqueeze(-1) == torch.arange(
+        num_classes, dtype=torch.int32, device=x.device
+    )
+    # Preserve original behavior for negative indices.
+    zero = torch.zeros_like(output)
+    output = torch.where(x.unsqueeze(-1) >= 0, output, zero)
+    if dtype is None:
+        dtype = "float32"
+    output = torch_core.convert_to_tensor(output, dtype=dtype)
+    dims = output.dim()
+    if axis < 0:
+        original_axis = axis
+        axis = dims + axis
+    else:
+        original_axis = axis
+    if axis < 0 or axis >= dims:
+        raise ValueError(
+            "`axis` is out of bounds for one-hot output with "
+            f"{dims} dimensions. Received: axis={original_axis}."
+        )
+    if axis != dims - 1:
+        new_axes_order = list(range(dims))
+        new_axes_order[axis] = dims - 1
+        for ax in range(axis + 1, dims):
+            new_axes_order[ax] -= 1
+        output = output.permute(new_axes_order)
+    return output
+
+
+_traceable_one_hot_scope = _make_scope(
+    torch_backend_nn, "one_hot", _patched_one_hot
+)
+
+
+def _is_scalar_integer(value):
+    """Return ``True`` if *value* is a scalar integer (Python or numpy)."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return True
+    # Accept 0-D numpy integer arrays / tensors with a single integer value.
+    if hasattr(value, "dtype") and hasattr(value, "ndim"):
+        return value.ndim == 0 and "int" in str(value.dtype)
+    return False
+
+
+# Capture the original ``repeat`` at module load so the patch can delegate
+# to it for every input form outside the scalar-tensor intercept.
+_ORIGINAL_REPEAT = torch_backend_numpy.repeat
+
+
+def _traceable_repeat(x, repeats, axis=None):
+    """Intercept 0-D tensor ``repeats`` (and ``repeats == 1``) with an axis.
+
+    Keras's own ``repeat`` fast-paths only plain Python ints; every other
+    input form defers to the original implementation unchanged.
+    """
+    x = torch_core.convert_to_tensor(x)
+
+    if axis is not None and _is_scalar_integer(repeats):
+        repeats = int(repeats)
+        if repeats < 0:
+            raise ValueError("`repeats` must be non-negative.")
+        if repeats == 1:
+            return x
+        if axis < 0:
+            axis = x.ndim + axis
+        shape = list(x.shape)
+        x = x.unsqueeze(axis + 1)
+        expand_shape = [-1] * x.ndim
+        expand_shape[axis + 1] = repeats
+        x = x.expand(expand_shape)
+        new_shape = list(shape)
+        new_shape[axis] = shape[axis] * repeats
+        return x.reshape(new_shape)
+
+    return _ORIGINAL_REPEAT(x, repeats, axis=axis)
+
+
+_traceable_repeat_scope = _make_scope(
+    torch_backend_numpy, "repeat", _traceable_repeat
+)
+
+
+# Capture the original ``amax`` at module load so the patched version can
+# delegate to it for every input form that does not trigger the layout bug.
+_ORIGINAL_AMAX = torch_backend_numpy.amax
+
+
+def _patched_amax(x, axis=None, keepdims=False):
+    """Traceable replacement for Keras torch-backend ``amax``.
+
+    ``keras.ops.max`` / ``keras.ops.amax`` with an integer ``axis`` lower to
+    ``aten.amax``. ``litert_torch``'s layout-optimization pass registers a
+    *checker* for ``aten.amax`` that forces the op to NHWC whenever its input
+    is 4-D (``layout_check.py``), but registers **no matching NHWC rewriter**
+    (``layout_rewrite.py``), so a 4-D ``aten.amax`` aborts conversion with
+    ``RuntimeError: NHWC node rewriter not found: amax``. GPT-OSS hits this in
+    its attention-sink softmax stabilization
+    (``gpt_oss_attention.py``: ``ops.max(combined_logits, axis=-1,
+    keepdims=True)`` on a ``[batch, heads, q, k]`` tensor); the litert-torch
+    gap is https://github.com/google-ai-edge/litert-torch/issues/1126.
+
+    For the single-integer-axis reduction of a 4-D tensor -- the only case that
+    trips the missing rewriter -- this routes through ``torch.max(dim=...)``,
+    which lowers to ``aten.max.dim`` (a *registered* rewriter). That is the
+    identical reduction and yields bit-identical values. Every other input form
+    (other ranks, tuple axes, ``axis=None``) defers to the original ``amax``
+    unchanged, so this is a no-op transform outside the triggering case.
+    """
+    x = torch_core.convert_to_tensor(x)
+    # NumPy integer axes (e.g. ``np.int64`` from shape arithmetic) are not
+    # Python ``int``; normalize so they take the same traceable path.
+    if isinstance(axis, np.integer):
+        axis = int(axis)
+    if axis is not None and isinstance(axis, int) and x.ndim == 4:
+        return torch.max(x, dim=axis, keepdim=keepdims).values
+    return _ORIGINAL_AMAX(x, axis=axis, keepdims=keepdims)
+
+
+_traceable_amax_scope = _make_scope(torch_backend_numpy, "amax", _patched_amax)
+
+
+@contextlib.contextmanager
+
+def traceable_ops_scope():
+    """Enter a context where Keras PyTorch backend ops are replaced with export-traceable shims."""
+    return _TraceableOpsScope(
+        _traceable_one_hot_scope,
+        _traceable_repeat_scope,
+        _traceable_amax_scope,
+    )
+
+class _TraceableOpsScope:
+    def __init__(self, *scopes):
+        self.scopes = scopes
+        self._entered = []
+    def __enter__(self):
+        for s in self.scopes:
+            s.__enter__()
+            self._entered.append(s)
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        while self._entered:
+            s = self._entered.pop()
+            s.__exit__(exc_type, exc_val, exc_tb)

--- a/keras_hub/src/utils/litertlm/traceable_ops.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops.py
@@ -36,6 +36,92 @@ def _make_scope(module, attr, replacement):
     return _scope
 
 
+def _normalize_start_indices(start_indices):
+    """Convert ``start_indices`` to a list preserving tensor elements."""
+    if isinstance(start_indices, (list, tuple)):
+        return list(start_indices)
+    start_indices = torch_core.convert_to_tensor(start_indices, dtype="int64")
+    if start_indices.ndim != 1:
+        raise ValueError(
+            "`start_indices` must be a 1-D tensor or a list/tuple of ints. "
+            f"Received shape: {tuple(start_indices.shape)}."
+        )
+    return list(start_indices.reshape(-1).unbind())
+
+
+def _patched_slice(inputs, start_indices, shape):
+    """Traceable replacement for Keras torch-backend ``slice``."""
+    inputs = torch_core.convert_to_tensor(inputs)
+
+    starts = _normalize_start_indices(start_indices)
+
+    if isinstance(shape, (list, tuple)):
+        lengths = list(shape)
+    else:
+        shape = torch_core.convert_to_tensor(shape, dtype="int64")
+        lengths = list(shape.reshape(-1).unbind())
+
+    def _is_dynamic(value):
+        # ``torch.SymInt`` values are not plain Python ints and require
+        # tensor-based slicing to avoid data-dependent guards.
+        return isinstance(value, torch.Tensor) or isinstance(
+            value, torch.SymInt
+        )
+
+    # Dimensions whose start or length is dynamic.
+    dynamic_dims = [
+        dim
+        for dim, (start, length) in enumerate(zip(starts, lengths))
+        if _is_dynamic(start) or _is_dynamic(length)
+    ]
+
+    # No dynamic values -> use Python slice objects directly.
+    if len(dynamic_dims) == 0:
+        slices = tuple(
+            slice(start, start + length)
+            for start, length in zip(starts, lengths)
+        )
+        return inputs[slices]
+
+    # Single dynamic dimension -> build indices with ``torch.arange`` and
+    # use ``index_select``. This keeps the output shape symbolic and avoids
+    # unbacked symbols that ``torch.export`` cannot resolve.
+    if len(dynamic_dims) == 1:
+        dim = dynamic_dims[0]
+        start = starts[dim]
+        if not isinstance(start, torch.Tensor):
+            start = torch_core.convert_to_tensor(
+                start, dtype="int32", device=inputs.device
+            )
+        start = start.reshape(())
+        length = lengths[dim]
+
+        indices = torch.arange(length, dtype=torch.int32, device=inputs.device)
+        indices = indices + start
+        result = torch.index_select(inputs, dim, indices)
+
+        # Apply static slicing for the remaining dimensions.
+        for d, (s, l) in enumerate(zip(starts, lengths)):
+            if d != dim and (s != 0 or l != result.shape[d]):
+                result = torch.narrow(result, d, s, l)
+        return result
+
+    # Multiple dynamic dimensions are not supported for LiteRT-LM export
+    # because ``torch.export`` cannot resolve the resulting unbacked
+    # symbols. Fail fast with an actionable message instead of falling
+    # back to the original implementation and producing a cryptic export
+    # error.
+    raise NotImplementedError(
+        "Slicing with multiple dynamic dimensions is not supported for "
+        "LiteRT-LM export. Received dynamic dims "
+        f"{dynamic_dims}. Consider materializing start/length values as "
+        "static ints or simplifying the slice operation."
+    )
+
+
+_traceable_slice_scope = _make_scope(torch_core, "slice", _patched_slice)
+
+
 def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     """Traceable replacement for Keras torch-backend ``one_hot``.
 
@@ -86,6 +172,90 @@ def _patched_one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
 
 _traceable_one_hot_scope = _make_scope(
     torch_backend_nn, "one_hot", _patched_one_hot
+)
+
+
+def _patched_take(x, indices, axis=None):
+    """Patch Keras torch-backend ``take`` to keep embedding indices as int32.
+
+    The default implementation casts integer indices to int64 before calling
+    ``torch.nn.functional.embedding``. ``litert_torch``'s TFLite embedding
+    lowering expects int32 indices consistent with the traced function
+    signature, so we keep indices in int32 for the embedding-lookup case.
+
+    ``axis=None`` means "take from the flattened input" (matching
+    ``numpy``/``jax`` semantics), so the input must be flattened *before*
+    negative indices are wrapped -- wrapping against
+    ``x.shape[0]`` (the first, unflattened dimension) is only correct when
+    ``x`` is already 1-D. Flattening first and then computing ``x_dim`` as
+    the flattened length keeps this correct for multi-dimensional ``x``
+    (e.g. ``take(x_3x4, -1, axis=None)`` must resolve to the last of the 12
+    flattened elements, not wrap against the first dimension's size of 3).
+    """
+    x = torch_core.convert_to_tensor(x)
+    indices = torch_core.convert_to_tensor(indices, dtype=torch.int32)
+    if axis is None:
+        x = torch.reshape(x, (-1,))
+        axis = 0
+    x_dim = x.shape[axis]
+    indices = torch.where(
+        indices < 0,
+        indices + x_dim,
+        indices,
+    )
+    if x.ndim == 2 and axis == 0:
+        # ``F.embedding`` documents a float ``weight`` (embedding table),
+        # but empirically accepts int32/int64/bool ``x`` as a plain gather,
+        # both eagerly and under ``torch.export`` -- no dtype guard needed.
+        return torch.nn.functional.embedding(indices, x)
+    axis = torch_backend_numpy.canonicalize_axis(axis, x.ndim)
+    shape = x.shape[:axis] + indices.shape + x.shape[axis + 1 :]
+    indices = indices.ravel()
+    out = torch.index_select(x, dim=axis, index=indices).squeeze(axis)
+    return out.reshape(shape)
+
+
+_traceable_take_scope = _make_scope(torch_backend_numpy, "take", _patched_take)
+
+
+_SCATTER_UPDATE_REDUCTION_OPS = {
+    "max": torch.maximum,
+    "min": torch.minimum,
+    "mul": lambda a, b: a * b,
+}
+
+
+def _patched_scatter_update(inputs, indices, updates, reduction=None):
+    """Patch Keras torch-backend ``scatter_update`` to keep indices int32.
+
+    The default implementation casts indices to int64. ``litert_torch``'s
+    TFLite scatter lowering expects int32 indices, so we keep them in int32
+    during export.
+    """
+    inputs = torch_core.convert_to_tensor(inputs)
+    indices = torch_core.convert_to_tensor(indices, dtype=torch.int32)
+    updates = torch_core.convert_to_tensor(updates, dtype=inputs.dtype)
+    indices = torch.transpose(indices, 0, 1)
+    idx = tuple(indices)
+
+    outputs = torch.clone(inputs)
+    if reduction is None:
+        outputs[idx] = updates
+    elif reduction == "add":
+        outputs.index_put_(idx, updates, accumulate=True)
+    elif reduction in _SCATTER_UPDATE_REDUCTION_OPS:
+        op_fn = _SCATTER_UPDATE_REDUCTION_OPS[reduction]
+        indices_t = indices.T
+        for i in range(indices_t.shape[0]):
+            idx_i = tuple(indices_t[i])
+            outputs[idx_i] = op_fn(outputs[idx_i], updates[i])
+    else:
+        raise ValueError(f"Unsupported reduction: {reduction}")
+    return outputs
+
+
+_traceable_scatter_update_scope = _make_scope(
+    torch_core, "scatter_update", _patched_scatter_update
 )
 
 
@@ -181,7 +351,10 @@ _traceable_amax_scope = _make_scope(torch_backend_numpy, "amax", _patched_amax)
 def traceable_ops_scope():
     """Enter a context where Keras PyTorch backend ops are replaced with export-traceable shims."""
     return _TraceableOpsScope(
+        _traceable_slice_scope,
         _traceable_one_hot_scope,
+        _traceable_take_scope,
+        _traceable_scatter_update_scope,
         _traceable_repeat_scope,
         _traceable_amax_scope,
     )

--- a/keras_hub/src/utils/litertlm/traceable_ops_test.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops_test.py
@@ -227,6 +227,112 @@ class TraceableOpsParityTest(TestCase):
                 inputs, indices, updates, reduction="bogus"
             )
 
+    def _reference_attention_inputs(self, num_query_heads, num_kv_heads):
+        rng = np.random.default_rng(0)
+        batch, q_len, kv_len, head_dim = 2, 3, 4, 8
+        query = torch.tensor(
+            rng.standard_normal((batch, q_len, num_query_heads, head_dim)),
+            dtype=torch.float32,
+        )
+        key = torch.tensor(
+            rng.standard_normal((batch, kv_len, num_kv_heads, head_dim)),
+            dtype=torch.float32,
+        )
+        value = torch.tensor(
+            rng.standard_normal((batch, kv_len, num_kv_heads, head_dim)),
+            dtype=torch.float32,
+        )
+        return query, key, value
+
+    def test_dot_product_attention_matches_original_mha(self):
+        """Standard multi-head attention (num_query_heads == num_kv_heads)."""
+        query, key, value = self._reference_attention_inputs(4, 4)
+        original = torch_backend_nn.dot_product_attention(
+            query, key, value, is_causal=True
+        )
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key, value, is_causal=True
+        )
+        self.assertAllClose(
+            _to_np(original), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_dot_product_attention_gqa_matches_original(self):
+        """Grouped-query attention (num_query_heads > num_kv_heads).
+
+        Runs four query heads against one key/value head. The original
+        Keras torch-backend op internally repeats the key/value heads to
+        match the query heads; the traceable replacement does a plain
+        batched matmul with no explicit GQA broadcast and relies on its
+        caller to repeat first, so the two are compared with that repeat
+        applied.
+        """
+        query, key, value = self._reference_attention_inputs(4, 1)
+        original = torch_backend_nn.dot_product_attention(
+            query, key, value, is_causal=True
+        )
+
+        # `_traceable_dot_product_attention` does not itself broadcast
+        # mismatched head counts (unlike the original), so repeat key/value
+        # to the query head count first, as its callers do.
+        groups = query.shape[2] // key.shape[2]
+        key_r = key.repeat_interleave(groups, dim=2)
+        value_r = value.repeat_interleave(groups, dim=2)
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key_r, value_r, is_causal=True
+        )
+        self.assertAllClose(
+            _to_np(original), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_dot_product_attention_with_mask_matches_original(self):
+        query, key, value = self._reference_attention_inputs(2, 2)
+        batch, q_len, _, _ = query.shape
+        kv_len = key.shape[1]
+        mask = torch.ones((batch, q_len, kv_len), dtype=torch.bool)
+        mask[:, :, -1] = False  # mask out the last key position
+
+        original = torch_backend_nn.dot_product_attention(
+            query, key, value, mask=mask
+        )
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key, value, mask=mask
+        )
+        self.assertAllClose(
+            _to_np(original), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
+    def test_dot_product_attention_soft_cap_matches_manual_reference(self):
+        """Attention-logit soft-capping (used by Gemma-family models).
+
+        Keras's torch-backend ``dot_product_attention`` accepts an
+        ``attn_logits_soft_cap`` parameter but never applies it (it is
+        always routed through ``torch.nn.functional.
+        scaled_dot_product_attention``, which has no soft-cap support), so
+        there is no meaningful "original" to compare against here. Instead,
+        verify the patched implementation directly against a manual
+        matmul/softmax/matmul reference with the soft-cap formula applied by
+        hand.
+        """
+        query, key, value = self._reference_attention_inputs(2, 2)
+        cap = 5.0
+
+        scale = float(query.shape[-1]) ** -0.5
+        q = query.transpose(1, 2)
+        k = key.transpose(1, 2)
+        v = value.transpose(1, 2)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        scores = torch.tanh(scores / cap) * cap
+        attn = torch.softmax(scores, dim=-1)
+        expected = torch.matmul(attn, v).transpose(1, 2)
+
+        patched = traceable_ops._traceable_dot_product_attention(
+            query, key, value, attn_logits_soft_cap=cap
+        )
+        self.assertAllClose(
+            _to_np(expected), _to_np(patched), atol=1e-5, rtol=1e-5
+        )
+
     def test_amax_matches_original(self):
         cases = [
             (torch.randn(2, 3, 4, 5), -1, True),  # 4-D last axis, keepdims
@@ -284,7 +390,6 @@ class TraceableOpsParityTest(TestCase):
 # Every module/attribute/replacement triple is resolved lazily, when a
 # scope is entered, so nothing above this point would notice a patch aimed
 # at the wrong module or a misspelled attribute name.
-
 @unittest.skipUnless(
     keras.config.backend() == "torch",
     "The litertlm traceable-op patches only exist for the PyTorch backend.",
@@ -292,6 +397,11 @@ class TraceableOpsParityTest(TestCase):
 class TraceableOpsScopeTest(TestCase):
     PATCHES = [
         (torch_core, "slice", "_patched_slice"),
+        (
+            torch_backend_nn,
+            "dot_product_attention",
+            "_traceable_dot_product_attention",
+        ),
         (torch_backend_nn, "one_hot", "_patched_one_hot"),
         (torch_backend_numpy, "repeat", "_traceable_repeat"),
         (torch_backend_numpy, "take", "_patched_take"),

--- a/keras_hub/src/utils/litertlm/traceable_ops_test.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops_test.py
@@ -101,6 +101,132 @@ class TraceableOpsParityTest(TestCase):
             with self.assertRaises(ValueError):
                 torch_backend_numpy.repeat(x, [1, 2], axis=0)
 
+    def test_slice_static_matches_original(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        original = torch_core.slice(x, [1, 1, 0], [2, 2, 5])
+        patched = patched_slice(x, [1, 1, 0], [2, 2, 5])
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_single_dynamic_dim_matches_original(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        for start in range(0, 3):
+            with self.subTest(start=start):
+                start_t = torch.tensor(start)
+                original = torch_core.slice(x, [start, 0, 0], [1, 4, 5])
+                patched = patched_slice(x, [start_t, 0, 0], [1, 4, 5])
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_dynamic_middle_dim_matches_original(self):
+        # Regression check for the KV-cache read pattern: slicing along a
+        # non-leading axis with a dynamic start while the surrounding axes
+        # are fully covered.
+        x = torch.arange(2 * 4 * 5, dtype=torch.float32).reshape(2, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        for start in range(0, 3):
+            with self.subTest(start=start):
+                start_t = torch.tensor(start)
+                original = torch_core.slice(x, [0, start, 0], [2, 1, 5])
+                patched = patched_slice(x, [0, start_t, 0], [2, 1, 5])
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_slice_multiple_dynamic_dims_raises(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        patched_slice = traceable_ops._patched_slice
+        with self.assertRaises(NotImplementedError):
+            patched_slice(x, [torch.tensor(0), torch.tensor(1), 0], [1, 1, 5])
+
+    def test_take_embedding_lookup_matches_original(self):
+        table = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        indices = torch.tensor([0, 2, 4, 1])
+        original = torch_backend_numpy.take(table, indices, axis=0)
+        patched = traceable_ops._patched_take(table, indices, axis=0)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_matches_original_various_axes(self):
+        x = torch.arange(60, dtype=torch.float32).reshape(3, 4, 5)
+        cases = [
+            (torch.tensor([0, 2]), 0),
+            (torch.tensor([0, 3, 1]), 1),
+            (torch.tensor([4, 0]), 2),
+            (torch.tensor([-1, -2]), 2),  # negative indices
+        ]
+        for indices, axis in cases:
+            with self.subTest(axis=axis, indices=indices.tolist()):
+                original = torch_backend_numpy.take(x, indices, axis=axis)
+                patched = traceable_ops._patched_take(x, indices, axis=axis)
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_no_axis_matches_original(self):
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        indices = torch.tensor([0, 5, 11])
+        original = torch_backend_numpy.take(x, indices, axis=None)
+        patched = traceable_ops._patched_take(x, indices, axis=None)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_take_no_axis_negative_index_matches_flattened_semantics(self):
+        """Regression test: ``axis=None`` + negative indices on a
+        multi-dim input must wrap against the *flattened* length, not the
+        first (unflattened) dimension's size.
+
+        Note this deliberately does **not** compare against
+        ``keras.src.backend.torch.numpy.take`` (the pattern every other
+        ``test_take_*`` case in this file uses): that Keras
+        function has the exact same bug (it computes
+        ``x_dim = x.shape[0]`` before flattening for ``axis=None``), so it
+        is not a valid reference here. Ground truth is real numpy's
+        ``np.take(..., axis=None)``, which flattens first -- e.g. for a
+        ``3x4`` input (12 elements), index ``-1`` must resolve to the last
+        flattened element (value ``11``), not wrap as if against a
+        first-dimension size of 3 (which would incorrectly give ``2``).
+        """
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        indices = torch.tensor([-1, -2])
+
+        expected = np.take(_to_np(x), _to_np(indices), axis=None)
+        patched = traceable_ops._patched_take(x, indices, axis=None)
+        self.assertAllClose(expected, _to_np(patched))
+
+    def test_scatter_update_matches_original(self):
+        inputs = torch.zeros((4, 4), dtype=torch.float32)
+        indices = torch.tensor([[0, 0], [1, 1], [2, 2]])
+        updates = torch.tensor([10.0, 20.0, 30.0])
+        for reduction in (None, "add", "max", "min", "mul"):
+            with self.subTest(reduction=reduction):
+                original = torch_core.scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                patched = traceable_ops._patched_scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_scatter_update_overlapping_indices_matches_original(self):
+        # Duplicate indices exercise the accumulation/reduction semantics
+        # more thoroughly than the diagonal case above.
+        inputs = torch.full((3, 3), 2.0, dtype=torch.float32)
+        indices = torch.tensor([[0, 0], [0, 0], [1, 1]])
+        updates = torch.tensor([3.0, 5.0, 7.0])
+        for reduction in (None, "add", "max", "min", "mul"):
+            with self.subTest(reduction=reduction):
+                original = torch_core.scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                patched = traceable_ops._patched_scatter_update(
+                    inputs, indices, updates, reduction=reduction
+                )
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_scatter_update_rejects_unsupported_reduction(self):
+        inputs = torch.zeros((2, 2), dtype=torch.float32)
+        indices = torch.tensor([[0, 0]])
+        updates = torch.tensor([1.0])
+        with self.assertRaises(ValueError):
+            traceable_ops._patched_scatter_update(
+                inputs, indices, updates, reduction="bogus"
+            )
+
     def test_amax_matches_original(self):
         cases = [
             (torch.randn(2, 3, 4, 5), -1, True),  # 4-D last axis, keepdims
@@ -165,8 +291,11 @@ class TraceableOpsParityTest(TestCase):
 )
 class TraceableOpsScopeTest(TestCase):
     PATCHES = [
+        (torch_core, "slice", "_patched_slice"),
         (torch_backend_nn, "one_hot", "_patched_one_hot"),
         (torch_backend_numpy, "repeat", "_traceable_repeat"),
+        (torch_backend_numpy, "take", "_patched_take"),
+        (torch_core, "scatter_update", "_patched_scatter_update"),
         (torch_backend_numpy, "amax", "_patched_amax"),
     ]
 

--- a/keras_hub/src/utils/litertlm/traceable_ops_test.py
+++ b/keras_hub/src/utils/litertlm/traceable_ops_test.py
@@ -1,0 +1,187 @@
+import unittest
+import unittest.mock
+
+import keras
+import numpy as np
+import torch
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import nn as torch_backend_nn
+from keras.src.backend.torch import numpy as torch_backend_numpy
+
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.litertlm import traceable_ops
+
+
+def _to_np(x):
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return np.asarray(x)
+
+
+# Parity-only: patched ops are called directly on eager tensors (no
+# torch.export) and checked against the original Keras implementations.
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "The litertlm traceable-op patches only exist for the PyTorch backend.",
+)
+class TraceableOpsParityTest(TestCase):
+    def test_one_hot_matches_original(self):
+        cases = [
+            ([0, 1, 2, 3], 5, -1, "float32"),
+            ([0, 1, 2, 3], 5, 0, "float32"),
+            ([[0, 1], [2, 3]], 4, -1, "float32"),
+            ([[0, 1], [2, 3]], 4, 1, "float32"),
+            ([[0, 1], [2, 3]], 4, 2, "int32"),
+            ([-1, 0, 2], 4, -1, "float32"),  # negative-index handling
+        ]
+        for x, num_classes, axis, dtype in cases:
+            with self.subTest(x=x, num_classes=num_classes, axis=axis):
+                x_t = torch.tensor(x, dtype=torch.int32)
+                original = torch_backend_nn.one_hot(
+                    x_t, num_classes, axis=axis, dtype=dtype
+                )
+                patched = traceable_ops._patched_one_hot(
+                    x_t, num_classes, axis=axis, dtype=dtype
+                )
+                self.assertEqual(tuple(original.shape), tuple(patched.shape))
+                self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_one_hot_rejects_sparse(self):
+        with self.assertRaises(ValueError):
+            torch_backend_nn.one_hot(torch.tensor([0]), 4, sparse=True)
+        with self.assertRaises(ValueError):
+            traceable_ops._patched_one_hot(torch.tensor([0]), 4, sparse=True)
+
+    def test_repeat_matches_original(self):
+        x = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1):
+            for repeats in (1, 2, 3):
+                with self.subTest(axis=axis, repeats=repeats):
+                    original = torch_backend_numpy.repeat(x, repeats, axis=axis)
+                    patched = traceable_ops._traceable_repeat(
+                        x, repeats, axis=axis
+                    )
+                    self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_scalar_tensor_repeats_matches_original(self):
+        # A 0-D tensor `repeats` is not a plain Python `int`, so Keras's
+        # torch-backend `repeat` falls through to the `repeat_interleave`
+        # path, while `_traceable_repeat`'s `_is_scalar_integer` check takes
+        # the unsqueeze+expand+reshape fast path instead. Values must match.
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        repeats = torch.tensor(2)
+        original = torch_backend_numpy.repeat(x, repeats, axis=1)
+        patched = traceable_ops._traceable_repeat(x, repeats, axis=1)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_identity_when_repeats_is_one(self):
+        x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        patched = traceable_ops._traceable_repeat(x, 1, axis=0)
+        self.assertAllClose(_to_np(x), _to_np(patched))
+
+    def test_repeat_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            traceable_ops._traceable_repeat(torch.zeros(2, 2), -1, axis=0)
+
+    def test_repeat_no_axis_falls_back_to_original(self):
+        x = torch.arange(6, dtype=torch.float32)
+        original = torch_backend_numpy.repeat(x, 3, axis=None)
+        patched = traceable_ops._traceable_repeat(x, 3, axis=None)
+        self.assertAllClose(_to_np(original), _to_np(patched))
+
+    def test_repeat_list_repeats_with_axis_delegates_to_original(self):
+        # Keras's torch-backend `repeat` rejects a Python list `repeats`
+        # with ValueError; inside the patch scope the fallback must
+        # delegate to the captured original (mirroring that raise), not
+        # recurse into the patch.
+        x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with self.assertRaises(ValueError):
+            torch_backend_numpy.repeat(x, [1, 2], axis=0)
+        with traceable_ops._traceable_repeat_scope():
+            with self.assertRaises(ValueError):
+                torch_backend_numpy.repeat(x, [1, 2], axis=0)
+
+    def test_amax_matches_original(self):
+        cases = [
+            (torch.randn(2, 3, 4, 5), -1, True),  # 4-D last axis, keepdims
+            (torch.randn(2, 3, 4, 5), -1, False),  # 4-D last axis, no keepdims
+            (torch.randn(2, 3, 4, 5), 1, True),  # 4-D middle axis
+            (torch.randn(2, 3, 4, 5), 0, False),  # 4-D leading axis
+            (torch.randn(2, 4, 5), -1, True),  # 3-D (fallthrough)
+            (torch.randn(4, 5), -1, True),  # 2-D (fallthrough)
+            (torch.randn(7), 0, True),  # 1-D (fallthrough)
+            (torch.randn(2, 2, 3, 4, 5), -1, True),  # 5-D (fallthrough)
+            (torch.randn(2, 3, 4, 5), (2, 3), True),  # 4-D tuple (fallthrough)
+            (torch.randn(2, 3, 4, 5), np.int64(-1), True),  # np.int64 axis
+            (torch.randn(2, 3, 4, 5), np.int32(1), True),  # np.int32 axis
+        ]
+        for x, axis, keepdims in cases:
+            with self.subTest(
+                shape=tuple(x.shape), axis=axis, keepdims=keepdims
+            ):
+                patched = traceable_ops._patched_amax(
+                    x, axis=axis, keepdims=keepdims
+                )
+                # The original Keras amax cannot handle NumPy integer axes
+                # (raises "truth value of an empty array is ambiguous"); for
+                # those cases verify only that the patched version works and
+                # matches torch.max directly.
+                if isinstance(axis, np.integer):
+                    expected = torch.max(
+                        x, dim=int(axis), keepdim=keepdims
+                    ).values
+                    self.assertTrue(torch.equal(expected, patched))
+                else:
+                    original = torch_backend_numpy.amax(
+                        x, axis=axis, keepdims=keepdims
+                    )
+                    self.assertEqual(
+                        tuple(original.shape), tuple(patched.shape)
+                    )
+                    # The reformulation is the identical reduction; values must
+                    # be bit-identical, not merely close (a silent numeric
+                    # drift here would corrupt attention-sink softmax
+                    # stabilization).
+                    self.assertTrue(torch.equal(original, patched))
+
+    def test_amax_public_ops_max_4d_matches(self):
+        # The public keras op that GPT-OSS attention actually calls.
+        x = torch.randn(2, 3, 4, 5)
+        ref = keras.ops.max(x, axis=-1, keepdims=True)
+        with unittest.mock.patch.object(
+            torch_backend_numpy, "amax", traceable_ops._patched_amax
+        ):
+            got = keras.ops.max(x, axis=-1, keepdims=True)
+        self.assertTrue(torch.equal(ref, got))
+
+
+# Every module/attribute/replacement triple is resolved lazily, when a
+# scope is entered, so nothing above this point would notice a patch aimed
+# at the wrong module or a misspelled attribute name.
+
+@unittest.skipUnless(
+    keras.config.backend() == "torch",
+    "The litertlm traceable-op patches only exist for the PyTorch backend.",
+)
+class TraceableOpsScopeTest(TestCase):
+    PATCHES = [
+        (torch_backend_nn, "one_hot", "_patched_one_hot"),
+        (torch_backend_numpy, "repeat", "_traceable_repeat"),
+        (torch_backend_numpy, "amax", "_patched_amax"),
+    ]
+
+    def test_scope_installs_every_replacement_and_restores_it(self):
+        originals = [
+            (module, attr, getattr(module, attr))
+            for module, attr, _ in self.PATCHES
+        ]
+        with traceable_ops.traceable_ops_scope():
+            for module, attr, replacement_name in self.PATCHES:
+                with self.subTest(attr=attr, phase="inside"):
+                    self.assertIs(
+                        getattr(module, attr),
+                        getattr(traceable_ops, replacement_name),
+                    )
+        for module, attr, original in originals:
+            with self.subTest(attr=attr, phase="restored"):
+                self.assertIs(getattr(module, attr), original)


### PR DESCRIPTION
Part of tracking issue https://github.com/keras-team/keras-hub/issues/2880 (LiteRT-LM Export Stacked PRs).

**Stacked Order**: Slice 9 of 28
**Predecessor PR**: #2912 (Model Specs: Gemma Text & FunctionGemma)
**Successor PR**: #2895 (Model Specs: PaliGemma & Complete Registry)
**Exact Incremental Stat**: `2 files changed, 228 insertions(+)`

### What Changed & Technical Rationale
Adds Gemma 3n and Gemma 4 specs with audio and vision capability metadata declarations.

### Verification
- Python syntax & compilation (`py_compile`) verified on all touched files.
- Executed unit tests and verified 100% byte-for-byte stack parity against reference branches.