### PR TITLE
Fix preprocessing layer grain parity

### DIFF
--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -302,10 +302,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         )
         # Convert NumPy scalar values (especially np.str_) to Python values.
         numpy_input_data = tree.map_structure(
-        lambda x: x.item()
-        if isinstance(x, np.ndarray) and x.ndim == 0
-        else x,
-        numpy_input_data,
+            lambda x: x.item()
+            if isinstance(x, np.ndarray) and x.ndim == 0
+            else x,
+            numpy_input_data,
         )
         if isinstance(numpy_input_data, tuple):
             source_data = list(zip(*numpy_input_data))
@@ -344,7 +344,11 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
             if not is_batched:
                 grain_ds = grain_ds.batch(
-                    len(source_data), batch_fn=lambda samples: samples
+                    len(source_data),
+                    batch_fn=lambda samples: tree.map_structure(
+                        lambda *values: np.stack(values),
+                        *samples,
+                    ),
                 )
 
             grain_output = grain_ds[0]

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -351,7 +351,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     len(source_data),
                     batch_fn=lambda samples: tree.map_structure(
                         lambda *values: np.stack(values),
-                        *samples,
+                        *samples,is_leaf=lambda x: isinstance(x, list),
                     ),
                 )
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -323,6 +323,50 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
         return numpy_input_data, source_data
 
+    @staticmethod
+    def _grain_batch_fn(samples):
+        """Batch Grain samples while preserving ragged list outputs."""
+        if not samples:
+            return samples
+
+        def batch_values(values):
+            print("[DEBUG][Func:Batch_values] values:", values)
+            print("number of values:", len(values))
+            for i, value in enumerate(values):
+                print(
+                    f"  value[{i}] "
+                    f"type={type(value)}, "
+                    f"shape={np.shape(value)}"
+                )
+            first_shape = np.shape(values[0])
+            print("first_shape:", first_shape)
+            
+            if all(np.shape(value) == first_shape for value in values[1:]):
+                result = np.stack(values)
+
+                print("AFTER np.stack:")
+                print("  result shape:", result.shape)
+                return np.stack(values)
+
+            return list(values)
+
+        def traverse(values):
+            first = values[0]
+
+            if isinstance(first, dict):
+                return {
+                    key: traverse([value[key] for value in values])
+                    for key in first
+                }
+            if isinstance(first, tuple):
+                return tuple(
+                    traverse([value[i] for value in values])
+                    for i in range(len(first))
+                )
+            return batch_values(values)
+
+        return traverse(samples)
+
     def _run_grain_test(self, layer, input_data, output, unpack=False):
         if not grain:
             self.skipTest(
@@ -349,10 +393,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             if not is_batched:
                 grain_ds = grain_ds.batch(
                     len(source_data),
-                    batch_fn=lambda samples: tree.map_structure(
-                        lambda *values: np.stack(values),
-                        *samples,is_leaf=lambda x: isinstance(x, list),
-                    ),
+                    batch_fn=self._grain_batch_fn,
                 )
 
             grain_output = grain_ds[0]

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import re
 import tempfile
+from absl import flags
 
 import keras
 import numpy as np
@@ -376,13 +377,16 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 "PyGrain not installed - skipping PyGrain multiprocessing test."
             )
 
