### PR TITLE
Port model tests to common test routines

### DIFF
--- a/keras_hub/src/models/blip2/blip2_custom_opt_test.py
+++ b/keras_hub/src/models/blip2/blip2_custom_opt_test.py
@@ -1,4 +1,3 @@
-import keras
 import numpy as np
 import pytest
 
@@ -41,8 +40,7 @@ class BLIP2CustomOPTTest(TestCase):
 
     def test_serialization(self):
         backbone = BLIP2CustomOPT(**self.init_kwargs)
-        new_backbone = BLIP2CustomOPT.from_config(backbone.get_config())
-        self.assertEqual(new_backbone.get_config(), backbone.get_config())
+        self.run_serialization_test(backbone)
 
     def test_position_embeddings(self):
         backbone = BLIP2CustomOPT(**self.init_kwargs)
@@ -58,15 +56,10 @@ class BLIP2CustomOPTTest(TestCase):
 
     @pytest.mark.large
     def test_saved_model(self):
-        from keras import ops
-
-        backbone = BLIP2CustomOPT(**self.init_kwargs)
-        model_path = self.get_temp_dir() + "/model.keras"
-        backbone.save(model_path)
-        reloaded_model = keras.models.load_model(model_path)
-
-        np.testing.assert_allclose(
-            ops.convert_to_numpy(backbone(self.input_data)),
-            ops.convert_to_numpy(reloaded_model(self.input_data)),
+        self.run_model_saving_test(
+            cls=BLIP2CustomOPT,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
             atol=1e-5,
+            rtol=1e-5,
         )

--- a/keras_hub/src/models/blip2/blip2_flan_t5_lm_test.py
+++ b/keras_hub/src/models/blip2/blip2_flan_t5_lm_test.py
@@ -153,7 +153,7 @@ class BLIP2FlanT5Test(TestCase):
         out = self.model(data)
         self.assertNotAllClose(out[0], out[1])
 
-    def test_config_round_trip(self):
+    def test_config_contains_expected_keys(self):
         cfg = self.model.get_config()
         self.assertIn("language_projection", cfg)
         self.assertIn("lm_head", cfg)

--- a/keras_hub/src/models/blip2/blip2_flan_t5_lm_test.py
+++ b/keras_hub/src/models/blip2/blip2_flan_t5_lm_test.py
@@ -157,7 +157,7 @@ class BLIP2FlanT5Test(TestCase):
         cfg = self.model.get_config()
         self.assertIn("language_projection", cfg)
         self.assertIn("lm_head", cfg)
-        self.assertEqual(BLIP2FlanT5.from_config(cfg).get_config(), cfg)
+        self.run_serialization_test(self.model)
 
     def test_weights_round_trip(self):
         import os
@@ -198,14 +198,10 @@ class BLIP2FlanT5Test(TestCase):
 
     @pytest.mark.large
     def test_saved_model(self):
-        import keras
-        from keras import ops
-
-        path = self.get_temp_dir() + "/flan_t5_lm.keras"
-        self.model.save(path)
-        loaded = keras.models.load_model(path)
-        self.assertAllClose(
-            ops.convert_to_numpy(self.model(self.data)),
-            ops.convert_to_numpy(loaded(self.data)),
+        self.run_model_saving_test(
+            cls=BLIP2FlanT5,
+            init_kwargs=_TINY,
+            input_data=self.data,
             atol=1e-5,
+            rtol=1e-5,
         )

--- a/keras_hub/src/models/blip2/blip2_qformer_test.py
+++ b/keras_hub/src/models/blip2/blip2_qformer_test.py
@@ -29,12 +29,11 @@ class BLIP2QFormerTest(TestCase):
     def test_serialization(self):
         qformer = BLIP2QFormer(**self.init_kwargs)
         qformer(self.vision_features)
+        self.run_serialization_test(qformer)
 
         restored = BLIP2QFormer.from_config(qformer.get_config())
         restored(self.vision_features)
         restored.set_weights(qformer.get_weights())
-
-        self.assertEqual(qformer.get_config(), restored.get_config())
         self.assertAllClose(
             qformer(self.vision_features), restored(self.vision_features)
         )

--- a/keras_hub/src/models/gemma3/gemma3_layers_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_layers_test.py
@@ -95,8 +95,8 @@ class Gemma3MeanPoolingTest(TestCase, parameterized.TestCase):
     def test_config_serialization(self):
         """Tests that the layer can be successfully saved and loaded."""
         layer = Gemma3MeanPooling(name="mean_pooling_test")
-        config = layer.get_config()
-        new_layer = Gemma3MeanPooling.from_config(config)
+        self.run_serialization_test(layer)
+        new_layer = Gemma3MeanPooling.from_config(layer.get_config())
         self.assertEqual(new_layer.name, layer.name)
         self.assertIsInstance(new_layer, Gemma3MeanPooling)
 

--- a/keras_hub/src/models/gemma3/gemma3_layers_test.py
+++ b/keras_hub/src/models/gemma3/gemma3_layers_test.py
@@ -96,9 +96,6 @@ class Gemma3MeanPoolingTest(TestCase, parameterized.TestCase):
         """Tests that the layer can be successfully saved and loaded."""
         layer = Gemma3MeanPooling(name="mean_pooling_test")
         self.run_serialization_test(layer)
-        new_layer = Gemma3MeanPooling.from_config(layer.get_config())
-        self.assertEqual(new_layer.name, layer.name)
-        self.assertIsInstance(new_layer, Gemma3MeanPooling)
 
 
 class Gemma3InterleaveEmbeddingsTest(TestCase):

--- a/keras_hub/src/models/gemma4/gemma4_audio_converter_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_audio_converter_test.py
@@ -131,8 +131,8 @@ class Gemma4AudioConverterTest(TestCase):
     def test_get_config_round_trip(self):
         """get_config / from_config should reproduce identical parameters."""
         converter = Gemma4AudioConverter(**self.init_kwargs)
-        config = converter.get_config()
-        restored = Gemma4AudioConverter.from_config(config)
+        self.run_serialization_test(converter)
+        restored = Gemma4AudioConverter.from_config(converter.get_config())
         for key, val in self.init_kwargs.items():
             self.assertEqual(getattr(restored, key), val)
 

--- a/keras_hub/src/models/gemma4/gemma4_layers_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_layers_test.py
@@ -93,8 +93,8 @@ class Gemma4MeanPoolingTest(TestCase, parameterized.TestCase):
     def test_config_serialization(self):
         """Tests that the layer can be successfully saved and loaded."""
         layer = Gemma4MeanPooling(name="mean_pooling_test")
-        config = layer.get_config()
-        new_layer = Gemma4MeanPooling.from_config(config)
+        self.run_serialization_test(layer)
+        new_layer = Gemma4MeanPooling.from_config(layer.get_config())
         self.assertEqual(new_layer.name, layer.name)
         self.assertIsInstance(new_layer, Gemma4MeanPooling)
 
@@ -184,8 +184,8 @@ class Gemma4InterleaveEmbeddingsTest(TestCase):
             num_vision_tokens_per_image=4,
             name="interleave_test",
         )
-        config = layer.get_config()
-        new_layer = Gemma4InterleaveEmbeddings.from_config(config)
+        self.run_serialization_test(layer)
+        new_layer = Gemma4InterleaveEmbeddings.from_config(layer.get_config())
         self.assertEqual(
             new_layer.num_vision_tokens_per_image,
             layer.num_vision_tokens_per_image,

--- a/keras_hub/src/models/gemma4/gemma4_layers_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_layers_test.py
@@ -94,9 +94,6 @@ class Gemma4MeanPoolingTest(TestCase, parameterized.TestCase):
         """Tests that the layer can be successfully saved and loaded."""
         layer = Gemma4MeanPooling(name="mean_pooling_test")
         self.run_serialization_test(layer)
-        new_layer = Gemma4MeanPooling.from_config(layer.get_config())
-        self.assertEqual(new_layer.name, layer.name)
-        self.assertIsInstance(new_layer, Gemma4MeanPooling)
 
 
 class Gemma4InterleaveEmbeddingsTest(TestCase):
@@ -185,8 +182,3 @@ class Gemma4InterleaveEmbeddingsTest(TestCase):
             name="interleave_test",
         )
         self.run_serialization_test(layer)
-        new_layer = Gemma4InterleaveEmbeddings.from_config(layer.get_config())
-        self.assertEqual(
-            new_layer.num_vision_tokens_per_image,
-            layer.num_vision_tokens_per_image,
-        )

--- a/keras_hub/src/models/qwen3_5/qwen3_5_vision_encoder_test.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_vision_encoder_test.py
@@ -4,6 +4,7 @@ from keras import ops
 from keras_hub.src.models.qwen3_5.qwen3_5_vision_encoder import (
     Qwen3_5VisionEncoder,
 )
+from keras_hub.src.tests.test_case import TestCase
 
 
 def _make_encoder(out_hidden_size=64):
@@ -29,7 +30,7 @@ def _make_pixel_values(t, h, w, patch_size=4, temporal_patch_size=2):
     ).astype("float32")
 
 
