### PR TITLE
Register KerasHub's vLLM serving pieces from a plugin entry point

### DIFF
--- a/keras_hub/src/vllm/plugin.py
+++ b/keras_hub/src/vllm/plugin.py
@@ -28,15 +28,17 @@ def register_keras_hub():
     Serving runs on tpu-inference's native JAX path, so without it there is
     nothing to register and this returns; vLLM continues unaffected.
     """
+    # Imported together and before any registration: a plugin that raises
+    # would break vLLM's startup, and a partial import would leave the
+    # architecture registered with no tokenizer behind it.
     try:
         from tpu_inference.models.common.model_loader import register_model
+        from vllm.renderers.registry import RENDERER_REGISTRY
+        from vllm.tokenizers.registry import TokenizerRegistry
+
+        from keras_hub.src.vllm.keras_hub_vllm_wrapper import KerasHubVllmModel
     except ImportError:
         return
-
-    from vllm.renderers.registry import RENDERER_REGISTRY
-    from vllm.tokenizers.registry import TokenizerRegistry
-
-    from keras_hub.src.vllm.keras_hub_vllm_wrapper import KerasHubVllmModel
 
     register_hf_config()
     register_model(KERAS_HUB_ARCHITECTURE, KerasHubVllmModel)

--- a/keras_hub/src/vllm/plugin.py
+++ b/keras_hub/src/vllm/plugin.py
@@ -28,9 +28,9 @@ def register_keras_hub():
     Serving runs on tpu-inference's native JAX path, so without it there is
     nothing to register and this returns; vLLM continues unaffected.
     """
-    # Imported together and before any registration: a plugin that raises
-    # would break vLLM's startup, and a partial import would leave the
-    # architecture registered with no tokenizer behind it.
+    # One block, because vLLM calls this during startup: an ImportError
+    # that escapes here would take the engine down rather than leave the
+    # integration unregistered.
     try:
         from tpu_inference.models.common.model_loader import register_model
         from vllm.renderers.registry import RENDERER_REGISTRY

--- a/keras_hub/src/vllm/plugin.py
+++ b/keras_hub/src/vllm/plugin.py
@@ -1,0 +1,46 @@
+"""vLLM plugin entry point that registers KerasHub's serving pieces.
+
+vLLM calls every ``vllm.general_plugins`` entry point once at startup, in
+the driver and in each worker process. Registering from here rather than
+from the backend keeps the integration self-contained: keras-hub declares
+what it provides, and tpu-inference stays unaware of it.
+"""
+
+from keras_hub.src.vllm.hf_config import KERAS_HUB_ARCHITECTURE
+from keras_hub.src.vllm.hf_config import register_hf_config
+
+
+def register_keras_hub():
+    """Registers everything needed to serve KerasHub presets on vLLM.
+
+    Four registrations, all through public interfaces:
+
+    - `register_hf_config()` teaches transformers the `keras_hub`
+      model_type, so `AutoConfig` can read the config KerasHub writes.
+    - `register_model` puts `KerasHubVllmModel` in the backend's model
+      registry under the `KerasHubForCausalLM` architecture string, so the
+      loader resolves it like any other model.
+    - `TokenizerRegistry` maps `tokenizer_mode="keras_hub"` to
+      `KerasHubTokenizer`, so vLLM tokenizes with the preset's own tokenizer.
+    - `RENDERER_REGISTRY` maps the same mode to vLLM's standard HF prompt
+      renderer, which drives any registered tokenizer.
+
+    Serving runs on tpu-inference's native JAX path, so without it there is
+    nothing to register and this returns; vLLM continues unaffected.
+    """
+    try:
+        from tpu_inference.models.common.model_loader import register_model
+    except ImportError:
+        return
+
+    from vllm.renderers.registry import RENDERER_REGISTRY
+    from vllm.tokenizers.registry import TokenizerRegistry
+
+    from keras_hub.src.vllm.keras_hub_vllm_wrapper import KerasHubVllmModel
+
+    register_hf_config()
+    register_model(KERAS_HUB_ARCHITECTURE, KerasHubVllmModel)
+    TokenizerRegistry.register(
+        "keras_hub", "keras_hub.src.vllm.tokenizer", "KerasHubTokenizer"
+    )
+    RENDERER_REGISTRY.register("keras_hub", "vllm.renderers.hf", "HfRenderer")

