### PR TITLE
Fix EditDistance crash with dense tensor inputs

### DIFF
--- a/keras_hub/src/metrics/edit_distance.py
+++ b/keras_hub/src/metrics/edit_distance.py
@@ -129,9 +129,7 @@ class EditDistance(keras.metrics.Metric):
 
         if self.normalize:
             self._aggregate_reference_length.assign_add(
-                convert_to_numpy(
-                    tf.cast(tf.size(y_true.flat_values), dtype=self.dtype)
-                )
+                convert_to_numpy(tf.cast(tf.size(y_true), dtype=self.dtype))
             )
 
         def calculate_edit_distance(args):

--- a/keras_hub/src/metrics/edit_distance.py
+++ b/keras_hub/src/metrics/edit_distance.py
@@ -128,8 +128,15 @@ class EditDistance(keras.metrics.Metric):
         y_pred = validate_and_fix_rank(y_pred, "y_pred")
 
         if self.normalize:
+            reference_values = (
+                y_true.flat_values
+                if isinstance(y_true, tf.RaggedTensor)
+                else y_true
+            )
             self._aggregate_reference_length.assign_add(
-                convert_to_numpy(tf.cast(tf.size(y_true), dtype=self.dtype))
+                convert_to_numpy(
+                    tf.cast(tf.size(reference_values), dtype=self.dtype)
+                )
             )
 
         def calculate_edit_distance(args):

--- a/keras_hub/src/metrics/edit_distance_test.py
+++ b/keras_hub/src/metrics/edit_distance_test.py
@@ -75,6 +75,14 @@ class EditDistanceTest(TestCase):
         edit_distance_val = edit_distance(y_true, y_pred)
         self.assertAlmostEqual(edit_distance_val, 0.733, delta=1e-3)
 
+    def test_dense_tensor_input(self):
+        edit_distance = EditDistance()
+        y_true = tf.constant([[1, 2], [3, 4]])
+        y_pred = tf.constant([[1, 2], [3, 5]])
+
+        edit_distance_val = edit_distance(y_true, y_pred)
+        self.assertAlmostEqual(edit_distance_val, 0.25, delta=1e-3)
+
     @pytest.mark.tf_only  # string model output only applies to tf.
     def test_model_compile_normalize(self):
         inputs = keras.Input(shape=(None,), dtype="string")


### PR DESCRIPTION
## Description of the change
This PR fixes a bug where EditDistance(normalize=True) would crash when provided with a dense 2D Tensor as input. The crash occurred because the metric attempted to access the flat_values attribute, which is only available on RaggedTensor.

I have replaced the y_true.flat_values access with tf.size(y_true), which works correctly for both dense and ragged tensors in TensorFlow. A new test case has been added to edit_distance_test.py to cover this scenario.

## Colab Notebook
https://colab.research.google.com/drive/1qkcPI-JIlDcaHKVTO6yx8u-gbAjUp_Hs?usp=sharing

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
