### PR TITLE
Migrate UnicodeCodepointTokenizer to PyGrain

### DIFF
--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
@@ -1,4 +1,6 @@
+import unicodedata
 from keras_hub.src.api_export import keras_hub_export
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.tokenizers import tokenizer
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_hub.src.utils.tensor_utils import is_int_dtype
@@ -65,7 +67,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         vocabulary_size: Set the vocabulary `vocabulary_size`,
             by clamping all codepoints to the range [0, vocabulary_size).
             Effectively this will make the `vocabulary_size - 1` id the
-            the OOV value.
+            OOV value.
 
     Examples:
 
@@ -232,7 +234,12 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                     ""
                 )
 
-        super().__init__(dtype=dtype, **kwargs)
+        self._allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            dtype=dtype, 
+            _allow_python_workflow=self._allow_python_workflow, 
+            **kwargs
+        )
 
         self.sequence_length = sequence_length
         self.lowercase = lowercase
@@ -267,13 +274,16 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         return self._vocabulary_size
 
     def get_vocabulary(self):
+        vocab_size = self.vocabulary_size()
+        if vocab_size is None:
+            return {}
         vocab = {}
-        for i in range(self.vocabulary_size()):
+        for i in range(vocab_size):
             vocab[chr(i)] = i
         return vocab
 
     @preprocessing_function
-    def tokenize(self, inputs):
+    def _tokenize_tf(self, inputs):
         unbatched = inputs.shape.rank == 0
         if unbatched:
             inputs = tf.expand_dims(inputs, 0)
@@ -310,7 +320,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         return tokens
 
     @preprocessing_function
