### PR TITLE
Match the reference YaRN implementation in RotaryEmbedding

### DIFF
--- a/keras_hub/src/layers/modeling/rotary_embedding.py
+++ b/keras_hub/src/layers/modeling/rotary_embedding.py
@@ -35,8 +35,9 @@ class RotaryEmbedding(keras.layers.Layer):
         original_max_position_embeddings: int. Original maximum position
             embeddings for YaRN scaling. Only used when rope_type="yarn".
             Defaults to 4096.
-        truncate: bool. Whether to apply truncation for YaRN scaling. Only used
-            when rope_type="yarn". Defaults to False.
+        truncate: bool. Whether to round the YaRN correction range to whole
+            dimensions. Only used when rope_type="yarn". Defaults to True,
+            matching the reference YaRN implementation.
         sequence_axis: int. Sequence axis in the input tensor.
         feature_axis: int. Feature axis in the input tensor.
         **kwargs: other keyword arguments passed to `keras.layers.Layer`,
@@ -85,7 +86,7 @@ class RotaryEmbedding(keras.layers.Layer):
         beta_fast=32.0,
         beta_slow=1.0,
         original_max_position_embeddings=4096,
-        truncate=False,
+        truncate=True,
         sequence_axis=1,
         feature_axis=-1,
         denominator_dim=None,
@@ -198,16 +199,6 @@ class RotaryEmbedding(keras.layers.Layer):
             if len(ops.shape(positions)) == 1:
                 positions = ops.expand_dims(positions, axis=batch_axis)
 
-        if (
-            self.rope_type == "yarn"
-            and self.truncate
-            and self.original_max_position_embeddings is not None
-        ):
-            positions = ops.minimum(
-                positions,
-                ops.cast(self.original_max_position_embeddings, "float32"),
-            )
-
         freq = ops.einsum("bi,j->bij", positions, inverse_freq)
 
         embedding = ops.stack((freq, freq), axis=-2)
@@ -300,7 +291,7 @@ class RotaryEmbedding(keras.layers.Layer):
 
         # Clamp to valid range
         low = ops.maximum(low, ops.cast(0, "float32"))
