### PR TITLE
Migrate: Gemma3nAudioConverter from TF ops to keras.ops

### DIFF
--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -1,7 +1,6 @@
 import math
 
 import numpy as np
-import tensorflow as tf
 from keras import KerasTensor
 from keras import ops
 from keras import random
@@ -523,6 +522,8 @@ class Gemma3nAudioConverter(AudioConverter):
         pad_to_multiple_of=128,
         return_attention_mask=True,
     ):
+        import tensorflow as tf
+
         if isinstance(raw_speech, KerasTensor):
             return self.compute_output_spec(raw_speech)
         if isinstance(raw_speech, (list, tuple)):

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -1,11 +1,6 @@
 import math
 
 import numpy as np
-
-try:
-    import tensorflow as tf
-except ImportError:
-    tf = None
 from keras import KerasTensor
 from keras import ops
 from keras import random
@@ -522,153 +517,134 @@ class Gemma3nAudioConverter(AudioConverter):
         return_attention_mask=True,
     ):
         if isinstance(raw_speech, KerasTensor):
-            return self.compute_output_spec(raw_speech)
-        if isinstance(raw_speech, (list, tuple)):
-            speech_list = [
-                np.asarray(speech).reshape(-1) for speech in raw_speech
-            ]
-            input_features_list, attention_mask_list = self.pad(
-                speech_list,
-                padding=padding,
-                max_length=max_length,
-                truncation=truncation,
-                pad_to_multiple_of=pad_to_multiple_of,
-                return_attention_mask=return_attention_mask,
+            return self.compute_output_spec(
+                raw_speech, return_attention_mask=return_attention_mask
             )
-            if not return_attention_mask:
-                attention_mask_list = [None] * len(input_features_list)
-            prepared_features = []
-            prepared_masks = []
-            for speech, mask in zip(input_features_list, attention_mask_list):
-                speech = ops.convert_to_tensor(
-                    np.asarray(speech).reshape(-1), dtype=self.compute_dtype
+
+        if ops.is_tensor(raw_speech):
+            waveform = ops.cast(raw_speech, dtype=self.compute_dtype)
+            waveform_rank = len(ops.shape(waveform))
+            if waveform_rank not in (1, 2):
+                raise ValueError(
+                    f"`raw_speech` must have rank 1 or 2. "
+                    f"Received shape: {ops.shape(raw_speech)}."
+                )
+            if (
+                max_length is not None
+                and pad_to_multiple_of is not None
+                and max_length % pad_to_multiple_of != 0
+            ):
+                max_length = (
+                    (max_length // pad_to_multiple_of) + 1
+                ) * pad_to_multiple_of
+
+            if truncation and max_length is not None:
+                waveform = waveform[..., :max_length]
+
+            if padding == "max_length" and max_length is not None:
+                current_len = ops.shape(waveform)[-1]
+                pad_len = ops.maximum(0, max_length - current_len)
+                paddings = (
+                    [[0, pad_len]]
+                    if waveform_rank == 1
+                    else [[0, 0], [0, pad_len]]
+                )
+                waveform = ops.pad(
+                    waveform, paddings, constant_values=self.padding_value
+                )
+            elif padding == "longest" and pad_to_multiple_of is not None:
+                current_len = ops.shape(waveform)[-1]
+                rem = current_len % pad_to_multiple_of
+                pad_len = (pad_to_multiple_of - rem) % pad_to_multiple_of
+                paddings = (
+                    [[0, pad_len]]
+                    if waveform_rank == 1
+                    else [[0, 0], [0, pad_len]]
+                )
+                waveform = ops.pad(
+                    waveform, paddings, constant_values=self.padding_value
                 )
 
-                mask_tensor = (
-                    ops.convert_to_tensor(
-                        np.asarray(mask).reshape(-1), dtype="int32"
-                    )
-                    if mask is not None
-                    else None
-                )
-
-                # Single waveform -> 1-D input.
-                features, feature_mask = self._extract_spectrogram(
-                    speech, mask_tensor
-                )
-                features = ops.reshape(features, (-1, self.feature_size))
-                if return_attention_mask:
-                    if feature_mask is None:
-                        feature_mask = ops.ones(
-                            (ops.shape(features)[0],), dtype="int32"
-                        )
-                    else:
-                        feature_mask = ops.reshape(feature_mask, (-1,))
-                        feature_mask = ops.cast(feature_mask, "int32")
-
-                    prepared_masks.append(feature_mask)
-                prepared_features.append(features)
-
-            input_features = ops.stack(prepared_features, axis=0)
             if return_attention_mask:
-                input_features_mask = ops.stack(prepared_masks, axis=0)
-            else:
-                input_features_mask = None
-            return input_features, input_features_mask
-
-        if isinstance(raw_speech, (list, tuple)):
-            raw_speech_tensor = ops.stack(
-                [
-                    speech
-                    if ops.is_tensor(speech)
-                    else ops.convert_to_tensor(speech)
-                    for speech in raw_speech
-                ],
-                axis=0,
-            )
-        elif ops.is_tensor(raw_speech):
-            raw_speech_tensor = raw_speech
-        else:
-            raw_speech_tensor = ops.convert_to_tensor(raw_speech)
-
-        rank = ops.ndim(raw_speech_tensor)
-        if rank == 1:
-            speech_np = np.asarray(raw_speech_tensor).reshape(-1)
-
-            input_features_list, attention_mask_list = self.pad(
-                [speech_np],
-                padding=padding,
-                max_length=max_length,
-                truncation=truncation,
-                pad_to_multiple_of=pad_to_multiple_of,
-                return_attention_mask=return_attention_mask,
-            )
-            if not input_features_list:
-                features = ops.zeros(
-                    (0, self.feature_size), dtype=self.compute_dtype
-                )
-                mask = (
-                    ops.zeros((0,), dtype="int32")
-                    if return_attention_mask
-                    else None
-                )
-                return features, mask
-
-            speech = ops.convert_to_tensor(
-                input_features_list[0], dtype=self.compute_dtype
-            )
-            if return_attention_mask:
-                mask = ops.convert_to_tensor(
-                    attention_mask_list[0], dtype="int32"
-                )
+                current_len = ops.shape(waveform)[-1]
+                if waveform_rank == 1:
+                    mask = ops.ones((current_len,), dtype="int32")
+                else:
+                    batch_size = ops.shape(waveform)[0]
+                    mask = ops.ones((batch_size, current_len), dtype="int32")
             else:
                 mask = None
-            features, feature_mask = self._extract_spectrogram(speech, mask)
-            features = ops.reshape(features, (-1, self.feature_size))
 
-            if return_attention_mask:
-                if feature_mask is None:
-                    feature_mask = ops.ones(
-                        (ops.shape(features)[0],), dtype="int32"
-                    )
-                else:
-                    feature_mask = ops.reshape(feature_mask, (-1,))
-                    feature_mask = ops.cast(feature_mask, "int32")
-            else:
-                feature_mask = None
+            features, feature_mask = self._extract_spectrogram(waveform, mask)
             return features, feature_mask
 
-        def process_one_audio(speech):
-            speech = ops.reshape(speech, (-1,))
-            speech = ops.cast(speech, self.compute_dtype)
-            speech_batched = ops.expand_dims(speech, axis=0)
-            speech_length = ops.shape(speech_batched)[1]
-            speech_mask = ops.ones((1, speech_length), dtype="int32")
-            features, feature_mask = self._extract_spectrogram(
-                speech_batched, speech_mask
-            )
-            features = ops.reshape(features, (-1, self.feature_size))
-            features = ops.cast(features, self.compute_dtype)
-            if feature_mask is None:
-                num_frames = ops.shape(features)[0]
-                feature_mask = ops.ones((num_frames,), dtype="int32")
+        # Handle NumPy inputs and determine whether input is batched
+        if isinstance(raw_speech, (list, tuple)):
+            is_batched = True
+            speech_list = [
+                ops.convert_to_numpy(s).reshape(-1) for s in raw_speech
+            ]
+        else:
+            speech_np = ops.convert_to_numpy(raw_speech)
+            if speech_np.ndim == 1:
+                is_batched = False
+                speech_list = [speech_np.reshape(-1)]
+            elif speech_np.ndim == 2:
+                is_batched = True
+                speech_list = [s.reshape(-1) for s in speech_np]
             else:
-                feature_mask = ops.reshape(feature_mask, (-1,))
-                feature_mask = ops.cast(feature_mask, "int32")
-            return features, feature_mask
+                raise ValueError(
+                    f"`raw_speech` must have rank 1 or 2. "
+                    f"Received shape: {speech_np.shape}."
+                )
 
-        input_features, input_features_mask = tf.map_fn(
-            process_one_audio,
-            raw_speech_tensor,
-            fn_output_signature=(
-                tf.TensorSpec(
-                    shape=(None, self.feature_size),
-                    dtype=tf.as_dtype(self.compute_dtype),
-                ),
-                tf.TensorSpec(shape=(None,), dtype=tf.int32),
-            ),
+        # Pad or truncate using self.pad()
+        input_features_list, attention_mask_list = self.pad(
+            speech_list,
+            padding=padding,
+            max_length=max_length,
+            truncation=truncation,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_attention_mask=return_attention_mask,
         )
-        return input_features, input_features_mask
+
+        if not input_features_list:
+            features = ops.zeros(
+                (0, 0, self.feature_size)
+                if is_batched
+                else (0, self.feature_size),
+                dtype=self.compute_dtype,
+            )
+            mask = (
+                ops.zeros((0, 0) if is_batched else (0,), dtype="int32")
+                if return_attention_mask
+                else None
+            )
+            return features, mask
+
+        # Stack into tensors
+        padded_speech = ops.convert_to_tensor(
+            np.stack(input_features_list, axis=0), dtype=self.compute_dtype
+        )
+        padded_mask = (
+            ops.convert_to_tensor(
+                np.stack(attention_mask_list, axis=0), dtype="int32"
+            )
+            if return_attention_mask
+            else None
+        )
+
+        # If unbatched (1D), squeeze the batch dimension
+        if not is_batched:
+            padded_speech = ops.squeeze(padded_speech, axis=0)
+            if padded_mask is not None:
+                padded_mask = ops.squeeze(padded_mask, axis=0)
+
+        # Extract spectrograms (natively supports 1D and 2D with Keras ops)
+        features, feature_mask = self._extract_spectrogram(
+            padded_speech, padded_mask
+        )
+        return features, feature_mask
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -1,6 +1,11 @@
 import math
 
 import numpy as np
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 from keras import KerasTensor
 from keras import ops
 from keras import random
@@ -516,8 +521,6 @@ class Gemma3nAudioConverter(AudioConverter):
         pad_to_multiple_of=128,
         return_attention_mask=True,
     ):
-        import tensorflow as tf
-
         if isinstance(raw_speech, KerasTensor):
             return self.compute_output_spec(raw_speech)
         if isinstance(raw_speech, (list, tuple)):
@@ -536,7 +539,6 @@ class Gemma3nAudioConverter(AudioConverter):
                 attention_mask_list = [None] * len(input_features_list)
             prepared_features = []
             prepared_masks = []
-
             for speech, mask in zip(input_features_list, attention_mask_list):
                 speech = ops.convert_to_tensor(
                     np.asarray(speech).reshape(-1), dtype=self.compute_dtype

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -235,13 +235,8 @@ class Gemma3nAudioConverter(AudioConverter):
                     frames_to_process[..., 1:-1]
                     - self.preemphasis * frames_to_process[..., :-2]
                 )
-
                 frames = ops.concatenate(
-                    [
-                        first_sample,
-                        rest_of_samples,
-                    ],
-                    axis=-1,
+                    [first_sample, rest_of_samples], axis=-1
                 )
             else:
                 frames = (
@@ -280,6 +275,8 @@ class Gemma3nAudioConverter(AudioConverter):
             stddev = ops.reshape(stddev, (1, self.feature_size))
             log_mel_spec = log_mel_spec / stddev
         mel_spectrogram = ops.cast(log_mel_spec, dtype=self.compute_dtype)
+
+        num_output_frames = ops.shape(mel_spectrogram)[-2]
         if attention_mask is None:
             mask = None
         else:
@@ -288,12 +285,8 @@ class Gemma3nAudioConverter(AudioConverter):
                 sequence_length=self.frame_length,
                 sequence_stride=self.hop_length,
             )
-            frame_masks_bool = ops.cast(frame_masks, dtype="bool")
-            mask = ops.all(frame_masks_bool, axis=-1)
-
-            # mask and spectrogram must have the same number
-            # of frames.
-            num_output_frames = ops.shape(mel_spectrogram)[-2]
+            frame_masks = ops.cast(frame_masks, dtype="bool")
+            mask = ops.all(frame_masks, axis=-1)
             mask = mask[..., :num_output_frames]
         return mel_spectrogram, mask
 
@@ -367,12 +360,9 @@ class Gemma3nAudioConverter(AudioConverter):
                 if return_attention_mask:
                     attention_mask = np.pad(attention_mask, (difference, 0))
                 if required_input.ndim > 1:
-                    padding_shape = (
-                        (difference, 0),
-                        (0, 0),
-                    )
+                    padding_shape = ((difference, 0), (0, 0))
                 else:
-                    padding_shape = ((difference, 0),)
+                    padding_shape = (difference, 0)
                 input_features = np.pad(
                     required_input,
                     padding_shape,
@@ -428,7 +418,6 @@ class Gemma3nAudioConverter(AudioConverter):
             if return_attention_mask is not None
             else self.return_attention_mask
         )
-
         if len(required_input) == 0:
             if return_attention_mask:
                 return [], []
@@ -550,12 +539,12 @@ class Gemma3nAudioConverter(AudioConverter):
 
                 mask_tensor = (
                     ops.convert_to_tensor(
-                        np.asarray(mask).reshape(-1),
-                        dtype="int32",
+                        np.asarray(mask).reshape(-1), dtype="int32"
                     )
                     if mask is not None
                     else None
                 )
+
                 # Single waveform -> 1-D input.
                 features, feature_mask = self._extract_spectrogram(
                     speech, mask_tensor
@@ -580,7 +569,21 @@ class Gemma3nAudioConverter(AudioConverter):
                 input_features_mask = None
             return input_features, input_features_mask
 
-        raw_speech_tensor = ops.convert_to_tensor(raw_speech)
+        if isinstance(raw_speech, (list, tuple)):
+            raw_speech_tensor = ops.stack(
+                [
+                    speech
+                    if ops.is_tensor(speech)
+                    else ops.convert_to_tensor(speech)
+                    for speech in raw_speech
+                ],
+                axis=0,
+            )
+        elif ops.is_tensor(raw_speech):
+            raw_speech_tensor = raw_speech
+        else:
+            raw_speech_tensor = ops.convert_to_tensor(raw_speech)
+
         rank = ops.ndim(raw_speech_tensor)
         if rank == 1:
             speech_np = np.asarray(raw_speech_tensor).reshape(-1)
@@ -598,25 +601,18 @@ class Gemma3nAudioConverter(AudioConverter):
                     (0, self.feature_size), dtype=self.compute_dtype
                 )
                 mask = (
-                    ops.zeros(
-                        (0,),
-                        dtype="int32",
-                    )
+                    ops.zeros((0,), dtype="int32")
                     if return_attention_mask
                     else None
                 )
-
                 return features, mask
 
             speech = ops.convert_to_tensor(
-                input_features_list[0],
-                dtype=self.compute_dtype,
+                input_features_list[0], dtype=self.compute_dtype
             )
-
             if return_attention_mask:
                 mask = ops.convert_to_tensor(
-                    attention_mask_list[0],
-                    dtype="int32",
+                    attention_mask_list[0], dtype="int32"
                 )
             else:
                 mask = None

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+from keras import KerasTensor
 from keras import ops
 from keras import random
 
@@ -57,7 +58,7 @@ class Gemma3nAudioConverter(AudioConverter):
             array. Can be unbatched (1D) or batched (list of 1D arrays).
         padding: str or bool. Padding strategy for batches. Options are
             `"longest"` (pad to longest sequence in batch), `True` (same as
-            "longest"), or `False` (no padding). Defaults to `"longest"`.
+            `"longest"`), or `False` (no padding). Defaults to `"longest"`.
         max_length: int. Maximum length to truncate or pad to. Defaults to
             480000.
         truncation: bool. Whether to truncate sequences longer than
@@ -71,12 +72,10 @@ class Gemma3nAudioConverter(AudioConverter):
     ```python
     import numpy as np
 
-    # Create a simple audio signal (1 second of 440 Hz sine wave).
     audio = np.sin(
         2 * np.pi * 440 * np.linspace(0, 1, 16000, dtype=np.float32)
     )
 
-    # Initialize the audio converter
     converter = keras_hub.layers.Gemma3nAudioConverter(
         feature_size=128,
         sampling_rate=16000,
@@ -97,24 +96,9 @@ class Gemma3nAudioConverter(AudioConverter):
         padding_side="right",
     )
 
-    # Convert audio to log-mel spectrogram.
     features, mask = converter(audio)
-    print(features.shape)  # (num_frames, 128)
-    print(mask.shape)      # (num_frames,)
-
-    # Convert a batch of audio with padding.
-    audio_1 = np.sin(
-        2 * np.pi * 440 * np.linspace(0, 1, 16000, dtype=np.float32)
-    )
-    audio_2 = np.sin(
-        2 * np.pi * 880 * np.linspace(0, 0.5, 8000, dtype=np.float32)
-    )
-    features, mask = converter(
-        [audio_1, audio_2],
-        padding="longest",
-        pad_to_multiple_of=128,
-    )
-    print(features.shape)  # (2, num_frames, 128)
+    print(features.shape)
+    print(mask.shape)
     ```
     """
 
@@ -179,6 +163,7 @@ class Gemma3nAudioConverter(AudioConverter):
             sample_rate=self.sampling_rate,
             fft_length=fft_length,
         )
+
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
         self.built = True
@@ -192,8 +177,8 @@ class Gemma3nAudioConverter(AudioConverter):
         sample_rate,
         fft_length,
     ):
-        # Keep all filterbank construction in float64 to match the
-        # Hugging Face / NumPy reference implementation.
+        # Construct the filterbank in float64 with NumPy at initialization
+        # time for numerical consistency with the reference implementation.
         all_freqs = np.arange(n_freqs, dtype=np.float64) * (
             sample_rate / fft_length
         )
@@ -216,13 +201,14 @@ class Gemma3nAudioConverter(AudioConverter):
         return ops.convert_to_tensor(fb, dtype=self.compute_dtype)
 
     def _extract_spectrogram(self, waveform, attention_mask):
-        # waveform from call() is normally: (1, num_samples)
+        # waveform is normally shaped (1, num_samples).
         if ops.ndim(waveform) == 1:
             waveform = ops.expand_dims(waveform, axis=0)
         waveform = ops.cast(waveform, dtype=self.compute_dtype)
         if self.dither > 0.0:
             waveform = waveform + self.dither * random.normal(
-                ops.shape(waveform), dtype=waveform.dtype
+                ops.shape(waveform),
+                dtype=waveform.dtype,
             )
         if self.input_scale_factor != 1.0:
             waveform = waveform * self.input_scale_factor
@@ -241,7 +227,8 @@ class Gemma3nAudioConverter(AudioConverter):
                     - self.preemphasis * frames_to_process[..., :-2]
                 )
                 frames = ops.concatenate(
-                    [first_sample, rest_of_samples], axis=-1
+                    [first_sample, rest_of_samples],
+                    axis=-1,
                 )
             else:
                 frames = (
@@ -250,8 +237,9 @@ class Gemma3nAudioConverter(AudioConverter):
                 )
         else:
             frames = frames_to_process[..., :-1]
+
         frames = frames * self.window
-        fft_frames = ops.cast(frames, dtype="float64")
+        fft_frames = ops.cast(frames, dtype=self.compute_dtype)
 
         fft_pad = self.fft_length - self.frame_length
         if fft_pad > 0:
@@ -260,29 +248,52 @@ class Gemma3nAudioConverter(AudioConverter):
                 [[0, 0], [0, 0], [0, fft_pad]],
             )
 
-        real, imag = ops.rfft(fft_frames, fft_length=self.fft_length)
-        magnitude_spec = ops.sqrt(ops.square(real) + ops.square(imag))
+        # Keras versions used by this repository may return the real and
+        # imaginary components separately from ops.rfft. Handle that form
+        # while also supporting versions returning a complex tensor.
+        stft = ops.rfft(fft_frames, fft_length=self.fft_length)
 
-        mel_filters = ops.cast(self.mel_filters, dtype="float64")
-        mel_spec = ops.matmul(magnitude_spec, mel_filters)
+        if isinstance(stft, (tuple, list)):
+            real, imag = stft
+            magnitude_spec = ops.sqrt(ops.square(real) + ops.square(imag))
+        else:
+            magnitude_spec = ops.abs(stft)
 
-        mel_floor_tensor = ops.cast(self.mel_floor, dtype="float64")
+        mel_spec = ops.matmul(magnitude_spec, self.mel_filters)
+
+        mel_floor_tensor = ops.cast(self.mel_floor, dtype=self.compute_dtype)
         log_mel_spec = ops.log(ops.maximum(mel_spec, mel_floor_tensor))
 
         if self.per_bin_mean is not None:
             per_bin_mean_tensor = ops.reshape(
-                ops.convert_to_tensor(self.per_bin_mean, dtype="float64"),
+                ops.convert_to_tensor(
+                    self.per_bin_mean,
+                    dtype=self.compute_dtype,
+                ),
                 (1, 1, self.feature_size),
             )
             log_mel_spec = log_mel_spec - per_bin_mean_tensor
 
         if self.per_bin_stddev is not None:
             per_bin_stddev_tensor = ops.reshape(
-                ops.convert_to_tensor(self.per_bin_stddev, dtype="float64"),
+                ops.convert_to_tensor(
+                    self.per_bin_stddev,
+                    dtype=self.compute_dtype,
+                ),
                 (1, 1, self.feature_size),
             )
             log_mel_spec = log_mel_spec / per_bin_stddev_tensor
-        mel_spectrogram = ops.squeeze(log_mel_spec, axis=0)
+
+        # Depending on the backend/version, the FFT/matmul path can preserve
+        # or remove the leading singleton dimension. Only squeeze it when it
+        # is actually present.
+        if ops.ndim(log_mel_spec) == 3:
+            if log_mel_spec.shape[0] == 1:
+                mel_spectrogram = ops.squeeze(log_mel_spec, axis=0)
+            else:
+                mel_spectrogram = log_mel_spec
+        else:
+            mel_spectrogram = log_mel_spec
         mask = ops.cast(attention_mask[:: self.hop_length], dtype="bool")
         mask = mask[: ops.shape(mel_spectrogram)[0]]
         mel_spectrogram = ops.cast(mel_spectrogram, dtype=self.compute_dtype)
@@ -296,13 +307,15 @@ class Gemma3nAudioConverter(AudioConverter):
                 padding_strategy = padding
         else:
             padding_strategy = "do_not_pad"
+
         if max_length is None:
             if padding_strategy == "max_length":
                 raise ValueError(
-                    "When setting padding='max_length', max_length must be "
-                    "defined"
+                    "When setting padding='max_length', max_length must "
+                    "be defined"
                 )
-        if padding_strategy != "do_not_pad" and (self.padding_value is None):
+
+        if padding_strategy != "do_not_pad" and self.padding_value is None:
             raise ValueError("Padding requested but no padding_value defined")
         return padding_strategy
 
@@ -316,16 +329,18 @@ class Gemma3nAudioConverter(AudioConverter):
         return_attention_mask=None,
     ):
         required_input = input_features
+
         if padding_strategy == "longest":
             max_length = len(required_input)
         if (
             max_length is not None
             and pad_to_multiple_of is not None
-            and (max_length % pad_to_multiple_of != 0)
+            and max_length % pad_to_multiple_of != 0
         ):
             max_length = (
                 (max_length // pad_to_multiple_of) + 1
             ) * pad_to_multiple_of
+
         needs_to_be_padded = (
             padding_strategy != "do_not_pad"
             and len(required_input) < max_length
@@ -336,7 +351,10 @@ class Gemma3nAudioConverter(AudioConverter):
             difference = max_length - len(required_input)
             if self.padding_side == "right":
                 if return_attention_mask:
-                    attention_mask = np.pad(attention_mask, (0, difference))
+                    attention_mask = np.pad(
+                        attention_mask,
+                        (0, difference),
+                    )
                 if required_input.ndim > 1:
                     padding_shape = ((0, difference), (0, 0))
                 else:
@@ -350,8 +368,15 @@ class Gemma3nAudioConverter(AudioConverter):
             elif self.padding_side == "left":
                 if return_attention_mask:
                     attention_mask = np.pad(attention_mask, (difference, 0))
+                    attention_mask = np.pad(
+                        attention_mask,
+                        (difference, 0),
+                    )
                 if required_input.ndim > 1:
-                    padding_shape = ((difference, 0), (0, 0))
+                    padding_shape = (
+                        (difference, 0),
+                        (0, 0),
+                    )
                 else:
                     padding_shape = ((difference, 0),)
                 input_features = np.pad(
@@ -372,19 +397,22 @@ class Gemma3nAudioConverter(AudioConverter):
     ):
         if not truncation:
             return input_features, attention_mask
-        elif truncation and max_length is None:
+
+        if truncation and max_length is None:
             raise ValueError(
                 "When setting truncation=True, max_length must be defined"
             )
+
         required_input = input_features
         if (
             max_length is not None
             and pad_to_multiple_of is not None
-            and (max_length % pad_to_multiple_of != 0)
+            and max_length % pad_to_multiple_of != 0
         ):
             max_length = (
                 (max_length // pad_to_multiple_of) + 1
             ) * pad_to_multiple_of
+
         needs_to_be_truncated = len(required_input) > max_length
         if needs_to_be_truncated:
             input_features = input_features[:max_length]
@@ -407,15 +435,23 @@ class Gemma3nAudioConverter(AudioConverter):
             if return_attention_mask is not None
             else self.return_attention_mask
         )
+
         if len(required_input) == 0:
-            return [], [] if return_attention_mask else None
+            if return_attention_mask:
+                return [], []
+            return [], None
+
         required_input = [np.asarray(v) for v in required_input]
+
         padding_strategy = self._get_padding_strategies(
-            padding=padding, max_length=max_length
+            padding=padding,
+            max_length=max_length,
         )
+
         batch_size = len(required_input)
         truncated_inputs = []
         truncated_masks = []
+
         for i in range(batch_size):
             inputs = required_input[i]
             mask = (
@@ -430,6 +466,7 @@ class Gemma3nAudioConverter(AudioConverter):
                 pad_to_multiple_of=pad_to_multiple_of,
                 truncation=truncation,
             )
+
             truncated_inputs.append(inputs_slice)
             if mask_slice is not None:
                 truncated_masks.append(mask_slice)
@@ -460,6 +497,20 @@ class Gemma3nAudioConverter(AudioConverter):
             return batch_outputs_features, None
         return batch_outputs_features, batch_outputs_masks
 
+    def compute_output_spec(self, raw_speech, *args, **kwargs):
+        was_batched = len(raw_speech.shape) > 1
+
+        if was_batched:
+            features_shape = (raw_speech.shape[0], None, self.feature_size)
+            mask_shape = (raw_speech.shape[0], None)
+        else:
+            features_shape = (None, self.feature_size)
+            mask_shape = (None,)
+        return (
+            KerasTensor(shape=features_shape, dtype=self.compute_dtype),
+            KerasTensor(shape=mask_shape, dtype="int32"),
+        )
+
     def call(
         self,
         raw_speech,
@@ -469,12 +520,19 @@ class Gemma3nAudioConverter(AudioConverter):
         pad_to_multiple_of=128,
         return_attention_mask=True,
     ):
+        # Handle symbolic inputs before NumPy conversion.
+        if isinstance(raw_speech, KerasTensor):
+            return self.compute_output_spec(
+                raw_speech,
+            )
+
         if isinstance(raw_speech, (list, tuple)):
             was_batched = True
             raw_speech_list = [np.asarray(speech) for speech in raw_speech]
         else:
             raw_speech_np = np.asarray(raw_speech)
             was_batched = raw_speech_np.ndim > 1
+
             if was_batched:
                 raw_speech_list = [speech for speech in raw_speech_np]
             else:
@@ -502,6 +560,7 @@ class Gemma3nAudioConverter(AudioConverter):
                 speech.T,
                 dtype=self.compute_dtype,
             )
+
             mask_tensor = ops.convert_to_tensor(
                 mask,
                 dtype="int32",
@@ -515,18 +574,39 @@ class Gemma3nAudioConverter(AudioConverter):
             prepared_speech.append(features)
             prepared_speech_mask.append(feature_mask)
 
-        input_features = ops.stack(prepared_speech, axis=0)
-        input_features_mask = ops.stack(prepared_speech_mask, axis=0)
+        input_features = ops.stack(
+            prepared_speech,
+            axis=0,
+        )
+
+        input_features_mask = ops.stack(
+            prepared_speech_mask,
+            axis=0,
+        )
 
         if not was_batched:
-            input_features = ops.squeeze(input_features, axis=0)
-            input_features_mask = ops.squeeze(input_features_mask, axis=0)
+            input_features = ops.squeeze(
+                input_features,
+                axis=0,
+            )
+            input_features_mask = ops.squeeze(
+                input_features_mask,
+                axis=0,
+            )
 
-        input_features_mask = ops.cast(input_features_mask, dtype="int32")
-        return input_features, input_features_mask
+        input_features_mask = ops.cast(
+            input_features_mask,
+            dtype="int32",
+        )
+
+        return (
+            input_features,
+            input_features_mask,
+        )
 
     def get_config(self):
         config = super().get_config()
+
         config.update(
             {
                 "feature_size": self.feature_size,
@@ -548,4 +628,5 @@ class Gemma3nAudioConverter(AudioConverter):
                 "padding_side": self.padding_side,
             }
         )
+
         return config

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+import tensorflow as tf
 from keras import KerasTensor
 from keras import ops
 from keras import random
@@ -201,7 +202,17 @@ class Gemma3nAudioConverter(AudioConverter):
         return ops.convert_to_tensor(fb, dtype=self.compute_dtype)
 
     def _extract_spectrogram(self, waveform, attention_mask=None):
-        waveform = ops.cast(waveform, dtype=self.compute_dtype)
+        waveform = ops.cast(
+            waveform,
+            dtype=self.compute_dtype,
+        )
+        waveform_rank = ops.ndim(waveform)
+        if waveform_rank not in (1, 2):
+            raise ValueError(
+                "`waveform` must have rank 1 or 2. "
+                f"Received rank={waveform_rank}, "
+                f"shape={ops.shape(waveform)}."
+            )
         if self.dither > 0.0:
             waveform = waveform + self.dither * random.normal(
                 ops.shape(waveform),
@@ -214,17 +225,23 @@ class Gemma3nAudioConverter(AudioConverter):
             sequence_length=self.frame_length + 1,
             sequence_stride=self.hop_length,
         )
+        # Pre-emphasis
         if self.preemphasis > 0.0:
             if self.preemphasis_htk_flavor:
                 first_sample = frames_to_process[..., :1] * (
                     1.0 - self.preemphasis
                 )
+
                 rest_of_samples = (
                     frames_to_process[..., 1:-1]
                     - self.preemphasis * frames_to_process[..., :-2]
                 )
+
                 frames = ops.concatenate(
-                    [first_sample, rest_of_samples],
+                    [
+                        first_sample,
+                        rest_of_samples,
+                    ],
                     axis=-1,
                 )
             else:
@@ -237,64 +254,48 @@ class Gemma3nAudioConverter(AudioConverter):
         frames = frames * self.window
         fft_pad = self.fft_length - self.frame_length
         if fft_pad > 0:
-            frames = ops.pad(
-                frames,
-                [[0, 0], [0, fft_pad]],
-            )
-        stft = ops.rfft(
-            frames,
-            fft_length=self.fft_length,
-        )
+            if waveform_rank == 1:
+                frames = ops.pad(frames, [[0, 0], [0, fft_pad]])
+            else:
+                frames = ops.pad(frames, [[0, 0], [0, 0], [0, fft_pad]])
+
+        stft = ops.rfft(frames, fft_length=self.fft_length)
         if isinstance(stft, (tuple, list)):
             real, imag = stft
             magnitude_spec = ops.sqrt(ops.square(real) + ops.square(imag))
         else:
             magnitude_spec = ops.abs(stft)
-        mel_spec = ops.matmul(
-            magnitude_spec,
-            self.mel_filters,
-        )
-        mel_floor_tensor = ops.cast(
-            self.mel_floor,
-            dtype=self.compute_dtype,
-        )
+        mel_spec = ops.matmul(magnitude_spec, self.mel_filters)
+        mel_floor_tensor = ops.cast(self.mel_floor, dtype=self.compute_dtype)
         log_mel_spec = ops.log(ops.maximum(mel_spec, mel_floor_tensor))
         if self.per_bin_mean is not None:
             mean = ops.convert_to_tensor(
-                self.per_bin_mean,
-                dtype=self.compute_dtype,
+                self.per_bin_mean, dtype=self.compute_dtype
             )
             mean = ops.reshape(mean, (1, self.feature_size))
             log_mel_spec = log_mel_spec - mean
         if self.per_bin_stddev is not None:
             stddev = ops.convert_to_tensor(
-                self.per_bin_stddev,
-                dtype=self.compute_dtype,
+                self.per_bin_stddev, dtype=self.compute_dtype
             )
             stddev = ops.reshape(stddev, (1, self.feature_size))
             log_mel_spec = log_mel_spec / stddev
-        mel_spectrogram = ops.cast(
-            log_mel_spec,
-            dtype=self.compute_dtype,
-        )
-        num_output_frames = ops.shape(mel_spectrogram)[-2]
+        mel_spectrogram = ops.cast(log_mel_spec, dtype=self.compute_dtype)
         if attention_mask is None:
             mask = None
         else:
-            # A spectrogram frame is valid only when all samples contributing
-            # to that frame are non-padding.
             frame_masks = ops.extract_sequences(
                 attention_mask,
                 sequence_length=self.frame_length,
                 sequence_stride=self.hop_length,
             )
-            mask = ops.all(
-                ops.cast(frame_masks, dtype="bool"),
-                axis=-1,
-            )
-            # Keep the mask exactly aligned with the frames produced by
-            # `ops.extract_sequences()` / STFT.
-            mask = mask[:num_output_frames]
+            frame_masks_bool = ops.cast(frame_masks, dtype="bool")
+            mask = ops.all(frame_masks_bool, axis=-1)
+
+            # mask and spectrogram must have the same number
+            # of frames.
+            num_output_frames = ops.shape(mel_spectrogram)[-2]
+            mask = mask[..., :num_output_frames]
         return mel_spectrogram, mask
 
     def _get_padding_strategies(self, padding=False, max_length=None):
@@ -524,133 +525,145 @@ class Gemma3nAudioConverter(AudioConverter):
     ):
         if isinstance(raw_speech, KerasTensor):
             return self.compute_output_spec(raw_speech)
-
         if isinstance(raw_speech, (list, tuple)):
-            was_batched = True
-            raw_speech_list = list(raw_speech)
-        else:
-            raw_speech_tensor = ops.convert_to_tensor(raw_speech)
-            was_batched = ops.ndim(raw_speech_tensor) > 1
-
-            if was_batched:
-                raw_speech_list = ops.unstack(
-                    raw_speech_tensor,
-                    axis=0,
-                )
-            else:
-                raw_speech_list = [raw_speech_tensor]
-
-        speech_list = [
-            np.asarray(speech).reshape(-1)
-            if not ops.is_tensor(speech)
-            else ops.reshape(speech, (-1,))
-            for speech in raw_speech_list
-        ]
-        input_features_list, attention_mask_list = self.pad(
-            speech_list,
-            padding=padding,
-            max_length=max_length,
-            truncation=truncation,
-            pad_to_multiple_of=pad_to_multiple_of,
-            return_attention_mask=return_attention_mask,
-        )
-        if not input_features_list:
-            if not was_batched:
-                empty_features = ops.zeros(
-                    (0, self.feature_size),
-                    dtype=self.compute_dtype,
-                )
-                empty_mask = (
-                    ops.zeros((0,), dtype="int32")
-                    if return_attention_mask
-                    else None
-                )
-                return empty_features, empty_mask
-
-            empty_features = ops.zeros(
-                (0, 0, self.feature_size),
-                dtype=self.compute_dtype,
+            speech_list = [
+                np.asarray(speech).reshape(-1) for speech in raw_speech
+            ]
+            input_features_list, attention_mask_list = self.pad(
+                speech_list,
+                padding=padding,
+                max_length=max_length,
+                truncation=truncation,
+                pad_to_multiple_of=pad_to_multiple_of,
+                return_attention_mask=return_attention_mask,
             )
-            empty_mask = (
-                ops.zeros((0, 0), dtype="int32")
-                if return_attention_mask
-                else None
-            )
-            return empty_features, empty_mask
+            if not return_attention_mask:
+                attention_mask_list = [None] * len(input_features_list)
+            prepared_features = []
+            prepared_masks = []
 
-        if not return_attention_mask:
-            attention_mask_list = [None] * len(input_features_list)
-
-        prepared_speech = []
-        prepared_speech_mask = []
-
-        for speech, mask in zip(
-            input_features_list,
-            attention_mask_list,
-        ):
-            if len(speech) == 0:
-                features = ops.zeros(
-                    (0, self.feature_size),
-                    dtype=self.compute_dtype,
-                )
-                feature_mask = (
-                    ops.zeros((0,), dtype="bool")
-                    if return_attention_mask
-                    else None
-                )
-            else:
-                speech_tensor = ops.convert_to_tensor(
-                    speech,
-                    dtype=self.compute_dtype,
+            for speech, mask in zip(input_features_list, attention_mask_list):
+                speech = ops.convert_to_tensor(
+                    np.asarray(speech).reshape(-1), dtype=self.compute_dtype
                 )
 
                 mask_tensor = (
-                    ops.convert_to_tensor(mask, dtype="int32")
+                    ops.convert_to_tensor(
+                        np.asarray(mask).reshape(-1),
+                        dtype="int32",
+                    )
                     if mask is not None
                     else None
                 )
-
+                # Single waveform -> 1-D input.
                 features, feature_mask = self._extract_spectrogram(
-                    speech_tensor,
-                    mask_tensor,
+                    speech, mask_tensor
+                )
+                features = ops.reshape(features, (-1, self.feature_size))
+                if return_attention_mask:
+                    if feature_mask is None:
+                        feature_mask = ops.ones(
+                            (ops.shape(features)[0],), dtype="int32"
+                        )
+                    else:
+                        feature_mask = ops.reshape(feature_mask, (-1,))
+                        feature_mask = ops.cast(feature_mask, "int32")
+
+                    prepared_masks.append(feature_mask)
+                prepared_features.append(features)
+
+            input_features = ops.stack(prepared_features, axis=0)
+            if return_attention_mask:
+                input_features_mask = ops.stack(prepared_masks, axis=0)
+            else:
+                input_features_mask = None
+            return input_features, input_features_mask
+
+        raw_speech_tensor = ops.convert_to_tensor(raw_speech)
+        rank = ops.ndim(raw_speech_tensor)
+        if rank == 1:
+            speech_np = np.asarray(raw_speech_tensor).reshape(-1)
+
+            input_features_list, attention_mask_list = self.pad(
+                [speech_np],
+                padding=padding,
+                max_length=max_length,
+                truncation=truncation,
+                pad_to_multiple_of=pad_to_multiple_of,
+                return_attention_mask=return_attention_mask,
+            )
+            if not input_features_list:
+                features = ops.zeros(
+                    (0, self.feature_size), dtype=self.compute_dtype
+                )
+                mask = (
+                    ops.zeros(
+                        (0,),
+                        dtype="int32",
+                    )
+                    if return_attention_mask
+                    else None
                 )
 
-            prepared_speech.append(features)
+                return features, mask
+
+            speech = ops.convert_to_tensor(
+                input_features_list[0],
+                dtype=self.compute_dtype,
+            )
 
             if return_attention_mask:
-                prepared_speech_mask.append(feature_mask)
-
-        input_features = ops.stack(
-            prepared_speech,
-            axis=0,
-        )
-
-        if return_attention_mask:
-            input_features_mask = ops.stack(
-                prepared_speech_mask,
-                axis=0,
-            )
-        else:
-            input_features_mask = None
-
-        if not was_batched:
-            input_features = ops.squeeze(
-                input_features,
-                axis=0,
-            )
-
-            if input_features_mask is not None:
-                input_features_mask = ops.squeeze(
-                    input_features_mask,
-                    axis=0,
+                mask = ops.convert_to_tensor(
+                    attention_mask_list[0],
+                    dtype="int32",
                 )
+            else:
+                mask = None
+            features, feature_mask = self._extract_spectrogram(speech, mask)
+            features = ops.reshape(features, (-1, self.feature_size))
 
-        if input_features_mask is not None:
-            input_features_mask = ops.cast(
-                input_features_mask,
-                dtype="int32",
+            if return_attention_mask:
+                if feature_mask is None:
+                    feature_mask = ops.ones(
+                        (ops.shape(features)[0],), dtype="int32"
+                    )
+                else:
+                    feature_mask = ops.reshape(feature_mask, (-1,))
+                    feature_mask = ops.cast(feature_mask, "int32")
+            else:
+                feature_mask = None
+            return features, feature_mask
+
+        def process_one_audio(speech):
+            speech = ops.reshape(speech, (-1,))
+            speech = ops.cast(speech, self.compute_dtype)
+            speech_batched = ops.expand_dims(speech, axis=0)
+            speech_length = ops.shape(speech_batched)[1]
+            speech_mask = ops.ones((1, speech_length), dtype="int32")
+            features, feature_mask = self._extract_spectrogram(
+                speech_batched, speech_mask
             )
+            features = ops.reshape(features, (-1, self.feature_size))
+            features = ops.cast(features, self.compute_dtype)
+            if feature_mask is None:
+                num_frames = ops.shape(features)[0]
+                feature_mask = ops.ones((num_frames,), dtype="int32")
+            else:
+                feature_mask = ops.reshape(feature_mask, (-1,))
+                feature_mask = ops.cast(feature_mask, "int32")
+            return features, feature_mask
 
+        input_features, input_features_mask = tf.map_fn(
+            process_one_audio,
+            raw_speech_tensor,
+            fn_output_signature=(
+                tf.TensorSpec(
+                    shape=(None, self.feature_size),
+                    dtype=tf.as_dtype(self.compute_dtype),
+                ),
+                tf.TensorSpec(shape=(None,), dtype=tf.int32),
+            ),
+        )
         return input_features, input_features_mask
 
     def get_config(self):

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -200,10 +200,7 @@ class Gemma3nAudioConverter(AudioConverter):
         fb = np.maximum(0.0, np.minimum(down_slopes, up_slopes))
         return ops.convert_to_tensor(fb, dtype=self.compute_dtype)
 
-    def _extract_spectrogram(self, waveform, attention_mask):
-        # waveform is normally shaped (1, num_samples).
-        if ops.ndim(waveform) == 1:
-            waveform = ops.expand_dims(waveform, axis=0)
+    def _extract_spectrogram(self, waveform, attention_mask=None):
         waveform = ops.cast(waveform, dtype=self.compute_dtype)
         if self.dither > 0.0:
             waveform = waveform + self.dither * random.normal(
@@ -237,66 +234,67 @@ class Gemma3nAudioConverter(AudioConverter):
                 )
         else:
             frames = frames_to_process[..., :-1]
-
         frames = frames * self.window
-        fft_frames = ops.cast(frames, dtype=self.compute_dtype)
-
         fft_pad = self.fft_length - self.frame_length
         if fft_pad > 0:
-            fft_frames = ops.pad(
-                fft_frames,
-                [[0, 0], [0, 0], [0, fft_pad]],
+            frames = ops.pad(
+                frames,
+                [[0, 0], [0, fft_pad]],
             )
-
-        # Keras versions used by this repository may return the real and
-        # imaginary components separately from ops.rfft. Handle that form
-        # while also supporting versions returning a complex tensor.
-        stft = ops.rfft(fft_frames, fft_length=self.fft_length)
-
+        stft = ops.rfft(
+            frames,
+            fft_length=self.fft_length,
+        )
         if isinstance(stft, (tuple, list)):
             real, imag = stft
             magnitude_spec = ops.sqrt(ops.square(real) + ops.square(imag))
         else:
             magnitude_spec = ops.abs(stft)
-
-        mel_spec = ops.matmul(magnitude_spec, self.mel_filters)
-
-        mel_floor_tensor = ops.cast(self.mel_floor, dtype=self.compute_dtype)
+        mel_spec = ops.matmul(
+            magnitude_spec,
+            self.mel_filters,
+        )
+        mel_floor_tensor = ops.cast(
+            self.mel_floor,
+            dtype=self.compute_dtype,
+        )
         log_mel_spec = ops.log(ops.maximum(mel_spec, mel_floor_tensor))
-
         if self.per_bin_mean is not None:
-            per_bin_mean_tensor = ops.reshape(
-                ops.convert_to_tensor(
-                    self.per_bin_mean,
-                    dtype=self.compute_dtype,
-                ),
-                (1, 1, self.feature_size),
+            mean = ops.convert_to_tensor(
+                self.per_bin_mean,
+                dtype=self.compute_dtype,
             )
-            log_mel_spec = log_mel_spec - per_bin_mean_tensor
-
+            mean = ops.reshape(mean, (1, self.feature_size))
+            log_mel_spec = log_mel_spec - mean
         if self.per_bin_stddev is not None:
-            per_bin_stddev_tensor = ops.reshape(
-                ops.convert_to_tensor(
-                    self.per_bin_stddev,
-                    dtype=self.compute_dtype,
-                ),
-                (1, 1, self.feature_size),
+            stddev = ops.convert_to_tensor(
+                self.per_bin_stddev,
+                dtype=self.compute_dtype,
             )
-            log_mel_spec = log_mel_spec / per_bin_stddev_tensor
-
-        # Depending on the backend/version, the FFT/matmul path can preserve
-        # or remove the leading singleton dimension. Only squeeze it when it
-        # is actually present.
-        if ops.ndim(log_mel_spec) == 3:
-            if log_mel_spec.shape[0] == 1:
-                mel_spectrogram = ops.squeeze(log_mel_spec, axis=0)
-            else:
-                mel_spectrogram = log_mel_spec
+            stddev = ops.reshape(stddev, (1, self.feature_size))
+            log_mel_spec = log_mel_spec / stddev
+        mel_spectrogram = ops.cast(
+            log_mel_spec,
+            dtype=self.compute_dtype,
+        )
+        num_output_frames = ops.shape(mel_spectrogram)[-2]
+        if attention_mask is None:
+            mask = None
         else:
-            mel_spectrogram = log_mel_spec
-        mask = ops.cast(attention_mask[:: self.hop_length], dtype="bool")
-        mask = mask[: ops.shape(mel_spectrogram)[0]]
-        mel_spectrogram = ops.cast(mel_spectrogram, dtype=self.compute_dtype)
+            # A spectrogram frame is valid only when all samples contributing
+            # to that frame are non-padding.
+            frame_masks = ops.extract_sequences(
+                attention_mask,
+                sequence_length=self.frame_length,
+                sequence_stride=self.hop_length,
+            )
+            mask = ops.all(
+                ops.cast(frame_masks, dtype="bool"),
+                axis=-1,
+            )
+            # Keep the mask exactly aligned with the frames produced by
+            # `ops.extract_sequences()` / STFT.
+            mask = mask[:num_output_frames]
         return mel_spectrogram, mask
 
     def _get_padding_strategies(self, padding=False, max_length=None):
@@ -368,10 +366,6 @@ class Gemma3nAudioConverter(AudioConverter):
             elif self.padding_side == "left":
                 if return_attention_mask:
                     attention_mask = np.pad(attention_mask, (difference, 0))
-                    attention_mask = np.pad(
-                        attention_mask,
-                        (difference, 0),
-                    )
                 if required_input.ndim > 1:
                     padding_shape = (
                         (difference, 0),
@@ -402,7 +396,6 @@ class Gemma3nAudioConverter(AudioConverter):
             raise ValueError(
                 "When setting truncation=True, max_length must be defined"
             )
-
         required_input = input_features
         if (
             max_length is not None
@@ -440,18 +433,13 @@ class Gemma3nAudioConverter(AudioConverter):
             if return_attention_mask:
                 return [], []
             return [], None
-
         required_input = [np.asarray(v) for v in required_input]
-
         padding_strategy = self._get_padding_strategies(
-            padding=padding,
-            max_length=max_length,
+            padding=padding, max_length=max_length
         )
-
         batch_size = len(required_input)
         truncated_inputs = []
         truncated_masks = []
-
         for i in range(batch_size):
             inputs = required_input[i]
             mask = (
@@ -466,7 +454,6 @@ class Gemma3nAudioConverter(AudioConverter):
                 pad_to_multiple_of=pad_to_multiple_of,
                 truncation=truncation,
             )
-
             truncated_inputs.append(inputs_slice)
             if mask_slice is not None:
                 truncated_masks.append(mask_slice)
@@ -497,19 +484,34 @@ class Gemma3nAudioConverter(AudioConverter):
             return batch_outputs_features, None
         return batch_outputs_features, batch_outputs_masks
 
-    def compute_output_spec(self, raw_speech, *args, **kwargs):
+    def compute_output_spec(
+        self, raw_speech, return_attention_mask=None, *args, **kwargs
+    ):
         was_batched = len(raw_speech.shape) > 1
-
         if was_batched:
-            features_shape = (raw_speech.shape[0], None, self.feature_size)
+            features_shape = (
+                raw_speech.shape[0],
+                None,
+                self.feature_size,
+            )
             mask_shape = (raw_speech.shape[0], None)
         else:
             features_shape = (None, self.feature_size)
             mask_shape = (None,)
-        return (
-            KerasTensor(shape=features_shape, dtype=self.compute_dtype),
-            KerasTensor(shape=mask_shape, dtype="int32"),
+
+        features_spec = KerasTensor(
+            shape=features_shape,
+            dtype=self.compute_dtype,
         )
+        if return_attention_mask is None:
+            return_attention_mask = self.return_attention_mask
+
+        if return_attention_mask:
+            return (
+                features_spec,
+                KerasTensor(shape=mask_shape, dtype="int32"),
+            )
+        return features_spec, None
 
     def call(
         self,
@@ -520,26 +522,30 @@ class Gemma3nAudioConverter(AudioConverter):
         pad_to_multiple_of=128,
         return_attention_mask=True,
     ):
-        # Handle symbolic inputs before NumPy conversion.
         if isinstance(raw_speech, KerasTensor):
-            return self.compute_output_spec(
-                raw_speech,
-            )
+            return self.compute_output_spec(raw_speech)
 
         if isinstance(raw_speech, (list, tuple)):
             was_batched = True
-            raw_speech_list = [np.asarray(speech) for speech in raw_speech]
+            raw_speech_list = list(raw_speech)
         else:
-            raw_speech_np = np.asarray(raw_speech)
-            was_batched = raw_speech_np.ndim > 1
+            raw_speech_tensor = ops.convert_to_tensor(raw_speech)
+            was_batched = ops.ndim(raw_speech_tensor) > 1
 
             if was_batched:
-                raw_speech_list = [speech for speech in raw_speech_np]
+                raw_speech_list = ops.unstack(
+                    raw_speech_tensor,
+                    axis=0,
+                )
             else:
-                raw_speech_list = [np.atleast_1d(raw_speech_np)]
+                raw_speech_list = [raw_speech_tensor]
 
-        speech_list = [speech.reshape(-1, 1) for speech in raw_speech_list]
-
+        speech_list = [
+            np.asarray(speech).reshape(-1)
+            if not ops.is_tensor(speech)
+            else ops.reshape(speech, (-1,))
+            for speech in raw_speech_list
+        ]
         input_features_list, attention_mask_list = self.pad(
             speech_list,
             padding=padding,
@@ -548,6 +554,32 @@ class Gemma3nAudioConverter(AudioConverter):
             pad_to_multiple_of=pad_to_multiple_of,
             return_attention_mask=return_attention_mask,
         )
+        if not input_features_list:
+            if not was_batched:
+                empty_features = ops.zeros(
+                    (0, self.feature_size),
+                    dtype=self.compute_dtype,
+                )
+                empty_mask = (
+                    ops.zeros((0,), dtype="int32")
+                    if return_attention_mask
+                    else None
+                )
+                return empty_features, empty_mask
+
+            empty_features = ops.zeros(
+                (0, 0, self.feature_size),
+                dtype=self.compute_dtype,
+            )
+            empty_mask = (
+                ops.zeros((0, 0), dtype="int32")
+                if return_attention_mask
+                else None
+            )
+            return empty_features, empty_mask
+
+        if not return_attention_mask:
+            attention_mask_list = [None] * len(input_features_list)
 
         prepared_speech = []
         prepared_speech_mask = []
@@ -556,57 +588,73 @@ class Gemma3nAudioConverter(AudioConverter):
             input_features_list,
             attention_mask_list,
         ):
-            speech_tensor = ops.convert_to_tensor(
-                speech.T,
-                dtype=self.compute_dtype,
-            )
+            if len(speech) == 0:
+                features = ops.zeros(
+                    (0, self.feature_size),
+                    dtype=self.compute_dtype,
+                )
+                feature_mask = (
+                    ops.zeros((0,), dtype="bool")
+                    if return_attention_mask
+                    else None
+                )
+            else:
+                speech_tensor = ops.convert_to_tensor(
+                    speech,
+                    dtype=self.compute_dtype,
+                )
 
-            mask_tensor = ops.convert_to_tensor(
-                mask,
-                dtype="int32",
-            )
+                mask_tensor = (
+                    ops.convert_to_tensor(mask, dtype="int32")
+                    if mask is not None
+                    else None
+                )
 
-            features, feature_mask = self._extract_spectrogram(
-                speech_tensor,
-                mask_tensor,
-            )
+                features, feature_mask = self._extract_spectrogram(
+                    speech_tensor,
+                    mask_tensor,
+                )
 
             prepared_speech.append(features)
-            prepared_speech_mask.append(feature_mask)
+
+            if return_attention_mask:
+                prepared_speech_mask.append(feature_mask)
 
         input_features = ops.stack(
             prepared_speech,
             axis=0,
         )
 
-        input_features_mask = ops.stack(
-            prepared_speech_mask,
-            axis=0,
-        )
+        if return_attention_mask:
+            input_features_mask = ops.stack(
+                prepared_speech_mask,
+                axis=0,
+            )
+        else:
+            input_features_mask = None
 
         if not was_batched:
             input_features = ops.squeeze(
                 input_features,
                 axis=0,
             )
-            input_features_mask = ops.squeeze(
+
+            if input_features_mask is not None:
+                input_features_mask = ops.squeeze(
+                    input_features_mask,
+                    axis=0,
+                )
+
+        if input_features_mask is not None:
+            input_features_mask = ops.cast(
                 input_features_mask,
-                axis=0,
+                dtype="int32",
             )
 
-        input_features_mask = ops.cast(
-            input_features_mask,
-            dtype="int32",
-        )
-
-        return (
-            input_features,
-            input_features_mask,
-        )
+        return input_features, input_features_mask
 
     def get_config(self):
         config = super().get_config()
-
         config.update(
             {
                 "feature_size": self.feature_size,

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -201,10 +201,7 @@ class Gemma3nAudioConverter(AudioConverter):
         return ops.convert_to_tensor(fb, dtype=self.compute_dtype)
 
     def _extract_spectrogram(self, waveform, attention_mask=None):
-        waveform = ops.cast(
-            waveform,
-            dtype=self.compute_dtype,
-        )
+        waveform = ops.cast(waveform, dtype=self.compute_dtype)
         waveform_rank = ops.ndim(waveform)
         if waveform_rank not in (1, 2):
             raise ValueError(
@@ -230,7 +227,6 @@ class Gemma3nAudioConverter(AudioConverter):
                 first_sample = frames_to_process[..., :1] * (
                     1.0 - self.preemphasis
                 )
-
                 rest_of_samples = (
                     frames_to_process[..., 1:-1]
                     - self.preemphasis * frames_to_process[..., :-2]
@@ -252,7 +248,6 @@ class Gemma3nAudioConverter(AudioConverter):
                 frames = ops.pad(frames, [[0, 0], [0, fft_pad]])
             else:
                 frames = ops.pad(frames, [[0, 0], [0, 0], [0, fft_pad]])
-
         stft = ops.rfft(frames, fft_length=self.fft_length)
         if isinstance(stft, (tuple, list)):
             real, imag = stft
@@ -275,19 +270,29 @@ class Gemma3nAudioConverter(AudioConverter):
             stddev = ops.reshape(stddev, (1, self.feature_size))
             log_mel_spec = log_mel_spec / stddev
         mel_spectrogram = ops.cast(log_mel_spec, dtype=self.compute_dtype)
-
         num_output_frames = ops.shape(mel_spectrogram)[-2]
         if attention_mask is None:
             mask = None
         else:
-            frame_masks = ops.extract_sequences(
-                attention_mask,
-                sequence_length=self.frame_length,
-                sequence_stride=self.hop_length,
+            # Compute valid frame counts based on unpadded lengths
+            # rather than sliding windows over padded areas
+            if waveform_rank == 2:
+                audio_lengths = ops.sum(
+                    ops.cast(attention_mask, dtype="int32"), axis=-1
+                )
+            else:
+                audio_lengths = ops.sum(ops.cast(attention_mask, dtype="int32"))
+            num_valid_frames = ops.maximum(
+                0, (audio_lengths - self.frame_length) // self.hop_length + 1
             )
-            frame_masks = ops.cast(frame_masks, dtype="bool")
-            mask = ops.all(frame_masks, axis=-1)
-            mask = mask[..., :num_output_frames]
+            if waveform_rank == 2:
+                indices = ops.arange(num_output_frames, dtype="int32")
+                indices = ops.expand_dims(indices, axis=0)
+                valid_lengths = ops.expand_dims(num_valid_frames, axis=1)
+                mask = ops.cast(indices < valid_lengths, dtype="int32")
+            else:
+                indices = ops.arange(num_output_frames, dtype="int32")
+                mask = ops.cast(indices < num_valid_frames, dtype="int32")
         return mel_spectrogram, mask
 
     def _get_padding_strategies(self, padding=False, max_length=None):

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -1,11 +1,9 @@
 import math
 
 import numpy as np
+from keras import ops
+from keras import random
 
-try:
-    import tensorflow as tf
-except ImportError:
-    tf = None
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.gemma3n.gemma3n_backbone import Gemma3nBackbone
@@ -168,9 +166,10 @@ class Gemma3nAudioConverter(AudioConverter):
         if self.fft_overdrive:
             fft_length *= 2
         self.fft_length = fft_length
-        hann_arange = tf.range(self.frame_length, dtype=self.compute_dtype)
-        self.window = 0.5 * (
-            1 - tf.cos(2 * np.pi * hann_arange / self.frame_length)
+        hann_arange = np.arange(self.frame_length, dtype=np.float32)
+        self.window = ops.convert_to_tensor(
+            0.5 * (1.0 - np.cos(2.0 * np.pi * hann_arange / self.frame_length)),
+            dtype=self.compute_dtype,
         )
         self.mel_filters = self._create_filterbank_matrix(
             n_freqs=self.fft_length // 2 + 1,
@@ -193,7 +192,9 @@ class Gemma3nAudioConverter(AudioConverter):
         sample_rate,
         fft_length,
     ):
-        all_freqs = tf.cast(tf.range(n_freqs), dtype=self.compute_dtype) * (
+        # Keep all filterbank construction in float64 to match the
+        # Hugging Face / NumPy reference implementation.
+        all_freqs = np.arange(n_freqs, dtype=np.float64) * (
             sample_rate / fft_length
         )
         # HTK mel-scale formula:
@@ -203,74 +204,89 @@ class Gemma3nAudioConverter(AudioConverter):
         # crossover that models human auditory perception. They are the
         # standard values used by HTK, Kaldi, and librosa.
         # Ref: https://en.wikipedia.org/wiki/Mel_scale#Formula
-        m_min = 2595.0 * math.log10(1.0 + (f_min / 700.0))
-        m_max = 2595.0 * math.log10(1.0 + (f_max / 700.0))
-        m_pts = np.linspace(m_min, m_max, n_mels + 2, dtype=np.float32)
-        f_pts = 700.0 * (10 ** (m_pts / 2595.0) - 1.0)
-        f_pts = tf.constant(f_pts, dtype=self.compute_dtype)
+        m_min = 2595.0 * math.log10(1.0 + f_min / 700.0)
+        m_max = 2595.0 * math.log10(1.0 + f_max / 700.0)
+        m_pts = np.linspace(m_min, m_max, n_mels + 2, dtype=np.float64)
+        f_pts = 700.0 * (10.0 ** (m_pts / 2595.0) - 1.0)
         f_diff = f_pts[1:] - f_pts[:-1]
-        slopes = tf.expand_dims(f_pts, 0) - tf.expand_dims(all_freqs, 1)
-        zero = tf.zeros(1, dtype=self.compute_dtype)
-        down_slopes = (-1.0 * slopes[:, :-2]) / f_diff[:-1]
+        slopes = f_pts[None, :] - all_freqs[:, None]
+        down_slopes = -slopes[:, :-2] / f_diff[:-1]
         up_slopes = slopes[:, 2:] / f_diff[1:]
-        fb = tf.maximum(zero, tf.minimum(down_slopes, up_slopes))
-        return tf.constant(fb, dtype=self.compute_dtype)
+        fb = np.maximum(0.0, np.minimum(down_slopes, up_slopes))
+        return ops.convert_to_tensor(fb, dtype=self.compute_dtype)
 
     def _extract_spectrogram(self, waveform, attention_mask):
-        waveform = tf.cast(waveform, dtype=self.compute_dtype)
+        # waveform from call() is normally: (1, num_samples)
+        if ops.ndim(waveform) == 1:
+            waveform = ops.expand_dims(waveform, axis=0)
+        waveform = ops.cast(waveform, dtype=self.compute_dtype)
         if self.dither > 0.0:
-            waveform = waveform + self.dither * tf.random.normal(
-                tf.shape(waveform), dtype=waveform.dtype
+            waveform = waveform + self.dither * random.normal(
+                ops.shape(waveform), dtype=waveform.dtype
             )
         if self.input_scale_factor != 1.0:
             waveform = waveform * self.input_scale_factor
+        frames_to_process = ops.extract_sequences(
+            waveform,
+            sequence_length=self.frame_length + 1,
+            sequence_stride=self.hop_length,
+        )
         if self.preemphasis > 0.0:
             if self.preemphasis_htk_flavor:
-                first_sample = waveform[:, :1] * (1.0 - self.preemphasis)
+                first_sample = frames_to_process[..., :1] * (
+                    1.0 - self.preemphasis
+                )
                 rest_of_samples = (
-                    waveform[:, 1:] - self.preemphasis * waveform[:, :-1]
+                    frames_to_process[..., 1:-1]
+                    - self.preemphasis * frames_to_process[..., :-2]
                 )
-                waveform = tf.concat([first_sample, rest_of_samples], axis=-1)
+                frames = ops.concatenate(
+                    [first_sample, rest_of_samples], axis=-1
+                )
             else:
-                waveform = tf.concat(
-                    [
-                        waveform[:, :1],
-                        waveform[:, 1:] - self.preemphasis * waveform[:, :-1],
-                    ],
-                    axis=-1,
+                frames = (
+                    frames_to_process[..., 1:]
+                    - self.preemphasis * frames_to_process[..., :-1]
                 )
-        frames = tf.signal.frame(
-            waveform,
-            frame_length=self.frame_length,
-            frame_step=self.hop_length,
-            pad_end=False,
-        )
+        else:
+            frames = frames_to_process[..., :-1]
         frames = frames * self.window
-        pad_length = self.fft_length - self.frame_length
-        paddings = [[0, 0], [0, 0], [0, pad_length]]
-        frames = tf.pad(frames, paddings)
-        stft = tf.signal.rfft(frames)
-        magnitude_spec = tf.abs(stft)
-        mel_spec = tf.matmul(magnitude_spec, self.mel_filters)
-        mel_floor_tensor = tf.constant(self.mel_floor, dtype=self.compute_dtype)
-        log_mel_spec = tf.math.log(tf.maximum(mel_spec, mel_floor_tensor))
+        fft_frames = ops.cast(frames, dtype="float64")
+
+        fft_pad = self.fft_length - self.frame_length
+        if fft_pad > 0:
+            fft_frames = ops.pad(
+                fft_frames,
+                [[0, 0], [0, 0], [0, fft_pad]],
+            )
+
+        real, imag = ops.rfft(fft_frames, fft_length=self.fft_length)
+        magnitude_spec = ops.sqrt(ops.square(real) + ops.square(imag))
+
+        mel_filters = ops.cast(self.mel_filters, dtype="float64")
+        mel_spec = ops.matmul(magnitude_spec, mel_filters)
+
+        mel_floor_tensor = ops.cast(self.mel_floor, dtype="float64")
+        log_mel_spec = ops.log(ops.maximum(mel_spec, mel_floor_tensor))
+
         if self.per_bin_mean is not None:
-            per_bin_mean_tensor = tf.constant(
-                self.per_bin_mean,
-                shape=(1, 1, self.feature_size),
-                dtype=self.compute_dtype,
+            per_bin_mean_tensor = ops.reshape(
+                ops.convert_to_tensor(self.per_bin_mean, dtype="float64"),
+                (1, 1, self.feature_size),
             )
             log_mel_spec = log_mel_spec - per_bin_mean_tensor
+
         if self.per_bin_stddev is not None:
-            per_bin_stddev_tensor = tf.constant(
-                self.per_bin_stddev,
-                shape=(1, 1, self.feature_size),
-                dtype=self.compute_dtype,
+            per_bin_stddev_tensor = ops.reshape(
+                ops.convert_to_tensor(self.per_bin_stddev, dtype="float64"),
+                (1, 1, self.feature_size),
             )
             log_mel_spec = log_mel_spec / per_bin_stddev_tensor
-        mel_spectrogram = tf.squeeze(log_mel_spec, axis=0)
-        mask = tf.cast(attention_mask[:: self.hop_length], dtype=tf.bool)
-        return mel_spectrogram, mask[: tf.shape(mel_spectrogram)[0]]
+        mel_spectrogram = ops.squeeze(log_mel_spec, axis=0)
+        mask = ops.cast(attention_mask[:: self.hop_length], dtype="bool")
+        mask = mask[: ops.shape(mel_spectrogram)[0]]
+        mel_spectrogram = ops.cast(mel_spectrogram, dtype=self.compute_dtype)
+        return mel_spectrogram, mask
 
     def _get_padding_strategies(self, padding=False, max_length=None):
         if padding is not False:
@@ -453,59 +469,60 @@ class Gemma3nAudioConverter(AudioConverter):
         pad_to_multiple_of=128,
         return_attention_mask=True,
     ):
-        def _process_in_py(raw_speech_tensor):
-            raw_speech_np = raw_speech_tensor.numpy()
-            is_batched = raw_speech_np.ndim > 1
-            if is_batched:
-                speech_list = [rs.reshape(-1, 1) for rs in raw_speech_np]
+        if isinstance(raw_speech, (list, tuple)):
+            was_batched = True
+            raw_speech_list = [np.asarray(speech) for speech in raw_speech]
+        else:
+            raw_speech_np = np.asarray(raw_speech)
+            was_batched = raw_speech_np.ndim > 1
+            if was_batched:
+                raw_speech_list = [speech for speech in raw_speech_np]
             else:
-                raw_speech_np = np.atleast_1d(raw_speech_np)
-                speech_list = [raw_speech_np.reshape(-1, 1)]
-            input_features_list, attention_mask_list = self.pad(
-                speech_list,
-                padding=padding,
-                max_length=max_length,
-                truncation=truncation,
-                pad_to_multiple_of=pad_to_multiple_of,
-                return_attention_mask=return_attention_mask,
-            )
-            prepared_speech = []
-            prepared_speech_mask = []
-            for speech, mask in zip(input_features_list, attention_mask_list):
-                speech_tensor = tf.constant(speech.T, dtype=self.compute_dtype)
-                mask_tensor = tf.constant(mask, dtype=tf.int32)
-                features, feature_mask = self._extract_spectrogram(
-                    speech_tensor, mask_tensor
-                )
-                prepared_speech.append(features)
-                prepared_speech_mask.append(feature_mask)
-            input_features = tf.stack(prepared_speech)
-            input_features_mask = tf.stack(prepared_speech_mask)
-            if not is_batched:
-                input_features = tf.squeeze(input_features, axis=0)
-                input_features_mask = tf.squeeze(input_features_mask, axis=0)
-            return input_features, input_features_mask
+                raw_speech_list = [np.atleast_1d(raw_speech_np)]
 
-        if not isinstance(raw_speech, (tf.Tensor, tf.RaggedTensor)):
-            was_batched = isinstance(raw_speech, (list, tuple))
-            raw_speech = tf.convert_to_tensor(
-                raw_speech, dtype=self.compute_dtype
-            )
-        else:
-            was_batched = raw_speech.shape.rank > 1
-        input_features, input_features_mask = tf.py_function(
-            _process_in_py,
-            inp=[raw_speech],
-            Tout=[self.compute_dtype, tf.bool],
+        speech_list = [speech.reshape(-1, 1) for speech in raw_speech_list]
+
+        input_features_list, attention_mask_list = self.pad(
+            speech_list,
+            padding=padding,
+            max_length=max_length,
+            truncation=truncation,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_attention_mask=return_attention_mask,
         )
-        num_frames = None
-        if was_batched:
-            input_features.set_shape([None, num_frames, self.feature_size])
-            input_features_mask.set_shape([None, num_frames])
-        else:
-            input_features.set_shape([num_frames, self.feature_size])
-            input_features_mask.set_shape([num_frames])
-        input_features_mask = tf.cast(input_features_mask, dtype="int32")
+
+        prepared_speech = []
+        prepared_speech_mask = []
+
+        for speech, mask in zip(
+            input_features_list,
+            attention_mask_list,
+        ):
+            speech_tensor = ops.convert_to_tensor(
+                speech.T,
+                dtype=self.compute_dtype,
+            )
+            mask_tensor = ops.convert_to_tensor(
+                mask,
+                dtype="int32",
+            )
+
+            features, feature_mask = self._extract_spectrogram(
+                speech_tensor,
+                mask_tensor,
+            )
+
+            prepared_speech.append(features)
+            prepared_speech_mask.append(feature_mask)
+
+        input_features = ops.stack(prepared_speech, axis=0)
+        input_features_mask = ops.stack(prepared_speech_mask, axis=0)
+
+        if not was_batched:
+            input_features = ops.squeeze(input_features, axis=0)
+            input_features_mask = ops.squeeze(input_features_mask, axis=0)
+
+        input_features_mask = ops.cast(input_features_mask, dtype="int32")
         return input_features, input_features_mask
 
     def get_config(self):

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
@@ -121,3 +121,34 @@ class Gemma3nAudioConverterTest(TestCase):
     def test_serialization(self):
         instance = Gemma3nAudioConverter(**self.init_kwargs)
         self.run_serialization_test(instance=instance)
+
+    def test_feature_mask_padding(self):
+        converter = Gemma3nAudioConverter(**self.init_kwargs)
+        audio = np.zeros(512, dtype=np.float32)
+        features, mask = converter(
+            audio,
+            padding="max_length",
+            max_length=1024,
+            truncation=True,
+            return_attention_mask=True,
+        )
+        self.assertEqual(len(features), len(mask))
+        self.assertTrue(mask[0])
+
+    def test_normalization_preserves_mask(self):
+        mean = np.random.rand(self.feature_size).tolist()
+        stddev = (np.random.rand(self.feature_size) + 0.1).tolist()
+
+        converter_no_norm = Gemma3nAudioConverter(**self.init_kwargs)
+
+        norm_kwargs = self.init_kwargs.copy()
+        norm_kwargs["per_bin_mean"] = mean
+        norm_kwargs["per_bin_stddev"] = stddev
+
+        converter_norm = Gemma3nAudioConverter(**norm_kwargs)
+
+        features_1, mask_1 = converter_no_norm(self.input_data)
+        features_2, mask_2 = converter_norm(self.input_data)
+
+        np.testing.assert_array_equal(mask_1, mask_2)
+        assert features_1.shape == features_2.shape

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
@@ -152,3 +152,62 @@ class Gemma3nAudioConverterTest(TestCase):
 
         np.testing.assert_array_equal(mask_1, mask_2)
         assert features_1.shape == features_2.shape
+
+    def test_batched_audio(self):
+        converter = Gemma3nAudioConverter(**self.init_kwargs)
+
+        audio_1 = np.sin(
+            2
+            * np.pi
+            * 440
+            * np.linspace(0, 1, self.sampling_rate, dtype=np.float32)
+        )
+        audio_2 = np.sin(
+            2
+            * np.pi
+            * 880
+            * np.linspace(0, 0.5, self.sampling_rate // 2, dtype=np.float32)
+        )
+
+        features, mask = converter(
+            [audio_1, audio_2],
+            padding="longest",
+            pad_to_multiple_of=128,
+        )
+
+        self.assertEqual(features.shape[0], 2)
+        self.assertEqual(features.shape[2], self.feature_size)
+        self.assertEqual(mask.shape[0], 2)
+        self.assertEqual(mask.shape[1], features.shape[1])
+
+        self.assertTrue(np.all(mask[0]))
+        self.assertTrue(np.any(mask[1] == 0))
+
+        def test_truncation(self):
+            converter = Gemma3nAudioConverter(**self.init_kwargs)
+
+            max_length = 1024
+            features, mask = converter(
+                self.input_data[0],
+                padding="max_length",
+                max_length=max_length,
+                truncation=True,
+            )
+
+            frame_length = int(
+                round(self.sampling_rate * self.frame_length_ms / 1000.0)
+            )
+            hop_length = int(
+                round(self.sampling_rate * self.hop_length_ms / 1000.0)
+            )
+
+            # _extract_spectrogram() uses frame_length + 1 because of
+            # the preemphasis calculation.
+            sequence_length = frame_length + 1
+            num_frames = ((max_length - sequence_length) // hop_length) + 1
+
+            self.assertEqual(
+                features.shape,
+                (num_frames, self.feature_size),
+            )
+            self.assertEqual(mask.shape, (num_frames,))

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+from keras import ops
 
 from keras_hub.src.models.gemma3n.gemma3n_audio_converter import (
     Gemma3nAudioConverter,
@@ -110,12 +111,13 @@ class Gemma3nAudioConverterTest(TestCase):
         self.assertEqual(len(outputs_norm), 2)
         features_no_norm, _ = outputs_no_norm
         features_norm, _ = outputs_norm
+        features_no_norm_np = ops.convert_to_numpy(features_no_norm)
         # We would want outputs to be different.
         self.assertNotAllClose(features_no_norm, features_norm)
         # Manually normalize and check for closeness.
-        manual_norm_features = (features_no_norm - np.array(mean)) / np.array(
-            stddev
-        )
+        manual_norm_features = (
+            features_no_norm_np - np.array(mean)
+        ) / np.array(stddev)
         self.assertAllClose(manual_norm_features, features_norm)
 
     def test_serialization(self):
@@ -150,12 +152,11 @@ class Gemma3nAudioConverterTest(TestCase):
         features_1, mask_1 = converter_no_norm(self.input_data)
         features_2, mask_2 = converter_norm(self.input_data)
 
-        np.testing.assert_array_equal(mask_1, mask_2)
-        assert features_1.shape == features_2.shape
+        self.assertAllEqual(mask_1, mask_2)
+        self.assertEqual(features_1.shape, features_2.shape)
 
     def test_batched_audio(self):
         converter = Gemma3nAudioConverter(**self.init_kwargs)
-
         audio_1 = np.sin(
             2
             * np.pi
@@ -180,34 +181,35 @@ class Gemma3nAudioConverterTest(TestCase):
         self.assertEqual(mask.shape[0], 2)
         self.assertEqual(mask.shape[1], features.shape[1])
 
-        self.assertTrue(np.all(mask[0]))
-        self.assertTrue(np.any(mask[1] == 0))
+        mask_np = ops.convert_to_numpy(mask)
+        self.assertTrue(np.all(mask_np[0]))
+        self.assertTrue(np.any(mask_np[1] == 0))
 
-        def test_truncation(self):
-            converter = Gemma3nAudioConverter(**self.init_kwargs)
+    def test_truncation(self):
+        converter = Gemma3nAudioConverter(**self.init_kwargs)
 
-            max_length = 1024
-            features, mask = converter(
-                self.input_data[0],
-                padding="max_length",
-                max_length=max_length,
-                truncation=True,
-            )
+        max_length = 1024
+        features, mask = converter(
+            self.input_data[0],
+            padding="max_length",
+            max_length=max_length,
+            truncation=True,
+        )
 
-            frame_length = int(
-                round(self.sampling_rate * self.frame_length_ms / 1000.0)
-            )
-            hop_length = int(
-                round(self.sampling_rate * self.hop_length_ms / 1000.0)
-            )
+        frame_length = int(
+            round(self.sampling_rate * self.frame_length_ms / 1000.0)
+        )
+        hop_length = int(
+            round(self.sampling_rate * self.hop_length_ms / 1000.0)
+        )
 
-            # _extract_spectrogram() uses frame_length + 1 because of
-            # the preemphasis calculation.
-            sequence_length = frame_length + 1
-            num_frames = ((max_length - sequence_length) // hop_length) + 1
+        # _extract_spectrogram() uses frame_length + 1 because of
+        # the preemphasis calculation.
+        sequence_length = frame_length + 1
+        num_frames = ((max_length - sequence_length) // hop_length) + 1
 
-            self.assertEqual(
-                features.shape,
-                (num_frames, self.feature_size),
-            )
-            self.assertEqual(mask.shape, (num_frames,))
+        self.assertEqual(
+            features.shape,
+            (num_frames, self.feature_size),
+        )
+        self.assertEqual(mask.shape, (num_frames,))


### PR DESCRIPTION
This PR migrates Gemma3nAudioConverter from TensorFlow ops to keras.ops.

Replaces TensorFlow-specific audio operations with Keras equivalents, including 
- tf.signal.frame → keras.ops.extract_sequences 
-  tf.signal.rfft → keras.ops.rfft, 
while preserving batched/unbatched audio handling, spectrogram padding, and attention-mask behavior.

Fixes: #2951 (1st part)

Numerical verification [colab](https://colab.sandbox.google.com/drive/1c1p6lQ1VpdLOTmo_UBeNIyUC8m-aANbI?resourcekey=0-RXQw0HI3WcFkDh0cCzUruw#scrollTo=NzenbbCpRl3Y).

### Numerical Verification Results

Verified numerical equivalence against pure NumPy reference :

  - Test 1 (Sine Wave): Log-Mel max diff = 9.64e-03 | Linear-Mel max diff = 1.14e-04 [PASS]
  - Test 2 (Normalized Audio): max diff = 2.19e-05 [PASS]
  - Test 3 (Silent Audio Floor): max diff = 3.17e-07 [PASS]
  - Test 4 (Batch Invariance): max diff = 0.00e+00 [PASS]

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