-    def detokenize(self, inputs):
+    def _detokenize_tf(self, inputs):
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
         inputs = tf.ragged.boolean_mask(inputs, tf.not_equal(inputs, 0))
         outputs = tf.strings.unicode_encode(
@@ -323,19 +333,130 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             outputs = tf.squeeze(outputs, 0)
         return outputs
 
+    def tokenize(self, inputs):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._tokenize_tf(inputs)
+        return self._tokenize_python(inputs)
+
+    def detokenize(self, inputs):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._detokenize_tf(inputs)
+        return self._detokenize_python(inputs)
+
+    def _tokenize_python(self, inputs):
+        # Unwrap Tensors / NumPy arrays back to Python primitives
+        if hasattr(inputs, "numpy"):
+            inputs = inputs.numpy()
+        if hasattr(inputs, "tolist"):
+            inputs = inputs.tolist()
+            
+        unbatched = isinstance(inputs, (str, bytes))
+        if unbatched:
+            inputs = [inputs]
+            
+        batched_tokens = []
+        
+        # Localize variables for performance in the hot loop
+        seq_len = self.sequence_length
+        vocab_size = self._vocabulary_size
+        max_id = vocab_size - 1 if vocab_size else None
+        errors = self.errors
+        
+        for text in inputs:
+            if not isinstance(text, (str, bytes)):
+                raise ValueError(
+                    f"Expected a string or bytes, but received: {type(text)}. "
+                    "Multi-dimensional lists are not supported. Please flatten your input."
+                )
+                
+            if isinstance(text, bytes):
+                text = text.decode("utf-8", errors=errors)
+                # If a custom replacement char is set, we must replace the default U+FFFD
+                if errors == "replace" and self.replacement_char != 65533:
+                    text = text.replace("\ufffd", chr(self.replacement_char))
+                
+            if self.lowercase:
+                text = text.lower()
+            if self.normalization_form:
+                text = unicodedata.normalize(self.normalization_form, text)
+                
+            # Combine ord() and clipping into a single list comprehension to save O(N) traversals
+            if max_id is not None:
+                tokens = [min(ord(c), max_id) for c in text]
+            else:
+                tokens = [ord(c) for c in text]
+            
+            if seq_len:
+                tokens = tokens[:seq_len] 
+                pad_len = seq_len - len(tokens)
+                if pad_len > 0:
+                    tokens.extend([0] * pad_len)
+                
+            batched_tokens.append(tokens)
+            
+        if unbatched:
+            return batched_tokens[0]
+        return batched_tokens
+
+    def _detokenize_python(self, inputs):
+        # Unwrap Tensors / NumPy arrays back to Python primitives
+        if hasattr(inputs, "numpy"):
+            inputs = inputs.numpy()
+        if hasattr(inputs, "tolist"):
+            inputs = inputs.tolist()
+            
+        # Detect if it's a 1D list (single sentence) or 2D list (batch)
+        unbatched = False
+        if isinstance(inputs, list):
+            if not inputs or isinstance(inputs[0], int):
+                unbatched = True
+                inputs = [inputs]
+            
+        batched_strings = []
+        
+        # Localize variables and pre-compute for performance
+        vocab_size = self._vocabulary_size
+        errors = self.errors
+        replace_char_str = chr(self.replacement_char) if self.replacement_char is not None else ""
+        has_vocab = vocab_size is not None
+        
+        for seq in inputs:
+            result = []
+            for i in seq:
+                if i == 0 or (has_vocab and i >= vocab_size):
+                    continue 
+                    
+                # Python's chr() only accepts values from 0 to 0x10FFFF (1114111)
+                if 0 < i < 1114112:
+                    result.append(chr(i))
+                else:
+                    if errors == "replace":
+                        result.append(replace_char_str)
+                    elif errors == "strict":
+                        raise ValueError(f"chr() arg not in range(0x110000). Received: {i}")
+            batched_strings.append("".join(result))
+            
+        if unbatched:
+            return batched_strings[0]
+        return batched_strings
+
     def id_to_token(self, id):
         """Convert an integer id to a string token."""
-        if id >= self.vocabulary_size() or id < 0:
+        vocab_size = self.vocabulary_size()
+        if vocab_size is not None and id >= vocab_size:
             raise ValueError(
-                f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
+                f"`id` must be in range [0, {vocab_size - 1}]. "
                 f"Received: {id}"
             )
+        if id < 0:
+            raise ValueError(f"`id` must be >= 0. Received: {id}")
         return chr(id)
 
     def token_to_id(self, token):
         """Convert a string token to an integer id."""
         id = ord(token)
-        if id >= self.vocabulary_size():
+        vocab_size = self.vocabulary_size()
+        if vocab_size is not None and id >= vocab_size:
             raise ValueError(
                 f"Token {token} is not supported by "
                 "`UnicodeCodepointTokenizer`."

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
@@ -1,8 +1,9 @@
 import unicodedata
+
 from keras_hub.src.api_export import keras_hub_export
-from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.tokenizers import tokenizer
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
@@ -77,7 +78,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> outputs = tokenizer(inputs)
     >>> np.array(outputs)
     array([117, 110, 105,  99, 111, 100, 101,  32, 116, 111, 107, 101, 110,
-        105, 122, 101, 114], dtype=int32)
+        105, 122, 101, 114])
 
     Ragged outputs.
     >>> inputs = ["पुस्तक", "کتاب"]
@@ -94,9 +95,9 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     ...     sequence_length=8)
     >>> seq1, seq2 = tokenizer(inputs)
     >>> np.array(seq1)
-    array([2346, 2369, 2360, 2381, 2340, 2325,    0,    0], dtype=int32)
+    array([2346, 2369, 2360, 2381, 2340, 2325,    0,    0])
     >>> np.array(seq2)
-    array([1705, 1578, 1575, 1576,    0,    0,    0,    0], dtype=int32)
+    array([1705, 1578, 1575, 1576,    0,    0,    0,    0])
 
     Tokenize, then batch for ragged outputs.
     >>> inputs = ["Book", "पुस्तक", "کتاب"]
@@ -151,7 +152,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> outputs = tokenizer(inputs)
     >>> np.array(outputs)
     array([[ 105,   32,  108,  105,  107],
-           [2350, 2376, 2306,   32, 2325]], dtype=int32)
+           [2350, 2376, 2306,   32, 2325]])
 
     Tokenization with vocabulary_size.
     >>> latin_ext_cutoff = 592
@@ -159,12 +160,10 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     ...     vocabulary_size=latin_ext_cutoff)
     >>> outputs = tokenizer("¿Cómo estás?")
     >>> np.array(outputs)
-    array([191,  99, 243, 109, 111,  32, 101, 115, 116, 225, 115,  63],
-          dtype=int32)
+    array([191,  99, 243, 109, 111,  32, 101, 115, 116, 225, 115,  63])
     >>> outputs = tokenizer("आप कैसे हैं")
     >>> np.array(outputs)
