### PR TITLE
Fix 'vit_pooling' value mismatch in PaliGemma documentation and error handling.

### DIFF
--- a/keras_hub/src/models/pali_gemma/pali_gemma_backbone.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_backbone.py
@@ -56,7 +56,7 @@ class PaliGemmaBackbone(Backbone):
             to `4304`.
         vit_pooling: `None` or string. The encoded vision embeddings are pooled
             using the specified polling setting. The accepted values are
-            `"map"`, `"gap"`, `"0"` or `None`. Defaults to `None`.
+            `"map"`, `"gap"`, `"zero"` or `None`. Defaults to `None`.
         vit_classifier_activation: activation function. The activation that
             is used for final output classification in the vision transformer.
             Defaults to `None`.

--- a/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
@@ -490,7 +490,7 @@ class PaliGemmaVit(keras.Model):
         else:
             raise ValueError(
                 "Invalid value for argument `pooling`. "
-                "Expected one of 'map', 'gap', None. "
+                "Expected one of 'map', 'gap', 'zero', None. "
                 f"Received: pooling={pooling}"
             )
         outputs = keras.layers.Dense(


### PR DESCRIPTION
## Description of the change
The `PaliGemmaBackbone` docstring listed "0" as an accepted value for `vit_pooling`. However, the underlying implementation in `PaliGemmaViT` expects "zero", and passing "0" would trigger a `ValueError`. Additionally, the `ValueError` message in `PaliGemmaViT` did not list "zero" as an expected value, making it incomplete.
Update the `vit_pooling` argument description in `PaliGemmaBackbone` docstring to list "zero" instead of "0". Update the `ValueError` message in `PaliGemmaViT` to include "zero" in the expected values list.


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
