### PR TITLE
Fix SentencePieceTokenizer for sentencepiece version(0.2.2) without Init

### DIFF
--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
@@ -150,13 +150,18 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
 
     def _set_proto_spm(self, proto):
         self._sentence_piece_spm = spm.SentencePieceProcessor()
-        self._sentence_piece_spm.Init(
-            model_proto=proto,
-            out_type=str if is_string_dtype(self.compute_dtype) else int,
-            add_bos=self.add_bos,
-            add_eos=self.add_eos,
-            alpha=1.0,
-        )
+        if hasattr(self._sentence_piece_spm, "Init"):
+            self._sentence_piece_spm.Init(
+                model_proto=proto,
+                out_type=str if is_string_dtype(self.compute_dtype) else int,
+                add_bos=self.add_bos,
+                add_eos=self.add_eos,
+                alpha=1.0,
+            )
+        else:
+            self._sentence_piece_spm = spm.SentencePieceProcessor(
+                model_proto=proto
+            )
 
     def set_proto(self, proto):
         if proto is None:
@@ -373,8 +378,12 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
                 )
 
         inputs, batched = _canonicalize_tokenize_inputs(inputs)
+        out_type = str if is_string_dtype(self.compute_dtype) else int
         batched_tokens = self._sentence_piece_spm.Encode(
-            inputs, add_bos=self.add_bos, add_eos=self.add_eos
+            inputs,
+            out_type=out_type,
+            add_bos=self.add_bos,
+            add_eos=self.add_eos,
         )
 
         # Convert to a dense output if `sequence_length` is set.

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
@@ -149,8 +149,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         )
 
     def _set_proto_spm(self, proto):
-        self._sentence_piece_spm = spm.SentencePieceProcessor()
-        if hasattr(self._sentence_piece_spm, "Init"):
+        if hasattr(spm.SentencePieceProcessor, "Init"):
+            self._sentence_piece_spm = spm.SentencePieceProcessor()
             self._sentence_piece_spm.Init(
                 model_proto=proto,
                 out_type=str if is_string_dtype(self.compute_dtype) else int,


### PR DESCRIPTION
## Description of the change
When running gemma3-keras, with SentencePiece version 0.2.2, there is a crash since Init() was removed. This change handles both versions : >=0.2.2 and < 0.2.2 so that there is no crash when running Gemma models
Fixes the issue in https://github.com/keras-team/keras-hub/issues/2964

## Reference


## Colab Notebook
to reproduce run the example at https://www.kaggle.com/models/google/gemma-3/keras

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change. --> this is a simple bug fix to handle api change
- [Y] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [Y] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [Y] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [Y] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [Y] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
