### PR TITLE
Migrate PyPI publishing to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,11 +10,15 @@ permissions:
 
 jobs:
   run-test-for-nightly:
-    uses: ./.github/workflows/actions.yml
+    uses: $/.github/workflows/actions.yml
   nightly:
     name: Build Wheel file and upload
     needs: [run-test-for-nightly]
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -43,13 +47,11 @@ jobs:
         run: |
           python pip_build.py --nightly
       - name: Publish KerasHub Nightly to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1 # zizmor: ignore[use-trusted-publishing]
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
-          password: ${{ secrets.PYPI_NIGHTLY_API_TOKEN_HUB }}
           verbose: true
       - name: Publish KerasNLP Nightly to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1 # zizmor: ignore[use-trusted-publishing]
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: keras_nlp/dist/
-          password: ${{ secrets.PYPI_NIGHTLY_API_TOKEN }}
           verbose: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   run-test-for-nightly:
-    uses: $/.github/workflows/actions.yml
+    uses: ./.github/workflows/actions.yml # zizmor: ignore[self-repository]
   nightly:
     name: Build Wheel file and upload
     needs: [run-test-for-nightly]

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,13 +4,15 @@ on: push
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -38,12 +40,12 @@ jobs:
           python pip_build.py
       - name: Publish KerasHub to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           verbose: true
       - name: Publish KerasNLP to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: keras_nlp/dist/
           verbose: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,11 +4,13 @@ on: push
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -36,14 +38,12 @@ jobs:
           python pip_build.py
       - name: Publish KerasHub to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1 # zizmor: ignore[use-trusted-publishing]
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN_HUB }}
           verbose: true
       - name: Publish KerasNLP to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1 # zizmor: ignore[use-trusted-publishing]
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           packages-dir: keras_nlp/dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Description of the change

Migrates the PyPI publishing workflow from long-lived API tokens to [OIDC Trusted Publishing](https://docs.pypi.org/trusted-publishers/), eliminating the need for stored secrets (`PYPI_API_TOKEN_HUB` and `PYPI_API_TOKEN`).

With Trusted Publishing, GitHub and PyPI exchange short-lived, cryptographically verifiable identity tokens on each release — no manual secret rotation or long-lived credentials required.

### Changes

- Added `id-token: write` permission to allow GitHub to mint OIDC tokens
- Added `environment: pypi` to the job to match the PyPI Trusted Publisher configuration
- Removed `password` fields from both `pypa/gh-action-pypi-publish` steps (keras-hub and keras-nlp)
- Removed `# zizmor: ignore[use-trusted-publishing]` suppression comments

### Follow-up

After a successful OIDC release, remove the unused GitHub Secrets:
- `PYPI_API_TOKEN_HUB`
- `PYPI_API_TOKEN`

Resolves the `use-trusted-publishing` finding from Zizmor (see PR #2792 for the temporary suppression).

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