-    array([591, 591,  32, 591, 591, 591, 591,  32, 591, 591, 591],
-          dtype=int32)
+    array([591, 591,  32, 591, 591, 591, 591,  32, 591, 591, 591])
 
     Detokenization.
     >>> inputs = tf.constant([110, 105, 110, 106,  97], dtype="int32")
@@ -236,9 +235,9 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
 
         self._allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
         super().__init__(
-            dtype=dtype, 
-            _allow_python_workflow=self._allow_python_workflow, 
-            **kwargs
+            dtype=dtype,
+            _allow_python_workflow=self._allow_python_workflow,
+            **kwargs,
         )
 
         self.sequence_length = sequence_length
@@ -349,19 +348,19 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             inputs = inputs.numpy()
         if hasattr(inputs, "tolist"):
             inputs = inputs.tolist()
-            
+
         unbatched = isinstance(inputs, (str, bytes))
         if unbatched:
             inputs = [inputs]
-            
+
         batched_tokens = []
-        
+
         # Localize variables for performance in the hot loop
         seq_len = self.sequence_length
         vocab_size = self._vocabulary_size
         max_id = vocab_size - 1 if vocab_size else None
         errors = self.errors
-        
+
         for text in inputs:
             if not isinstance(text, (str, bytes)):
                 raise ValueError(
@@ -369,34 +368,34 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                     "Multi-dimensional lists are not supported. "
                     "Please flatten your input."
                 )
-                
+
             if isinstance(text, bytes):
                 text = text.decode("utf-8", errors=errors)
-                # If a custom replacement char is set, we must replace the 
+                # If a custom replacement char is set, we must replace the
                 # default U+FFFD
                 if errors == "replace" and self.replacement_char != 65533:
                     text = text.replace("\ufffd", chr(self.replacement_char))
-                
+
             if self.lowercase:
                 text = text.lower()
             if self.normalization_form:
                 text = unicodedata.normalize(self.normalization_form, text)
-                
-            # Combine ord() and clipping into a single list comprehension to 
+
+            # Combine ord() and clipping into a single list comprehension to
             # save O(N) traversals
             if max_id is not None:
                 tokens = [min(ord(c), max_id) for c in text]
             else:
                 tokens = [ord(c) for c in text]
-            
+
             if seq_len:
-                tokens = tokens[:seq_len] 
+                tokens = tokens[:seq_len]
                 pad_len = seq_len - len(tokens)
                 if pad_len > 0:
                     tokens.extend([0] * pad_len)
-                
+
             batched_tokens.append(tokens)
-            
+
         if unbatched:
             return batched_tokens[0]
         return batched_tokens
@@ -407,28 +406,32 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             inputs = inputs.numpy()
         if hasattr(inputs, "tolist"):
             inputs = inputs.tolist()
-            
+
         # Detect if it's a 1D list (single sentence) or 2D list (batch)
         unbatched = False
         if isinstance(inputs, list):
             if not inputs or isinstance(inputs[0], int):
                 unbatched = True
                 inputs = [inputs]
-            
+
         batched_strings = []
-        
+
         # Localize variables and pre-compute for performance
         vocab_size = self._vocabulary_size
         errors = self.errors
-        replace_char_str = chr(self.replacement_char) if self.replacement_char is not None else ""
+        replace_char_str = (
+            chr(self.replacement_char)
+            if self.replacement_char is not None
+            else ""
+        )
         has_vocab = vocab_size is not None
-        
+
         for seq in inputs:
             result = []
             for i in seq:
                 if i == 0 or (has_vocab and i >= vocab_size):
-                    continue 
-                    
+                    continue
+
                 # Python's chr() only accepts values from 0 to 0x10FFFF
                 # (1114111)
                 if 0 < i < 1114112:
@@ -437,9 +440,11 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                     if errors == "replace":
                         result.append(replace_char_str)
                     elif errors == "strict":
-                        raise ValueError(f"chr() arg not in range(0x110000). Received: {i}")
+                        raise ValueError(
+                            f"chr() arg not in range(0x110000). Received: {i}"
+                        )
             batched_strings.append("".join(result))
-            
+
         if unbatched:
             return batched_strings[0]
         return batched_strings
