### PR TITLE
Fix Falcon ALiBi bias when using the KV cache

### DIFF
--- a/keras_hub/src/models/falcon/falcon_causal_lm_test.py
+++ b/keras_hub/src/models/falcon/falcon_causal_lm_test.py
@@ -148,6 +148,48 @@ class FalconCausalLMTest(TestCase):
             # We should immediately abort and output the prompt.
             self.assertEqual(prompt, output)
 
+    def test_cached_decoding_matches_full_forward(self):
+        # The ALiBi bias must span the cache, not just the query window.
+        # Building it from the query length breaks cached decoding two ways:
+        # it fails to broadcast when more than one token is passed, and it
+        # collapses to all zeros for a single token, silently disabling ALiBi.
+        causal_lm = FalconCausalLM(**self.init_kwargs)
+        token_ids = self.input_data["token_ids"]
+        batch_size, seq_length = token_ids.shape
+        num_layers = self.backbone.num_layers
+        num_heads = self.backbone.num_attention_heads
+        head_dim = self.backbone.hidden_dim // num_heads
+        cache_shape = [
+            batch_size,
+            num_layers,
+            2,
+            seq_length,
+            num_heads,
+            head_dim,
+        ]
+        dtype = causal_lm.compute_dtype
+
+        # One pass over the whole sequence, seeding an empty cache.
+        full_logits, _, _ = causal_lm.call_with_cache(
+            token_ids, ops.zeros(cache_shape, dtype=dtype), 0
+        )
+
+        # Prefill half the sequence, then decode a token at a time.
+        cache = ops.zeros(cache_shape, dtype=dtype)
+        prefill = seq_length // 2
+        logits, _, cache = causal_lm.call_with_cache(
+            token_ids[:, :prefill], cache, 0
+        )
+        pieces = [logits]
+        for i in range(prefill, seq_length):
+            logits, _, cache = causal_lm.call_with_cache(
+                token_ids[:, i : i + 1], cache, i
+            )
+            pieces.append(logits)
+        stepwise_logits = ops.concatenate(pieces, axis=1)
+
+        self.assertAllClose(stepwise_logits, full_logits, atol=1e-5, rtol=1e-5)
+
     def test_generate_compilation(self):
         causal_lm = FalconCausalLM(**self.init_kwargs)
         # Assert we do not recompile with successive calls.

--- a/keras_hub/src/models/falcon/falcon_transformer_decoder.py
+++ b/keras_hub/src/models/falcon/falcon_transformer_decoder.py
@@ -118,10 +118,22 @@ class FalconTransformerDecoder(keras.layers.Layer):
 
         x = self.input_layernorm(inputs)
 
-        mask = decoder_padding_mask
-        if mask is None:
-            batch_size, seq_length = ops.shape(inputs)[:2]
-            mask = ops.ones((batch_size, seq_length), dtype="int32")
+        if attention_cache is not None:
+            # Keys and values span the whole cache, so the ALiBi bias must
+            # too. Building it from the query window instead leaves the bias
+            # shorter than the attention scores: it fails to broadcast when
+            # more than one token is passed, and collapses to all zeros
+            # during single-token decoding, silently disabling ALiBi.
+            # Unused cache positions are already masked out by the causal
+            # attention mask, so an all-ones mask gives absolute positions.
+            batch_size = ops.shape(inputs)[0]
+            kv_length = ops.shape(attention_cache)[2]
+            mask = ops.ones((batch_size, kv_length), dtype="int32")
+        else:
+            mask = decoder_padding_mask
+            if mask is None:
+                batch_size, seq_length = ops.shape(inputs)[:2]
+                mask = ops.ones((batch_size, seq_length), dtype="int32")
         alibi = self._build_alibi_tensor(self.num_attention_heads, mask)
 
         # Attention block.


### PR DESCRIPTION
## Description of the change

`_build_alibi_tensor` builds the bias from the query window, so with a cache it returns `(batch, heads, 1, q_len)` against attention scores of `(batch, heads, q_len, kv_len)`:

- Multi-token steps don't broadcast → `InvalidArgumentError`. This is the reported bug.
- Single-token steps *do* broadcast, to `(batch, heads, 1, 1)`, and evaluate to all zeros since `cumsum(ones(1)) - 1 == 0`. `generate_step` decodes one token at a time, so `FalconCausalLM.generate()` has been running with ALiBi disabled at every decode step. Not mentioned in the issue, and the worse of the two.

Building the bias over the cache length fixes both. Unused cache slots are already masked out by the causal mask, which `_compute_attention_mask` already accounts for.

Verified in the Colab: cached decoding matches a full forward pass (max abs diff 2.98e-07), and the no-cache path is bit-identical before and after, with and without a padding mask. `keras_hub/src/models/falcon/` passes (18 passed, 11 skipped), and reverting the fix while keeping the new test makes it fail.

## Reference

Fixes #2861. Same fix as #2862 by @pctablet505, which was closed unmerged by its author.

## Colab Notebook

https://colab.research.google.com/drive/1Hg1h55GT7wfn0lvz-R92Y5brx5I6jkJz

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).