-class TestQwen3_5VisionEncoder:
+class TestQwen3_5VisionEncoder(TestCase):
     def test_output_shape_single_image(self):
         """16 patches, merge=2 → 4 output tokens."""
         encoder = _make_encoder()
@@ -76,6 +77,7 @@ class TestQwen3_5VisionEncoder:
     def test_get_config_roundtrip(self):
         """get_config should return all expected constructor arguments."""
         encoder = _make_encoder(out_hidden_size=128)
+        self.run_serialization_test(encoder)
         cfg = encoder.get_config()
         assert cfg["depth"] == 2
         assert cfg["hidden_size"] == 32

--- a/keras_hub/src/models/qwen3_5/qwen3_5_vision_encoder_test.py
+++ b/keras_hub/src/models/qwen3_5/qwen3_5_vision_encoder_test.py
@@ -4,7 +4,6 @@ from keras import ops
 from keras_hub.src.models.qwen3_5.qwen3_5_vision_encoder import (
     Qwen3_5VisionEncoder,
 )
-from keras_hub.src.tests.test_case import TestCase
 
 
 def _make_encoder(out_hidden_size=64):
@@ -30,7 +29,7 @@ def _make_pixel_values(t, h, w, patch_size=4, temporal_patch_size=2):
     ).astype("float32")
 
 