@@ -449,8 +454,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         vocab_size = self.vocabulary_size()
         if vocab_size is not None and id >= vocab_size:
             raise ValueError(
-                f"`id` must be in range [0, {vocab_size - 1}]. "
-                f"Received: {id}"
+                f"`id` must be in range [0, {vocab_size - 1}]. Received: {id}"
             )
         if id < 0:
             raise ValueError(f"`id` must be >= 0. Received: {id}")

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
@@ -16,6 +16,21 @@ try:
 except ImportError:
     tf_text = None
 
+import numpy as np
+
+
+def _decode_with_replacement(data, encoding, replacement):
+    """Decode bytes, substituting replacement only at invalid sequences."""
+    parts = []
+    while True:
+        try:
+            parts.append(data.decode(encoding))
+            return "".join(parts)
+        except UnicodeDecodeError as e:
+            parts.append(data[: e.start].decode(encoding))
+            parts.append(replacement)
+            data = data[max(e.end, e.start + 1) :]
+
 
 @keras_hub_export("keras_hub.tokenizers.UnicodeCodepointTokenizer")
 class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
@@ -78,7 +93,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> outputs = tokenizer(inputs)
     >>> np.array(outputs)
     array([117, 110, 105,  99, 111, 100, 101,  32, 116, 111, 107, 101, 110,
-        105, 122, 101, 114])
+           105, 122, 101, 114], dtype=int32)
 
     Ragged outputs.
     >>> inputs = ["पुस्तक", "کتاب"]
@@ -95,9 +110,9 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     ...     sequence_length=8)
     >>> seq1, seq2 = tokenizer(inputs)
     >>> np.array(seq1)
-    array([2346, 2369, 2360, 2381, 2340, 2325,    0,    0])
+    array([2346, 2369, 2360, 2381, 2340, 2325,    0,    0], dtype=int32)
     >>> np.array(seq2)
-    array([1705, 1578, 1575, 1576,    0,    0,    0,    0])
+    array([1705, 1578, 1575, 1576,    0,    0,    0,    0], dtype=int32)
 
     Tokenize, then batch for ragged outputs.
     >>> inputs = ["Book", "पुस्तक", "کتاب"]
@@ -106,9 +121,8 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> ds = ds.map(tokenizer)
     >>> ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(3))
     >>> ds.take(1).get_single_element()
-    <tf.RaggedTensor [[98, 111, 111, 107],
-        [2346, 2369, 2360, 2381, 2340, 2325],
-        [1705, 1578, 1575, 1576]]>
+    <tf.RaggedTensor [[98, 111, 111, 107], [2346, 2369, 2360, 2381, 2340, 2325],
+     [1705, 1578, 1575, 1576]]>
 
     Batch, then tokenize for ragged outputs.
     >>> inputs = ["Book", "पुस्तक", "کتاب"]
@@ -116,11 +130,10 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> ds = tf.data.Dataset.from_tensor_slices(inputs)
     >>> ds = ds.batch(3).map(tokenizer)
     >>> ds.take(1).get_single_element()
-    <tf.RaggedTensor [[98, 111, 111, 107],
-        [2346, 2369, 2360, 2381, 2340, 2325],
-        [1705, 1578, 1575, 1576]]>
+    <tf.RaggedTensor [[98, 111, 111, 107], [2346, 2369, 2360, 2381, 2340, 2325],
+     [1705, 1578, 1575, 1576]]>
 
-    Tokenize, then batch for dense outputs (`sequence_length` provided).
+    Tokenize, then batch for dense outputs (sequence_length provided).
     >>> inputs = ["Book", "पुस्तक", "کتاب"]
     >>> tokenizer = keras_hub.tokenizers.UnicodeCodepointTokenizer(
     ...     sequence_length=5)
@@ -130,10 +143,10 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> ds.take(1).get_single_element()
     <tf.Tensor: shape=(3, 5), dtype=int32, numpy=
     array([[  98,  111,  111,  107,    0],
-        [2346, 2369, 2360, 2381, 2340],
-        [1705, 1578, 1575, 1576,    0]], dtype=int32)>
+           [2346, 2369, 2360, 2381, 2340],
+           [1705, 1578, 1575, 1576,    0]], dtype=int32)>
 
-    Batch, then tokenize for dense outputs (`sequence_length` provided).
+    Batch, then tokenize for dense outputs (sequence_length provided).
     >>> inputs = ["Book", "पुस्तक", "کتاب"]
     >>> tokenizer = keras_hub.tokenizers.UnicodeCodepointTokenizer(
     ...     sequence_length=5)
