### PR TITLE
Add missing RoBERTa converter

### DIFF
--- a/keras_hub/src/utils/transformers/convert_roberta.py
+++ b/keras_hub/src/utils/transformers/convert_roberta.py
@@ -1,0 +1,142 @@
+import numpy as np
+
+from keras_hub.src.models.roberta.roberta_backbone import RobertaBackbone
+from keras_hub.src.utils.preset_utils import get_file
+
+backbone_cls = RobertaBackbone
+
+# RoBERTa reserves the first `padding_idx + 1` position embedding rows
+# (padding_idx=1 for RoBERTa) and starts real positions at index 2.
+_POSITION_OFFSET = 2
+
+
+def convert_backbone_config(transformers_config):
+    return {
+        "vocabulary_size": transformers_config["vocab_size"],
+        "num_layers": transformers_config["num_hidden_layers"],
+        "num_heads": transformers_config["num_attention_heads"],
+        "hidden_dim": transformers_config["hidden_size"],
+        "intermediate_dim": transformers_config["intermediate_size"],
+        "dropout": transformers_config["hidden_dropout_prob"],
+        "max_sequence_length": transformers_config["max_position_embeddings"]
+        - _POSITION_OFFSET,
+    }
+
+
+def transpose_and_reshape(x, shape):
+    return np.reshape(np.transpose(x), shape)
+
+
+def convert_weights(backbone, loader, transformers_config):
+    # Embeddings
+    loader.port_weight(
+        keras_variable=backbone.token_embedding.embeddings,
+        hf_weight_key="roberta.embeddings.word_embeddings.weight",
+    )
+    loader.port_weight(
+        keras_variable=backbone.embeddings.position_embedding.position_embeddings,
+        hf_weight_key="roberta.embeddings.position_embeddings.weight",
+        hook_fn=lambda x, _: x[_POSITION_OFFSET:, :],
+    )
+    loader.port_weight(
+        keras_variable=backbone.embeddings_layer_norm.gamma,
+        hf_weight_key="roberta.embeddings.LayerNorm.weight",
+    )
+    loader.port_weight(
+        keras_variable=backbone.embeddings_layer_norm.beta,
+        hf_weight_key="roberta.embeddings.LayerNorm.bias",
+    )
+
+    # Attention blocks
+    for index in range(backbone.num_layers):
+        encoder_layer = backbone.transformer_layers[index]
+        hf_prefix = f"roberta.encoder.layer.{index}"
+
+        # Attention layers
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.query_dense.kernel,
+            hf_weight_key=f"{hf_prefix}.attention.self.query.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.query_dense.bias,
+            hf_weight_key=f"{hf_prefix}.attention.self.query.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.key_dense.kernel,
+            hf_weight_key=f"{hf_prefix}.attention.self.key.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.key_dense.bias,
+            hf_weight_key=f"{hf_prefix}.attention.self.key.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.value_dense.kernel,
+            hf_weight_key=f"{hf_prefix}.attention.self.value.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.value_dense.bias,
+            hf_weight_key=f"{hf_prefix}.attention.self.value.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.output_dense.kernel,
+            hf_weight_key=f"{hf_prefix}.attention.output.dense.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer.output_dense.bias,
+            hf_weight_key=f"{hf_prefix}.attention.output.dense.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        # Attention layer norm.
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer_norm.gamma,
+            hf_weight_key=f"{hf_prefix}.attention.output.LayerNorm.weight",
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._self_attention_layer_norm.beta,
+            hf_weight_key=f"{hf_prefix}.attention.output.LayerNorm.bias",
+        )
+        # MLP layers
+        loader.port_weight(
+            keras_variable=encoder_layer._feedforward_intermediate_dense.kernel,
+            hf_weight_key=f"{hf_prefix}.intermediate.dense.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._feedforward_intermediate_dense.bias,
+            hf_weight_key=f"{hf_prefix}.intermediate.dense.bias",
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._feedforward_output_dense.kernel,
+            hf_weight_key=f"{hf_prefix}.output.dense.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._feedforward_output_dense.bias,
+            hf_weight_key=f"{hf_prefix}.output.dense.bias",
+        )
+        # Output layer norm.
+        loader.port_weight(
+            keras_variable=encoder_layer._feedforward_layer_norm.gamma,
+            hf_weight_key=f"{hf_prefix}.output.LayerNorm.weight",
+        )
+        loader.port_weight(
+            keras_variable=encoder_layer._feedforward_layer_norm.beta,
+            hf_weight_key=f"{hf_prefix}.output.LayerNorm.bias",
+        )
+
+
+def convert_tokenizer(cls, preset, **kwargs):
+    vocab_file = get_file(preset, "vocab.json")
+    merges_file = get_file(preset, "merges.txt")
+    return cls(
+        vocabulary=vocab_file,
+        merges=merges_file,
+        **kwargs,
+    )