-        high = ops.minimum(high, ops.cast(rotary_dim // 2 - 1, "float32"))
+        high = ops.minimum(high, ops.cast(rotary_dim - 1, "float32"))
 
         # Linear ramp function
         dim_half = rotary_dim // 2

--- a/keras_hub/src/layers/modeling/rotary_embedding_test.py
+++ b/keras_hub/src/layers/modeling/rotary_embedding_test.py
@@ -237,29 +237,11 @@ class RotaryEmbeddingTest(TestCase):
         )
 
     def test_yarn_rope_scaling(self):
-        # Reference values computed from the Huggingface mistral implementation
-        # from transformers import MistralConfig
-        # from transformers.models.mistral.modeling_mistral import (
-        #     MistralRotaryEmbedding, apply_rotary_pos_emb
-        # )
-        # import torch
-        # torch.set_printoptions(precision=9)
-        # config = MistralConfig(
-        #     hidden_size=16, num_attention_heads=2, num_key_value_heads=2,
-        #     head_dim=8, max_position_embeddings=128,
-        #     rope_parameters={
-        #         "rope_type": "yarn", "rope_theta": 100.0, "factor": 2.0,
-        #         "beta_fast": 32.0, "beta_slow": 1.0,
-        #         "original_max_position_embeddings": 64,
-        #     },
-        # )
-        # rotary_emb = MistralRotaryEmbedding(config)
-        # query = torch.ones((1, 2, 3, 8))
-        # cos, sin = rotary_emb(
-        #     query, torch.unsqueeze(torch.arange(3, dtype=torch.int32), 0)
-        # )
-        # query, _ = apply_rotary_pos_emb(query, query, cos, sin)
-        # print(query.transpose(1, 2))
+        # Reference values computed from the Huggingface mistral
+        # implementation, running `MistralRotaryEmbedding` and
+        # `apply_rotary_pos_emb` over `torch.ones((1, 2, 3, 8))` at positions
+        # `arange(3)`, with the YaRN parameters set below (`rope_theta` is
+        # `max_wavelength` and `factor` is `scaling_factor`).
         row0 = [1.069314718] * 8
         row1 = [
             -0.322044015,

--- a/keras_hub/src/layers/modeling/rotary_embedding_test.py
+++ b/keras_hub/src/layers/modeling/rotary_embedding_test.py
@@ -236,6 +236,79 @@ class RotaryEmbeddingTest(TestCase):
             ops.convert_to_tensor(expected),
         )
 
+    def test_yarn_rope_scaling(self):
+        # Reference values computed from the Huggingface mistral implementation
+        # from transformers import MistralConfig
+        # from transformers.models.mistral.modeling_mistral import (
+        #     MistralRotaryEmbedding, apply_rotary_pos_emb
+        # )
+        # import torch
+        # torch.set_printoptions(precision=9)
+        # config = MistralConfig(
+        #     hidden_size=16, num_attention_heads=2, num_key_value_heads=2,
+        #     head_dim=8, max_position_embeddings=128,
+        #     rope_parameters={
+        #         "rope_type": "yarn", "rope_theta": 100.0, "factor": 2.0,
+        #         "beta_fast": 32.0, "beta_slow": 1.0,
+        #         "original_max_position_embeddings": 64,
+        #     },
+        # )
+        # rotary_emb = MistralRotaryEmbedding(config)
+        # query = torch.ones((1, 2, 3, 8))
+        # cos, sin = rotary_emb(
+        #     query, torch.unsqueeze(torch.arange(3, dtype=torch.int32), 0)
+        # )
+        # query, _ = apply_rotary_pos_emb(query, query, cos, sin)
+        # print(query.transpose(1, 2))
+        row0 = [1.069314718] * 8
+        row1 = [
+            -0.322044015,
+            0.753861070,
+            0.995704532,
+            1.052274466,
+            1.477550507,
+            1.310939193,
+            1.138174176,
+            1.086087704,
+        ]
+        row2 = [
+            -1.417317033,
+            0.386358202,
+            0.917670548,
+            1.034970999,
+            0.527333140,
+            1.462051630,
+            1.201977015,
+            1.102589130,
+        ]
+        expected = [[[row0, row0], [row1, row1], [row2, row2]]]
+
+        layer = RotaryEmbedding(
+            max_wavelength=100.0,
+            rope_type="yarn",
+            scaling_factor=2.0,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            original_max_position_embeddings=64,
+        )
+        self.assertAllClose(
+            layer(ops.ones((1, 3, 2, 8))),
+            ops.convert_to_tensor(expected),
+        )
+
+    def test_yarn_beyond_original_context(self):
+        # Positions past `original_max_position_embeddings` must keep
+        # advancing, which is the case YaRN exists for.
+        layer = RotaryEmbedding(
+            max_wavelength=10000.0,
+            rope_type="yarn",
+            scaling_factor=2.0,
+            original_max_position_embeddings=4,
+            truncate=True,
+        )
+        output = ops.convert_to_numpy(layer(ops.ones((1, 8, 2, 4))))
+        self.assertNotAllClose(output[:, 4], output[:, 7])
+
     def test_rope_scaling_with_kv_cache(self):
         # Reference values computed from Huggingface llama implementation
         # With `scaling_factor` = 5.0

--- a/keras_hub/src/models/gpt_oss/gpt_oss_attention.py
+++ b/keras_hub/src/models/gpt_oss/gpt_oss_attention.py
@@ -142,6 +142,9 @@ class GptOssAttention(keras.layers.Layer):
             beta_fast=32.0,
             beta_slow=1.0,
             original_max_position_embeddings=4096,
+            # GPT-OSS sets `truncate=False` in its `rope_parameters`, unlike
+            # the reference default.
+            truncate=False,
             dtype=self.dtype_policy,
         )
 


