### PR TITLE
Pin tensorflow-text<2.21.0 to fix CI and Keras hub PyPi usage breakage 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "kagglesdk==0.1.28",
     "sentencepiece<0.2.2",
     "tokenizers",
-    "tensorflow-text;platform_system != 'Windows'",
+    "tensorflow-text>=2.20.1,<2.21.0;platform_system != 'Windows'",
 ]
 
 [project.urls]

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
 tensorflow-cpu
-tensorflow-text>=2.20.1
+tensorflow-text>=2.20.1,<2.21.0
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow with cuda support.
 tensorflow[and-cuda]
-tensorflow-text>=2.20.1
+tensorflow-text>=2.20.1,<2.21.0
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
 tensorflow-cpu
-tensorflow-text>=2.20.1
+tensorflow-text>=2.20.1,<2.21.0
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu126

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Tensorflow.
 tensorflow-cpu;sys_platform != 'darwin'
 tensorflow;sys_platform == 'darwin'
-tensorflow-text>=2.20.1;platform_system != 'Windows'
+tensorflow-text>=2.20.1,<2.21.0;platform_system != 'Windows'
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary

`tensorflow-text==2.21.0` was released recently and breaks all KerasHub CI
across every backend (JAX, TF, PyTorch, OpenVINO). This pins
`tensorflow-text>=2.20.1,<2.21.0` until the incompatibility is resolved.

### Root Cause

`tensorflow-text==2.21.0` introduces breaking changes that cause widespread
test failures in tokenizer and preprocessor layers (RWKV7, Moonshine,
PaliGemma, T5, Stable Diffusion, etc.).

### Files Changed

- `requirements.txt` — CI CPU tests
- `requirements-tensorflow-cuda.txt` — CI TF GPU tests
- `requirements-jax-cuda.txt` — CI JAX GPU tests
- `requirements-torch-cuda.txt` — CI Torch GPU tests
- `pyproject.toml` — end-user `pip install keras-hub` dependencies

### Impact

- **CI**: All PRs are currently blocked. This unblocks them.
- **Users**: A patch release is recommended to protect users doing
  `pip install keras-hub` in fresh environments.

## Test plan
- CI should go green once this is merged.



## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
