### PR TITLE
Add KV caching and a Seq2SeqLM task to T5

### DIFF
--- a/keras_hub/api/models/__init__.py
+++ b/keras_hub/api/models/__init__.py
@@ -884,6 +884,10 @@ from keras_hub.src.models.t5.t5_backbone import T5Backbone as T5Backbone
 from keras_hub.src.models.t5.t5_preprocessor import (
     T5Preprocessor as T5Preprocessor,
 )
+from keras_hub.src.models.t5.t5_seq_2_seq_lm import T5Seq2SeqLM as T5Seq2SeqLM
+from keras_hub.src.models.t5.t5_seq_2_seq_lm_preprocessor import (
+    T5Seq2SeqLMPreprocessor as T5Seq2SeqLMPreprocessor,
+)
 from keras_hub.src.models.t5.t5_tokenizer import T5Tokenizer as T5Tokenizer
 from keras_hub.src.models.t5gemma.t5gemma_backbone import (
     T5GemmaBackbone as T5GemmaBackbone,

--- a/keras_hub/src/models/blip2/blip2_flan_t5_lm.py
+++ b/keras_hub/src/models/blip2/blip2_flan_t5_lm.py
@@ -175,14 +175,12 @@ class BLIP2FlanT5(keras.Model):
         enc_attn_mask = full_enc_mask[:, None, :]
         position_bias = None
         for layer in t5.encoder_transformer_layers:
-            out = layer(
+            x, position_bias = layer(
                 x,
                 attention_mask=enc_attn_mask,
                 position_bias=position_bias,
                 use_causal_mask=False,
             )
-            if isinstance(out, tuple):
-                x, position_bias = out
         x = t5.encoder_layer_norm(x)
         x = t5.encoder_dropout(x)
         return x, enc_attn_mask
@@ -194,25 +192,56 @@ class BLIP2FlanT5(keras.Model):
         decoder_padding_mask,
         encoder_hidden_states,
         encoder_attention_mask,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
+        cross_attention_cache=None,
+        cross_attention_cache_update_index=None,
     ):
         dec_emb = t5.token_embedding(decoder_token_ids)
         x = t5.decoder_embedding_dropout(dec_emb)
-        dec_attn_mask = decoder_padding_mask[:, None, :]
+        dec_attn_mask = (
+            None
+            if decoder_padding_mask is None
+            else decoder_padding_mask[:, None, :]
+        )
+        cached = self_attention_cache is not None
         position_bias = None
-        for layer in t5.decoder_transformer_layers:
-            out = layer(
+        self_attention_caches = []
+        cross_attention_caches = []
+        for i, layer in enumerate(t5.decoder_transformer_layers):
+            outputs = layer(
                 x,
                 attention_mask=dec_attn_mask,
                 position_bias=position_bias,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
                 use_causal_mask=True,
+                self_attention_cache=(
+                    self_attention_cache[:, i, ...] if cached else None
+                ),
+                self_attention_cache_update_index=self_attention_cache_update_index,
+                cross_attention_cache=(
+                    cross_attention_cache[:, i, ...] if cached else None
+                ),
+                cross_attention_cache_update_index=cross_attention_cache_update_index,
             )
-            if isinstance(out, tuple):
-                x, position_bias = out
+            if not cached:
+                x, position_bias = outputs
+                continue
+            x, position_bias, next_self, next_cross = outputs
+            if self_attention_cache_update_index is not None:
+                self_attention_caches.append(next_self)
+            if cross_attention_cache_update_index is not None:
+                cross_attention_caches.append(next_cross)
         x = t5.decoder_layer_norm(x)
         x = t5.decoder_dropout(x)
-        return x
+        if not cached:
+            return x
+        if self_attention_cache_update_index is not None:
+            self_attention_cache = ops.stack(self_attention_caches, axis=1)
+        if cross_attention_cache_update_index is not None:
+            cross_attention_cache = ops.stack(cross_attention_caches, axis=1)
+        return x, self_attention_cache, cross_attention_cache
 
     def call_encoder(self, token_ids, padding_mask, qformer_features=None):
         return self._run_encoder(
@@ -236,6 +265,34 @@ class BLIP2FlanT5(keras.Model):
             decoder_padding_mask,
             encoder_hidden_states,
             encoder_attention_mask,
+        )
+
+    def call_decoder_with_cache(
+        self,
+        decoder_token_ids,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        self_attention_cache,
+        self_attention_cache_update_index,
+        cross_attention_cache,
+        cross_attention_cache_update_index,
+    ):
+        """Runs the T5 decoder with key/value caches for generative decoding.
+
+        Returns a `(hidden_states, self_attention_cache,
+        cross_attention_cache)` tuple. No decoder padding mask is taken, as the
+        causal mask alone is correct during cached decoding.
+        """
+        return self._run_decoder(
+            self.t5,
+            decoder_token_ids,
+            None,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            self_attention_cache=self_attention_cache,
+            self_attention_cache_update_index=self_attention_cache_update_index,
+            cross_attention_cache=cross_attention_cache,
+            cross_attention_cache_update_index=cross_attention_cache_update_index,
         )
 
     @property

--- a/keras_hub/src/models/blip2/blip2_seq_2_seq_lm.py
+++ b/keras_hub/src/models/blip2/blip2_seq_2_seq_lm.py
@@ -20,9 +20,10 @@ class BLIP2Seq2SeqLM(Seq2SeqLM):
 
     The forward pass runs the frozen vision encoder and the Q-Former once to
     obtain visual query features, projects and prepends them to the T5 encoder
-    sequence, and decodes the answer. Because the underlying T5 stack does not
-    support a key/value cache, generation recomputes the decoder at each step;
-    the vision encoder and Q-Former are only run once per `generate()` call.
+    sequence, and decodes the answer. During generation the vision encoder,
+    Q-Former and T5 encoder are run once per `generate()` call, and the decoder
+    reuses cached self-attention and cross-attention key/value tensors so each
+    step only attends over a single new token.
 
     This model has a `generate()` method, which generates text based on the
     image and an optional encoder/decoder prompt. The generation strategy used
@@ -102,6 +103,86 @@ class BLIP2Seq2SeqLM(Seq2SeqLM):
             encoder_attention_mask,
         )
 
+    def call_decoder_with_cache(
+        self,
+        decoder_token_ids,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        self_attention_cache,
+        self_attention_cache_update_index,
+        cross_attention_cache,
+        cross_attention_cache_update_index,
+    ):
+        """Run the T5 decoder with key/value caches and return its logits.
+
+        Returns a `(logits, hidden_states, self_attention_cache,
+        cross_attention_cache)` tuple.
+        """
+        language_model = self.backbone.language_model
+        hidden_states, self_attention_cache, cross_attention_cache = (
+            language_model.call_decoder_with_cache(
+                decoder_token_ids,
+                encoder_hidden_states,
+                encoder_attention_mask,
+                self_attention_cache,
+                self_attention_cache_update_index,
+                cross_attention_cache,
+                cross_attention_cache_update_index,
+            )
+        )
+        logits = language_model.lm_head(hidden_states)
+        return (
+            logits,
+            hidden_states,
+            self_attention_cache,
+            cross_attention_cache,
+        )
+
+    def _initialize_cache(self, encoder_hidden_states, decoder_token_ids):
+        """Initializes empty self-attention and cross-attention caches."""
+        language_model = self.backbone.language_model
+        batch_size = ops.shape(decoder_token_ids)[0]
+        decoder_max_length = ops.shape(decoder_token_ids)[1]
+        # The encoder sequence includes the prepended Q-Former query tokens,
+        # so its length is read off the encoder output rather than the inputs.
+        encoder_max_length = ops.shape(encoder_hidden_states)[1]
+
+        num_heads = language_model.num_heads
+        head_dim = language_model.key_value_dim or (
+            language_model.hidden_dim // num_heads
+        )
+        shape = [
+            batch_size,
+            language_model.num_layers,
+            2,
+            decoder_max_length,
+            num_heads,
+            head_dim,
+        ]
+        self_attention_cache = ops.zeros(shape, dtype=self.compute_dtype)
+        shape[3] = encoder_max_length
+        cross_attention_cache = ops.zeros(shape, dtype=self.compute_dtype)
+        return (self_attention_cache, cross_attention_cache)
+
+    def _build_cache(
+        self, encoder_hidden_states, encoder_attention_mask, decoder_token_ids
+    ):
+        """Seeds both caches with a single decoder forward pass."""
+        self_attention_cache, cross_attention_cache = self._initialize_cache(
+            encoder_hidden_states, decoder_token_ids
+        )
+        # Straight to the language model, skipping the `lm_head` projection —
+        # the seeding pass only needs hidden states and the caches.
+        return self.backbone.language_model.call_decoder_with_cache(
+            decoder_token_ids,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            self_attention_cache,
+            0,
+            cross_attention_cache,
+            0,
+        )
+
     def generate_step(self, inputs, stop_token_ids=None):
         """A compilable generation function for a single batch of inputs.
 
@@ -118,7 +199,6 @@ class BLIP2Seq2SeqLM(Seq2SeqLM):
         decoder_token_ids = inputs["decoder_token_ids"]
         decoder_padding_mask = inputs["decoder_padding_mask"]
         images = inputs.get("images")
-        lm_head = self.backbone.language_model.lm_head
 
         # Encode the image + prompt once; reused for every decoding step.
         encoder_hidden_states, encoder_attention_mask = self.call_encoder(
@@ -127,12 +207,13 @@ class BLIP2Seq2SeqLM(Seq2SeqLM):
             images,
         )
 
-        # Seed the decoder hidden states for the sampler.
-        hidden_states = self.call_decoder(
-            decoder_token_ids,
-            decoder_padding_mask,
-            encoder_hidden_states,
-            encoder_attention_mask,
+        # Create and seed both decoder caches with a single forward pass.
+        (
+            hidden_states,
+            self_attention_cache,
+            cross_attention_cache,
+        ) = self._build_cache(
+            encoder_hidden_states, encoder_attention_mask, decoder_token_ids
         )
 
         batch_size = ops.shape(decoder_token_ids)[0]
@@ -142,7 +223,10 @@ class BLIP2Seq2SeqLM(Seq2SeqLM):
         index = ops.min(row_lengths)
 
         def next(prompt, cache, index):
+            # The cache index is the index of our previous token.
+            cache_index = index - 1
             num_samples = ops.shape(prompt)[0]
+            prompt = ops.slice(prompt, [0, cache_index], [num_samples, 1])
 
             def repeat_for_beams(x):
                 """Repeats along the batch axis to match beam-search width."""
@@ -150,26 +234,25 @@ class BLIP2Seq2SeqLM(Seq2SeqLM):
                     return x
                 return ops.repeat(x, num_samples // batch_size, axis=0)
 
-            # T5 has no KV cache, so recompute the decoder over the full prompt.
-            # The causal mask ensures position `index - 1` only attends to real
-            # (already generated) tokens, so a constant decoder mask is safe.
-            decoder_mask = ops.ones_like(prompt)
-            hidden = self.call_decoder(
-                prompt,
-                decoder_mask,
-                repeat_for_beams(encoder_hidden_states),
-                repeat_for_beams(encoder_attention_mask),
+            logits, hidden, cache, _ = self.call_decoder_with_cache(
+                decoder_token_ids=prompt,
+                encoder_hidden_states=repeat_for_beams(encoder_hidden_states),
+                encoder_attention_mask=repeat_for_beams(encoder_attention_mask),
+                self_attention_cache=cache,
+                self_attention_cache_update_index=cache_index,
+                cross_attention_cache=repeat_for_beams(cross_attention_cache),
+                cross_attention_cache_update_index=None,
             )
-            logits = lm_head(hidden)
-            # Select the next-token logits/hidden states at position index - 1.
-            logits = ops.take(logits, index - 1, axis=1)
-            hidden = ops.take(hidden, index - 1, axis=1)
-            return logits, hidden, cache
+            return (
+                ops.squeeze(logits, axis=1),
+                ops.squeeze(hidden, axis=1),
+                cache,
+            )
 
         decoder_token_ids = self.sampler(
             next=next,
             prompt=decoder_token_ids,
-            cache=None,
+            cache=self_attention_cache,
             index=index,
             mask=decoder_padding_mask,
             stop_token_ids=stop_token_ids,

--- a/keras_hub/src/models/blip2/blip2_seq_2_seq_lm_test.py
+++ b/keras_hub/src/models/blip2/blip2_seq_2_seq_lm_test.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pytest
+from keras import ops
 
 from keras_hub.src.models.blip2.blip2_backbone import BLIP2Backbone
 from keras_hub.src.models.blip2.blip2_flan_t5_lm import BLIP2FlanT5
@@ -97,6 +98,51 @@ class BLIP2Seq2SeqLMTest(TestCase):
                 self.preprocessor.tokenizer.vocabulary_size(),
             ),
         )
+
+    def test_cached_decoding_matches_uncached_forward_pass(self):
+        """Cached decoding must match recomputing the decoder every step."""
+        seq_2_seq_lm = BLIP2Seq2SeqLM(**self.init_kwargs)
+        lm_head = seq_2_seq_lm.backbone.language_model.lm_head
+        images = np.ones((2, 32, 32, 3), dtype="float32")
+        encoder_token_ids = ops.array([[4, 9, 5, 7, 1]] * 2, "int32")
+        encoder_padding_mask = ops.ones((2, 5), "int32")
+        decoder_token_ids = ops.array([[0, 4, 6, 8, 10]] * 2, "int32")
+        decoder_length = 5
+
+        encoder_hidden_states, encoder_attention_mask = (
+            seq_2_seq_lm.call_encoder(
+                encoder_token_ids, encoder_padding_mask, images
+            )
+        )
+        # Reference: a single uncached pass over the whole decoder sequence.
+        expected_logits = lm_head(
+            seq_2_seq_lm.call_decoder(
+                decoder_token_ids,
+                ops.ones((2, decoder_length), "int32"),
+                encoder_hidden_states,
+                encoder_attention_mask,
+            )
+        )
+
+        _, self_cache, cross_cache = seq_2_seq_lm._build_cache(
+            encoder_hidden_states, encoder_attention_mask, decoder_token_ids
+        )
+        for index in range(decoder_length):
+            logits, _, self_cache, _ = seq_2_seq_lm.call_decoder_with_cache(
+                decoder_token_ids=decoder_token_ids[:, index : index + 1],
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                self_attention_cache=self_cache,
+                self_attention_cache_update_index=index,
+                cross_attention_cache=cross_cache,
+                cross_attention_cache_update_index=None,
+            )
+            self.assertAllClose(
+                logits[:, 0, :],
+                expected_logits[:, index, :],
+                atol=1e-4,
+                rtol=1e-4,
+            )
 
     def test_generate_compilation(self):
         seq_2_seq_lm = BLIP2Seq2SeqLM(**self.init_kwargs)

--- a/keras_hub/src/models/stable_diffusion_3/t5_encoder.py
+++ b/keras_hub/src/models/stable_diffusion_3/t5_encoder.py
@@ -77,14 +77,12 @@ class T5Encoder(keras.Model):
         encoder_attention_mask = encoder_padding_mask_input[:, None, :]
         position_bias = None
         for transformer_layer in self.encoder_transformer_layers:
-            output = transformer_layer(
+            x, position_bias = transformer_layer(
                 x,
                 attention_mask=encoder_attention_mask,
                 position_bias=position_bias,
                 use_causal_mask=False,
             )
-            if isinstance(output, tuple):
-                x, position_bias = output
         x = self.encoder_layer_norm(x)
         x = self.encoder_dropout(x)
         sequence_output = x

--- a/keras_hub/src/models/t5/t5_backbone.py
+++ b/keras_hub/src/models/t5/t5_backbone.py
@@ -168,14 +168,12 @@ class T5Backbone(Backbone):
         encoder_attention_mask = encoder_padding_mask_input[:, None, :]
         position_bias = None
         for transformer_layer in self.encoder_transformer_layers:
-            output = transformer_layer(
+            x, position_bias = transformer_layer(
                 x,
                 attention_mask=encoder_attention_mask,
                 position_bias=position_bias,
                 use_causal_mask=False,
             )
-            if isinstance(output, tuple):
-                x, position_bias = output
         x = self.encoder_layer_norm(x)
         x = self.encoder_dropout(x)
         encoder_output = x
@@ -185,7 +183,7 @@ class T5Backbone(Backbone):
         decoder_attention_mask = decoder_padding_mask_input[:, None, :]
         position_bias = None
         for transformer_layer in self.decoder_transformer_layers:
-            output = transformer_layer(
+            x, position_bias = transformer_layer(
                 x,
                 attention_mask=decoder_attention_mask,
                 position_bias=position_bias,
@@ -193,8 +191,6 @@ class T5Backbone(Backbone):
                 encoder_attention_mask=encoder_attention_mask,
                 use_causal_mask=True,
             )
-            if isinstance(output, tuple):
-                x, position_bias = output
         x = self.decoder_layer_norm(x)
         x = self.decoder_dropout(x)
         decoder_output = x

--- a/keras_hub/src/models/t5/t5_multi_head_attention.py
+++ b/keras_hub/src/models/t5/t5_multi_head_attention.py
@@ -4,6 +4,63 @@ from keras import ops
 
 
 class T5MultiHeadAttention(keras.layers.Layer):
+    """Multi-head attention with T5 relative position bias and cache support.
+
+    This layer implements the attention variant used by T5, where positional
+    information is injected as a learned bias added to the attention scores
+    rather than as a position embedding. Only the first layer of an encoder or
+    decoder stack computes the bias; the remaining layers receive it through
+    the `position_bias` call argument.
+
+    The layer can be used for both self-attention and cross-attention, and
+    supports a static key/value cache for autoregressive decoding. The forward
+    pass can happen in one of three modes:
+
+    - No cache (`cache` is `None`), same as regular multi-head attention.
+    - Static cache (`cache` is set, `cache_update_index` is `None`). The cached
+      key/value projections are used as is and the inputs are ignored. This is
+      how cross-attention reuses the encoder projections during generation.
+    - Updated cache (`cache` and `cache_update_index` are both set). New
+      key/value projections are computed from the inputs and spliced into the
+      cache at `cache_update_index`.
+
+    Note that caching is useful only during inference and should not be used
+    during training.
+
+    Args:
+        is_decoder: bool. Whether this layer belongs to the decoder stack. The
+            relative position bias is unidirectional for the decoder and
+            bidirectional for the encoder.
+        hidden_dim: int. The size of the layer output.
+        key_value_dim: int. The size of each attention head.
+        num_heads: int. The number of attention heads.
+        dropout: float. Dropout probability applied to the attention weights.
+        use_relative_attention_bias: bool. Whether this layer owns the relative
+            attention bias weights. Only the first layer of a stack should set
+            this to `True`.
+
+    Call arguments:
+        mask: Optional mask of shape
+            `(batch_size, target_length, source_length)`, where a `1` marks a
+            position that can be attended to. It is folded into the returned
+            `position_bias`, so it is ignored when `position_bias` is passed.
+        key_value_states: Optional key/value input of shape
+            `(batch_size, source_length, dim)`, which makes this a
+            cross-attention layer. When `None`, the layer attends over
+            `hidden_states`.
+        position_bias: Optional bias of shape
+            `(batch_size, num_heads, target_length, source_length)` returned by
+            an earlier layer of the same stack, reused as is.
+        cache: Optional key/value cache of shape
+            `(batch_size, 2, source_length, num_heads, key_value_dim)`.
+        cache_update_index: Optional int or int tensor, the index along the
+            sequence axis at which to update `cache`.
+
+    Returns:
+        An `(attention_output, position_bias, cache)` tuple. `cache` is `None`
+        when no cache was passed in.
+    """
+
     # This layer is adapted from Hugging Face
     # Ref: https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_tf_t5.py
     def __init__(
@@ -137,9 +194,14 @@ class T5MultiHeadAttention(keras.layers.Layer):
         )
         return relative_buckets
 
-    def compute_bias(self, query_length, key_length):
-        """Compute binned relative position bias"""
-        context_position = ops.arange(query_length)[:, None]
+    def compute_bias(self, query_length, key_length, query_start_index=0):
+        """Compute binned relative position bias.
+
+        `query_start_index` is the absolute position of the first query. It is
+        non-zero during cached decoding, where the queries are a short slice
+        of a longer sequence and the keys span the whole cache.
+        """
+        context_position = ops.arange(query_length)[:, None] + query_start_index
         memory_position = ops.arange(key_length)[None, :]
         relative_position = (
             memory_position - context_position
@@ -164,124 +226,74 @@ class T5MultiHeadAttention(keras.layers.Layer):
         mask=None,
         key_value_states=None,
         position_bias=None,
-        past_key_value=None,
-        layer_head_mask=None,
-        query_length=None,
+        cache=None,
+        cache_update_index=None,
         training=False,
     ):
-        # Input is (batch_size, query_length, dim)
-        # past_key_value[0] is (batch_size, num_heads, q_len - 1, dim_per_head)
+        # Input is (batch_size, query_length, dim).
         batch_size, seq_length = ops.shape(hidden_states)[:2]
 
-        real_seq_length = seq_length
-
-        if past_key_value is not None:
-            if len(past_key_value) != 2:
-                raise ValueError(
-                    f"Argument `past_key_value` should have 2 past states: "
-                    f"keys and values. Got {len(past_key_value)} past states."
-                )
-            real_seq_length += (
-                ops.shape(past_key_value[0])[2]
-                if query_length is None
-                else query_length
-            )
-
-        key_length = (
-            real_seq_length
-            if key_value_states is None
-            else ops.shape(key_value_states)[1]
-        )
-
-        def shape(hidden_states):
-            return ops.transpose(
-                ops.reshape(
-                    hidden_states,
-                    (batch_size, -1, self.num_heads, self.key_value_dim),
-                ),
-                axes=(0, 2, 1, 3),
-            )
-
-        def unshape(hidden_states):
+        def shape(states):
+            # (batch_size, length, dim) -> (batch_size, length, heads, head_dim)
             return ops.reshape(
-                ops.transpose(hidden_states, axes=(0, 2, 1, 3)),
-                (batch_size, -1, self.inner_dim),
+                states,
+                (batch_size, -1, self.num_heads, self.key_value_dim),
             )
 
-        def project(
-            hidden_states, proj_layer, key_value_states, past_key_value
-        ):
-            """projects hidden states correctly to key/query states"""
-            if key_value_states is None:
-                # self-attention
-                # (batch_size, num_heads, seq_length, dim_per_head)
-                hidden_states = shape(proj_layer(hidden_states))
-            elif past_key_value is None:
-                # cross-attention
-                # (batch_size, num_heads, seq_length, dim_per_head)
-                hidden_states = shape(proj_layer(key_value_states))
+        query_states = shape(self.query_projector(hidden_states))
 
-            if past_key_value is not None:
-                if key_value_states is None:
-                    # self-attention
-                    # (batch_size, num_heads, key_length, dim_per_head)
-                    hidden_states = ops.concat(
-                        [past_key_value, hidden_states], axis=2
-                    )
-                else:
-                    # cross-attention
-                    hidden_states = past_key_value
-            return hidden_states
-
-        # get query
-        query_states = shape(
-            self.query_projector(hidden_states)
-        )  # (batch_size, num_heads, query_length, dim_per_head)
-
-        # get key/value
-        key_states = project(
-            hidden_states,
-            self.key_projector,
-            key_value_states,
-            past_key_value[0] if past_key_value is not None else None,
+        # Self-attention projects the inputs; cross-attention projects the
+        # encoder states passed as `key_value_states`.
+        key_value_inputs = (
+            hidden_states if key_value_states is None else key_value_states
         )
-        value_states = project(
-            hidden_states,
-            self.value_projector,
-            key_value_states,
-            past_key_value[1] if past_key_value is not None else None,
-        )
+        if cache is not None:
+            key_cache = cache[:, 0, ...]
+            value_cache = cache[:, 1, ...]
+            if cache_update_index is None:
+                key_states = key_cache
+                value_states = value_cache
+            else:
+                key_update = shape(self.key_projector(key_value_inputs))
+                value_update = shape(self.value_projector(key_value_inputs))
+                start = [0, cache_update_index, 0, 0]
+                key_states = ops.slice_update(key_cache, start, key_update)
+                value_states = ops.slice_update(
+                    value_cache, start, value_update
+                )
+                cache = ops.stack((key_states, value_states), axis=1)
+        else:
+            if cache_update_index is not None:
+                raise ValueError(
+                    "`cache_update_index` should not be set if `cache` is "
+                    f"`None`. Received: cache={cache}, "
+                    f"cache_update_index={cache_update_index}"
+                )
+            key_states = shape(self.key_projector(key_value_inputs))
+            value_states = shape(self.value_projector(key_value_inputs))
+
+        key_length = ops.shape(key_states)[1]
 
         scores = ops.einsum(
-            "bnqd,bnkd->bnqk", query_states, key_states
+            "bqnd,bknd->bnqk", query_states, key_states
         )  # (batch_size, num_heads, query_length, key_length)
 
         if position_bias is None:
             if not self.use_relative_attention_bias:
                 position_bias = ops.zeros(
-                    (1, self.num_heads, real_seq_length, key_length),
+                    (1, self.num_heads, seq_length, key_length),
                     self.compute_dtype,
                 )
             else:
-                position_bias = self.compute_bias(real_seq_length, key_length)
-
-            # if key and values are already calculated we want only
-            # the last query position bias
-            if past_key_value is not None:
-                if not self.use_relative_attention_bias:
-                    position_bias = position_bias[:, :, -seq_length:, :]
-                else:
-                    # we might have a padded past structure,
-                    # in which case we want to fetch the position bias slice
-                    # right after the most recently filled past index
-                    most_recently_filled_past_index = ops.amax(
-                        ops.where(past_key_value[0][0, 0, :, 0] != 0.0)
-                    )
-                    position_bias = ops.slice(
-                        position_bias,
-                        (0, 0, most_recently_filled_past_index + 1, 0),
-                        (1, self.num_heads, seq_length, real_seq_length),
-                    )
+                # During cached decoding the queries are a slice of a longer
+                # sequence, so the bias rows start at the cache index.
+                position_bias = self.compute_bias(
+                    seq_length,
+                    key_length,
+                    query_start_index=(
+                        0 if cache_update_index is None else cache_update_index
+                    ),
+                )
 
             if mask is not None:
                 # Add a new mask axis for the head dim.
@@ -298,13 +310,11 @@ class T5MultiHeadAttention(keras.layers.Layer):
             weights, training=training
         )  # (batch_size, num_heads, query_length, key_length)
 
-        # Optionally mask heads
-        if layer_head_mask is not None:
-            weights = ops.reshape(layer_head_mask, (1, -1, 1, 1)) * weights
-
-        attention_output = ops.matmul(
-            weights, value_states
-        )  # (batch_size, num_heads, query_length, dim_per_head)
-
-        attention_output = self.output_projector(unshape(attention_output))
-        return (attention_output, position_bias)
+        attention_output = ops.einsum(
+            "bnqk,bknd->bqnd", weights, value_states
+        )  # (batch_size, query_length, num_heads, head_dim)
+        attention_output = ops.reshape(
+            attention_output, (batch_size, -1, self.inner_dim)
+        )
+        attention_output = self.output_projector(attention_output)
+        return (attention_output, position_bias, cache)

--- a/keras_hub/src/models/t5/t5_seq_2_seq_lm.py
+++ b/keras_hub/src/models/t5/t5_seq_2_seq_lm.py
@@ -1,0 +1,439 @@
+from keras import ops
+
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.models.seq_2_seq_lm import Seq2SeqLM
+from keras_hub.src.models.t5.t5_backbone import T5Backbone
+from keras_hub.src.models.t5.t5_seq_2_seq_lm_preprocessor import (
+    T5Seq2SeqLMPreprocessor,
+)
+from keras_hub.src.utils.tensor_utils import any_equal
+
+
+@keras_hub_export("keras_hub.models.T5Seq2SeqLM")
+class T5Seq2SeqLM(Seq2SeqLM):
+    """An end-to-end T5 model for seq2seq language modeling.
+
+    A seq2seq language model (LM) is an encoder-decoder model which is used for
+    conditional text generation. The encoder is given a "context" text (fed to
+    the encoder), and the decoder predicts the next token based on both the
+    encoder inputs and the previous tokens. You can finetune `T5Seq2SeqLM` to
+    generate text for any seq2seq task (e.g., translation or summarization).
+
+    T5 is trained with a task prefix on the encoder input, e.g.
+    `"translate English to German: ..."` or `"summarize: ..."`, and the
+    pretrained checkpoints will follow whichever prefixes they were trained on.
+
+    This model has a `generate()` method, which generates text based on
+    encoder inputs and an optional prompt for the decoder. The generation
+    strategy used is controlled by an additional `sampler` argument passed to
+    `compile()`. You can recompile the model with different `keras_hub.samplers`
+    objects to control the generation. By default, `"top_k"` sampling will be
+    used.
+
+    This model can optionally be configured with a `preprocessor` layer, in
+    which case it will automatically apply preprocessing to string inputs during
+    `fit()`, `predict()`, `evaluate()` and `generate()`. This is done by default
+    when creating the model with `from_preset()`.
+
+    Disclaimer: Pre-trained models are provided on an "as is" basis, without
+    warranties or conditions of any kind.
+
+    Args:
+        backbone: A `keras_hub.models.T5Backbone` instance.
+        preprocessor: A `keras_hub.models.T5Seq2SeqLMPreprocessor` or `None`.
+            If `None`, this model will not apply preprocessing, and inputs
+            should be preprocessed before calling the model.
+
+    Examples:
+
+    Use `generate()` to do text generation, given an input context.
+    ```python
+    t5_lm = keras_hub.models.T5Seq2SeqLM.from_preset("t5_small_multi")
+    t5_lm.generate("translate English to German: The quick brown fox")
+
+    # Generate with batched inputs.
+    t5_lm.generate(
+        [
+            "translate English to German: The quick brown fox",
+            "summarize: The quick brown fox jumped over the lazy dog.",
+        ]
+    )
+    ```
+
+    Compile the `generate()` function with a custom sampler.
+    ```python
+    t5_lm = keras_hub.models.T5Seq2SeqLM.from_preset("t5_small_multi")
+    t5_lm.compile(sampler="greedy")
+    t5_lm.generate("summarize: The quick brown fox")
+    ```
+
+    Use `generate()` with encoder inputs and an incomplete decoder input
+    (prompt).
+    ```python
+    t5_lm = keras_hub.models.T5Seq2SeqLM.from_preset("t5_small_multi")
+    t5_lm.generate(
+        {
+            "encoder_text": "translate English to German: The quick brown fox",
+            "decoder_text": "Der schnelle",
+        }
+    )
+    ```
+
+    Call `fit()` on a single batch.
+    ```python
+    features = {
+        "encoder_text": ["summarize: The quick fox jumped.", "summarize: Hi."],
+        "decoder_text": ["The fast fox leapt.", "Hello."],
+    }
+    t5_lm = keras_hub.models.T5Seq2SeqLM.from_preset("t5_small_multi")
+    t5_lm.fit(x=features, batch_size=2)
+    ```
+
+    Call `fit()` without preprocessing.
+    ```python
+    x = {
+        "encoder_token_ids": np.array([[133, 2119, 1]] * 2),
+        "encoder_padding_mask": np.array([[1, 1, 1]] * 2),
+        "decoder_token_ids": np.array([[0, 133, 1769]] * 2),
+        "decoder_padding_mask": np.array([[1, 1, 1]] * 2),
+    }
+    y = np.array([[133, 1769, 1]] * 2)
+    sw = np.array([[1, 1, 1]] * 2)
+
+    t5_lm = keras_hub.models.T5Seq2SeqLM.from_preset(
+        "t5_small_multi",
+        preprocessor=None,
+    )
+    t5_lm.fit(x=x, y=y, sample_weight=sw, batch_size=2)
+    ```
+    """
+
+    backbone_cls = T5Backbone
+    preprocessor_cls = T5Seq2SeqLMPreprocessor
+
+    def __init__(
+        self,
+        backbone,
+        preprocessor=None,
+        **kwargs,
+    ):
+        # === Layers ===
+        self.backbone = backbone
+        self.preprocessor = preprocessor
+
+        # === Functional Model ===
+        inputs = backbone.input
+        hidden_states = backbone(inputs)["decoder_sequence_output"]
+        outputs = self._logits(hidden_states)
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            **kwargs,
+        )
+
+    def _logits(self, hidden_states):
+        """Project decoder hidden states onto the vocabulary."""
+        # T5 rescales the decoder output before the language model head when
+        # the head shares weights with the token embedding.
+        if self.backbone.tie_embedding_weights:
+            hidden_states = ops.multiply(
+                hidden_states,
+                ops.cast(self.backbone.hidden_dim**-0.5, hidden_states.dtype),
+            )
+        return self.backbone.token_embedding(hidden_states, reverse=True)
+
+    def call_encoder(self, token_ids, padding_mask):
+        """Does a forward pass on the encoder and returns the encoder output."""
+        x = self.backbone.token_embedding(token_ids)
+        x = self.backbone.encoder_embedding_dropout(x)
+        attention_mask = padding_mask[:, None, :]
+        position_bias = None
+        for transformer_layer in self.backbone.encoder_transformer_layers:
+            x, position_bias = transformer_layer(
+                x,
+                attention_mask=attention_mask,
+                position_bias=position_bias,
+                use_causal_mask=False,
+            )
+        x = self.backbone.encoder_layer_norm(x)
+        x = self.backbone.encoder_dropout(x)
+        return x
+
+    def call_decoder_with_cache(
+        self,
+        encoder_hidden_states,
+        encoder_padding_mask,
+        decoder_token_ids,
+        self_attention_cache,
+        self_attention_cache_update_index,
+        cross_attention_cache,
+        cross_attention_cache_update_index,
+    ):
+        """Forward pass with key/value caches for generative decoding.
+
+        `call_decoder_with_cache` adds an additional inference-time forward pass
+        for the model for seq2seq text generation. Unlike calling the model
+        directly, this method does two things to optimize text generation:
+
+        - Allows caching previous key/value tensors in the decoder's
+          self-attention layer to avoid recomputing the outputs of seen tokens.
+        - Allows caching key/value tensors in the decoder's cross-attention
+          layer to avoid recomputing the encoder outputs.
+
+        Args:
+            encoder_hidden_states: a dense float Tensor of shape
+                `(batch_size, encoder_sequence_length, hidden_dim)`. The
+                sequence of hidden states at the output of the encoder's last
+                layer.
+            encoder_padding_mask: a dense float Tensor of shape
+                `(batch_size, encoder_sequence_length)`. The padding mask for
+                the encoder input.
+            decoder_token_ids: a dense int Tensor of shape
+                `(batch_size, max_length)`. Input token ids to be fed to
+                the decoder.
+            self_attention_cache: a dense float Tensor of shape
+                `(batch_size, num_layers, 2, max_length, num_heads, key_value_dim)`.
+                The cached key/value tensors of previously seen tokens in the
+                decoder's self-attention layer.
+            self_attention_cache_update_index: an int or int Tensor, the index
+                at which to update the `self_attention_cache`. Usually, this is
+                the index of the current token being processed during decoding.
+            cross_attention_cache: a dense float Tensor of shape
+                `(batch_size, num_layers, 2, encoder_sequence_length, num_heads, key_value_dim)`.
+                The cached key/value tensors of the encoder outputs in the
+                decoder's cross-attention layer.
+            cross_attention_cache_update_index: an int or int Tensor, the index
+                at which to update the `cross_attention_cache`. Usually, this is
+                either `0` (compute the entire `cross_attention_cache`), or
+                `None` (reuse a previously computed `cross_attention_cache`).
+
+        Returns:
+            A `(logits, hidden_states, self_attention_cache, cross_attention_cache)`
+            tuple, where `logits` is the language model logits for the input
+            `decoder_token_ids`, `hidden_states` is the final hidden
+            representation of the input tokens, `self_attention_cache` is the
+            key/value cache in the decoder's self-attention layer and
+            `cross_attention_cache` is the key/value cache in the decoder's
+            cross-attention layer.
+        """  # noqa: E501
+        x = self.backbone.token_embedding(decoder_token_ids)
+        x = self.backbone.decoder_embedding_dropout(x)
+        encoder_attention_mask = encoder_padding_mask[:, None, :]
+
+        # Every decoder layer has a separate cache for the self-attention layer
+        # and the cross-attention layer. We update all of them separately. The
+        # relative attention bias is computed once by the first layer, along
+        # with the causal mask, and threaded through the rest of the stack.
+        self_attention_caches = []
+        cross_attention_caches = []
+        position_bias = None
+        for i, layer in enumerate(self.backbone.decoder_transformer_layers):
+            (
+                x,
+                position_bias,
+                next_self_attention_cache,
+                next_cross_attention_cache,
+            ) = layer(
+                x,
+                position_bias=position_bias,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                use_causal_mask=True,
+                self_attention_cache=self_attention_cache[:, i, ...],
+                self_attention_cache_update_index=self_attention_cache_update_index,
+                cross_attention_cache=cross_attention_cache[:, i, ...],
+                cross_attention_cache_update_index=cross_attention_cache_update_index,
+            )
+            if self_attention_cache_update_index is not None:
+                self_attention_caches.append(next_self_attention_cache)
+            if cross_attention_cache_update_index is not None:
+                cross_attention_caches.append(next_cross_attention_cache)
+
+        if self_attention_cache_update_index is not None:
+            self_attention_cache = ops.stack(self_attention_caches, axis=1)
+        if cross_attention_cache_update_index is not None:
+            cross_attention_cache = ops.stack(cross_attention_caches, axis=1)
+
+        x = self.backbone.decoder_layer_norm(x)
+        x = self.backbone.decoder_dropout(x)
+        hidden_states = x
+        logits = self._logits(hidden_states)
+        return (
+            logits,
+            hidden_states,
+            self_attention_cache,
+            cross_attention_cache,
+        )
+
+    def _initialize_cache(self, encoder_token_ids, decoder_token_ids):
+        """Initializes empty self-attention cache and cross-attention cache."""
+        batch_size = ops.shape(encoder_token_ids)[0]
+        encoder_max_length = ops.shape(encoder_token_ids)[1]
+        decoder_max_length = ops.shape(decoder_token_ids)[1]
+
+        num_layers = self.backbone.num_layers
+        num_heads = self.backbone.num_heads
+        head_dim = self.backbone.key_value_dim or (
+            self.backbone.hidden_dim // num_heads
+        )
+
+        shape = [
+            batch_size,
+            num_layers,
+            2,
+            decoder_max_length,
+            num_heads,
+            head_dim,
+        ]
+        self_attention_cache = ops.zeros(shape, dtype=self.compute_dtype)
+
+        shape[3] = encoder_max_length
+        cross_attention_cache = ops.zeros(shape, dtype=self.compute_dtype)
+
+        return (self_attention_cache, cross_attention_cache)
+
+    def _build_cache(
+        self, encoder_token_ids, encoder_padding_mask, decoder_token_ids
+    ):
+        """Builds the self-attention cache and the cross-attention cache."""
+        encoder_hidden_states = self.call_encoder(
+            token_ids=encoder_token_ids, padding_mask=encoder_padding_mask
+        )
+        self_attention_cache, cross_attention_cache = self._initialize_cache(
+            encoder_token_ids, decoder_token_ids
+        )
+
+        # Seed the self-attention cache and the cross-attention cache.
+        (
+            _,
+            hidden_states,
+            self_attention_cache,
+            cross_attention_cache,
+        ) = self.call_decoder_with_cache(
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_padding_mask=encoder_padding_mask,
+            decoder_token_ids=decoder_token_ids,
+            self_attention_cache=self_attention_cache,
+            self_attention_cache_update_index=0,
+            cross_attention_cache=cross_attention_cache,
+            cross_attention_cache_update_index=0,
+        )
+        return (
+            hidden_states,
+            encoder_hidden_states,
+            self_attention_cache,
+            cross_attention_cache,
+        )
+
+    def generate_step(
+        self,
+        inputs,
+        stop_token_ids=None,
+    ):
+        """A compilable generation function for a batch of inputs.
+
+        This function represents the inner, XLA-compilable, generation function
+        for a single batch of inputs. Inputs should have the same structure as
+        model inputs, a dictionary with keys `"encoder_token_ids"`,
+        `"encoder_padding_mask"`, `"decoder_token_ids"` and
+        `"decoder_padding_mask"`.
+
+        Args:
+            inputs: A dictionary with four keys - `"encoder_token_ids"`,
+                `"encoder_padding_mask"`, `"decoder_token_ids"` and
+                `"decoder_padding_mask"`, with batched tensor values.
+            stop_token_ids: Tuple of id's of end token's to stop on. If all
+                sequences have produced a new stop token, generation
+                will stop.
+        """
+        (
+            encoder_token_ids,
+            encoder_padding_mask,
+            decoder_token_ids,
+            decoder_padding_mask,
+        ) = (
+            inputs["encoder_token_ids"],
+            inputs["encoder_padding_mask"],
+            inputs["decoder_token_ids"],
+            inputs["decoder_padding_mask"],
+        )
+
+        batch_size = ops.shape(encoder_token_ids)[0]
+
+        # Create and seed cache with a single forward pass.
+        (
+            hidden_states,
+            encoder_hidden_states,
+            self_attention_cache,
+            cross_attention_cache,
+        ) = self._build_cache(
+            encoder_token_ids, encoder_padding_mask, decoder_token_ids
+        )
+        # Compute the lengths of all user inputted tokens ids.
+        row_lengths = ops.sum(ops.cast(decoder_padding_mask, "int32"), axis=-1)
+        # Start at the first index that has no user inputted id.
+        index = ops.min(row_lengths)
+
+        def next(prompt, cache, index):
+            # The cache index is the index of our previous token.
+            cache_index = index - 1
+            num_samples = ops.shape(prompt)[0]
+            prompt = ops.slice(prompt, [0, cache_index], [num_samples, 1])
+
+            def repeat_tensor(x):
+                """Repeats along batch axis to match dim for beam search."""
+                if ops.shape(x)[0] == num_samples:
+                    return x
+                return ops.repeat(x, repeats=num_samples // batch_size, axis=0)
+
+            logits, hidden_states, cache, _ = self.call_decoder_with_cache(
+                encoder_hidden_states=repeat_tensor(encoder_hidden_states),
+                encoder_padding_mask=repeat_tensor(encoder_padding_mask),
+                decoder_token_ids=prompt,
+                self_attention_cache=cache,
+                self_attention_cache_update_index=cache_index,
+                cross_attention_cache=repeat_tensor(cross_attention_cache),
+                cross_attention_cache_update_index=None,
+            )
+            return (
+                ops.squeeze(logits, axis=1),
+                ops.squeeze(hidden_states, axis=1),
+                cache,
+            )
+
+        decoder_token_ids = self.sampler(
+            next=next,
+            prompt=decoder_token_ids,
+            cache=self_attention_cache,
+            index=index,
+            mask=decoder_padding_mask,
+            stop_token_ids=stop_token_ids,
+            hidden_states=hidden_states,
+            model=self,
+        )
+
+        # Compute an output padding mask with the token ids we updated.
+        if stop_token_ids is not None:
+            # Build a mask of `stop_token_ids` locations not in the original
+            # prompt (not in locations where `decoder_padding_mask` is True).
+            end_locations = any_equal(
+                decoder_token_ids,
+                stop_token_ids,
+                ops.logical_not(decoder_padding_mask),
+            )
+            end_locations = ops.cast(end_locations, "int32")
+            # Use cumsum to get ones in all locations after `end_locations`.
+            cumsum = ops.cast(ops.cumsum(end_locations, axis=-1), "int32")
+            overflow = cumsum - end_locations
+            # Our padding mask is the inverse of these overflow locations.
+            decoder_padding_mask = ops.logical_not(ops.cast(overflow, "bool"))
+        else:
+            # Without early stopping, all locations will have been updated.
+            decoder_padding_mask = ops.ones_like(
+                decoder_token_ids, dtype="bool"
+            )
+
+        return {
+            "decoder_token_ids": decoder_token_ids,
+            "decoder_padding_mask": decoder_padding_mask,
+        }

--- a/keras_hub/src/models/t5/t5_seq_2_seq_lm_preprocessor.py
+++ b/keras_hub/src/models/t5/t5_seq_2_seq_lm_preprocessor.py
@@ -1,0 +1,101 @@
+from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.layers.preprocessing.start_end_packer import StartEndPacker
+from keras_hub.src.models.seq_2_seq_lm_preprocessor import Seq2SeqLMPreprocessor
+from keras_hub.src.models.t5.t5_backbone import T5Backbone
+from keras_hub.src.models.t5.t5_tokenizer import T5Tokenizer
+
+
+@keras_hub_export("keras_hub.models.T5Seq2SeqLMPreprocessor")
+class T5Seq2SeqLMPreprocessor(Seq2SeqLMPreprocessor):
+    """T5 Seq2Seq LM preprocessor.
+
+    This layer is used as preprocessor for seq2seq tasks using the T5 model.
+    This class subclasses `keras_hub.models.Seq2SeqLMPreprocessor` and keeps
+    most of its functionality, changing only how the two sequences are packed:
+
+     1. T5 has no beginning-of-sequence token, so the encoder input is packed
+        as `[tokens..., "</s>", padding...]`.
+     2. The decoder input is shifted one step to the right by T5's decoder
+        start token, which is the padding token, giving
+        `["<pad>", tokens..., "</s>", padding...]`.
+
+    Like the superclass, this layer sets the `y` (label) and `sample_weight`
+    fields by shifting the decoder input sequence one step to the left, and
+    drops the last token of the decoder input as it has no successor.
+
+    Args:
+        tokenizer: A `keras_hub.models.T5Tokenizer` instance.
+        encoder_sequence_length: The length of the packed encoder inputs.
+        decoder_sequence_length: The length of the packed decoder inputs.
+
+    Call arguments:
+        x: A dictionary with `encoder_text` and `decoder_text` as its keys.
+            Each value in the dictionary should be a tensor of single string
+            sequences. Inputs may be batched or unbatched. Raw python inputs
+            will be converted to tensors.
+        y: Label data. Should always be `None` as the layer generates labels by
+            shifting the decoder input sequence one step to the left.
+        sample_weight: Label weights. Should always be `None` as the layer
+            generates label weights by shifting the padding mask one step to
+            the left.
+
+    Examples:
+
+    Directly calling the layer on data.
+    ```python
+    preprocessor = keras_hub.models.T5Seq2SeqLMPreprocessor.from_preset(
+        "t5_small_multi"
+    )
+
+    # Preprocess unbatched inputs.
+    inputs = {
+        "encoder_text": "translate English to German: The fox was sleeping.",
+        "decoder_text": "Der Fuchs schlief.",
+    }
+    preprocessor(inputs)
+
+    # Preprocess batched inputs.
+    inputs = {
+        "encoder_text": ["summarize: The fox was sleeping."],
+        "decoder_text": ["The fox slept."],
+    }
+    preprocessor(inputs)
+    ```
+
+    Mapping with `tf.data.Dataset`.
+    ```python
+    preprocessor = keras_hub.models.T5Seq2SeqLMPreprocessor.from_preset(
+        "t5_small_multi"
+    )
+
+    features = {
+        "encoder_text": tf.constant(["summarize: The fox was sleeping."]),
+        "decoder_text": tf.constant(["The fox slept."]),
+    }
+    ds = tf.data.Dataset.from_tensor_slices(features)
+    ds = ds.map(preprocessor, num_parallel_calls=tf.data.AUTOTUNE)
+    ```
+    """
+
+    backbone_cls = T5Backbone
+    tokenizer_cls = T5Tokenizer
+
+    def build(self, input_shape):
+        # Both packers are built here rather than by the superclass, whose
+        # `start_value` would be T5's `start_token` — an alias for `"</s>"`
+        # that T5 packs into neither sequence.
+        self.encoder_packer = StartEndPacker(
+            start_value=None,
+            end_value=self.tokenizer.end_token_id,
+            pad_value=self.tokenizer.pad_token_id,
+            sequence_length=self.encoder_sequence_length,
+            return_padding_mask=True,
+        )
+        self.decoder_packer = StartEndPacker(
+            start_value=self.tokenizer.pad_token_id,
+            end_value=self.tokenizer.end_token_id,
+            pad_value=self.tokenizer.pad_token_id,
+            sequence_length=self.decoder_sequence_length,
+            return_padding_mask=True,
+        )
+        self.built = True

--- a/keras_hub/src/models/t5/t5_seq_2_seq_lm_preprocessor_test.py
+++ b/keras_hub/src/models/t5/t5_seq_2_seq_lm_preprocessor_test.py
@@ -1,0 +1,79 @@
+import os
+
+import pytest
+
+from keras_hub.src.models.t5.t5_seq_2_seq_lm_preprocessor import (
+    T5Seq2SeqLMPreprocessor,
+)
+from keras_hub.src.models.t5.t5_tokenizer import T5Tokenizer
+from keras_hub.src.tests.test_case import TestCase
+
+
+class T5Seq2SeqLMPreprocessorTest(TestCase):
+    def setUp(self):
+        self.tokenizer = T5Tokenizer(
+            # Generated using create_t5_test_proto.py
+            proto=os.path.join(self.get_test_data_dir(), "t5_test_vocab.spm")
+        )
+        self.init_kwargs = {
+            "tokenizer": self.tokenizer,
+            "encoder_sequence_length": 8,
+            "decoder_sequence_length": 8,
+        }
+        self.input_data = (
+            {
+                "encoder_text": ["the quick brown fox"],
+                "decoder_text": ["the earth is round"],
+            },
+        )
+
+    def test_preprocessor_basics(self):
+        self.run_preprocessing_layer_test(
+            cls=T5Seq2SeqLMPreprocessor,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_output=(
+                {
+                    # The encoder sequence has no start token, just `"</s>"`.
+                    "encoder_token_ids": [[4, 9, 5, 7, 1, 0, 0, 0]],
+                    "encoder_padding_mask": [[1, 1, 1, 1, 1, 0, 0, 0]],
+                    # The decoder sequence is shifted right by `"<pad>"`.
+                    "decoder_token_ids": [[0, 4, 6, 8, 10, 1, 0, 0]],
+                    "decoder_padding_mask": [[1, 1, 1, 1, 1, 1, 0, 0]],
+                },
+                [[4, 6, 8, 10, 1, 0, 0, 0]],  # Labels shifted left.
+                [[1, 1, 1, 1, 1, 0, 0, 0]],  # Zero out unlabeled positions.
+            ),
+        )
+
+    def test_generate_preprocess(self):
+        input_data = {
+            "encoder_text": "the quick brown fox",
+            "decoder_text": "the earth",
+        }
+        preprocessor = T5Seq2SeqLMPreprocessor(**self.init_kwargs)
+        x = preprocessor.generate_preprocess(input_data)
+        self.assertAllEqual(x["encoder_token_ids"], [4, 9, 5, 7, 1, 0, 0, 0])
+        self.assertAllEqual(x["encoder_padding_mask"], [1, 1, 1, 1, 1, 0, 0, 0])
+        # No end token is added, as generation continues from the prompt.
+        self.assertAllEqual(x["decoder_token_ids"], [0, 4, 6, 0, 0, 0, 0, 0])
+        self.assertAllEqual(x["decoder_padding_mask"], [1, 1, 1, 0, 0, 0, 0, 0])
+
+    def test_generate_postprocess(self):
+        input_data = {
+            "decoder_token_ids": [0, 4, 6, 8, 10, 1, 0, 0],
+            "decoder_padding_mask": [1, 1, 1, 1, 1, 1, 0, 0],
+        }
+        preprocessor = T5Seq2SeqLMPreprocessor(**self.init_kwargs)
+        x = preprocessor.generate_postprocess(input_data)
+        self.assertAllEqual(x, "the earth is round")
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.extra_large
+    def test_all_presets(self):
+        for preset in T5Seq2SeqLMPreprocessor.presets:
+            self.run_preset_test(
+                cls=T5Seq2SeqLMPreprocessor,
+                preset=preset,
+                input_data=self.input_data,
+            )

--- a/keras_hub/src/models/t5/t5_seq_2_seq_lm_test.py
+++ b/keras_hub/src/models/t5/t5_seq_2_seq_lm_test.py
@@ -1,0 +1,178 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from keras import ops
+
+from keras_hub.src.models.t5.t5_backbone import T5Backbone
+from keras_hub.src.models.t5.t5_seq_2_seq_lm import T5Seq2SeqLM
+from keras_hub.src.models.t5.t5_seq_2_seq_lm_preprocessor import (
+    T5Seq2SeqLMPreprocessor,
+)
+from keras_hub.src.models.t5.t5_tokenizer import T5Tokenizer
+from keras_hub.src.tests.test_case import TestCase
+
+
+class T5Seq2SeqLMTest(TestCase):
+    def setUp(self):
+        self.tokenizer = T5Tokenizer(
+            # Generated using create_t5_test_proto.py
+            proto=os.path.join(self.get_test_data_dir(), "t5_test_vocab.spm")
+        )
+        self.preprocessor = T5Seq2SeqLMPreprocessor(
+            self.tokenizer,
+            encoder_sequence_length=12,
+            decoder_sequence_length=10,
+        )
+        self.vocabulary_size = self.tokenizer.vocabulary_size()
+        self.backbone = T5Backbone(
+            vocabulary_size=self.vocabulary_size,
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=4,
+            intermediate_dim=8,
+        )
+        self.init_kwargs = {
+            "preprocessor": self.preprocessor,
+            "backbone": self.backbone,
+        }
+        self.train_data = (
+            {
+                "encoder_text": ["the quick brown fox", "the quick brown fox"],
+                "decoder_text": ["the earth is round", "the earth is round"],
+            },
+        )
+        self.input_data = self.preprocessor(*self.train_data)[0]
+
+    def test_seq_2_seq_lm_basics(self):
+        self.run_task_test(
+            cls=T5Seq2SeqLM,
+            init_kwargs=self.init_kwargs,
+            train_data=self.train_data,
+            expected_output_shape=(2, 10, self.vocabulary_size),
+        )
+
+    def test_generate(self):
+        # String input.
+        inputs = {
+            "encoder_text": "the quick brown fox",
+            "decoder_text": "the earth",
+        }
+        seq_2_seq_lm = T5Seq2SeqLM(**self.init_kwargs)
+        output = seq_2_seq_lm.generate(inputs)
+        self.assertTrue("the earth" in output)
+        # String tensor input.
+        self.assertIsInstance(seq_2_seq_lm.generate("the quick brown fox"), str)
+
+        # Int tensor input.
+        seq_2_seq_lm.preprocessor = None
+        preprocessed_batch = self.preprocessor.generate_preprocess(inputs)
+        outputs = seq_2_seq_lm.generate(preprocessed_batch, stop_token_ids=None)
+        # Assert prompt is in output in token id space.
+        self.assertAllEqual(
+            outputs["decoder_token_ids"][:, :3],
+            preprocessed_batch["decoder_token_ids"][:, :3],
+        )
+        self.assertAllEqual(
+            outputs["decoder_padding_mask"][:, :3],
+            preprocessed_batch["decoder_padding_mask"][:, :3],
+        )
+
+    def test_cached_decoding_matches_uncached_forward_pass(self):
+        """Decoding a token at a time must match a single full forward pass."""
+        seq_2_seq_lm = T5Seq2SeqLM(**self.init_kwargs)
+        decoder_length = 5
+        # Use fully unpadded inputs; the uncached forward pass additionally
+        # masks padded decoder positions, which cached decoding leaves to the
+        # sampler.
+        inputs = {
+            "encoder_token_ids": ops.array([[4, 9, 5, 7, 1]] * 2, "int32"),
+            "encoder_padding_mask": ops.ones((2, 5), "int32"),
+            "decoder_token_ids": ops.array([[0, 4, 6, 8, 10]] * 2, "int32"),
+            "decoder_padding_mask": ops.ones((2, decoder_length), "int32"),
+        }
+        expected_logits = seq_2_seq_lm(inputs, training=False)
+
+        _, encoder_hidden_states, self_cache, cross_cache = (
+            seq_2_seq_lm._build_cache(
+                inputs["encoder_token_ids"],
+                inputs["encoder_padding_mask"],
+                inputs["decoder_token_ids"],
+            )
+        )
+
+        for index in range(decoder_length):
+            logits, _, self_cache, _ = seq_2_seq_lm.call_decoder_with_cache(
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_padding_mask=inputs["encoder_padding_mask"],
+                decoder_token_ids=inputs["decoder_token_ids"][
+                    :, index : index + 1
+                ],
+                self_attention_cache=self_cache,
+                self_attention_cache_update_index=index,
+                cross_attention_cache=cross_cache,
+                cross_attention_cache_update_index=None,
+            )
+            self.assertAllClose(
+                logits[:, 0, :],
+                expected_logits[:, index, :],
+                atol=1e-4,
+                rtol=1e-4,
+            )
+
+    def test_early_stopping(self):
+        seq_2_seq_lm = T5Seq2SeqLM(**self.init_kwargs)
+        call_decoder_with_cache = seq_2_seq_lm.call_decoder_with_cache
+
+        def wrapper(*args, **kwargs):
+            """Modify output logits to always favor end_token_id"""
+            (
+                logits,
+                hidden_states,
+                self_attention_cache,
+                cross_attention_cache,
+            ) = call_decoder_with_cache(*args, **kwargs)
+            index = self.tokenizer.end_token_id
+            update = ops.ones_like(logits)[:, :, index] * 1.0e9
+            update = ops.expand_dims(update, axis=-1)
+            logits = ops.slice_update(logits, (0, 0, index), update)
+            return (
+                logits,
+                hidden_states,
+                self_attention_cache,
+                cross_attention_cache,
+            )
+
+        with patch.object(
+            seq_2_seq_lm, "call_decoder_with_cache", wraps=wrapper
+        ):
+            inputs = {
+                "encoder_text": ["the quick brown fox", "the quick brown fox"],
+                "decoder_text": ["the earth", "the"],
+            }
+            output = seq_2_seq_lm.generate(inputs)
+            # We should immediately abort and output the prompt.
+            self.assertAllEqual(inputs["decoder_text"], output)
+
+    def test_beam_search(self):
+        seq_2_seq_lm = T5Seq2SeqLM(**self.init_kwargs)
+        seq_2_seq_lm.compile(sampler="beam")
+        seq_2_seq_lm.generate("the quick brown fox")
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=T5Seq2SeqLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )
+
+    @pytest.mark.kaggle_key_required
+    @pytest.mark.extra_large
+    def test_all_presets(self):
+        for preset in T5Seq2SeqLM.presets:
+            self.run_preset_test(
+                cls=T5Seq2SeqLM,
+                preset=preset,
+                input_data=self.input_data,
+            )

--- a/keras_hub/src/models/t5/t5_transformer_layer.py
+++ b/keras_hub/src/models/t5/t5_transformer_layer.py
@@ -9,6 +9,56 @@ from keras_hub.src.models.t5.t5_multi_head_attention import T5MultiHeadAttention
 
 
 class T5TransformerLayer(keras.layers.Layer):
+    """A single encoder or decoder layer of a T5 stack.
+
+    Decoder layers add a cross-attention block over the encoder output, and
+    support a static key/value cache for both attention blocks so that
+    generation does not recompute the states of already seen tokens. See
+    `T5MultiHeadAttention` for the caching modes.
+
+    Args:
+        is_decoder: bool. Whether this layer belongs to the decoder stack.
+            Decoder layers add a cross-attention block and mask causally.
+        hidden_dim: int. The size of the layer output.
+        intermediate_dim: int. The output dimension of the first dense layer
+            of the feedforward block.
+        key_value_dim: int. The size of each attention head.
+        dropout: float. Dropout probability for the layer.
+        activation: string. The activation to use in the feedforward block.
+        layer_norm_epsilon: float. Epsilon factor for the layer normalization
+            layers.
+        num_heads: int. The number of attention heads.
+        use_gated_activation: bool. Whether to gate the inner dense block of
+            the feedforward network.
+        use_relative_attention_bias: bool. Whether the self-attention block
+            owns the relative attention bias weights. Only the first layer of
+            a stack should set this to `True`.
+
+    Call arguments:
+        position_bias: Optional relative attention bias returned by an earlier
+            layer of the same stack. The first layer of a stack computes it,
+            along with the causal mask, and the rest reuse it.
+        use_causal_mask: bool. Whether to build a causal mask and combine it
+            with `attention_mask`. The mask is rectangular during cached
+            decoding, where the queries are a slice of the cached sequence.
+        self_attention_cache: Optional key/value cache for the self-attention
+            block, of shape
+            `(batch_size, 2, target_length, num_heads, key_value_dim)`.
+        self_attention_cache_update_index: Optional int or int tensor, the
+            index at which to update `self_attention_cache`.
+        cross_attention_cache: Optional key/value cache for the
+            cross-attention block, of shape
+            `(batch_size, 2, source_length, num_heads, key_value_dim)`.
+        cross_attention_cache_update_index: Optional int or int tensor, the
+            index at which to update `cross_attention_cache`. Pass `None` to
+            reuse the cache without recomputing the encoder projections.
+
+    Returns:
+        A `(hidden_states, position_bias)` tuple, or a
+        `(hidden_states, position_bias, self_attention_cache,
+        cross_attention_cache)` tuple when `self_attention_cache` is set.
+    """
+
     def __init__(
         self,
         is_decoder,
@@ -112,22 +162,32 @@ class T5TransformerLayer(keras.layers.Layer):
         encoder_hidden_states=None,
         encoder_attention_mask=None,
         use_causal_mask=False,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
+        cross_attention_cache=None,
+        cross_attention_cache_update_index=None,
         training=False,
     ):
-        if use_causal_mask:
-            shape = ops.shape(hidden_states)
-            batch_size, length = shape[0], shape[1]
-            causal_mask = compute_causal_mask(batch_size, length, length)
-            attention_mask = causal_mask & ops.cast(attention_mask, "bool")
+        # Only the first layer of a stack builds the mask; the rest inherit it
+        # through `position_bias`, which already has it folded in.
+        if use_causal_mask and position_bias is None:
+            attention_mask = self._compute_self_attention_mask(
+                hidden_states,
+                attention_mask,
+                self_attention_cache,
+                self_attention_cache_update_index,
+            )
 
         x = hidden_states  # Intermediate result.
 
         residual = x
         x = self.self_attention_layer_norm(x)
-        x, position_bias = self.self_attention(
+        x, position_bias, self_attention_cache = self.self_attention(
             x,
             mask=attention_mask,
             position_bias=position_bias,
+            cache=self_attention_cache,
+            cache_update_index=self_attention_cache_update_index,
             training=training,
         )
         x = self.self_attention_dropout(x, training=training)
@@ -136,10 +196,12 @@ class T5TransformerLayer(keras.layers.Layer):
         if self.is_decoder:
             residual = x
             x = self.cross_attention_layer_norm(x)
-            x, _ = self.cross_attention(
+            x, _, cross_attention_cache = self.cross_attention(
                 x,
                 key_value_states=encoder_hidden_states,
                 mask=encoder_attention_mask,
+                cache=cross_attention_cache,
+                cache_update_index=cross_attention_cache_update_index,
                 training=training,
             )
             x = self.cross_attention_dropout(x, training=training)
@@ -158,7 +220,36 @@ class T5TransformerLayer(keras.layers.Layer):
         x = self.dropout_layer(x, training=training)
         x = x + residual
 
-        if position_bias is not None:
-            return x, position_bias
-        else:
-            return x
+        # Keras rejects `None` inside a functional model's output structure, so
+        # the caches are only returned when the caller actually passed some.
+        if self_attention_cache is not None:
+            return x, position_bias, self_attention_cache, cross_attention_cache
+        return x, position_bias
+
+    def _compute_self_attention_mask(
+        self,
+        hidden_states,
+        attention_mask,
+        self_attention_cache,
+        self_attention_cache_update_index,
+    ):
+        batch_size = ops.shape(hidden_states)[0]
+        input_length = output_length = ops.shape(hidden_states)[1]
+        # We need a rectangular causal mask when doing cached decoding. For
+        # generative inference `hidden_states` will generally be length 1,
+        # while the cache spans the full generation length.
+        if self_attention_cache is not None:
+            input_length = ops.shape(self_attention_cache)[2]
+        causal_mask = compute_causal_mask(
+            batch_size,
+            input_length,
+            output_length,
+            (
+                0
+                if self_attention_cache_update_index is None
+                else self_attention_cache_update_index
+            ),
+        )
+        if attention_mask is None:
+            return causal_mask
+        return causal_mask & ops.cast(attention_mask, "bool")


### PR DESCRIPTION
Description of the change

Adds KV caching to T5 and the T5Seq2SeqLM task, so T5 can generate().

T5MultiHeadAttention took a past_key_value argument, but T5TransformerLayer never passed one — the code was unreachable. It was also the wrong shape for this library: HF-style dynamic concat, recovering the cache position by scanning for nonzero entries (amax(where(past_key_value[0][0,0,:,0] != 0.0))), which cannot work against a preallocated cache and is not XLA-friendly.

Replaced with the static cache convention used elsewhere (cache / cache_update_index / slice_update, as in CachedMultiHeadAttention), per @mattdangerw's preference in #1698 for extending T5MultiHeadAttention over reusing CachedMultiHeadAttention. compute_bias takes a query_start_index so the relative attention bias is computed at the query's absolute position. HF main reached the same formula via past_seen_tokens.

Head layout moves from (B, H, S, D) to (B, S, H, D), which removes all four transposes from the attention path and matches BART's cache layout. Bit-identical: 0.0 max abs diff on encoder and decoder against the previous implementation with fixed weights.

Two T5 specifics in the new task:

- The preprocessor builds both packers itself. T5Tokenizer aliases start_token to "</s>", which belongs in neither sequence — the encoder takes [tokens..., </s>], the decoder is shifted right by <pad> (decoder_start_token_id). Same packing BLIP2Seq2SeqLMPreprocessor already uses.
- _logits() applies the hidden_dim ** -0.5 rescale when the head is tied, per convert_t5_checkpoints.py:397. It lives on the task, not the backbone, because BLIP-2 uses a separate untied lm_head and must not get the rescale.

Also in scope, since both consume T5 internals:

- BLIP-2 recomputed the entire decoder every step because T5 had no cache. It now uses one. The cross-attention cache is sized from the encoder output rather than the input ids, since Q-Former query tokens are prepended to the encoder sequence.
- SD3's T5Encoder needed only the return-unpacking change.