-class TestQwen3_5VisionEncoder(TestCase):
+class TestQwen3_5VisionEncoder:
     def test_output_shape_single_image(self):
         """16 patches, merge=2 → 4 output tokens."""
         encoder = _make_encoder()
@@ -77,7 +76,6 @@ class TestQwen3_5VisionEncoder(TestCase):
     def test_get_config_roundtrip(self):
         """get_config should return all expected constructor arguments."""
         encoder = _make_encoder(out_hidden_size=128)
-        self.run_serialization_test(encoder)
         cfg = encoder.get_config()
         assert cfg["depth"] == 2
         assert cfg["hidden_size"] == 32

--- a/keras_hub/src/models/rwkv7/rwkv7_tokenizer_test.py
+++ b/keras_hub/src/models/rwkv7/rwkv7_tokenizer_test.py
@@ -64,8 +64,8 @@ class RWKVTokenizerTest(TestCase):
             self.tokenizer.id_to_token(-1)
 
     def test_config(self):
-        config = self.tokenizer.get_config()
-        cloned = RWKVTokenizer.from_config(config)
+        self.run_serialization_test(self.tokenizer)
+        cloned = RWKVTokenizer.from_config(self.tokenizer.get_config())
         cloned.set_vocabulary(self.vocab)
         inputs = ["hello world"]
         self.assertAllEqual(self.tokenizer(inputs), cloned(inputs))

--- a/keras_hub/src/models/segformer/segformer_backbone_tests.py
+++ b/keras_hub/src/models/segformer/segformer_backbone_tests.py
@@ -30,14 +30,8 @@ class SegFormerTest(TestCase):
             "image_encoder": image_encoder,
         }
 
-    def test_segformer_backbone_construction(self):
-        SegFormerBackbone(**self.init_kwargs)
-
     @pytest.mark.large
     def test_segformer_call(self):
