### PR TITLE
Migrate `benchmarks/glue.py` from TF-Keras to Keras 3

### DIFF
--- a/benchmarks/glue.py
+++ b/benchmarks/glue.py
@@ -16,17 +16,17 @@ Disclaimer: This script only supports GLUE/mrpc (for now).
 import inspect
 import time
 
+import keras
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from absl import app
 from absl import flags
 from absl import logging
-from tensorflow import keras
 
 import keras_hub
 
 seed = 42
-tf.random.set_seed(seed)
+keras.utils.set_random_seed(seed)
 
 
 flags.DEFINE_string(
@@ -138,12 +138,12 @@ def main(_):
     loss = keras.losses.SparseCategoricalCrossentropy(from_logits=True)
     metrics = [keras.metrics.SparseCategoricalAccuracy()]
     # Configure optimizer.
-    lr = tf.keras.optimizers.schedules.PolynomialDecay(
+    lr = keras.optimizers.schedules.PolynomialDecay(
         FLAGS.learning_rate,
         decay_steps=train_ds.cardinality() * FLAGS.epochs,
         end_learning_rate=0.0,
     )
-    optimizer = tf.keras.optimizers.experimental.AdamW(lr, weight_decay=0.01)
+    optimizer = keras.optimizers.AdamW(learning_rate=lr, weight_decay=0.01)
     optimizer.exclude_from_weight_decay(
         var_names=["LayerNorm", "layer_norm", "bias"]
     )

--- a/benchmarks/glue.py
+++ b/benchmarks/glue.py
@@ -140,7 +140,7 @@ def main(_):
     # Configure optimizer.
     lr = keras.optimizers.schedules.PolynomialDecay(
         FLAGS.learning_rate,
-        decay_steps=train_ds.cardinality() * FLAGS.epochs,
+        decay_steps=int(train_ds.cardinality()) * FLAGS.epochs,
         end_learning_rate=0.0,
     )
     optimizer = keras.optimizers.AdamW(learning_rate=lr, weight_decay=0.01)


### PR DESCRIPTION
## Description of the change


Migrates `benchmarks/glue.py` from the legacy `tf.keras` / TF-Keras 2.x API to Keras 3.


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist

- No functional changes; all Keras API calls are 1:1 equivalents in Keras 3.

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