### PR DESCRIPTION
## Description of the change

`RotaryEmbedding`'s YaRN scaling does not match the reference implementation that `transformers` follows. Plain RoPE matches to float32 precision, YaRN does not, and the error grows with `factor`:

| case | max abs diff vs HF |
| :--- | ---: |
| plain rope | 3.58e-07 |
| yarn, factor=4 | 6.51e-02 |
| yarn, factor=8 | 2.68e-01 |

`RotaryEmbedding` diverges from the reference YaRN implementation in three ways.

**`truncate` defaulted to `False`.** The reference reads it as `rope_parameters.get("truncate", True)`, so a config that does not set the key gets the rounded correction range. With the defaults aligned the inverse frequencies become identical:

| KerasHub `truncate` | HF `truncate` | inv_freq max diff |
| :--- | :--- | ---: |
| False | True (HF default) | 1.73e-03 |
| True | True | 0.000e+00 |

**The correction range clamped `high` to `rotary_dim // 2 - 1`,** where the reference uses `rotary_dim - 1`. This only matters once the range reaches past half the head dimension, which happens at long original context lengths:

| head_dim | `original_max_position_embeddings` | raw high | HF clamp | KerasHub clamp | rel err |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 64 | 4096 | 22.51 | 22.51 | 22.51 | 9.4e-08 |
| 64 | 131072 | 34.55 | 34.55 | 31.00 | 6.8e-01 |
| 128 | 131072 | 69.11 | 69.11 | 63.00 | 6.6e-01 |

**`truncate` also clamped the positions themselves** to `original_max_position_embeddings`. The reference has no such clamp, and it makes every position past the original context identical, which defeats the point of YaRN. With `original_max_position_embeddings=128`:

| seq | before | after |
| ---: | ---: | ---: |
| 64 | 1.82e+00 | 4.77e-07 |
| 512 | 7.78e+00 | 4.77e-07 |

### Key updates for reviewers

* GPT-OSS is the only caller using YaRN today, and its output does not change. Its HF config sets `truncate: False` explicitly, so `gpt_oss_attention.py` now passes that rather than relying on the old default. The position clamp only ran when `truncate` was true, and its correction range tops out at 17.4, well inside the old `rotary_dim // 2 - 1` bound of 31, so neither of the other two fixes reaches it. Verified bit identical against master for an 8192 position input.
* `truncate` keeps its name and stays public, but now means only what it means in the reference: whether to round the correction range to whole dimensions.
* No other model passes `truncate` or uses `rope_type="yarn"`, so nothing else changes.

## Reference

Related to the YaRN plumbing added in #2384. Turned up while comparing numerics for #2696, which is now closed in favour of #3020, but this is independent of both: it is a fix to the shared layer, and `MistralTransformerDecoder` uses it, so #3020 inherits it by reusing that decoder.

## Colab Notebook

Not applicable, no public API is added.

## Validation

* `rotary_embedding_test.py`: 14 passed, 2 skipped. The two new tests fail on master and pass here.
* `layers` / `gpt_oss` / `mistral` / `gemma` / `llama` / `qwen`: 285 passed, 112 skipped.
* GPT-OSS rotary output compared against master directly: `max_abs_diff = 0.000e+00`.
* Rotated output matches HF to float32 precision across head dims, thetas, factors, betas and context lengths, for Mistral and GPT-OSS configs. The residual is shared rounding, not a formula difference: against a float64 reference at 16k positions, HF is off by 2.075e-03 and KerasHub by 2.074e-03.
* Ruff lint and format pass.

## Checklist

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch.
- [x] I have followed the Keras Hub Model contribution guidelines (not applicable; no model is added).
- [x] I have followed the Keras Hub API design guidelines (not applicable; no API is added).
- [x] I have signed the Contributor License Agreement.