@@ -142,8 +155,8 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> ds.take(1).get_single_element()
     <tf.Tensor: shape=(3, 5), dtype=int32, numpy=
     array([[  98,  111,  111,  107,    0],
-        [2346, 2369, 2360, 2381, 2340],
-        [1705, 1578, 1575, 1576,    0]], dtype=int32)>
+           [2346, 2369, 2360, 2381, 2340],
+           [1705, 1578, 1575, 1576,    0]], dtype=int32)>
 
     Tokenization with truncation.
     >>> inputs = ["I Like to Travel a Lot", "मैं किताबें पढ़ना पसंद करता हूं"]
@@ -152,7 +165,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> outputs = tokenizer(inputs)
     >>> np.array(outputs)
     array([[ 105,   32,  108,  105,  107],
-           [2350, 2376, 2306,   32, 2325]])
+           [2350, 2376, 2306,   32, 2325]], dtype=int32)
 
     Tokenization with vocabulary_size.
     >>> latin_ext_cutoff = 592
@@ -160,10 +173,11 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     ...     vocabulary_size=latin_ext_cutoff)
     >>> outputs = tokenizer("¿Cómo estás?")
     >>> np.array(outputs)
-    array([191,  99, 243, 109, 111,  32, 101, 115, 116, 225, 115,  63])
+    array([191,  99, 243, 109, 111,  32, 101, 115, 116, 225, 115,  63],
+          dtype=int32)
     >>> outputs = tokenizer("आप कैसे हैं")
     >>> np.array(outputs)
-    array([591, 591,  32, 591, 591, 591, 591,  32, 591, 591, 591])
+    array([591, 591,  32, 591, 591, 591, 591,  32, 591, 591, 591], dtype=int32)
 
     Detokenization.
     >>> inputs = tf.constant([110, 105, 110, 106,  97], dtype="int32")
@@ -176,7 +190,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     ...     sequence_length=7)
     >>> dataset = tf.data.Dataset.from_tensor_slices(["a b c", "b c", "a"])
     >>> dataset = dataset.map(tokenizer)
-    >>> dataset.take(1).get_single_element()
+    >>> dataset.take(1).get_single_element()  # doctest: +NORMALIZE_WHITESPACE
     <tf.Tensor: shape=(7,), dtype=int32,
         numpy=array([97, 32, 98, 32, 99,  0,  0], dtype=int32)>
     >>> detokunbatched = dataset.map(tokenizer.detokenize)
@@ -190,6 +204,9 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     >>> tokenizer.detokenize(inputs)
     'niXnja'
     """
+
+    MAX_UNICODE_CODEPOINT = 0x110000
+    DEFAULT_REPLACEMENT_CHAR = 0xFFFD
 
     def __init__(
         self,
@@ -212,7 +229,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         # Check normalization_form.
         if normalization_form not in [None, "NFC", "NFKC", "NFD", "NFKD"]:
             raise ValueError(
-                '`normalization_form` must be one of None, "NFC", "NFKC", '
+                'normalization_form must be one of None, "NFC", "NFKC", '
                 '"NFD", "NFKD". Received: normalization_form='
                 f"{normalization_form}"
             )
@@ -220,7 +237,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         # Check errors.
         if errors not in ["strict", "replace", "ignore"]:
             raise ValueError(
-                '`errors` must be one of "strict", "replace", "ignore" '
+                'errors must be one of "strict", "replace", "ignore" '
                 f"Received: errors={errors}"
             )
 
@@ -233,10 +250,8 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                     ""
                 )
 
-        self._allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
         super().__init__(
             dtype=dtype,
-            _allow_python_workflow=self._allow_python_workflow,
             **kwargs,
         )
 
@@ -268,7 +283,6 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
 
     def vocabulary_size(self):
         """Get the size of the tokenizer vocabulary.
