### PR TITLE
Add HGNetV2 timm checkpoint converter

### DIFF
--- a/keras_hub/src/utils/timm/convert_hgnetv2.py
+++ b/keras_hub/src/utils/timm/convert_hgnetv2.py
@@ -1,0 +1,278 @@
+import keras
+import numpy as np
+
+from keras_hub.src.models.hgnetv2.hgnetv2_backbone import HGNetV2Backbone
+from keras_hub.src.models.hgnetv2.hgnetv2_layers import HGNetV2ConvLayerLight
+
+backbone_cls = HGNetV2Backbone
+
+
+HGNETV2_CONFIGS = {
+    "hgnetv2_b0": {
+        "stem_channels": [3, 16, 16],
+        "stackwise_stage_filters": [
+            [16, 16, 64, 1, 3, 3],
+            [64, 32, 256, 1, 3, 3],
+            [256, 64, 512, 2, 3, 5],
+            [512, 128, 1024, 1, 3, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 16,
+        "hidden_sizes": [64, 256, 512, 1024],
+        "depths": [1, 1, 2, 1],
+    },
+    "hgnetv2_b1": {
+        "stem_channels": [3, 24, 32],
+        "stackwise_stage_filters": [
+            [32, 32, 64, 1, 3, 3],
+            [64, 48, 256, 1, 3, 3],
+            [256, 96, 512, 2, 3, 5],
+            [512, 192, 1024, 1, 3, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 32,
+        "hidden_sizes": [64, 256, 512, 1024],
+        "depths": [1, 1, 2, 1],
+    },
+    "hgnetv2_b2": {
+        "stem_channels": [3, 24, 32],
+        "stackwise_stage_filters": [
+            [32, 32, 96, 1, 4, 3],
+            [96, 64, 384, 1, 4, 3],
+            [384, 128, 768, 3, 4, 5],
+            [768, 256, 1536, 1, 4, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 32,
+        "hidden_sizes": [96, 384, 768, 1536],
+        "depths": [1, 1, 3, 1],
+    },
+    "hgnetv2_b3": {
+        "stem_channels": [3, 24, 32],
+        "stackwise_stage_filters": [
+            [32, 32, 128, 1, 5, 3],
+            [128, 64, 512, 1, 5, 3],
+            [512, 128, 1024, 3, 5, 5],
+            [1024, 256, 2048, 1, 5, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 32,
+        "hidden_sizes": [128, 512, 1024, 2048],
+        "depths": [1, 1, 3, 1],
+    },
+    "hgnetv2_b4": {
+        "stem_channels": [3, 32, 48],
+        "stackwise_stage_filters": [
+            [48, 48, 128, 1, 6, 3],
+            [128, 96, 512, 1, 6, 3],
+            [512, 192, 1024, 3, 6, 5],
+            [1024, 384, 2048, 1, 6, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 48,
+        "hidden_sizes": [128, 512, 1024, 2048],
+        "depths": [1, 1, 3, 1],
+    },
+    "hgnetv2_b5": {
+        "stem_channels": [3, 32, 64],
+        "stackwise_stage_filters": [
+            [64, 64, 128, 1, 6, 3],
+            [128, 128, 512, 2, 6, 3],
+            [512, 256, 1024, 5, 6, 5],
+            [1024, 512, 2048, 2, 6, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 64,
+        "hidden_sizes": [128, 512, 1024, 2048],
+        "depths": [1, 2, 5, 2],
+    },
+    "hgnetv2_b6": {
+        "stem_channels": [3, 48, 96],
+        "stackwise_stage_filters": [
+            [96, 96, 192, 2, 6, 3],
+            [192, 192, 512, 3, 6, 3],
+            [512, 384, 1024, 6, 6, 5],
+            [1024, 768, 2048, 3, 6, 5],
+        ],
+        "apply_downsample": [False, True, True, True],
+        "use_lightweight_conv_block": [False, False, True, True],
+        "embedding_size": 96,
+        "hidden_sizes": [192, 512, 1024, 2048],
+        "depths": [2, 3, 6, 3],
+    },
+}
+
+
+def _use_learnable_affine_block(timm_config):
+    # SSLD-distilled checkpoints drop the learnable affine block that the
+    # default (e.g. `ra_in1k`) checkpoints train with.
+    tag = (timm_config.get("pretrained_cfg") or {}).get("tag", "") or ""
+    return not tag.startswith("ssld")
+
+
+def convert_backbone_config(timm_config):
+    architecture = timm_config["architecture"]
+    config = HGNETV2_CONFIGS[architecture]
+    return {
+        "depths": config["depths"],
+        "embedding_size": config["embedding_size"],
+        "hidden_sizes": config["hidden_sizes"],
+        "stem_channels": config["stem_channels"],
+        "hidden_act": "relu",
+        "use_learnable_affine_block": _use_learnable_affine_block(timm_config),
+        "stackwise_stage_filters": config["stackwise_stage_filters"],
+        "apply_downsample": config["apply_downsample"],
+        "use_lightweight_conv_block": config["use_lightweight_conv_block"],
+    }
+
+
+def convert_weights(backbone, loader, timm_config):
+    def port_conv(keras_layer, hf_prefix):
+        loader.port_weight(
+            keras_layer.convolution.kernel,
+            hf_weight_key=f"{hf_prefix}.conv.weight",
+            hook_fn=lambda x, _: np.transpose(x, (2, 3, 1, 0)),
+        )
+        loader.port_weight(
+            keras_layer.normalization.gamma,
+            hf_weight_key=f"{hf_prefix}.bn.weight",
+        )
+        loader.port_weight(
+            keras_layer.normalization.beta,
+            hf_weight_key=f"{hf_prefix}.bn.bias",
+        )
+        loader.port_weight(
+            keras_layer.normalization.moving_mean,
+            hf_weight_key=f"{hf_prefix}.bn.running_mean",
+        )
+        loader.port_weight(
+            keras_layer.normalization.moving_variance,
+            hf_weight_key=f"{hf_prefix}.bn.running_var",
+        )
+        if not isinstance(keras_layer.lab, keras.layers.Identity):
+            loader.port_weight(
+                keras_layer.lab.scale, hf_weight_key=f"{hf_prefix}.lab.scale"
+            )
+            loader.port_weight(
+                keras_layer.lab.bias, hf_weight_key=f"{hf_prefix}.lab.bias"
+            )
+
+    def port_conv_light(keras_layer, hf_prefix):
+        port_conv(keras_layer.conv1_layer, f"{hf_prefix}.conv1")
+        port_conv(keras_layer.conv2_layer, f"{hf_prefix}.conv2")
+
+    def port_basic_layer(keras_layer, hf_prefix):
+        for i, layer in enumerate(keras_layer.layer_list):
+            layer_prefix = f"{hf_prefix}.layers.{i}"
+            if isinstance(layer, HGNetV2ConvLayerLight):
+                port_conv_light(layer, layer_prefix)
+            else:
+                port_conv(layer, layer_prefix)
+        port_conv(
+            keras_layer.aggregation_squeeze_conv,
+            f"{hf_prefix}.aggregation.0",
+        )
+        port_conv(
+            keras_layer.aggregation_excitation_conv,
+            f"{hf_prefix}.aggregation.1",
+        )
+
+    def port_stage(keras_stage, hf_prefix):
+        if not isinstance(keras_stage.downsample_layer, keras.layers.Identity):
+            port_conv(keras_stage.downsample_layer, f"{hf_prefix}.downsample")
+        for block_idx, block in enumerate(keras_stage.blocks_list):
+            port_basic_layer(block, f"{hf_prefix}.blocks.{block_idx}")
+
+    embedder = backbone.embedder_layer
+    port_conv(embedder.stem1_layer, "stem.stem1")
+    port_conv(embedder.stem2a_layer, "stem.stem2a")
+    port_conv(embedder.stem2b_layer, "stem.stem2b")
+    port_conv(embedder.stem3_layer, "stem.stem3")
+    port_conv(embedder.stem4_layer, "stem.stem4")
+
+    for i, stage in enumerate(backbone.encoder_layer.stages_list):
+        port_stage(stage, f"stages.{i}")
+
+
+def _has_weight_key(loader, hf_weight_key):
+    try:
+        loader.get_tensor(hf_weight_key)
+        return True
+    except Exception:
+        return False
+
+
+def convert_head(task, loader, timm_config):
+    # `head.last_conv` is a plain `nn.Sequential(conv, [bn], [lab])`, so HF
+    # weight keys are positionally indexed rather than named `.conv`/`.bn`.
+    prefix = "head.last_conv"
+    conv_layer = task.last_conv
+
+    loader.port_weight(
+        conv_layer.convolution.kernel,
+        hf_weight_key=f"{prefix}.0.weight",
+        hook_fn=lambda x, _: np.transpose(x, (2, 3, 1, 0)),
+    )
+
+    if _has_weight_key(loader, f"{prefix}.1.weight"):
+        loader.port_weight(
+            conv_layer.normalization.gamma, hf_weight_key=f"{prefix}.1.weight"
+        )
+        loader.port_weight(
+            conv_layer.normalization.beta, hf_weight_key=f"{prefix}.1.bias"
+        )
+        loader.port_weight(
+            conv_layer.normalization.moving_mean,
+            hf_weight_key=f"{prefix}.1.running_mean",
+        )
+        loader.port_weight(
+            conv_layer.normalization.moving_variance,
+            hf_weight_key=f"{prefix}.1.running_var",
+        )
+        # when BN is present, LAB (if any) is only ever found at index 2.
+        lab_prefixes = [f"{prefix}.2"]
+    else:
+        # BN is folded into the conv on some checkpoints; leave the
+        # normalization layer as an identity transform.
+        gamma = conv_layer.normalization.gamma
+        identity_value = np.sqrt(1.0 + conv_layer.normalization.epsilon)
+        gamma.assign(np.full_like(gamma.numpy(), identity_value))
+        conv_layer.normalization.beta.assign(
+            np.zeros_like(conv_layer.normalization.beta.numpy())
+        )
+        conv_layer.normalization.moving_mean.assign(
+            np.zeros_like(conv_layer.normalization.moving_mean.numpy())
+        )
+        conv_layer.normalization.moving_variance.assign(
+            np.ones_like(conv_layer.normalization.moving_variance.numpy())
+        )
+        # Matches the reference conversion script: without BN, LAB may sit
+        # at index 1 (immediately after the conv) or, failing that, index 2.
+        lab_prefixes = [f"{prefix}.1", f"{prefix}.2"]
+
+    if not isinstance(conv_layer.lab, keras.layers.Identity):
+        for lab_prefix in lab_prefixes:
+            if _has_weight_key(loader, f"{lab_prefix}.scale"):
+                loader.port_weight(
+                    conv_layer.lab.scale, hf_weight_key=f"{lab_prefix}.scale"
+                )
+                loader.port_weight(
+                    conv_layer.lab.bias, hf_weight_key=f"{lab_prefix}.bias"
+                )
+                break
+
+    loader.port_weight(
+        task.output_dense.kernel,
+        hf_weight_key="head.fc.weight",
+        hook_fn=lambda x, _: np.transpose(x, (1, 0)),
+    )
+    loader.port_weight(
+        task.output_dense.bias,
+        hf_weight_key="head.fc.bias",
+    )

--- a/keras_hub/src/utils/timm/convert_hgnetv2_test.py
+++ b/keras_hub/src/utils/timm/convert_hgnetv2_test.py
@@ -1,0 +1,22 @@
+import pytest
+from keras import ops
+
+from keras_hub.src.models.backbone import Backbone
+from keras_hub.src.models.image_classifier import ImageClassifier
+from keras_hub.src.tests.test_case import TestCase
+
+
+class TimmHGNetV2BackboneTest(TestCase):
+    @pytest.mark.extra_large
+    def test_convert_hgnetv2_backbone(self):
+        model = Backbone.from_preset("hf://timm/hgnetv2_b4.ssld_stage2_ft_in1k")
+        outputs = model.predict(ops.ones((1, 224, 224, 3)))
+        self.assertEqual(outputs["stage4"].shape[0], 1)
+
+    @pytest.mark.extra_large
+    def test_convert_hgnetv2_classifier(self):
+        model = ImageClassifier.from_preset(
+            "hf://timm/hgnetv2_b4.ssld_stage2_ft_in1k"
+        )
+        outputs = model.predict(ops.ones((1, 224, 224, 3)))
+        self.assertEqual(outputs.shape, (1, 1000))

--- a/keras_hub/src/utils/timm/preset_loader.py
+++ b/keras_hub/src/utils/timm/preset_loader.py
@@ -6,6 +6,7 @@ from keras_hub.src.utils.preset_utils import jax_memory_cleanup
 from keras_hub.src.utils.timm import convert_cspnet
 from keras_hub.src.utils.timm import convert_densenet
 from keras_hub.src.utils.timm import convert_efficientnet
+from keras_hub.src.utils.timm import convert_hgnetv2
 from keras_hub.src.utils.timm import convert_mobilenet
 from keras_hub.src.utils.timm import convert_mobilenetv5
 from keras_hub.src.utils.timm import convert_resnet
@@ -31,6 +32,8 @@ class TimmPresetLoader(PresetLoader):
             self.converter = convert_vgg
         elif architecture.startswith("efficientnet"):
             self.converter = convert_efficientnet
+        elif architecture.startswith("hgnetv2"):
+            self.converter = convert_hgnetv2
         else:
             raise ValueError(
                 "KerasHub has no converter for timm models "

--- a/tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
@@ -4,7 +4,9 @@ Usage:
     export KAGGLE_USERNAME=XXX
     export KAGGLE_KEY=XXX
 
-    python tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
+    python tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py \
+        --preset hgnetv2_b4_ssld_stage2_ft_in1k \
+        --upload_uri kaggle://keras/hgnetv2/keras/hgnetv2_b4_ssld_stage2_ft_in1k
 """
 
 import os
@@ -23,8 +25,6 @@ from keras_hub.src.utils.imagenet.imagenet_utils import (
     decode_imagenet_predictions,
 )
 
-FLAGS = flags.FLAGS
-
 PRESET_MAP = {
     "hgnetv2_b6_ssld_stage2_ft_in1k": "timm/hgnetv2_b6.ssld_stage2_ft_in1k",
     "hgnetv2_b6_ssld_stage1_in22k_in1k": "timm/hgnetv2_b6.ssld_stage1_in22k_in1k",  # noqa: E501
@@ -33,11 +33,16 @@ PRESET_MAP = {
     "hgnetv2_b4_ssld_stage2_ft_in1k": "timm/hgnetv2_b4.ssld_stage2_ft_in1k",
 }
 
-flags.DEFINE_string(
+PRESET = flags.DEFINE_string(
+    "preset",
+    None,
+    f"Must be one of {','.join(PRESET_MAP.keys())}",
+    required=True,
+)
+UPLOAD_URI = flags.DEFINE_string(
     "upload_uri",
     None,
     'Could be "kaggle://keras/hgnetv2/keras/{preset}"',
-    required=False,
 )
 
 
@@ -80,32 +85,34 @@ def validate_output(keras_model, hf_model):
 
 
 def main(_):
-    for preset, hf_preset in PRESET_MAP.items():
-        if os.path.exists(preset):
-            shutil.rmtree(preset)
-
-        print(f"\nConverting {preset}")
-        hf_model = create_model(hf_preset, pretrained=True)
-        hf_model.eval()
-
-        # `ImageClassifier.from_preset` dispatches through
-        # `convert_hgnetv2.py`, which handles config translation and weight
-        # porting directly from the Hugging Face safetensors checkpoint.
-        keras_model = keras_hub.models.ImageClassifier.from_preset(
-            f"hf://{hf_preset}"
+    preset = PRESET.value
+    if preset not in PRESET_MAP:
+        raise ValueError(
+            f"Invalid preset {preset}. "
+            f"Must be one of {','.join(PRESET_MAP.keys())}"
         )
-        print("KerasHub model loaded.")
+    hf_preset = PRESET_MAP[preset]
+    if os.path.exists(preset):
+        shutil.rmtree(preset)
 
-        validate_output(keras_model, hf_model)
+    print(f"\nConverting {preset}")
+    hf_model = create_model(hf_preset, pretrained=True)
+    hf_model.eval()
 
-        keras_model.save_to_preset(f"./{preset}")
-        print(f"Preset saved to ./{preset}.")
+    keras_model = keras_hub.models.ImageClassifier.from_preset(
+        f"hf://{hf_preset}"
+    )
+    print("KerasHub model loaded.")
 
-        upload_uri = FLAGS.upload_uri
-        if upload_uri:
-            keras_hub.upload_preset(uri=upload_uri, preset=f"./{preset}")
-            print(f"Successfully uploaded {preset} to {upload_uri}")
-    print("\nAll presets validated and saved successfully!")
+    validate_output(keras_model, hf_model)
+
+    keras_model.save_to_preset(f"./{preset}")
+    print(f"Preset saved to ./{preset}.")
+
+    upload_uri = UPLOAD_URI.value
+    if upload_uri:
+        keras_hub.upload_preset(uri=upload_uri, preset=f"./{preset}")
+        print(f"Successfully uploaded {preset} to {upload_uri}")
 
 
 if __name__ == "__main__":

--- a/tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
@@ -48,7 +48,10 @@ UPLOAD_URI = flags.DEFINE_string(
 
 def validate_output(keras_model, hf_model):
     file = keras.utils.get_file(
-        origin="https://upload.wikimedia.org/wikipedia/commons/4/43/Cute_dog.jpg"
+        origin=(
+            "https://storage.googleapis.com/keras-cv/"
+            "models/paligemma/cow_beach_1.png"
+        )
     )
     image = Image.open(file)
     images = np.expand_dims(np.array(image).astype("float32"), axis=0)

--- a/tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
@@ -7,13 +7,11 @@ Usage:
     python tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py
 """
 
-import json
 import os
 import shutil
 
 import keras
 import numpy as np
-import safetensors.torch
 import torch
 from absl import app
 from absl import flags
@@ -21,20 +19,6 @@ from PIL import Image
 from timm import create_model
 
 import keras_hub
-from keras_hub.src.models.hgnetv2.hgnetv2_backbone import HGNetV2Backbone
-from keras_hub.src.models.hgnetv2.hgnetv2_image_classifier import (
-    HGNetV2ImageClassifier,
-)
-from keras_hub.src.models.hgnetv2.hgnetv2_image_classifier_preprocessor import (
-    HGNetV2ImageClassifierPreprocessor,
-)
-from keras_hub.src.models.hgnetv2.hgnetv2_image_converter import (
-    HGNetV2ImageConverter,
-)
-from keras_hub.src.models.hgnetv2.hgnetv2_layers import HGNetV2ConvLayerLight
-from keras_hub.src.models.hgnetv2.hgnetv2_layers import (
-    HGNetV2LearnableAffineBlock,
-)
 from keras_hub.src.utils.imagenet.imagenet_utils import (
     decode_imagenet_predictions,
 )
@@ -48,13 +32,6 @@ PRESET_MAP = {
     "hgnetv2_b5_ssld_stage1_in22k_in1k": "timm/hgnetv2_b5.ssld_stage1_in22k_in1k",  # noqa: E501
     "hgnetv2_b4_ssld_stage2_ft_in1k": "timm/hgnetv2_b4.ssld_stage2_ft_in1k",
 }
-LAB_FALSE_PRESETS = [
-    "hgnetv2_b6_ssld_stage2_ft_in1k",
-    "hgnetv2_b6_ssld_stage1_in22k_in1k",
-    "hgnetv2_b5_ssld_stage2_ft_in1k",
-    "hgnetv2_b5_ssld_stage1_in22k_in1k",
-    "hgnetv2_b4_ssld_stage2_ft_in1k",
-]
 
 flags.DEFINE_string(
     "upload_uri",
@@ -62,352 +39,9 @@ flags.DEFINE_string(
     'Could be "kaggle://keras/hgnetv2/keras/{preset}"',
     required=False,
 )
-HGNETV2_CONFIGS = {
-    "hgnetv2_b0": {
-        "stem_channels": [3, 16, 16],
-        "stackwise_stage_filters": [
-            [16, 16, 64, 1, 3, 3],
-            [64, 32, 256, 1, 3, 3],
-            [256, 64, 512, 2, 3, 5],
-            [512, 128, 1024, 1, 3, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 16,
-        "hidden_sizes": [64, 256, 512, 1024],
-        "depths": [1, 1, 2, 1],
-    },
-    "hgnetv2_b1": {
-        "stem_channels": [3, 24, 32],
-        "stackwise_stage_filters": [
-            [32, 32, 64, 1, 3, 3],
-            [64, 48, 256, 1, 3, 3],
-            [256, 96, 512, 2, 3, 5],
-            [512, 192, 1024, 1, 3, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 32,
-        "hidden_sizes": [64, 256, 512, 1024],
-        "depths": [1, 1, 2, 1],
-    },
-    "hgnetv2_b2": {
-        "stem_channels": [3, 24, 32],
-        "stackwise_stage_filters": [
-            [32, 32, 96, 1, 4, 3],
-            [96, 64, 384, 1, 4, 3],
-            [384, 128, 768, 3, 4, 5],
-            [768, 256, 1536, 1, 4, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 32,
-        "hidden_sizes": [96, 384, 768, 1536],
-        "depths": [1, 1, 3, 1],
-    },
-    "hgnetv2_b3": {
-        "stem_channels": [3, 24, 32],
-        "stackwise_stage_filters": [
-            [32, 32, 128, 1, 5, 3],
-            [128, 64, 512, 1, 5, 3],
-            [512, 128, 1024, 3, 5, 5],
-            [1024, 256, 2048, 1, 5, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 32,
-        "hidden_sizes": [128, 512, 1024, 2048],
-        "depths": [1, 1, 3, 1],
-    },
-    "hgnetv2_b4": {
-        "stem_channels": [3, 32, 48],
-        "stackwise_stage_filters": [
-            [48, 48, 128, 1, 6, 3],
-            [128, 96, 512, 1, 6, 3],
-            [512, 192, 1024, 3, 6, 5],
-            [1024, 384, 2048, 1, 6, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 48,
-        "hidden_sizes": [128, 512, 1024, 2048],
-        "depths": [1, 1, 3, 1],
-    },
-    "hgnetv2_b5": {
-        "stem_channels": [3, 32, 64],
-        "stackwise_stage_filters": [
-            [64, 64, 128, 1, 6, 3],
-            [128, 128, 512, 2, 6, 3],
-            [512, 256, 1024, 5, 6, 5],
-            [1024, 512, 2048, 2, 6, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 64,
-        "hidden_sizes": [128, 512, 1024, 2048],
-        "depths": [1, 2, 5, 2],
-    },
-    "hgnetv2_b6": {
-        "stem_channels": [3, 48, 96],
-        "stackwise_stage_filters": [
-            [96, 96, 192, 2, 6, 3],
-            [192, 192, 512, 3, 6, 3],
-            [512, 384, 1024, 6, 6, 5],
-            [1024, 768, 2048, 3, 6, 5],
-        ],
-        "apply_downsample": [False, True, True, True],
-        "use_lightweight_conv_block": [False, False, True, True],
-        "embedding_size": 96,
-        "hidden_sizes": [192, 512, 1024, 2048],
-        "depths": [2, 3, 6, 3],
-    },
-}
 
 
-def load_hf_config(hf_preset, hf_model):
-    config_path = keras.utils.get_file(
-        origin=f"https://huggingface.co/{hf_preset}/raw/main/config.json",
-        cache_subdir=f"hf_models/{hf_preset}",
-    )
-    with open(config_path, "r") as f:
-        config = json.load(f)
-    config["pretrained_cfg"] = hf_model.pretrained_cfg
-    return config
-
-
-def convert_model(hf_config, architecture, preset_name):
-    config = HGNETV2_CONFIGS[architecture]
-    image_size = hf_config["pretrained_cfg"]["input_size"][1]
-    use_lab = preset_name not in LAB_FALSE_PRESETS
-
-    backbone = HGNetV2Backbone(
-        image_shape=(image_size, image_size, 3),
-        depths=config["depths"],
-        embedding_size=config["embedding_size"],
-        hidden_sizes=config["hidden_sizes"],
-        stem_channels=config["stem_channels"],
-        hidden_act="relu",
-        use_learnable_affine_block=use_lab,
-        stackwise_stage_filters=config["stackwise_stage_filters"],
-        apply_downsample=config["apply_downsample"],
-        use_lightweight_conv_block=config["use_lightweight_conv_block"],
-    )
-    pretrained_cfg = hf_config["pretrained_cfg"]
-    image_size = (
-        pretrained_cfg["input_size"][1],
-        pretrained_cfg["input_size"][2],
-    )
-    mean = pretrained_cfg["mean"]
-    std = pretrained_cfg["std"]
-    interpolation = pretrained_cfg["interpolation"]
-    scale = [1 / (255.0 * s) for s in std] if std else 1 / 255.0
-    offset = [-m / s for m, s in zip(mean, std)] if mean and std else 0
-    image_converter = HGNetV2ImageConverter(
-        image_size=image_size,
-        scale=scale,
-        offset=offset,
-        interpolation=interpolation,
-        antialias=True if interpolation == "bicubic" else False,
-    )
-    preprocessor = HGNetV2ImageClassifierPreprocessor(
-        image_converter=image_converter
-    )
-    keras_model = HGNetV2ImageClassifier(
-        backbone=backbone,
-        preprocessor=preprocessor,
-        num_classes=hf_config["num_classes"],
-    )
-    return keras_model, config, image_size
-
-
-def convert_weights(keras_model, hf_model):
-    state_dict = hf_model.state_dict()
-
-    def port_weights(keras_variable, weight_key, hook_fn=None):
-        if weight_key not in state_dict:
-            raise KeyError(f"Weight key '{weight_key}' not found in state_dict")
-        torch_tensor = state_dict[weight_key].cpu().numpy()
-        if hook_fn:
-            torch_tensor = hook_fn(torch_tensor, list(keras_variable.shape))
-        if (
-            keras_variable.shape == ()
-            and isinstance(torch_tensor, np.ndarray)
-            and torch_tensor.shape == (1,)
-        ):
-            torch_tensor = torch_tensor[0]
-        keras_variable.assign(torch_tensor)
-
-    def port_last_conv(keras_conv_layer, state_dict, prefix="head.last_conv"):
-        port_weights(
-            keras_conv_layer.convolution.kernel,
-            f"{prefix}.0.weight",
-            hook_fn=lambda x, _: np.transpose(x, (2, 3, 1, 0)),
-        )
-        if f"{prefix}.1.weight" in state_dict:
-            port_weights(
-                keras_conv_layer.normalization.gamma, f"{prefix}.1.weight"
-            )
-            port_weights(
-                keras_conv_layer.normalization.beta, f"{prefix}.1.bias"
-            )
-            port_weights(
-                keras_conv_layer.normalization.moving_mean,
-                f"{prefix}.1.running_mean",
-            )
-            port_weights(
-                keras_conv_layer.normalization.moving_variance,
-                f"{prefix}.1.running_var",
-            )
-            if isinstance(keras_conv_layer.lab, HGNetV2LearnableAffineBlock):
-                lab_scale_key = f"{prefix}.2.scale"
-                lab_bias_key = f"{prefix}.2.bias"
-                if lab_scale_key in state_dict:
-                    port_weights(keras_conv_layer.lab.scale, lab_scale_key)
-                    port_weights(keras_conv_layer.lab.bias, lab_bias_key)
-        else:
-            gamma_dtype = keras_conv_layer.normalization.gamma.dtype
-            if isinstance(gamma_dtype, keras.DTypePolicy):
-                gamma_dtype = gamma_dtype.name
-            gamma_identity_value = np.sqrt(
-                1.0 + keras_conv_layer.normalization.epsilon
-            ).astype(gamma_dtype)
-            keras_conv_layer.normalization.gamma.assign(
-                np.full_like(
-                    keras_conv_layer.normalization.gamma.numpy(),
-                    gamma_identity_value,
-                )
-            )
-            keras_conv_layer.normalization.beta.assign(
-                np.zeros_like(keras_conv_layer.normalization.beta.numpy())
-            )
-            keras_conv_layer.normalization.moving_mean.assign(
-                np.zeros_like(
-                    keras_conv_layer.normalization.moving_mean.numpy()
-                )
-            )
-            keras_conv_layer.normalization.moving_variance.assign(
-                np.ones_like(
-                    keras_conv_layer.normalization.moving_variance.numpy()
-                )
-            )
-            if isinstance(keras_conv_layer.lab, HGNetV2LearnableAffineBlock):
-                lab_scale_key_idx1 = f"{prefix}.1.scale"
-                lab_bias_key_idx1 = f"{prefix}.1.bias"
-                lab_scale_key_idx2 = f"{prefix}.2.scale"
-                lab_bias_key_idx2 = f"{prefix}.2.bias"
-                if lab_scale_key_idx1 in state_dict:
-                    port_weights(keras_conv_layer.lab.scale, lab_scale_key_idx1)
-                    port_weights(keras_conv_layer.lab.bias, lab_bias_key_idx1)
-                elif lab_scale_key_idx2 in state_dict:
-                    port_weights(keras_conv_layer.lab.scale, lab_scale_key_idx2)
-                    port_weights(keras_conv_layer.lab.bias, lab_bias_key_idx2)
-
-    def port_conv(keras_conv_layer, weight_key_prefix):
-        port_weights(
-            keras_conv_layer.convolution.kernel,
-            f"{weight_key_prefix}.conv.weight",
-            hook_fn=lambda x, _: np.transpose(x, (2, 3, 1, 0)),
-        )
-        port_weights(
-            keras_conv_layer.normalization.gamma,
-            f"{weight_key_prefix}.bn.weight",
-        )
-        port_weights(
-            keras_conv_layer.normalization.beta,
-            f"{weight_key_prefix}.bn.bias",
-        )
-        port_weights(
-            keras_conv_layer.normalization.moving_mean,
-            f"{weight_key_prefix}.bn.running_mean",
-        )
-        port_weights(
-            keras_conv_layer.normalization.moving_variance,
-            f"{weight_key_prefix}.bn.running_var",
-        )
-        if not isinstance(keras_conv_layer.lab, keras.layers.Identity):
-            port_weights(
-                keras_conv_layer.lab.scale, f"{weight_key_prefix}.lab.scale"
-            )
-            port_weights(
-                keras_conv_layer.lab.bias, f"{weight_key_prefix}.lab.bias"
-            )
-
-    def port_conv_light(keras_conv_light_layer, weight_key_prefix):
-        port_conv(
-            keras_conv_light_layer.conv1_layer, f"{weight_key_prefix}.conv1"
-        )
-        port_conv(
-            keras_conv_light_layer.conv2_layer, f"{weight_key_prefix}.conv2"
-        )
-
-    def port_embeddings(keras_embeddings, weight_key_prefix):
-        port_conv(keras_embeddings.stem1_layer, f"{weight_key_prefix}.stem1")
-        port_conv(keras_embeddings.stem2a_layer, f"{weight_key_prefix}.stem2a")
-        port_conv(keras_embeddings.stem2b_layer, f"{weight_key_prefix}.stem2b")
-        port_conv(keras_embeddings.stem3_layer, f"{weight_key_prefix}.stem3")
-        port_conv(keras_embeddings.stem4_layer, f"{weight_key_prefix}.stem4")
-
-    def port_basic_layer(keras_basic_layer, weight_key_prefix):
-        for i, layer in enumerate(keras_basic_layer.layer_list):
-            layer_prefix = f"{weight_key_prefix}.layers.{i}"
-            if isinstance(layer, HGNetV2ConvLayerLight):
-                port_conv_light(layer, layer_prefix)
-            else:
-                port_conv(layer, layer_prefix)
-        port_conv(
-            keras_basic_layer.aggregation_squeeze_conv,
-            f"{weight_key_prefix}.aggregation.0",
-        )
-        port_conv(
-            keras_basic_layer.aggregation_excitation_conv,
-            f"{weight_key_prefix}.aggregation.1",
-        )
-
-    def port_stage(keras_stage, weight_key_prefix):
-        if not isinstance(keras_stage.downsample_layer, keras.layers.Identity):
-            port_conv(
-                keras_stage.downsample_layer, f"{weight_key_prefix}.downsample"
-            )
-        for block_idx, block in enumerate(keras_stage.blocks_list):
-            port_basic_layer(block, f"{weight_key_prefix}.blocks.{block_idx}")
-
-    def port_encoder(keras_encoder, weight_key_prefix):
-        for i, stage in enumerate(keras_encoder.stages_list):
-            port_stage(stage, f"{weight_key_prefix}.{i}")
-
-    port_embeddings(keras_model.backbone.embedder_layer, "stem")
-    port_encoder(keras_model.backbone.encoder_layer, "stages")
-    port_last_conv(keras_model.last_conv, state_dict)
-    port_weights(
-        keras_model.output_dense.kernel,
-        "head.fc.weight",
-        hook_fn=lambda x, _: np.transpose(x, (1, 0)),
-    )
-    port_weights(keras_model.output_dense.bias, "head.fc.bias")
-
-
-def convert_image_converter(hf_config):
-    pretrained_cfg = hf_config["pretrained_cfg"]
-    image_size = (
-        pretrained_cfg["input_size"][1],
-        pretrained_cfg["input_size"][2],
-    )
-    mean = pretrained_cfg["mean"]
-    std = pretrained_cfg["std"]
-    interpolation = pretrained_cfg["interpolation"]
-    scale = [1 / (255.0 * s) for s in std] if std else 1 / 255.0
-    offset = [-m / s for m, s in zip(mean, std)] if mean and std else 0
-    image_converter = HGNetV2ImageConverter(
-        image_size=image_size,
-        scale=scale,
-        offset=offset,
-        interpolation=interpolation,
-        antialias=True if interpolation == "bicubic" else False,
-    )
-    return image_converter, mean, std
-
-
-def validate_output(keras_model, keras_image_converter, hf_model, mean, std):
+def validate_output(keras_model, hf_model):
     file = keras.utils.get_file(
         origin="https://upload.wikimedia.org/wikipedia/commons/4/43/Cute_dog.jpg"
     )
@@ -418,75 +52,60 @@ def validate_output(keras_model, keras_image_converter, hf_model, mean, std):
         keras_preprocessed, dtype="float32"
     )
     keras_logits = keras_model.predict(keras_preprocessed)
+
     hf_inputs = torch.from_numpy(
         keras.ops.convert_to_numpy(
             keras.ops.transpose(keras_preprocessed, (0, 3, 1, 2))
         )
     )
-    keras_backbone_output_dict = keras_model.backbone(
-        keras_preprocessed, training=False
-    )
     last_stage_name = keras_model.backbone.stage_names[-1]
-    keras_last_stage_tensor = keras_backbone_output_dict[last_stage_name]
+    keras_backbone_output = keras_model.backbone(
+        keras_preprocessed, training=False
+    )[last_stage_name]
     hf_backbone = torch.nn.Sequential(*list(hf_model.children())[:-1])
     hf_backbone_output = hf_backbone(hf_inputs)
-    keras_output_np = keras.ops.convert_to_numpy(keras_last_stage_tensor)
-    hf_output_np = hf_backbone_output.detach().cpu().numpy()
-    hf_output_np = np.transpose(hf_output_np, (0, 2, 3, 1))
-    print(
-        "🔶 Modeling Difference (Mean Absolute):",
-        np.mean(np.abs(keras_output_np - hf_output_np)),
+
+    keras_output_np = keras.ops.convert_to_numpy(keras_backbone_output)
+    hf_output_np = np.transpose(
+        hf_backbone_output.detach().cpu().numpy(), (0, 2, 3, 1)
     )
     print(
-        "🔬 Keras top 5 ImageNet predictions:",
+        "Keras top 5 ImageNet predictions:",
         decode_imagenet_predictions(keras_logits, top=5),
     )
+    np.testing.assert_allclose(
+        keras_output_np, hf_output_np, atol=1e-4, rtol=1e-4
+    )
+    print("Numerical check passed.")
 
 
 def main(_):
-    for preset in PRESET_MAP.keys():
-        hf_preset = PRESET_MAP[preset]
+    for preset, hf_preset in PRESET_MAP.items():
         if os.path.exists(preset):
             shutil.rmtree(preset)
-        os.makedirs(preset)
 
-        print(f"\n🏃 Converting {preset}")
+        print(f"\nConverting {preset}")
         hf_model = create_model(hf_preset, pretrained=True)
-        safetensors_file = keras.utils.get_file(
-            origin=f"https://huggingface.co/{hf_preset}/resolve/main/model.safetensors",
-            cache_subdir=f"hf_models/{hf_preset}",
-        )
-        try:
-            state_dict = safetensors.torch.load_file(safetensors_file)
-            hf_model.load_state_dict(state_dict)
-        except Exception as e:
-            print(f"Error loading Safetensors file for {preset}: {e}")
-            print("Clearing cache and retrying download...")
-            cache_dir = os.path.dirname(safetensors_file)
-            if os.path.exists(cache_dir):
-                shutil.rmtree(cache_dir)
-            safetensors_file = keras.utils.get_file(
-                origin=f"https://huggingface.co/{hf_preset}/resolve/main/model.safetensors",
-                cache_subdir=f"hf_models/{hf_preset}",
-            )
-            state_dict = safetensors.torch.load_file(safetensors_file)
         hf_model.eval()
-        hf_config = load_hf_config(hf_preset, hf_model)
-        architecture = hf_config["architecture"]
-        keras_model, _, _ = convert_model(hf_config, architecture, preset)
-        print("✅ KerasHub model loaded.")
-        convert_weights(keras_model, hf_model)
-        print("✅ Weights converted.")
-        keras_image_converter, mean, std = convert_image_converter(hf_config)
-        validate_output(keras_model, keras_image_converter, hf_model, mean, std)
-        print("✅ Output validated.")
+
+        # `ImageClassifier.from_preset` dispatches through
+        # `convert_hgnetv2.py`, which handles config translation and weight
+        # porting directly from the Hugging Face safetensors checkpoint.
+        keras_model = keras_hub.models.ImageClassifier.from_preset(
+            f"hf://{hf_preset}"
+        )
+        print("KerasHub model loaded.")
+
+        validate_output(keras_model, hf_model)
+
         keras_model.save_to_preset(f"./{preset}")
-        print(f"🏁 Preset saved to ./{preset}.")
+        print(f"Preset saved to ./{preset}.")
+
         upload_uri = FLAGS.upload_uri
         if upload_uri:
             keras_hub.upload_preset(uri=upload_uri, preset=f"./{preset}")
-            print(f"🏁 Successfully uploaded {preset} to {upload_uri}")
-    print("\n🏁 All presets validated and saved successfully!")
+            print(f"Successfully uploaded {preset} to {upload_uri}")
+    print("\nAll presets validated and saved successfully!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of the change

Split out of #2929 per review feedback, isolating the HGNetV2 timm→KerasHub converter (backbone + classification head) for independent review.

- Adds `keras_hub/src/utils/timm/convert_hgnetv2.py` and wires  `architecture.startswith("hgnetv2")` into `TimmPresetLoader`.
- Adds `convert_hgnetv2_test.py`.

## Verification

Verified against `tools/checkpoint_conversion/convert_hgnetv2_checkpoints.py`'s weight mapping and against the real `pretrained_cfg.tag` field across every published `timm/hgnetv2_*` checkpoint (carried over from the
original PR discussion).

Colab: [colab](https://colab.research.google.com/gist/Ahmed0830/2c9666e4af79967b8a9c6941552193a9/hgnetv2.ipynb)

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).