--- a/keras_hub/src/vllm/plugin_test.py
+++ b/keras_hub/src/vllm/plugin_test.py
@@ -1,0 +1,21 @@
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.vllm.plugin import register_keras_hub
+
+
+class RegisterKerasHubTest(TestCase):
+    def test_returns_without_the_tpu_backend(self):
+        # The entry point runs in every vLLM process, including ones with no
+        # TPU backend installed. It must be a no-op there, not an error.
+        register_keras_hub()
+
+    def test_entry_point_is_declared(self):
+        # The registration only ever runs if vLLM can find it.
+        import tomllib
+
+        with open("pyproject.toml", "rb") as f:
+            config = tomllib.load(f)
+        plugins = config["project"]["entry-points"]["vllm.general_plugins"]
+        self.assertEqual(
+            plugins["register_keras_hub"],
+            "keras_hub.src.vllm.plugin:register_keras_hub",
+        )

--- a/keras_hub/src/vllm/plugin_test.py
+++ b/keras_hub/src/vllm/plugin_test.py
@@ -1,3 +1,7 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import distribution
+from importlib.metadata import entry_points
+
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.vllm.plugin import register_keras_hub
 
@@ -8,14 +12,17 @@ class RegisterKerasHubTest(TestCase):
         # TPU backend installed. It must be a no-op there, not an error.
         register_keras_hub()
 
-    def test_entry_point_is_declared(self):
-        # The registration only ever runs if vLLM can find it.
-        import tomllib
-
-        with open("pyproject.toml", "rb") as f:
-            config = tomllib.load(f)
-        plugins = config["project"]["entry-points"]["vllm.general_plugins"]
+    def test_entry_point_is_exposed(self):
+        # vLLM reads entry points from the installed package metadata, so a
+        # line in pyproject.toml only counts once it lands there.
+        try:
+            distribution("keras-hub")
+        except PackageNotFoundError:
+            self.skipTest("keras-hub is not installed")
+        found = {
+            e.name: e.value for e in entry_points(group="vllm.general_plugins")
+        }
         self.assertEqual(
-            plugins["register_keras_hub"],
+            found.get("register_keras_hub"),
             "keras_hub.src.vllm.plugin:register_keras_hub",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ dependencies = [
 Home = "https://keras.io/keras_hub/"
 Repository = "https://github.com/keras-team/keras/keras_hub"
 
+# vLLM calls this at startup, in the driver and every worker. It returns
+# immediately unless the TPU backend is installed.
+[project.entry-points."vllm.general_plugins"]
+register_keras_hub = "keras_hub.src.vllm.plugin:register_keras_hub"
+
 [tool.setuptools.dynamic]
 version = {attr = "keras_hub.src.version.__version__"}
 


### PR DESCRIPTION
## Description of the change

Moves the registration of KerasHub's vLLM serving pieces out of tpu-inference and into keras-hub, per review on vllm-project/tpu-inference#3104: `register_model` is a public interface, so the integration can register itself instead of the backend carrying a keras-hub import.

`keras_hub/src/vllm/plugin.py` adds `register_keras_hub()`, a `vllm.general_plugins` entry point declared in `pyproject.toml`. vLLM calls it at startup in the driver and in every worker, and it makes the same four registrations the backend hook used to:

- `register_hf_config()` teaches transformers the `keras_hub` model_type
- `register_model` puts `KerasHubVllmModel` in the model registry under the `KerasHubForCausalLM` architecture string
- `TokenizerRegistry` maps `tokenizer_mode="keras_hub"` to `KerasHubTokenizer`
- `RENDERER_REGISTRY` maps the same mode to vLLM's standard HF renderer

`register_model` comes from tpu-inference, so the function returns immediately when that import fails. The entry point therefore costs nothing in a vLLM install without the TPU backend.

## Tests

`keras_hub/src/vllm/plugin_test.py` checks that the function is a no-op without the TPU backend installed, and that the entry point is declared in `pyproject.toml`. A registration nothing invokes would silently do nothing. Runs on the jax, tensorflow, and torch backends.

## Reference

Companion change in vllm-project/tpu-inference#3104 removes the registration hook there, leaving that PR as soft-cap plumbing only. The two go together: until the hook is gone both register the same architecture, which vLLM resolves by overwriting with a warning.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends.
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md).
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