--- a/keras_hub/src/utils/transformers/convert_roberta_test.py
+++ b/keras_hub/src/utils/transformers/convert_roberta_test.py
@@ -1,0 +1,33 @@
+import pytest
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.roberta.roberta_backbone import RobertaBackbone
+from keras_hub.src.models.roberta.roberta_text_classifier import (
+    RobertaTextClassifier,
+)
+from keras_hub.src.models.text_classifier import TextClassifier
+from keras_hub.src.tests.test_case import TestCase
+
+
+class TestRobertaConverter(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_tiny_preset(self):
+        model = RobertaTextClassifier.from_preset(
+            "hf://FacebookAI/roberta-base", num_classes=2
+        )
+        prompt = "That movies was terrible."
+        model.predict([prompt])
+
+    @pytest.mark.large
+    def test_class_detection(self):
+        model = TextClassifier.from_preset(
+            "hf://FacebookAI/roberta-base",
+            num_classes=2,
+            load_weights=False,
+        )
+        self.assertIsInstance(model, RobertaTextClassifier)
+        model = Backbone.from_preset(
+            "hf://FacebookAI/roberta-base",
+            load_weights=False,
+        )
+        self.assertIsInstance(model, RobertaBackbone)

--- a/keras_hub/src/utils/transformers/preset_loader.py
+++ b/keras_hub/src/utils/transformers/preset_loader.py
@@ -32,6 +32,7 @@ from keras_hub.src.utils.transformers import convert_qwen3_5
 from keras_hub.src.utils.transformers import convert_qwen3_5_moe
 from keras_hub.src.utils.transformers import convert_qwen3_moe
 from keras_hub.src.utils.transformers import convert_qwen_moe
+from keras_hub.src.utils.transformers import convert_roberta
 from keras_hub.src.utils.transformers import convert_sam3
 from keras_hub.src.utils.transformers import convert_smollm3
 from keras_hub.src.utils.transformers import convert_t5gemma
@@ -102,6 +103,8 @@ class TransformersPresetLoader(PresetLoader):
             self.converter = convert_qwen3_5_moe
         elif model_type == "qwen3_5":
             self.converter = convert_qwen3_5
+        elif model_type == "roberta":
+            self.converter = convert_roberta
         elif model_type == "sam3_video":
             self.converter = convert_sam3
         elif model_type == "xlm-roberta":

--- a/tools/checkpoint_conversion/convert_roberta_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_roberta_checkpoints.py
@@ -1,12 +1,5 @@
 """Convert RoBERTa checkpoints from Hugging Face to KerasHub format.
 
-RoBERTa's Hugging Face converter (`keras_hub/src/utils/transformers/
-convert_roberta.py`) is registered with the general `from_preset()` loading
-path, so this script does not port weights manually. It loads the backbone
-and tokenizer straight from the Hugging Face preset, checks numerical parity
-against the reference Hugging Face model, and saves the result as a
-KerasHub preset.
-
 Usage:
 ```shell
 cd tools/checkpoint_conversion
@@ -22,11 +15,8 @@ from absl import flags
 
 import keras_hub
 
-# Silence the transformers `from_pretrained` state-dict load report. Loading
-# a bare `RobertaModel` from a checkpoint saved for MLM pretraining always
-# reports the (expected, harmless) unused `lm_head.*` weights and the
-# freshly-initialized `pooler.*` weights, neither of which affects the
-# `last_hidden_state` output this script checks against.
+# Silence the harmless from_pretrained load report (unused lm_head /
+# freshly-initialized pooler weights — expected for a bare RobertaModel).
 transformers.logging.set_verbosity_error()
 
 PRESET_MAP = {
@@ -59,12 +49,8 @@ def check_output(
     )
     hf_output = hf_model(**hf_inputs).last_hidden_state.detach().numpy()
 
-    # Padding positions aren't comparable: HF reuses a single constant
-    # `padding_idx` position embedding for every pad token, while KerasHub's
-    # `PositionEmbedding` assigns sequential positions regardless of padding.
-    # That divergence is masked out of self-attention and any downstream
-    # pooling/loss on both sides, so it never affects real output — but it
-    # does swamp a whole-sequence diff. Restrict the check to real tokens.
+    # HF and KerasHub assign padding positions different (but functionally
+    # inert) position embeddings, so restrict the check to real tokens.
     padding_mask = keras_hub_inputs["padding_mask"].numpy()[0]
     num_real_tokens = int(padding_mask.sum())
     keras_hub_content = keras_hub_output[0, :num_real_tokens, :]
@@ -72,10 +58,11 @@ def check_output(
 
     print("KerasHub output:", keras_hub_content[0, :10])
     print("HF output:", hf_content[0, :10])
-    print("Max abs difference:", np.max(np.abs(keras_hub_content - hf_content)))
 
-    np.testing.assert_allclose(keras_hub_content, hf_content, atol=1e-4)
-    print("-> Numerical check passed (atol=1e-4).")
+    np.testing.assert_allclose(
+        keras_hub_content, hf_content, atol=1e-4, rtol=1e-4
+    )
+    print("-> Numerical check passed.")
 
 
 def main(_):
@@ -87,9 +74,6 @@ def main(_):
     hf_preset = PRESET_MAP[preset]
 
     print(f"\n-> Convert {hf_preset} to KerasHub format.")
-    # `RobertaBackbone`/`RobertaTokenizer.from_preset` dispatch through
-    # `convert_roberta.py`, which handles config translation and weight
-    # porting directly from the Hugging Face safetensors checkpoint.
     keras_hub_model = keras_hub.models.RobertaBackbone.from_preset(
         f"hf://{hf_preset}"
     )

--- a/tools/checkpoint_conversion/convert_roberta_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_roberta_checkpoints.py
@@ -1,284 +1,36 @@
-import os
-import shutil
+"""Convert RoBERTa checkpoints from Hugging Face to KerasHub format.
+
+RoBERTa's Hugging Face converter (`keras_hub/src/utils/transformers/
+convert_roberta.py`) is registered with the general `from_preset()` loading
+path, so this script does not port weights manually. It loads the backbone
+and tokenizer straight from the Hugging Face preset, checks numerical parity
+against the reference Hugging Face model, and saves the result as a
+KerasHub preset.
+
+Usage:
+```shell
+cd tools/checkpoint_conversion
+python convert_roberta_checkpoints.py --preset roberta_base_en
+```
+"""
 
 import numpy as np
 import tensorflow as tf
-import torch
 import transformers
 from absl import app
 from absl import flags
-from checkpoint_conversion_utils import extract_files_from_archive
-from checkpoint_conversion_utils import get_md5_checksum
-from tensorflow import keras
 
 import keras_hub
 
 PRESET_MAP = {
-    "roberta_base_en": ("roberta.base", "roberta-base"),
-    "roberta_large_en": ("roberta.large", "roberta-large"),
+    "roberta_base_en": "FacebookAI/roberta-base",
+    "roberta_large_en": "FacebookAI/roberta-large",
 }
-
-DOWNLOAD_SCRIPT_URL = "https://dl.fbaipublicfiles.com/fairseq/models/{}.tar.gz"
-
-EXTRACT_DIR = "./{}"
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string(
     "preset", None, f"Must be one of {','.join(PRESET_MAP.keys())}"
 )
-
-
-def download_model(size, hf_model_name):
-    print("-> Download original weights.")
-    extract_dir = EXTRACT_DIR.format(size)
-    archive_file_path = keras.utils.get_file(
-        fname=None,
-        origin=DOWNLOAD_SCRIPT_URL.format(size),
-        cache_subdir=os.path.join("checkpoint_conversion", FLAGS.preset),
-    )
-
-    extract_files_from_archive(archive_file_path)
-
-    # The original `tar.gz` file does not have the vocab files. Let's fetch
-    # them from HF.
-    vocabulary_path = keras.utils.get_file(
-        fname=None,
-        origin=f"https://huggingface.co/{hf_model_name}/raw/main/vocab.json",
-    )
-    shutil.copy(vocabulary_path, extract_dir)
-    merges_path = keras.utils.get_file(
-        fname=None,
-        origin=f"https://huggingface.co/{hf_model_name}/raw/main/merges.txt",
-    )
-    shutil.copy(merges_path, extract_dir)
-
-
-def convert_checkpoints(size):
-    print("\n-> Convert original weights to KerasHub format.")
-    # RoBERTa paths.
-    extract_dir = EXTRACT_DIR.format(size)
-    checkpoint_path = os.path.join(extract_dir, "model.pt")
-
-    # Load PyTorch RoBERTa checkpoint.
-    pt_ckpt = torch.load(
-        checkpoint_path, map_location=torch.device("cpu"), weights_only=True
-    )
-    pt_cfg = pt_ckpt["args"]
-    pt_model = pt_ckpt["model"]
-
-    cfg = {
-        "num_layers": pt_cfg.encoder_layers,
-        "num_heads": pt_cfg.encoder_attention_heads,
-        "hidden_dim": pt_cfg.encoder_embed_dim,
-        "intermediate_dim": pt_cfg.encoder_ffn_embed_dim,
-        "dropout": pt_cfg.dropout,
-        "max_sequence_length": pt_cfg.max_positions,
-        "vocab_size": (
-            pt_model["decoder.sentence_encoder.embed_tokens.weight"]
-            .numpy()
-            .shape[0]
-        ),
-    }
-    print("Config:", cfg)
-
-    keras_hub_model = keras_hub.models.RobertaBackbone.from_preset(
-        FLAGS.preset, load_weights=False
-    )
-
-    # Embedding Layer.
-    keras_hub_model.get_layer("embeddings").token_embedding.embeddings.assign(
-        pt_model["decoder.sentence_encoder.embed_tokens.weight"].numpy()
-    )
-    keras_hub_model.get_layer(
-        "embeddings"
-    ).position_embedding.position_embeddings.assign(
-        pt_model["decoder.sentence_encoder.embed_positions.weight"].numpy()[
-            2:, :
-        ]
-    )
-
-    # Embedding LayerNorm.
-    keras_hub_model.get_layer("embeddings_layer_norm").gamma.assign(
-        pt_model["decoder.sentence_encoder.emb_layer_norm.weight"].numpy()
-    )
-    keras_hub_model.get_layer("embeddings_layer_norm").beta.assign(
-        pt_model["decoder.sentence_encoder.emb_layer_norm.bias"].numpy()
-    )
-
-    # The QKV weights in the original checkpoint are present as one single
-    # dense layer of shape `(3 * cfg["hidden_dim"], cfg["hidden_dim"])`. Our
-    # model has three separate dense layers for each of QKV. Hence, we need to
-    # split the original QKV weights into three chunks.
-    range_1 = (0, cfg["hidden_dim"])
-    range_2 = (cfg["hidden_dim"], 2 * cfg["hidden_dim"])
-    range_3 = (2 * cfg["hidden_dim"], 3 * cfg["hidden_dim"])
-    # Transformer layers.
-    for i in range(keras_hub_model.num_layers):
-        q_k_v_wts = (
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.self_attn.in_proj_weight"
-            ]
-            .numpy()
-            .T
-        )
-        q_k_v_bias = (
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.self_attn.in_proj_bias"
-            ]
-            .numpy()
-            .T
-        )
-
-        # Query
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._query_dense.kernel.assign(
-            q_k_v_wts[:, range_1[0] : range_1[1]].reshape(
-                (cfg["hidden_dim"], cfg["num_heads"], -1)
-            )
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._query_dense.bias.assign(
-            q_k_v_bias[range_1[0] : range_1[1]].reshape((cfg["num_heads"], -1))
-        )
-
-        # Key
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._key_dense.kernel.assign(
-            q_k_v_wts[:, range_2[0] : range_2[1]].reshape(
-                (cfg["hidden_dim"], cfg["num_heads"], -1)
-            )
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._key_dense.bias.assign(
-            q_k_v_bias[range_2[0] : range_2[1]].reshape((cfg["num_heads"], -1))
-        )
-
-        # Value
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._value_dense.kernel.assign(
-            q_k_v_wts[:, range_3[0] : range_3[1]].reshape(
-                (cfg["hidden_dim"], cfg["num_heads"], -1)
-            )
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._value_dense.bias.assign(
-            q_k_v_bias[range_3[0] : range_3[1]].reshape((cfg["num_heads"], -1))
-        )
-
-        # Attention output
-        attn_output_wts = (
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.self_attn.out_proj.weight"
-            ]
-            .numpy()
-            .T
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._output_dense.kernel.assign(
-            attn_output_wts.reshape((cfg["num_heads"], -1, cfg["hidden_dim"]))
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer._output_dense.bias.assign(
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.self_attn.out_proj.bias"
-            ].numpy()
-        )
-
-        # Attention LayerNorm
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer_norm.gamma.assign(
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.self_attn_layer_norm.weight"
-            ].numpy()
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._self_attention_layer_norm.beta.assign(
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.self_attn_layer_norm.bias"
-            ].numpy()
-        )
-
-        # Intermediate FF layer
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._feedforward_intermediate_dense.kernel.assign(
-            pt_model[f"decoder.sentence_encoder.layers.{i}.fc1.weight"]
-            .numpy()
-            .T
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._feedforward_intermediate_dense.bias.assign(
-            pt_model[f"decoder.sentence_encoder.layers.{i}.fc1.bias"].numpy()
-        )
-
-        # Output dense layer
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._feedforward_output_dense.kernel.assign(
-            pt_model[f"decoder.sentence_encoder.layers.{i}.fc2.weight"]
-            .numpy()
-            .T
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._feedforward_output_dense.bias.assign(
-            pt_model[f"decoder.sentence_encoder.layers.{i}.fc2.bias"].numpy()
-        )
-
-        # FF LayerNorm
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._feedforward_layer_norm.gamma.assign(
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.final_layer_norm.weight"
-            ].numpy()
-        )
-        keras_hub_model.get_layer(
-            f"transformer_layer_{i}"
-        )._feedforward_layer_norm.beta.assign(
-            pt_model[
-                f"decoder.sentence_encoder.layers.{i}.final_layer_norm.bias"
-            ].numpy()
-        )
-
-    # Save the model.
-    print(f"\n-> Save KerasHub model weights to `{FLAGS.preset}.h5`.")
-    keras_hub_model.save_weights(f"{FLAGS.preset}.h5")
-
-    return keras_hub_model
-
-
-def define_preprocessor(hf_model_name, size):
-    print("\n-> Define the tokenizers.")
-    extract_dir = EXTRACT_DIR.format(size)
-    vocabulary_path = os.path.join(extract_dir, "vocab.json")
-    merges_path = os.path.join(extract_dir, "merges.txt")
-
-    keras_hub_tokenizer = keras_hub.models.RobertaTokenizer(
-        vocabulary=vocabulary_path, merges=merges_path
-    )
-    keras_hub_preprocessor = keras_hub.models.RobertaTextClassifierPreprocessor(
-        keras_hub_tokenizer
-    )
-
-    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(hf_model_name)
-
-    print("\n-> Print MD5 checksum of the vocab files.")
-    print(f"`{vocabulary_path}` md5sum: ", get_md5_checksum(vocabulary_path))
-    print(f"`{merges_path}` md5sum: ", get_md5_checksum(merges_path))
-
-    return keras_hub_preprocessor, hf_tokenizer
 
 
 def check_output(
@@ -304,31 +56,33 @@ def check_output(
     print("HF output:", hf_output[0, 0, :10])
     print("Difference:", np.mean(keras_hub_output - hf_output.detach().numpy()))
 
-    # Show the MD5 checksum of the model weights.
-    print("Model md5sum: ", get_md5_checksum(f"./{FLAGS.preset}.h5"))
-
-    return keras_hub_output
-
 
 def main(_):
     assert FLAGS.preset in PRESET_MAP.keys(), (
         f"Invalid preset {FLAGS.preset}. "
         f"Must be one of {','.join(PRESET_MAP.keys())}"
     )
-    size = PRESET_MAP[FLAGS.preset][0]
-    hf_model_name = PRESET_MAP[FLAGS.preset][1]
+    preset = FLAGS.preset
+    hf_preset = PRESET_MAP[preset]
 
-    download_model(size, hf_model_name)
-
-    keras_hub_model = convert_checkpoints(size)
+    print(f"\n-> Convert {hf_preset} to KerasHub format.")
+    # `RobertaBackbone`/`RobertaTokenizer.from_preset` dispatch through
+    # `convert_roberta.py`, which handles config translation and weight
+    # porting directly from the Hugging Face safetensors checkpoint.
+    keras_hub_model = keras_hub.models.RobertaBackbone.from_preset(
+        f"hf://{hf_preset}"
+    )
+    keras_hub_tokenizer = keras_hub.models.RobertaTokenizer.from_preset(
+        f"hf://{hf_preset}"
+    )
+    keras_hub_preprocessor = keras_hub.models.RobertaTextClassifierPreprocessor(
+        keras_hub_tokenizer
+    )
 
     print("\n-> Load HF model.")
-    hf_model = transformers.AutoModel.from_pretrained(hf_model_name)
+    hf_model = transformers.AutoModel.from_pretrained(hf_preset)
     hf_model.eval()
-
-    keras_hub_preprocessor, hf_tokenizer = define_preprocessor(
-        hf_model_name, size
-    )
+    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(hf_preset)
 
     check_output(
         keras_hub_model,
@@ -336,6 +90,10 @@ def main(_):
         hf_model,
         hf_tokenizer,
     )
+
+    print(f"\n-> Save KerasHub preset to `./{preset}`.")
+    keras_hub_model.save_to_preset(preset)
+    keras_hub_tokenizer.save_to_preset(preset)
 
 
 if __name__ == "__main__":

--- a/tools/checkpoint_conversion/convert_roberta_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_roberta_checkpoints.py
@@ -22,6 +22,13 @@ from absl import flags
 
 import keras_hub
 
+# Silence the transformers `from_pretrained` state-dict load report. Loading
+# a bare `RobertaModel` from a checkpoint saved for MLM pretraining always
+# reports the (expected, harmless) unused `lm_head.*` weights and the
+# freshly-initialized `pooler.*` weights, neither of which affects the
+# `last_hidden_state` output this script checks against.
+transformers.logging.set_verbosity_error()
+
 PRESET_MAP = {
     "roberta_base_en": "FacebookAI/roberta-base",
     "roberta_large_en": "FacebookAI/roberta-large",
@@ -50,11 +57,25 @@ def check_output(
     hf_inputs = hf_tokenizer(
         input_str, padding="max_length", return_tensors="pt"
     )
-    hf_output = hf_model(**hf_inputs).last_hidden_state
+    hf_output = hf_model(**hf_inputs).last_hidden_state.detach().numpy()
 
-    print("KerasHub output:", keras_hub_output[0, 0, :10])
-    print("HF output:", hf_output[0, 0, :10])
-    print("Difference:", np.mean(keras_hub_output - hf_output.detach().numpy()))
+    # Padding positions aren't comparable: HF reuses a single constant
+    # `padding_idx` position embedding for every pad token, while KerasHub's
+    # `PositionEmbedding` assigns sequential positions regardless of padding.
+    # That divergence is masked out of self-attention and any downstream
+    # pooling/loss on both sides, so it never affects real output — but it
+    # does swamp a whole-sequence diff. Restrict the check to real tokens.
+    padding_mask = keras_hub_inputs["padding_mask"].numpy()[0]
+    num_real_tokens = int(padding_mask.sum())
+    keras_hub_content = keras_hub_output[0, :num_real_tokens, :]
+    hf_content = hf_output[0, :num_real_tokens, :]
+
+    print("KerasHub output:", keras_hub_content[0, :10])
+    print("HF output:", hf_content[0, :10])
+    print("Max abs difference:", np.max(np.abs(keras_hub_content - hf_content)))
+
+    np.testing.assert_allclose(keras_hub_content, hf_content, atol=1e-4)
+    print("-> Numerical check passed (atol=1e-4).")
 
 
 def main(_):


### PR DESCRIPTION
## Description of the change

Split out of #2929 per review feedback, isolating the RoBERTa HF→KerasHub converter so it can be reviewed and numerically verified independently of the other converters in that PR.

- Adds `keras_hub/src/utils/transformers/convert_roberta.py` and wires `model_type == "roberta"` into `TransformersPresetLoader`.
- Adds `convert_roberta_test.py` (`test_convert_tiny_preset`,  `test_class_detection`).
- Additionally addresses the reviewer's follow-up: `tools/checkpoint_conversion/convert_roberta_checkpoints.py` previously hand-ported weights from the original *fairseq* RoBERTa checkpoint, layer by layer. Since `convert_roberta.py` now handles the Hugging Face weight mapping directly via `from_preset()`, that manual porting code is not needed, the script now loads straight from huggingface via `from_preset()`, matching the pattern in `convert_bert_sentence_transformer_checkpoints.py`.

## Verification

Ran the rewritten `convert_roberta_checkpoints.py --preset roberta_base_en` end-to-end against the live `FacebookAI/roberta-base` checkpoint and compared `last_hidden_state` against the reference HF model.
**Colab Reference:** [colab](https://gist.github.com/Ahmed0830/dcede0244002fd9674f5c9475aa4f8d4)

- Resulting preset directory loads correctly (config.json, model.weights.h5, tokenizer.json, assets/).
- `pytest --run_extra_large keras_hub/src/utils/transformers/convert_roberta_test.py` — 2 passed.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
