### PR TITLE
Unskip classifier_basics tests for densenet, mit, resnet, efficientnet

### DIFF
--- a/keras_hub/src/models/densenet/densenet_image_classifier_test.py
+++ b/keras_hub/src/models/densenet/densenet_image_classifier_test.py
@@ -5,6 +5,12 @@ from keras_hub.src.models.densenet.densenet_backbone import DenseNetBackbone
 from keras_hub.src.models.densenet.densenet_image_classifier import (
     DenseNetImageClassifier,
 )
+from keras_hub.src.models.densenet.densenet_image_classifier_preprocessor import (  # noqa: E501
+    DenseNetImageClassifierPreprocessor,
+)
+from keras_hub.src.models.densenet.densenet_image_converter import (
+    DenseNetImageConverter,
+)
 from keras_hub.src.tests.test_case import TestCase
 
 
@@ -12,7 +18,7 @@ class DenseNetImageClassifierTest(TestCase):
     def setUp(self):
         # Setup model.
         self.images = np.ones((2, 224, 224, 3), dtype="float32")
-        self.labels = [0, 3]
+        self.labels = [0, 1]
         self.backbone = DenseNetBackbone(
             stackwise_num_repeats=[6, 12, 24, 16],
             compression_ratio=0.5,
@@ -24,6 +30,9 @@ class DenseNetImageClassifierTest(TestCase):
             "num_classes": 2,
             "activation": "softmax",
             "pooling": "avg",
+            "preprocessor": DenseNetImageClassifierPreprocessor(
+                image_converter=DenseNetImageConverter(image_size=(224, 224))
+            ),
         }
         self.train_data = (
             self.images,
@@ -31,9 +40,6 @@ class DenseNetImageClassifierTest(TestCase):
         )
 
     def test_classifier_basics(self):
