### PR TITLE
Remove keras-team-review-pending from Gemini triage allowed_labels

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -42,5 +42,5 @@ jobs:
       GEMINI_API: '${{ secrets.GEMINI_API }}'
     with:
       issue_number: '${{ github.event.inputs.issue_number || inputs.issue_number }}'
-      allowed_labels: 'backend:jax,backend:tensorflow,backend:torch,backend:OpenVino,Gemma,layers,python,dependencies,Duplicate,stale,stat:awaiting response from contributor,stat:awaiting keras-eng,Good first issue,keras-team-review-pending,irrelevant issue'
+      allowed_labels: 'backend:jax,backend:tensorflow,backend:torch,backend:OpenVino,Gemma,layers,python,dependencies,Duplicate,stale,stat:awaiting response from contributor,stat:awaiting keras-eng,Good first issue,irrelevant issue'
       gemini_model: 'gemini-3.5-flash'


### PR DESCRIPTION
## Description of the change

The Gemini automated issue triage workflow was including 'keras-team-review-pending' in its allowed_labels list, causing the gemini to auto-apply it on nearly every new issue. This label should only be added manually when escalating to the eng team."


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