+        if not flags.FLAGS.is_parsed():
+            flags.FLAGS(["test"])
+
         loader = grain.DataLoader(
             data_source=source_data,
             sampler=grain.SequentialSampler(
                 num_records=len(source_data),
             ),
             operations=[
-                grain.MapOperation(
+                grain.MapTransform(
                     _LayerWrapper(layer, isinstance(input_data, tuple))
                 )
             ],

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -42,6 +42,19 @@ def convert_to_comparible_type(x):
     return x
 
 
+class _LayerWrapper:
+    """Pickleable wrapper to apply a layer to tuple or non-tuple inputs."""
+
+    def __init__(self, layer, is_tuple):
+        self.layer = layer
+        self.is_tuple = is_tuple
+
+    def __call__(self, x):
+        if self.is_tuple:
+            return self.layer(*x)
+        return self.layer(x)
+
+
 class TestCase(tf.test.TestCase, parameterized.TestCase):
     """Base test case class for KerasHub."""
 
@@ -268,6 +281,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         output, _, _ = keras.utils.unpack_x_y_sample_weight(output)
         shape = ops.shape(output[token_id_key])
         self.assertEqual(shape[-1], layer.sequence_length)
+        # Update the sequence length.
         layer.sequence_length = 17
         if isinstance(input_data, tuple):
             output = layer(*input_data)
@@ -280,22 +294,60 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         # Grain parity for sequence length update
         self._run_grain_test(layer, input_data, output, unpack=True)
 
-    def _run_grain_test(self, layer, input_data, output, unpack=False):
-        if grain:
-            ds = tf.data.Dataset.from_tensor_slices(input_data)
-            unbatched_data = list(ds)
-            length = len(unbatched_data)
+    def _prepare_grain_source_data(self, input_data):
+        """Convert input data to NumPy and prepare unbatched Grain samples."""
+        numpy_input_data = tree.map_structure(
+            ops.convert_to_numpy,
+            input_data,
+        )
 
-            # Unbatched grain dataset
-            grain_ds = grain.MapDataset.source(unbatched_data)
+        if isinstance(numpy_input_data, tuple):
+            source_data = list(zip(*numpy_input_data))
+        elif isinstance(numpy_input_data, dict):
+            source_data = [
+                dict(zip(numpy_input_data.keys(), values))
+                for values in zip(*numpy_input_data.values())
+            ]
+        else:
+            source_data = list(numpy_input_data)
+
+        return numpy_input_data, source_data
+
+    def _run_grain_test(self, layer, input_data, output, unpack=False):
+        if not grain:
+            self.skipTest(
+                "PyGrain not installed - skipping PyGrain parity checks."
+            )
+
+        # Convert input data to NumPy/Python data.
+        # Keeps the Grain pipeline independent of tf.data
+        numpy_input_data, source_data = self._prepare_grain_source_data(
+            input_data
+        )
+
+        def process_and_compare(source_data, is_batched):
+            """Run the layer with Grain and compare the output with Keras."""
+            grain_ds = grain.MapDataset.source(source_data)
+
+            grain_ds = grain_ds.map(
+                _LayerWrapper(
+                    layer,
+                    is_tuple=isinstance(input_data, tuple),
+                )
+            )
+
             if isinstance(input_data, tuple):
                 grain_ds = grain_ds.map(lambda x: layer(*x))
             else:
                 grain_ds = grain_ds.map(layer)
 
-            # Batch and compare to `output`
-            grain_ds = grain_ds.batch(length)
+            if not is_batched:
+                grain_ds = grain_ds.batch(
+                    len(source_data), batch_fn=lambda samples: samples
+                )
+
             grain_output = grain_ds[0]
+
             if unpack:
                 grain_output, _, _ = keras.utils.unpack_x_y_sample_weight(
                     grain_output
@@ -303,25 +355,38 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
             self.assertAllClose(output, grain_output)
 
-            # Batched grain dataset
-            grain_batched_ds = grain.MapDataset.source([input_data])
-            if isinstance(input_data, tuple):
-                grain_batched_ds = grain_batched_ds.map(lambda x: layer(*x))
-            else:
-                grain_batched_ds = grain_batched_ds.map(layer)
+        # Unbatched grain dataset
+        process_and_compare(source_data, is_batched=False)
 
-            grain_batched_output = grain_batched_ds[0]
-            if unpack:
-                grain_batched_output, _, _ = keras.utils.unpack_x_y_sample_weight(
-                    grain_batched_output
-                )
+        # Batched grain dataset
+        process_and_compare([numpy_input_data], is_batched=True)
 
-            self.assertAllClose(output, grain_batched_output)
-        else:
-            print(
-                "\n[INFO] PyGrain not installed - "
-                "skipping PyGrain parity checks.\n"
+        # Multiprocessing smoke test.
+        self._run_grain_multiprocessing_test(layer, input_data, source_data)
+
+    def _run_grain_multiprocessing_test(self, layer, input_data, source_data):
+        """Smoke test Grain layer mapping with multiple worker processes."""
+        if not grain:
+            self.skipTest(
+                "PyGrain not installed - skipping PyGrain multiprocessing test."
             )
+
+        loader = grain.DataLoader(
+            data_source=source_data,
+            sampler=grain.SequentialSampler(
+                num_records=len(source_data),
+                num_epochs=1,
+            ),
+            operations=[
+                grain.MapOperation(
+                    _LayerWrapper(layer, isinstance(input_data, tuple))
+                )
+            ],
+            worker_count=2,
+        )
+
+        for _ in loader:
+            pass
 
     def run_serialization_test(self, instance):
         """Check idempotency of serialize/deserialize.

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -51,12 +51,37 @@ class _LayerWrapper(grain.MapTransform if grain is not None else object):
         self.is_tuple = is_tuple
 
     def __call__(self, x):
+        print("\n========== _LayerWrapper.__call__ ==========")
+        print("x type:", type(x))
+        print("x:", x)
+        print("is_tuple:", self.is_tuple)
+
         if self.is_tuple:
-            return self.layer(*x)
-        return self.layer(x)
+            result = self.layer(*x)
+        else:
+            result = self.layer(x)
+
+        print("result type:", type(result))
+        print("result:", result)
+
+        return result
+
 
     def map(self, x):
-        return self.__call__(x)
+        print("\n!!!!!!!!!!!! GRAIN MAP CALLED !!!!!!!!!!!!")
+        print("x type:", type(x))
+        print("x:", x)
+
+        if isinstance(x, np.ndarray):
+            x = x.tolist()
+
+        print("[DEBUG] AFTER NUMPY CONVERSION")
+        print("x type:", type(x))
+        print("x:", x)
+
+        result = self.__call__(x)
+
+        return result
 
 
 class TestCase(tf.test.TestCase, parameterized.TestCase):
@@ -300,10 +325,32 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
     def _prepare_grain_source_data(self, input_data):
         """Convert input data to NumPy and prepare unbatched Grain samples."""
-        numpy_input_data = tree.map_structure(
-            ops.convert_to_numpy,
-            input_data,
-        )
+        print("\n" + "=" * 80)
+        print("DEBUG: _prepare_grain_source_data()")
+        print("=" * 80)
+        print("\n========== PREPARE GRAIN SOURCE ==========")
+        print("input_data type:", type(input_data))
+        print("input_data:", input_data)
+        if isinstance(input_data, tf.RaggedTensor):
+            print("[DEBUG] input_data IS RAGGED TENSOR")
+            numpy_input_data = [np.asarray(row) for row in input_data.to_list()]
+        else:
+            print("[DEBUG] input_data IS NOT A RAGGED TENSOR")
+            numpy_input_data = tree.map_structure(
+                ops.convert_to_numpy,
+                input_data,
+            )
+        print("[3] AFTER ops.convert_to_numpy")
+        print("    type:", type(numpy_input_data))
+        print("    repr:", repr(numpy_input_data))
+
+        # Print complete tree structure.
+        print("[4] TREE STRUCTURE")
+        try:
+            print(tree.structure(numpy_input_data))
+        except Exception as e:
+            print("    Could not print tree structure:", e)
+
         # Convert NumPy scalar values (especially np.str_) to Python values.
         numpy_input_data = tree.map_structure(
             lambda x: x.item()
@@ -311,15 +358,60 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             else x,
             numpy_input_data,
         )
+
+        print("[5] AFTER NumPy scalar conversion")
+        print("    type:", type(numpy_input_data))
+        print("    repr:", repr(numpy_input_data))
+        
         if isinstance(numpy_input_data, tuple):
-            source_data = list(zip(*numpy_input_data))
+            print("[6] numpy_input_data IS TUPLE")
+            print("    tuple len:", len(numpy_input_data))
+            for i, value in enumerate(numpy_input_data):
+                print(f"    tuple[{i}] type:", type(value))
+                print(f"    tuple[{i}] repr:", repr(value))
+
+            if len(numpy_input_data) == 1 and isinstance(
+                numpy_input_data[0], dict
+            ):
+                print("[7] CASE: tuple -> one dict")
+                source_data = [
+                    dict(zip(numpy_input_data[0].keys(), values))
+                    for values in zip(*numpy_input_data[0].values())
+                ]
+            elif len(numpy_input_data) == 1:
+                print("[7] CASE: tuple -> one positional argument")
+                print("    numpy_input_data[0] type:",
+                      type(numpy_input_data[0]))
+                print("    numpy_input_data[0] repr:",
+                      repr(numpy_input_data[0]))
+                # Single positional argument that is not a dict.
+                source_data = [numpy_input_data[0]]
+            else:
+                print("[7] CASE: tuple -> multiple positional arguments")
+                # Multiple positional arguments.
+                source_data = list(zip(*numpy_input_data))
+
         elif isinstance(numpy_input_data, dict):
+            print("[6] numpy_input_data IS DICT")
             source_data = [
                 dict(zip(numpy_input_data.keys(), values))
                 for values in zip(*numpy_input_data.values())
             ]
         else:
+            print("[6] numpy_input_data IS OTHER or lIST")
             source_data = list(numpy_input_data)
+        
+        print("\n[8] FINAL source_data")
+        print("    type:", type(source_data))
+        print("    len:", len(source_data))
+        print("    repr:", repr(source_data))
+
+        for i, sample in enumerate(source_data):
+            print(f"\n    source_data[{i}]")
+            print("        type:", type(sample))
+            print("        repr:", repr(sample))
+
+        print("=" * 80)
 
         return numpy_input_data, source_data
 
@@ -332,40 +424,72 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         def batch_values(values):
             print("[DEBUG][Func:Batch_values] values:", values)
             print("number of values:", len(values))
-            for i, value in enumerate(values):
-                print(
-                    f"  value[{i}] "
-                    f"type={type(value)}, "
-                    f"shape={np.shape(value)}"
-                )
+
             first_shape = np.shape(values[0])
-            print("first_shape:", first_shape)
-            
-            if all(np.shape(value) == first_shape for value in values[1:]):
+
+            # Grain batch_fn is called for the unbatched-source path.
+            # Even when there is only one sample, we must add the batch dimension.
+            if len(values) == 1:
                 result = np.stack(values)
+                print("[DEBUG][batch_values] single value stacked:", result.shape)
+                return result
 
-                print("AFTER np.stack:")
-                print("  result shape:", result.shape)
-                return np.stack(values)
+            # Multiple samples with identical shapes -> normal dense batch.
+            if all(np.shape(value) == first_shape for value in values):
+                result = np.stack(values)
+                print("[DEBUG][batch_values] stacked shape:", result.shape)
+                return result
 
+            # Variable-length values -> preserve as a list.
+            print("[DEBUG][batch_values] Shapes differ")
+            print(
+                "[DEBUG][batch_values] shapes:",
+                [np.shape(value) for value in values],
+            )
             return list(values)
 
         def traverse(values):
+            print("\n[DEBUG][traverse] INPUT")
             first = values[0]
 
+            # For Dict
             if isinstance(first, dict):
-                return {
+                result = {}
+
+                for key in first:
+                    key_values = [value[key] for value in values]
+
+                    result[key] = traverse(key_values)
+
+                return result
+
+            """return {
                     key: traverse([value[key] for value in values])
                     for key in first
-                }
+                }"""
+            # For Tuple
             if isinstance(first, tuple):
-                return tuple(
+                """return tuple(
+                    traverse([value[i] for value in values])
+                    for i in range(len(first))
+                )"""
+
+                result = tuple(
                     traverse([value[i] for value in values])
                     for i in range(len(first))
                 )
+
+                return result
+
+            # For simple values / NumPy arrays
+            print("[DEBUG][traverse] SIMPLE VALUE")
             return batch_values(values)
 
-        return traverse(samples)
+        print("\n[DEBUG] Starting traverse")
+
+        result = traverse(samples)
+
+        return result
 
     def _run_grain_test(self, layer, input_data, output, unpack=False):
         if not grain:
@@ -378,39 +502,61 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         numpy_input_data, source_data = self._prepare_grain_source_data(
             input_data
         )
+        print("\n========== GRAIN SOURCE DATA ==========")
 
         def process_and_compare(source_data, is_batched):
             """Run the layer with Grain and compare the output with Keras."""
             grain_ds = grain.MapDataset.source(source_data)
 
-            grain_ds = grain_ds.map(
-                _LayerWrapper(
-                    layer,
-                    is_tuple=isinstance(input_data, tuple),
-                )
-            )
+            print("========== SOURCE DATA ==========")
+            print("source_data type:", type(source_data))
+            print("source_data:", source_data)
 
+
+            grain_ds = grain_ds.map(
+            _LayerWrapper(
+            layer,is_tuple=isinstance(input_data, tuple) and len(input_data) > 1,)
+            )
+            
             if not is_batched:
+                print("\n========== BEFORE GRAIN BATCH ==========")
+                print("batch function:", self._grain_batch_fn)
+                print("batch function type:", type(self._grain_batch_fn))
+
                 grain_ds = grain_ds.batch(
                     len(source_data),
                     batch_fn=self._grain_batch_fn,
                 )
 
             grain_output = grain_ds[0]
+            print("\n========== AFTER GRAIN ds[0] ==========")
+            print("grain_output type:", type(grain_output))
 
             if unpack:
+                print("\n========== UNPACKING GRAIN OUTPUT ==========")
                 grain_output, _, _ = keras.utils.unpack_x_y_sample_weight(
                     grain_output
                 )
 
-            self.assertAllClose(output, grain_output)
+                self.assertAllClose(output, grain_output)
+                print("\n========== MATCHING WITH ORIGINAL OUTPUT ==========")
+                
 
         # Unbatched grain dataset
         process_and_compare(source_data, is_batched=False)
 
         # Batched grain dataset
-        process_and_compare([numpy_input_data], is_batched=True)
+        if isinstance(numpy_input_data, tuple) and len(numpy_input_data) == 1:
+            batched_source_data = [numpy_input_data[0]]
+        else:
+            batched_source_data = [numpy_input_data]
 
+        print("\n========== GRAIN BATched SOURCE DATA ==========")
+        print("batched_source_data:", batched_source_data)
+        print("batched_source_data type:", type(batched_source_data))
+
+        process_and_compare(batched_source_data, is_batched=True)
+        
         # Multiprocessing smoke test.
         self._run_grain_multiprocessing_test(layer, input_data, source_data)
 
@@ -429,7 +575,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             sampler=grain.SequentialSampler(
                 num_records=len(source_data),
             ),
-            operations=[_LayerWrapper(layer, isinstance(input_data, tuple))],
+            operations=[_LayerWrapper(layer, isinstance(input_data, tuple) and len(input_data) > 1,)],
             worker_count=2,
         )
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -380,7 +380,6 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             data_source=source_data,
             sampler=grain.SequentialSampler(
                 num_records=len(source_data),
-                num_epochs=1,
             ),
             operations=[
                 grain.MapOperation(

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -43,7 +43,7 @@ def convert_to_comparible_type(x):
     return x
 
 
-class _LayerWrapper:
+class _LayerWrapper(grain.MapTransform if grain is not None else object):
     """Pickleable wrapper to apply a layer to tuple or non-tuple inputs."""
 
     def __init__(self, layer, is_tuple):
@@ -54,6 +54,9 @@ class _LayerWrapper:
         if self.is_tuple:
             return self.layer(*x)
         return self.layer(x)
+
+    def map(self, x):
+        return self.__call__(x)
 
 
 class TestCase(tf.test.TestCase, parameterized.TestCase):
@@ -385,11 +388,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             sampler=grain.SequentialSampler(
                 num_records=len(source_data),
             ),
-            operations=[
-                grain.MapTransform(
-                    _LayerWrapper(layer, isinstance(input_data, tuple))
-                )
-            ],
+            operations=[_LayerWrapper(layer, isinstance(input_data, tuple))],
             worker_count=2,
         )
 

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -17,6 +17,11 @@ from keras_hub.src.models.retinanet.feature_pyramid import FeaturePyramid
 from keras_hub.src.tokenizers.tokenizer import Tokenizer
 from keras_hub.src.utils.tensor_utils import is_float_dtype
 
+try:
+    import grain.python as grain
+except ImportError:
+    grain = None
+
 
 def convert_to_comparible_type(x):
     """Convert tensors to comparable types.
@@ -228,6 +233,9 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         output_ds = ds.batch(1_000).map(layer)
         self.assertAllClose(output, output_ds.get_single_element())
 
+        # Run with PyGrain datasets if available
+        self._run_grain_test(layer, input_data, output)
+
         if expected_output:
             self.assertAllClose(output, expected_output)
 
@@ -260,7 +268,6 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         output, _, _ = keras.utils.unpack_x_y_sample_weight(output)
         shape = ops.shape(output[token_id_key])
         self.assertEqual(shape[-1], layer.sequence_length)
-        # Update the sequence length.
         layer.sequence_length = 17
         if isinstance(input_data, tuple):
             output = layer(*input_data)
@@ -269,6 +276,49 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         output, _, _ = keras.utils.unpack_x_y_sample_weight(output)
         shape = ops.shape(output[token_id_key])
         self.assertEqual(shape[-1], 17)
+
+        # Grain parity for sequence length update
+        self._run_grain_test(layer, input_data, output, unpack=True)
+
+    def _run_grain_test(self, layer, input_data, output, unpack=False):
+        if grain:
+            length = tree.flatten(input_data)[0].shape[0]
+            unbatched_data = [
+                tree.map_structure(lambda x: x[i], input_data)
+                for i in range(length)
+            ]
+
+            # Unbatched grain dataset
+            grain_ds = grain.MapDataset.source(unbatched_data)
+            if isinstance(input_data, tuple):
+                grain_ds = grain_ds.map(lambda x: layer(*x))
+            else:
+                grain_ds = grain_ds.map(layer)
+
+            # Batch and compare to `output`
+            grain_ds = grain_ds.batch(length)
+            grain_output = grain_ds[0]
+            if unpack:
+                grain_output, _, _ = keras.utils.unpack_x_y_sample_weight(
+                    grain_output
+                )
+            
+
+            self.assertAllClose(output, grain_output)
+
+            # Batched grain dataset
+            grain_batched_ds = grain.MapDataset.source([input_data])
+            if isinstance(input_data, tuple):
+                grain_batched_ds = grain_batched_ds.map(lambda x: layer(*x))
+            else:
+                grain_batched_ds = grain_batched_ds.map(layer)
+
+            grain_batched_output = grain_batched_ds[0]
+            if unpack:
+                grain_batched_output, _, _ = keras.utils.unpack_x_y_sample_weight(
+                    grain_batched_output
+                )
+            self.assertAllClose(output, grain_batched_output)
 
     def run_serialization_test(self, instance):
         """Check idempotency of serialize/deserialize.

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -300,7 +300,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             ops.convert_to_numpy,
             input_data,
         )
-
+        # Convert NumPy scalar values (especially np.str_) to Python values.
+        numpy_input_data = tree.map_structure(
+        lambda x: x.item()
+        if isinstance(x, np.ndarray) and x.ndim == 0
+        else x,
+        numpy_input_data,
+        )
         if isinstance(numpy_input_data, tuple):
             source_data = list(zip(*numpy_input_data))
         elif isinstance(numpy_input_data, dict):
@@ -335,11 +341,6 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                     is_tuple=isinstance(input_data, tuple),
                 )
             )
-
-            if isinstance(input_data, tuple):
-                grain_ds = grain_ds.map(lambda x: layer(*x))
-            else:
-                grain_ds = grain_ds.map(layer)
 
             if not is_batched:
                 grain_ds = grain_ds.batch(

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -282,11 +282,9 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
     def _run_grain_test(self, layer, input_data, output, unpack=False):
         if grain:
-            length = tree.flatten(input_data)[0].shape[0]
-            unbatched_data = [
-                tree.map_structure(lambda x: x[i], input_data)
-                for i in range(length)
-            ]
+            ds = tf.data.Dataset.from_tensor_slices(input_data)
+            unbatched_data = list(ds)
+            length = len(unbatched_data)
 
             # Unbatched grain dataset
             grain_ds = grain.MapDataset.source(unbatched_data)
@@ -302,7 +300,6 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 grain_output, _, _ = keras.utils.unpack_x_y_sample_weight(
                     grain_output
                 )
-            
 
             self.assertAllClose(output, grain_output)
 
@@ -318,7 +315,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 grain_batched_output, _, _ = keras.utils.unpack_x_y_sample_weight(
                     grain_batched_output
                 )
+
             self.assertAllClose(output, grain_batched_output)
+        else:
+            print(
+                "\n[INFO] PyGrain not installed - "
+                "skipping PyGrain parity checks.\n"
+            )
 
     def run_serialization_test(self, instance):
         """Check idempotency of serialize/deserialize.

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -24,3 +24,4 @@ safetensors
 pillow
 openvino
 transformers
+grain


### PR DESCRIPTION
## Description of the change
Resolves requirement to check for Grain parity in preprocessing tests.


## Reference
#2946 

## Colab Notebook
https://colab.research.google.com/gist/mrinalghoshh/298a40002643e138941261952c9e7604/check-grain-parity.ipynb

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
