### PR TITLE
Fix Perplexity metric accumulation across batches

### DIFF
--- a/keras_hub/src/metrics/perplexity.py
+++ b/keras_hub/src/metrics/perplexity.py
@@ -112,8 +112,6 @@ class Perplexity(keras.metrics.Metric):
         if sample_weight is not None:
             sample_weight = ops.cast(sample_weight, self.dtype)
 
-        batch_size = ops.cast(ops.shape(y_true)[0], self.dtype)
-
         if self.mask_token_id is not None:
             mask = ops.cast(
                 ops.logical_not(ops.equal(y_true, self.mask_token_id)),
@@ -124,25 +122,20 @@ class Perplexity(keras.metrics.Metric):
             else:
                 sample_weight = ops.multiply(mask, sample_weight)
 
-        # Calculate the Cross Entropy Loss.
-        crossentropy_value = ops.cast(
+        # Calculate the Cross Entropy Loss sum.
+        crossentropy_sum = ops.cast(
             self._crossentropy(y_true, y_pred, sample_weight=sample_weight),
             self.dtype,
         )  # scalar
 
-        # Divide the loss by the number of non-masked tokens
+        # Total number of non-masked tokens
         if sample_weight is not None:
-            crossentropy_value = crossentropy_value / ops.sum(
-                sample_weight
-            )  # scalar
+            num_tokens = ops.sum(sample_weight)
         else:
-            crossentropy_value = crossentropy_value / (
-                ops.cast(ops.shape(y_true)[0], self.dtype)
-                * ops.cast(ops.shape(y_true)[1], self.dtype)
-            )  # scalar
+            num_tokens = ops.cast(ops.size(y_true), self.dtype)
 
-        self._aggregate_crossentropy.assign_add(batch_size * crossentropy_value)
-        self._number_of_samples.assign_add(batch_size)
+        self._aggregate_crossentropy.assign_add(crossentropy_sum)
+        self._number_of_samples.assign_add(num_tokens)
 
     def result(self):
         perplexity_score = ops.where(

--- a/keras_hub/src/metrics/perplexity_test.py
+++ b/keras_hub/src/metrics/perplexity_test.py
@@ -1,3 +1,4 @@
+import keras
 from keras import ops
 
 from keras_hub.src.metrics.perplexity import Perplexity
@@ -253,6 +254,43 @@ class PerplexityTest(TestCase):
         perplexity.update_state(y_true_2, y_pred_2)
         perplexity_val = perplexity.result()
         self.assertAlmostEqual(perplexity_val, 3.8563, delta=1e-3)
+
+    def test_unequal_batch_sizes(self):
+        perplexity = Perplexity(from_logits=True, mask_token_id=0)
+
+        # Batch 1: size 2, 4 active tokens
+        y_true_1 = ops.array([[1, 2, 0], [2, 1, 0]])
+        y_pred_1 = ops.ones((2, 3, 4))
+        perplexity.update_state(y_true_1, y_pred_1)
+
+        # Batch 2: size 1, 1 active token
+        y_true_2 = ops.array([[1, 0, 0]])
+        y_pred_2 = ops.ones((1, 3, 4))
+        perplexity.update_state(y_true_2, y_pred_2)
+
+        # Total loss sum: 5 tokens * log(4) = 6.93147
+        # Total tokens: 5
+        # Expected: exp(log(4)) = 4.0
+        self.assertAlmostEqual(perplexity.result(), 4.0, delta=1e-3)
+
+    def test_multi_batch_fractional_weights(self):
+        perplexity = Perplexity(from_logits=True)
+
+        y_true = ops.array([[1, 2]])
+        y_pred = ops.ones((1, 2, 4))
+
+        # Batch 1: weight sum = 1.0
+        sw_1 = ops.array([[0.5, 0.5]])
+        perplexity.update_state(y_true, y_pred, sw_1)
+
+        # Batch 2: weight sum = 1.0
+        sw_2 = ops.array([[0.2, 0.8]])
+        perplexity.update_state(y_true, y_pred, sw_2)
+
+        # Total weighted loss sum: 2.0 * log(4)
+        # Total weights: 2.0
+        # Expected: exp(log(4)) = 4.0
+        self.assertAlmostEqual(perplexity.result(), 4.0, delta=1e-3)
 
     def test_get_config(self):
         perplexity = Perplexity(

--- a/keras_hub/src/metrics/perplexity_test.py
+++ b/keras_hub/src/metrics/perplexity_test.py
@@ -136,7 +136,7 @@ class PerplexityTest(TestCase):
             ]
         )
         perplexity_val = perplexity(y_true_2, y_pred_2)
-        self.assertAlmostEqual(perplexity_val, 3.9998, delta=1e-3)
+        self.assertAlmostEqual(perplexity_val, 3.8563, delta=1e-3)
 
     def test_from_probs_with_sample_weight(self):
         perplexity = Perplexity(from_logits=False)
@@ -252,7 +252,7 @@ class PerplexityTest(TestCase):
 
         perplexity.update_state(y_true_2, y_pred_2)
         perplexity_val = perplexity.result()
-        self.assertAlmostEqual(perplexity_val, 3.9998, delta=1e-3)
+        self.assertAlmostEqual(perplexity_val, 3.8563, delta=1e-3)
 
     def test_get_config(self):
         perplexity = Perplexity(

--- a/keras_hub/src/metrics/perplexity_test.py
+++ b/keras_hub/src/metrics/perplexity_test.py
@@ -1,4 +1,3 @@
-import keras
 from keras import ops
 
 from keras_hub.src.metrics.perplexity import Perplexity
@@ -258,9 +257,9 @@ class PerplexityTest(TestCase):
     def test_unequal_batch_sizes(self):
         perplexity = Perplexity(from_logits=True, mask_token_id=0)
 
-        # Batch 1: size 2, 4 active tokens
-        y_true_1 = ops.array([[1, 2, 0], [2, 1, 0]])
-        y_pred_1 = ops.ones((2, 3, 4))
+        # Batch 1: size 3, 6 active tokens
+        y_true_1 = ops.array([[1, 2, 0], [2, 1, 0], [1, 1, 0]])
+        y_pred_1 = ops.ones((3, 3, 4))
         perplexity.update_state(y_true_1, y_pred_1)
 
         # Batch 2: size 1, 1 active token
@@ -268,29 +267,44 @@ class PerplexityTest(TestCase):
         y_pred_2 = ops.ones((1, 3, 4))
         perplexity.update_state(y_true_2, y_pred_2)
 
-        # Total loss sum: 5 tokens * log(4) = 6.93147
-        # Total tokens: 5
+        # Total loss sum: 7 tokens * log(4)
+        # Total tokens: 7
         # Expected: exp(log(4)) = 4.0
         self.assertAlmostEqual(perplexity.result(), 4.0, delta=1e-3)
 
     def test_multi_batch_fractional_weights(self):
-        perplexity = Perplexity(from_logits=True)
+        perplexity = Perplexity(from_logits=True, mask_token_id=0)
 
-        y_true = ops.array([[1, 2]])
-        y_pred = ops.ones((1, 2, 4))
+        y_pred_1 = ops.array(
+            [
+                [
+                    [1.034, 4.797, 2.82, 1.154],
+                    [2.258, 1.591, 1.811, 1.852],
+                    [3.216, 1.037, 0.3662, 2.7],
+                ]
+            ]
+        )
+        y_true_1 = ops.array([[1, 3, 0]])
+        sw_1 = ops.array([[0.5, 0.1, 0.9]])
 
-        # Batch 1: weight sum = 1.0
-        sw_1 = ops.array([[0.5, 0.5]])
-        perplexity.update_state(y_true, y_pred, sw_1)
+        y_pred_2 = ops.array(
+            [
+                [
+                    [1.363, 1.726, 1.898, 2.582],
+                    [1.163, 1.943, 1.761, 1.497],
+                    [2.766, 1.453, 2.61, 2.805],
+                ]
+            ]
+        )
+        y_true_2 = ops.array([[2, 1, 3]])
+        sw_2 = ops.array([[1, 0.7, 0.5]])
 
-        # Batch 2: weight sum = 1.0
-        sw_2 = ops.array([[0.2, 0.8]])
-        perplexity.update_state(y_true, y_pred, sw_2)
+        # Split update_state calls
+        perplexity.update_state(y_true_1, y_pred_1, sw_1)
+        perplexity.update_state(y_true_2, y_pred_2, sw_2)
 
-        # Total weighted loss sum: 2.0 * log(4)
-        # Total weights: 2.0
-        # Expected: exp(log(4)) = 4.0
-        self.assertAlmostEqual(perplexity.result(), 4.0, delta=1e-3)
+        # Result should match the single-batch calculation (2.9442)
+        self.assertAlmostEqual(perplexity.result(), 2.9442, delta=1e-3)
 
     def test_get_config(self):
         perplexity = Perplexity(


### PR DESCRIPTION
## Description of the change
The Perplexity metric was incorrectly accumulating results by averaging the per-batch perplexity scores. This led to mathematically incorrect results when batches contained a different number of active (non-masked) tokens.

The Root Cause
  Mathematically, the perplexity of a dataset should be calculated as the exponent of the average cross-entropy loss over all tokens in that dataset:
  $$Perplexity = \exp\left( \frac{\sum \text{Loss}_i}{\sum \text{Tokens}_i} \right)$$


  However, the previous implementation followed this logic in update_state:
   1. Calculated the total loss for the current batch.
   2. Divided that loss by the number of active tokens in the current batch to get a batch-average loss.
   3. Multiplied that average by the batch_size (number of sequences) and added it to an aggregate weight.
   4. Incremented a counter by the batch_size.


  Why it was Incorrect
  This approach resulted in an unweighted average of averages. It failed in two scenarios:
   1. Variable Padding: If Batch A had 100 active tokens and Batch B had only 10 active tokens, their batch-average losses were treated with equal weight in the final calculation, even though Batch A should have 10x more influence on the final result.
   2. Sequence Count vs. Token Count: It used batch_size (number of sequences) as the accumulation weight rather than the actual number of tokens processed.


  Example of the Failure
  In the reproduction case:
   - Batch 1: 5 active tokens, sum loss = 5.287 $\rightarrow$ avg loss = 1.057
   - Batch 2: 4 active tokens, sum loss = 6.860 $\rightarrow$ avg loss = 1.715


  Incorrect Logic (Previous): averaged the batch losses $(1.057 + 1.715) / 2 = 1.386 \rightarrow \exp(1.386) \approx \mathbf{3.999}$
  Correct Logic (Fixed): sum of losses / sum of tokens $(5.287 + 6.860) / (5 + 4) = 1.349 \rightarrow \exp(1.349) \approx \mathbf{3.856}$

Changes:
   - Updated Perplexity.update_state to accumulate the total cross-entropy loss sum and the total count of non-masked tokens across all batches.
   - Modified Perplexity.result to calculate perplexity as exp(total_loss / total_tokens).
   - Updated PerplexityTest to verify the correct weighted accumulation behavior.

This ensures the metric provides a mathematically accurate perplexity score over the entire dataset, regardless of batch size or masking distribution.

## Colab Notebook
https://colab.research.google.com/drive/1lkcDlfJLpjRgb39I-MYeG1crUoOiG7pI?resourcekey=0-tR3iPLbMVXyZhnBgm_pVqA&usp=sharing

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