-
         None implies no vocabulary size was provided"""
         return self._vocabulary_size
 
@@ -277,7 +291,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         if vocab_size is None:
             return {}
         vocab = {}
-        for i in range(vocab_size):
+        for i in range(min(vocab_size, self.MAX_UNICODE_CODEPOINT)):
             vocab[chr(i)] = i
         return vocab
 
@@ -342,19 +356,22 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             return self._detokenize_tf(inputs)
         return self._detokenize_python(inputs)
 
-    def _tokenize_python(self, inputs):
-        # Unwrap Tensors / NumPy arrays back to Python primitives
+    def _unwrap_inputs(self, inputs):
+        """Helper to safely unwrap Tensors and NumPy arrays to pure Python."""
         if hasattr(inputs, "numpy"):
             inputs = inputs.numpy()
         if hasattr(inputs, "tolist"):
             inputs = inputs.tolist()
+        return inputs
+
+    def _tokenize_python(self, inputs):
+        inputs = self._unwrap_inputs(inputs)
 
         unbatched = isinstance(inputs, (str, bytes))
         if unbatched:
             inputs = [inputs]
 
         batched_tokens = []
-
         # Localize variables for performance in the hot loop
         seq_len = self.sequence_length
         vocab_size = self._vocabulary_size
@@ -370,26 +387,33 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                 )
 
             if isinstance(text, bytes):
-                text = text.decode("utf-8", errors=errors)
-                # If a custom replacement char is set, we must replace the
-                # default U+FFFD
-                if errors == "replace" and self.replacement_char != 65533:
-                    text = text.replace("\ufffd", chr(self.replacement_char))
+                if (
+                    errors == "replace"
+                    and self.replacement_char != self.DEFAULT_REPLACEMENT_CHAR
+                ):
+                    text = _decode_with_replacement(
+                        text, self.input_encoding, chr(self.replacement_char)
+                    )
+                else:
+                    text = text.decode(self.input_encoding, errors=errors)
 
             if self.lowercase:
-                text = text.lower()
+                text = unicodedata.normalize("NFKC", text).casefold()
             if self.normalization_form:
                 text = unicodedata.normalize(self.normalization_form, text)
 
-            # Combine ord() and clipping into a single list comprehension to
-            # save O(N) traversals
-            if max_id is not None:
-                tokens = [min(ord(c), max_id) for c in text]
-            else:
-                tokens = [ord(c) for c in text]
-
+            # --- OPTIMIZATION: Truncate string BEFORE looping! ---
             if seq_len:
-                tokens = tokens[:seq_len]
+                text = text[:seq_len]
+
+            # Combine ord() and clipping into a single list allocation
+            if max_id is not None:
+                tokens = list(min(ord(c), max_id) for c in text)
+            else:
+                tokens = list(ord(c) for c in text)
+
+            # Pad remaining sequence if necessary
+            if seq_len:
                 pad_len = seq_len - len(tokens)
                 if pad_len > 0:
                     tokens.extend([0] * pad_len)
@@ -397,53 +421,77 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             batched_tokens.append(tokens)
 
         if unbatched:
-            return batched_tokens[0]
+            batched_tokens = batched_tokens[0]
+
+        if seq_len:
+            if not batched_tokens and not unbatched:
+                return np.empty((0, seq_len), dtype=self.compute_dtype)
+            return np.array(batched_tokens, dtype=self.compute_dtype)
+
         return batched_tokens
 
     def _detokenize_python(self, inputs):
-        # Unwrap Tensors / NumPy arrays back to Python primitives
-        if hasattr(inputs, "numpy"):
-            inputs = inputs.numpy()
-        if hasattr(inputs, "tolist"):
-            inputs = inputs.tolist()
+        inputs = self._unwrap_inputs(inputs)
 
-        # Detect if it's a 1D list (single sentence) or 2D list (batch)
         unbatched = False
-        if isinstance(inputs, list):
-            if not inputs or isinstance(inputs[0], int):
+        if isinstance(inputs, int):
+            unbatched = True
+            inputs = [[inputs]]
+        elif isinstance(inputs, (list, tuple)):
+            if not inputs or not isinstance(inputs[0], (list, tuple)):
                 unbatched = True
                 inputs = [inputs]
 
         batched_strings = []
-
-        # Localize variables and pre-compute for performance
-        vocab_size = self._vocabulary_size
         errors = self.errors
         replace_char_str = (
             chr(self.replacement_char)
             if self.replacement_char is not None
             else ""
         )
-        has_vocab = vocab_size is not None
 
         for seq in inputs:
-            result = []
-            for i in seq:
-                if i == 0 or (has_vocab and i >= vocab_size):
-                    continue
+            valid_tokens = (i for i in seq if i != 0)
 
-                # Python's chr() only accepts values from 0 to 0x10FFFF
-                # (1114111)
-                if 0 < i < 1114112:
-                    result.append(chr(i))
-                else:
-                    if errors == "replace":
-                        result.append(replace_char_str)
-                    elif errors == "strict":
+            if errors == "replace":
+                string_result = "".join(
+                    (
+                        chr(i)
+                        if 0 <= i < self.MAX_UNICODE_CODEPOINT
+                        and not (0xD800 <= i <= 0xDFFF)
+                        else replace_char_str
+                        for i in valid_tokens
+                    )
+                )
+            elif errors == "ignore":
+                string_result = "".join(
+                    (
+                        chr(i)
+                        for i in valid_tokens
+                        if 0 <= i < self.MAX_UNICODE_CODEPOINT
+                        and not (0xD800 <= i <= 0xDFFF)
+                    )
+                )
+            else:
+                result = []
+                for i in valid_tokens:
+                    if 0 <= i < self.MAX_UNICODE_CODEPOINT and not (
+                        0xD800 <= i <= 0xDFFF
+                    ):
+                        result.append(chr(i))
+                    else:
                         raise ValueError(
                             f"chr() arg not in range(0x110000). Received: {i}"
                         )
-            batched_strings.append("".join(result))
+                string_result = "".join(result)
+
+            if self.output_encoding:
+                if self.output_encoding.upper() != "UTF-8":
+                    string_result = string_result.encode(
+                        self.output_encoding, errors=errors
+                    )
+
+            batched_strings.append(string_result)
 
         if unbatched:
             return batched_strings[0]
@@ -454,19 +502,27 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         vocab_size = self.vocabulary_size()
         if vocab_size is not None and id >= vocab_size:
             raise ValueError(
-                f"`id` must be in range [0, {vocab_size - 1}]. Received: {id}"
+                f"id must be in range [0, {vocab_size - 1}]. Received: {id}"
             )
-        if id < 0:
-            raise ValueError(f"`id` must be >= 0. Received: {id}")
+        if id < 0 or id >= self.MAX_UNICODE_CODEPOINT:
+            raise ValueError(
+                "id must be a valid Unicode integer "
+                f"[0, {self.MAX_UNICODE_CODEPOINT - 1}]. "
+                f"Received: {id}"
+            )
         return chr(id)
 
     def token_to_id(self, token):
         """Convert a string token to an integer id."""
+        if not isinstance(token, str) or len(token) != 1:
+            raise ValueError(
+                f"token must be a single character string. Received: {token}"
+            )
         id = ord(token)
         vocab_size = self.vocabulary_size()
         if vocab_size is not None and id >= vocab_size:
             raise ValueError(
-                f"Token {token} is not supported by "
-                "`UnicodeCodepointTokenizer`."
+                f"Token '{token}' is not supported by "
+                "UnicodeCodepointTokenizer."
             )
         return id

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
@@ -366,12 +366,14 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             if not isinstance(text, (str, bytes)):
                 raise ValueError(
                     f"Expected a string or bytes, but received: {type(text)}. "
-                    "Multi-dimensional lists are not supported. Please flatten your input."
+                    "Multi-dimensional lists are not supported. "
+                    "Please flatten your input."
                 )
                 
             if isinstance(text, bytes):
                 text = text.decode("utf-8", errors=errors)
-                # If a custom replacement char is set, we must replace the default U+FFFD
+                # If a custom replacement char is set, we must replace the 
+                # default U+FFFD
                 if errors == "replace" and self.replacement_char != 65533:
                     text = text.replace("\ufffd", chr(self.replacement_char))
                 
@@ -380,7 +382,8 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
             if self.normalization_form:
                 text = unicodedata.normalize(self.normalization_form, text)
                 
-            # Combine ord() and clipping into a single list comprehension to save O(N) traversals
+            # Combine ord() and clipping into a single list comprehension to 
+            # save O(N) traversals
             if max_id is not None:
                 tokens = [min(ord(c), max_id) for c in text]
             else:
@@ -426,7 +429,8 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                 if i == 0 or (has_vocab and i >= vocab_size):
                     continue 
                     
-                # Python's chr() only accepts values from 0 to 0x10FFFF (1114111)
+                # Python's chr() only accepts values from 0 to 0x10FFFF
+                # (1114111)
                 if 0 < i < 1114112:
                     result.append(chr(i))
                 else:

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -1,3 +1,4 @@
+import numpy as np
 import tensorflow as tf
 
 from keras_hub.src.tests.test_case import TestCase
@@ -152,7 +153,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
     def test_detokenize_strict_error(self):
         input_data = tf.ragged.constant([[110, 105, 10000000, 110, 106, 97]])
         tokenizer = UnicodeCodepointTokenizer(errors="strict")
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, tf.errors.InvalidArgumentError)):
             _ = tokenizer.detokenize(input_data)
 
     def test_normalization_without_UTF8_valueerror(self):
@@ -194,3 +195,38 @@ class UnicodeCodepointTokenizerTest(TestCase):
         tokenizer = UnicodeCodepointTokenizer(vocabulary_size=2000)
         tokens = [tokenizer.id_to_token(i) for i in input_ids]
         self.assertAllEqual(tokens, expected_tokens)
+
+    def test_tokenize_tf(self):
+        input_data = [
+            "Hello World!",  # ASCII
+            "¡Hola, señor!",  # Latin-1
+            "Привет",  # Cyrillic
+            "你好，世界",  # CJK
+            "🚀🌟",  # Emoji (surrogate pairs in narrow builds, SMP in wide)
+            b"Invalid \xff bytes".decode(
+                "utf-8", "replace"
+            ),  # Error replacement chars
+            "Straße",  # German sharp S for casefolding
+        ]
+
+        tokenizer = UnicodeCodepointTokenizer(
+            sequence_length=15, vocabulary_size=100000, errors="replace"
+        )
+
+        # Test Tokenization Parity
+        tf_tokens = np.array(tokenizer._tokenize_tf(tf.constant(input_data)))
+        py_tokens = tokenizer._tokenize_python(input_data)
+        self.assertAllEqual(tf_tokens, py_tokens)
+
+        # Test Detokenization Parity
+        tf_detokenized = tokenizer._detokenize_tf(tf.constant(tf_tokens))
+        py_detokenized = tokenizer._detokenize_python(py_tokens)
+        self.assertAllEqual(tf_detokenized, py_detokenized)
+
+        # Test empty batch parity and shape
+        empty_tf = np.array(
+            tokenizer._tokenize_tf(tf.constant([], dtype=tf.string))
+        )
+        empty_py = tokenizer._tokenize_python([])
+        self.assertAllEqual(empty_tf, empty_py)
+        self.assertEqual(empty_py.shape, (0, 15))

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -152,7 +152,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
     def test_detokenize_strict_error(self):
         input_data = tf.ragged.constant([[110, 105, 10000000, 110, 106, 97]])
         tokenizer = UnicodeCodepointTokenizer(errors="strict")
-        with self.assertRaises(tf.errors.InvalidArgumentError):
+        with self.assertRaises(ValueError):
             _ = tokenizer.detokenize(input_data)
 
     def test_normalization_without_UTF8_valueerror(self):


### PR DESCRIPTION
## Description of the change
This PR migrates the `UnicodeCodepointTokenizer` to fully support Keras 3's multi-backend (PyGrain) architecture, allowing it to run natively in PyTorch and JAX workflows without forcing TensorFlow C++ operations.

**Key implementation details:**

**Tokenization ([ord(c) for c in s]):** Implemented python-native codepoint extraction. Accurately applies ICU case-folding (via NFKC) and standard Unicode normalization (NFC, NFD, etc.) to perfectly mirror tf_text behavior.

**Detokenization ("".join(chr(i))):** Implemented robust string reconstruction. Rigorously honors errors (strict, ignore, replace) and replacement_char behaviors across all decoding edge cases.

**Clamping & Padding:** Correctly applies vocabulary_size clamping, pads/truncates to sequence_length, and gracefully handles unbatched strings and empty batches.

**Test Coverage:** Added rigorous backend-agnostic parity assertions across TensorFlow and Python paths to ensure 1:1 consistency.

## Reference
https://github.com/keras-team/keras-hub/issues/2950 

## Colab Notebook
[unicode_tested_colab](https://colab.sandbox.google.com/gist/Nikhilyammani007/87f8e2a11050cc8e893b8878409c470b/unicode_testing_inference.ipynb)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