-        pytest.skip(
-            reason="TODO: enable after preprocessor flow is figured out"
-        )
         self.run_task_test(
             cls=DenseNetImageClassifier,
             init_kwargs=self.init_kwargs,

--- a/keras_hub/src/models/efficientnet/efficientnet_image_classifier_test.py
+++ b/keras_hub/src/models/efficientnet/efficientnet_image_classifier_test.py
@@ -51,14 +51,11 @@ class EfficientNetImageClassifierTest(TestCase):
         self.train_data = (self.images, self.labels)
 
     def test_classifier_basics(self):
-        pytest.skip(
-            reason="TODO: enable after preprocessor flow is figured out"
-        )
         self.run_task_test(
             cls=EfficientNetImageClassifier,
             init_kwargs=self.init_kwargs,
             train_data=self.train_data,
-            expected_output_shape=(2, 2),
+            expected_output_shape=(2, 1000),
         )
 
     @pytest.mark.extra_large

--- a/keras_hub/src/models/mit/mit_image_classifier_test.py
+++ b/keras_hub/src/models/mit/mit_image_classifier_test.py
@@ -3,6 +3,10 @@ import pytest
 
 from keras_hub.src.models.mit.mit_backbone import MiTBackbone
 from keras_hub.src.models.mit.mit_image_classifier import MiTImageClassifier
+from keras_hub.src.models.mit.mit_image_classifier_preprocessor import (
+    MiTImageClassifierPreprocessor,
+)
+from keras_hub.src.models.mit.mit_image_converter import MiTImageConverter
 from keras_hub.src.tests.test_case import TestCase
 
 
@@ -10,7 +14,7 @@ class MiTImageClassifierTest(TestCase):
     def setUp(self):
         # Setup model.
         self.images = np.ones((2, 32, 32, 3), dtype="float32")
-        self.labels = [0, 3]
+        self.labels = [0, 1]
         self.backbone = MiTBackbone(
             layerwise_depths=[2, 2, 2, 2],
             image_shape=(32, 32, 3),
@@ -26,6 +30,9 @@ class MiTImageClassifierTest(TestCase):
             "backbone": self.backbone,
             "num_classes": 2,
             "activation": "softmax",
+            "preprocessor": MiTImageClassifierPreprocessor(
+                image_converter=MiTImageConverter(image_size=(32, 32))
+            ),
         }
         self.train_data = (
             self.images,
@@ -33,14 +40,11 @@ class MiTImageClassifierTest(TestCase):
         )
 
     def test_classifier_basics(self):
-        pytest.skip(
-            reason="TODO: enable after preprocessor flow is figured out"
-        )
         self.run_task_test(
             cls=MiTImageClassifier,
             init_kwargs=self.init_kwargs,
             train_data=self.train_data,
-            expected_output_shape=(4, 4),
+            expected_output_shape=(2, 2),
         )
 
     @pytest.mark.large

--- a/keras_hub/src/models/resnet/resnet_image_classifier_test.py
+++ b/keras_hub/src/models/resnet/resnet_image_classifier_test.py
@@ -5,13 +5,19 @@ from keras_hub.src.models.resnet.resnet_backbone import ResNetBackbone
 from keras_hub.src.models.resnet.resnet_image_classifier import (
     ResNetImageClassifier,
 )
+from keras_hub.src.models.resnet.resnet_image_classifier_preprocessor import (
+    ResNetImageClassifierPreprocessor,
+)
+from keras_hub.src.models.resnet.resnet_image_converter import (
+    ResNetImageConverter,
+)
 from keras_hub.src.tests.test_case import TestCase
 
 
 class ResNetImageClassifierTest(TestCase):
     def setUp(self):
         self.images = ops.ones((2, 16, 16, 3))
-        self.labels = [0, 3]
+        self.labels = [0, 1]
         self.backbone = ResNetBackbone(
             input_conv_filters=[64],
             input_conv_kernel_sizes=[7],
@@ -27,13 +33,13 @@ class ResNetImageClassifierTest(TestCase):
             "num_classes": 2,
             "pooling": "avg",
             "activation": "softmax",
+            "preprocessor": ResNetImageClassifierPreprocessor(
+                image_converter=ResNetImageConverter(image_size=(16, 16))
+            ),
         }
         self.train_data = (self.images, self.labels)
 
     def test_classifier_basics(self):
-        pytest.skip(
-            reason="TODO: enable after preprocessor flow is figured out"
-        )
         self.run_task_test(
             cls=ResNetImageClassifier,
             init_kwargs=self.init_kwargs,


### PR DESCRIPTION
## Description of the change

`test_classifier_basics` has been `pytest.skip`-ed in these files since it was first introduced (PR #1737, VGG16), with the reason `"TODO: enable after preprocessor flow is figured out"`. That reason no longer holds for these four image classifiers, they've had a working `preprocessor_cls` / `ImageConverter` for a while — so the skip was just hiding stale test fixtures nobody could see under it.

### What was actually broken

| File | Bug hidden by the skip |
|---|---|
| `densenet_image_classifier_test.py` | `init_kwargs` never passed a `preprocessor`, so `task.preprocessor` was `None` → `TypeError: 'NoneType' object is not callable` |
| `mit_image_classifier_test.py` | Same missing `preprocessor`, **plus** `expected_output_shape=(4, 4)` didn't match `num_classes=2` with a batch of 2 |
| `resnet_image_classifier_test.py` | Same missing `preprocessor` |
| `efficientnet_image_classifier_test.py` | `expected_output_shape=(2, 2)` didn't match `num_classes=1000` (already set in `setUp`) |

On top of that, `densenet`, `mit`, and `resnet` all set `self.labels = [0, 3]`, which is out of range for `num_classes=2`. 

Fixed each of these and removed the skip. `test_classifier_basics` now passes on **JAX, PyTorch, and TensorFlow** for all four files, with no regressions in the other tests in these files (`test_saved_model`, `test_litert_export`, `test_head_dtype`, etc.).

### What's still skipped, on purpose

The same skip reason shows up in five other files: `sam_image_segmenter_test.py`, `flux_text_to_image_preprocessor_test.py`, and the three Stable Diffusion 3 tests. I checked those too, and left them alone: they have real, distinct blockers that aren't a matter of fixing stale fixtures.

| File | Why it's still blocked |
|---|---|
| `sam_image_segmenter_test.py` | `SAMImageSegmenter.fit()` explicitly raises `NotImplementedError` — the shared `run_task_test` helper calls `.fit()`, so it can never pass as-is |
| `flux_text_to_image_preprocessor_test.py` | Preprocessor only implements `generate_preprocess()`, not the `call(x, y, sample_weight)` contract `run_task_test`/`run_preprocessing_layer_test` assume |
| `stable_diffusion_3_text_to_image_preprocessor_test.py` | Same as Flux — CLIP-only `generate_preprocess()`, no `call()` |
| `stable_diffusion_3_text_to_image_test.py` | Same as Flux — CLIP-only `generate_preprocess()`, no `call()` |
| `stable_diffusion_3_image_to_image_test.py` | Same as Flux — CLIP-only `generate_preprocess()`, no `call()` |
| `stable_diffusion_3_inpaint_test.py` | Same as Flux — CLIP-only `generate_preprocess()`, no `call()` |

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