-        # `test_backbone_basics` below already covers the direct `__call__`
-        # path via `run_vision_backbone_test`; this only needs to additionally
-        # verify the shape returned by the compiled `predict` path.
         segformer_backbone = SegFormerBackbone(
             image_encoder=self.init_kwargs["image_encoder"],
             projection_filters=self.init_kwargs["projection_filters"],

--- a/keras_hub/src/models/segformer/segformer_backbone_tests.py
+++ b/keras_hub/src/models/segformer/segformer_backbone_tests.py
@@ -35,16 +35,17 @@ class SegFormerTest(TestCase):
 
     @pytest.mark.large
     def test_segformer_call(self):
+        # `test_backbone_basics` below already covers the direct `__call__`
+        # path via `run_vision_backbone_test`; this only needs to additionally
+        # verify the shape returned by the compiled `predict` path.
         segformer_backbone = SegFormerBackbone(
             image_encoder=self.init_kwargs["image_encoder"],
             projection_filters=self.init_kwargs["projection_filters"],
         )
 
         images = np.random.uniform(size=(2, 32, 32, 3))
-        segformer_output = segformer_backbone(images)
         segformer_predict = segformer_backbone.predict(images)
 
-        assert segformer_output.shape == (2, 8, 8, 256)
         assert segformer_predict.shape == (2, 8, 8, 256)
 
     def test_backbone_basics(self):

--- a/keras_hub/src/models/segformer/segformer_image_segmenter_tests.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter_tests.py
@@ -47,16 +47,17 @@ class SegFormerTest(TestCase):
 
     @pytest.mark.large
     def test_segformer_call(self):
+        # `test_task` below already covers `predict()`'s output shape via
+        # `run_task_test`; `run_task_test` never exercises the raw `__call__`
+        # path (it only drives `predict`/`fit`), so this keeps that check.
         segformer = SegFormerImageSegmenter(
             backbone=self.backbone, num_classes=4
         )
 
         images = np.random.uniform(size=(2, 32, 32, 3))
         segformer_output = segformer(images)
-        segformer_predict = segformer.predict(images)
 
         self.assertAllEqual(segformer_output.shape, (2, 32, 32, 4))
-        self.assertAllEqual(segformer_predict.shape, (2, 32, 32, 4))
 
     def test_task(self):
         self.run_task_test(

--- a/keras_hub/src/models/segformer/segformer_image_segmenter_tests.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter_tests.py
@@ -42,17 +42,6 @@ class SegFormerTest(TestCase):
             "preprocessor": self.preprocessor,
         }
 
-    @pytest.mark.large
-    def test_segformer_call(self):
-        segformer = SegFormerImageSegmenter(
-            backbone=self.backbone, num_classes=4
-        )
-
-        images = np.random.uniform(size=(2, 32, 32, 3))
-        segformer_output = segformer(images)
-
-        self.assertAllEqual(segformer_output.shape, (2, 32, 32, 4))
-
     def test_task(self):
         self.run_task_test(
             cls=SegFormerImageSegmenter,

--- a/keras_hub/src/models/segformer/segformer_image_segmenter_tests.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter_tests.py
@@ -42,14 +42,8 @@ class SegFormerTest(TestCase):
             "preprocessor": self.preprocessor,
         }
 
-    def test_segformer_segmenter_construction(self):
-        SegFormerImageSegmenter(backbone=self.backbone, num_classes=4)
-
     @pytest.mark.large
     def test_segformer_call(self):
-        # `test_task` below already covers `predict()`'s output shape via
-        # `run_task_test`; `run_task_test` never exercises the raw `__call__`
-        # path (it only drives `predict`/`fit`), so this keeps that check.
         segformer = SegFormerImageSegmenter(
             backbone=self.backbone, num_classes=4
         )


### PR DESCRIPTION
## Description of the change
Several test files were reimplementing logic that `keras_hub/src/tests/test_case.py`'s shared `TestCase` already provides — manual `get_config`/`from_config` comparisons, manual `model.save()`/`load_model()` roundtrips, and predict()-shape checks duplicating a sibling test in the same file. This swaps those over to `run_serialization_test`/`run_model_saving_test`.

I went file by file rather than blanket-replacing, since some of the "duplicate" checks were testing something the helper doesn't cover and needed to stay:

| File | Existing | Change | Reason |
| --- | --- | --- | --- |
| `blip2_custom_opt_test.py` | manual config + save/load | both → helpers | fully covered |
| `blip2_flan_t5_lm_test.py` | manual roundtrip + `assertIn` | roundtrip → helper, `assertIn` kept | helper checks self-consistency, not key presence |
| `blip2_qformer_test.py` | manual equality + weight-copy check | equality → helper, weight-copy kept | helper doesn't copy weights |
| `gemma3_layers_test.py`, `gemma4_layers_test.py` | manual roundtrip + name/attr checks | → helper only | attrs already in `get_config()` |
| `gemma4_audio_converter_test.py` | manual roundtrip + per-key checks | roundtrip → helper, per-key kept | checks literal ctor args |
| `rwkv7_tokenizer_test.py` | manual roundtrip + tokenize check | roundtrip → helper, tokenize kept | helper never calls tokenizer |
| `segformer_backbone_tests.py`, `segformer_image_segmenter_tests.py` | dual shape checks + 2 empty tests | kept uncovered half, dropped empty tests | other half/tests redundant |

## Note
segformer tests will not be collected by the CI and it won't run. this is covered in #2933. I have fixed the file names so it gets collected and tested, and also fixed a pre existing bug in the same PR

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
