### PR TITLE
Fix NameError in Bleu rank validation 

### DIFF
--- a/keras_hub/src/metrics/bleu.py
+++ b/keras_hub/src/metrics/bleu.py
@@ -323,7 +323,7 @@ class Bleu(keras.metrics.Metric):
             elif inputs.shape.rank == base_rank + 2:
                 if tf.shape(inputs)[-1] != 1:
                     raise ValueError(
-                        f"{tensor_name} is of rank {input.shape.rank}. The "
+                        f"{tensor_name} is of rank {inputs.shape.rank}. The "
                         f"last dimension must be of size 1."
                     )
                 return tf.squeeze(inputs, axis=-1)

--- a/keras_hub/src/metrics/bleu_test.py
+++ b/keras_hub/src/metrics/bleu_test.py
@@ -181,3 +181,20 @@ class BleuTest(TestCase):
             "smooth": True,
         }
         self.assertEqual(config, {**config, **expected_config_subset})
+
+    def test_invalid_input_rank(self):
+        bleu = Bleu()
+        # y_pred has base_rank 0. Rank 2 (base_rank + 2) is allowed ONLY if
+        # last dim is 1.
+        y_pred = tf.constant([["a", "b"], ["c", "d"]])
+        y_true = [["a b"], ["c d"]]
+        with self.assertRaisesRegex(ValueError, "y_pred is of rank 2"):
+            bleu.update_state(y_true, y_pred)
+
+        # y_true has base_rank 1. Rank 4 (base_rank + 3) is never allowed.
+        y_true = tf.constant([[[["a"]]]])
+        y_pred = ["a"]
+        with self.assertRaisesRegex(
+            ValueError, "y_true must be of rank 1, 2, or 3"
+        ):
+            bleu.update_state(y_true, y_pred)


### PR DESCRIPTION
Corrected a typo where 'input' was used instead of 'inputs' in a ValueError message, which caused an AttributeError/NameError when triggered. Added a new test case to verify correct rank validation behavior.

## Description of the change
Corrected a typo in keras_hub/src/metrics/bleu.py where input.shape.rank was used instead of inputs.shape.rank. This typo caused an AttributeError (masking a NameError) when a user provided a tensor with a rank of base_rank + 2 but an incorrect last dimension size. Additionally, added a new test case test_invalid_input_rank in keras_hub/src/metrics/bleu_test.py to ensure this error path is covered and to prevent future regressions.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
