### PR TITLE
Fix miscellaneous documentation typos and grammatical errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ maintain two lists of github tags for contributors:
 If you would like propose a new symbol or feature, please first review our
 design guide and roadmap linked above, and open an issue to discuss. If you have
 a specific design in mind, please include a Colab notebook showing the proposed
-design in a end-to-end example. Keep in mind that design for a new feature or
+design in an end-to-end example. Keep in mind that design for a new feature or
 use case may take longer than contributing to an open issue with a
 vetted-design.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -21,7 +21,7 @@ is considered as a common noun and not an abbreviation anymore.
 ## Naming of Models and Presets
 
 Naming of models and presets is a difficult and important element of our
-library usability. In general we try to to follow the branding of "upstream"
+library usability. In general we try to follow the branding of "upstream"
 model naming, subject to the consistency constraints laid out here.
 
 - The model and preset names should be recognizable to users familiar with the

--- a/keras_hub/src/layers/modeling/box_matcher.py
+++ b/keras_hub/src/layers/modeling/box_matcher.py
@@ -38,7 +38,7 @@ class BoxMatcher(keras.layers.Layer):
     Args:
         thresholds: A sorted list of floats to classify the matches into
             different results (e.g. positive or negative or ignored match). The
-            list will be prepended with -Inf and and appended with +Inf.
+            list will be prepended with -Inf and appended with +Inf.
         match_values: A list of integers representing matched results (e.g.
             positive or negative or ignored match). len(`match_values`) must
             equal to len(`thresholds`) + 1.

--- a/keras_hub/src/layers/modeling/cached_multi_head_attention.py
+++ b/keras_hub/src/layers/modeling/cached_multi_head_attention.py
@@ -50,7 +50,7 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
             `[B, 2, S, num_heads, key_dims]`, where `S` must agree with the
             `attention_mask` shape. This argument is intended for use during
             generation to avoid recomputing intermediate state.
-        cache_update_index: a int or int Tensor, the index at which to update
+        cache_update_index: an int or int Tensor, the index at which to update
             `cache` (usually the index of the current token being processed
             when running generation). If `cache_update_index=None` while `cache`
             is set, the cache will not be updated.

--- a/keras_hub/src/layers/modeling/rotary_embedding.py
+++ b/keras_hub/src/layers/modeling/rotary_embedding.py
@@ -164,7 +164,7 @@ class RotaryEmbedding(keras.layers.Layer):
 
     def _apply_rotary_pos_emb(self, tensor, cos_emb, sin_emb):
         x1, x2 = ops.split(tensor, 2, axis=-1)
-        # Avoid `ops.concatenate` for now, to avoid a obscure bug with XLA
+        # Avoid `ops.concatenate` for now, to avoid an obscure bug with XLA
         # compilation on jax. We should be able to remove this once the
         # following PR is in all jax releases we care about:
         # https://github.com/openxla/xla/pull/7875

--- a/keras_hub/src/models/deit/deit_image_classifier.py
+++ b/keras_hub/src/models/deit/deit_image_classifier.py
@@ -20,10 +20,11 @@ class DeiTImageClassifier(ImageClassifier):
     `num_classes` argument, controlling the number of predicted output classes.
 
     To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
-    labels where `x` is a string and `y` is a integer from `[0, num_classes)`.
+    labels where `x` is a string and `y` is an integer from `[0, num_classes)`.
 
-    Not that unlike `keras_hub.model.ImageClassifier`, the `DeiTImageClassifier`
-    we pluck out `cls_token` which is first seqence from the backbone.
+    Note that unlike `keras_hub.model.ImageClassifier`, the
+    `DeiTImageClassifier` we pluck out `cls_token` which is first seqence from
+    the backbone.
 
     Args:
         backbone: A `keras_hub.models.DeiTBackbone` instance or a `keras.Model`.

--- a/keras_hub/src/models/depth_estimator_preprocessor.py
+++ b/keras_hub/src/models/depth_estimator_preprocessor.py
@@ -16,7 +16,7 @@ class DepthEstimatorPreprocessor(Preprocessor):
 
     All `DepthEstimatorPreprocessor` take inputs three inputs, `x`, `y`, and
     `sample_weight`. `x`, the first input, should always be included. It can
-    be a image or batch of images. See examples below. `y` and `sample_weight`
+    be an image or batch of images. See examples below. `y` and `sample_weight`
     are optional inputs that will be passed through unaltered. Usually, `y` will
     be the depths, and `sample_weight` will not be provided.
 

--- a/keras_hub/src/models/flux/flux_text_to_image_preprocessor.py
+++ b/keras_hub/src/models/flux/flux_text_to_image_preprocessor.py
@@ -18,7 +18,7 @@ class FluxTextToImagePreprocessor(Preprocessor):
 
     Args:
         clip_l_preprocessor: A `keras_hub.models.CLIPPreprocessor` instance.
-        t5_preprocessor: A optional `keras_hub.models.T5Preprocessor` instance.
+        t5_preprocessor: An optional `keras_hub.models.T5Preprocessor` instance.
     """
 
     backbone_cls = FluxBackbone

--- a/keras_hub/src/models/image_classifier.py
+++ b/keras_hub/src/models/image_classifier.py
@@ -14,7 +14,7 @@ class ImageClassifier(Task):
     `num_classes` argument, controlling the number of predicted output classes.
 
     To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
-    labels where `x` is a string and `y` is a integer from `[0, num_classes)`.
+    labels where `x` is a string and `y` is an integer from `[0, num_classes)`.
     All `ImageClassifier` tasks include a `from_preset()` constructor which can
     be used to load a pre-trained config and weights.
 

--- a/keras_hub/src/models/image_classifier_preprocessor.py
+++ b/keras_hub/src/models/image_classifier_preprocessor.py
@@ -16,7 +16,7 @@ class ImageClassifierPreprocessor(Preprocessor):
 
     All `ImageClassifierPreprocessor` take inputs three inputs, `x`, `y`, and
     `sample_weight`. `x`, the first input, should always be included. It can
-    be a image or batch of images. See examples below. `y` and `sample_weight`
+    be an image or batch of images. See examples below. `y` and `sample_weight`
     are optional inputs that will be passed through unaltered. Usually, `y` will
     be the classification label, and `sample_weight` will not be provided.
 

--- a/keras_hub/src/models/object_detector_preprocessor.py
+++ b/keras_hub/src/models/object_detector_preprocessor.py
@@ -21,7 +21,7 @@ class ObjectDetectorPreprocessor(Preprocessor):
 
     All `ObjectDetectorPreprocessor` take three inputs, `x`, `y`, and
     `sample_weight`. `x`, the first input, should always be included. It can
-    be a image or batch of images. See examples below. `y` and `sample_weight`
+    be an image or batch of images. See examples below. `y` and `sample_weight`
     are optional inputs that will be passed through unaltered. Usually, `y`
     will be the a dict of `{"boxes": Tensor(batch_size, num_boxes, 4),
     "classes": (batch_size, num_boxes)}.

--- a/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
+++ b/keras_hub/src/models/pali_gemma/pali_gemma_vit.py
@@ -423,7 +423,7 @@ class PaliGemmaVit(keras.Model):
         intermediate_dim: int. The output dimension of the first Dense layer in
             a two-layer feedforward network for transformer.
         num_classes: int. The number of output classes. If this model is used
-            as a image classifier, this value would correspond to the number of
+            as an image classifier, this value would correspond to the number of
             output classes.
         pooling: string. The encoded vision embeddings are pooled using the
             specified pooling setting. The accepted values are `"map"`, `"gap"`,

--- a/keras_hub/src/models/segformer/segformer_image_segmenter.py
+++ b/keras_hub/src/models/segformer/segformer_image_segmenter.py
@@ -19,7 +19,7 @@ class SegFormerImageSegmenter(ImageSegmenter):
     (https://github.com/DavidLandup0/deepvision/tree/main/deepvision/models/segmentation/segformer).
 
     SegFormers are meant to be used with the MixTransformer (MiT) encoder
-    family, and and use a very lightweight all-MLP decoder head.
+    family, and use a very lightweight all-MLP decoder head.
 
     The MiT encoder uses a hierarchical transformer which outputs features at
     multiple scales, similar to that of the hierarchical outputs typically

--- a/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_preprocessor.py
+++ b/keras_hub/src/models/stable_diffusion_3/stable_diffusion_3_text_to_image_preprocessor.py
@@ -23,7 +23,7 @@ class StableDiffusion3TextToImagePreprocessor(TextToImagePreprocessor):
     Args:
         clip_l_preprocessor: A `keras_hub.models.CLIPPreprocessor` instance.
         clip_g_preprocessor: A `keras_hub.models.CLIPPreprocessor` instance.
-        t5_preprocessor: A optional `keras_hub.models.T5Preprocessor` instance.
+        t5_preprocessor: An optional `keras_hub.models.T5Preprocessor` instance.
     """
 
     backbone_cls = StableDiffusion3Backbone

--- a/keras_hub/src/models/text_classifier.py
+++ b/keras_hub/src/models/text_classifier.py
@@ -19,7 +19,7 @@ class TextClassifier(Task):
     `num_classes` argument, controlling the number of predicted output classes.
 
     To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
-    labels where `x` is a string and `y` is a integer from `[0, num_classes)`.
+    labels where `x` is a string and `y` is an integer from `[0, num_classes)`.
 
     All `TextClassifier` tasks include a `from_preset()` constructor which can
     be used to load a pre-trained config and weights.

--- a/keras_hub/src/models/text_to_image_preprocessor.py
+++ b/keras_hub/src/models/text_to_image_preprocessor.py
@@ -12,7 +12,7 @@ class TextToImagePreprocessor(Preprocessor):
 
     The exact specifics of this layer will vary depending on the subclass
     implementation per model architecture. Generally, it will take text input,
-    and tokenize, then pad/truncate so it is ready to be fed to a image
+    and tokenize, then pad/truncate so it is ready to be fed to an image
     generation model (e.g. a diffusion model).
 
     Examples.

--- a/keras_hub/src/models/vgg/vgg_image_classifier.py
+++ b/keras_hub/src/models/vgg/vgg_image_classifier.py
@@ -19,7 +19,7 @@ class VGGImageClassifier(ImageClassifier):
     `num_classes` argument, controlling the number of predicted output classes.
 
     To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
-    labels where `x` is a string and `y` is a integer from `[0, num_classes)`.
+    labels where `x` is a string and `y` is an integer from `[0, num_classes)`.
 
     Note that unlike `keras_hub.model.ImageClassifier`, the `VGGImageClassifier`
     allows `pooling="flatten"`, where the backbone outputs are flattened and

--- a/keras_hub/src/models/vit/vit_image_classifier.py
+++ b/keras_hub/src/models/vit/vit_image_classifier.py
@@ -20,9 +20,9 @@ class ViTImageClassifier(ImageClassifier):
     `num_classes` argument, controlling the number of predicted output classes.
 
     To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
-    labels where `x` is a string and `y` is a integer from `[0, num_classes)`.
+    labels where `x` is a string and `y` is an integer from `[0, num_classes)`.
 
-    Not that unlike `keras_hub.model.ImageClassifier`, the `ViTImageClassifier`
+    Note that unlike `keras_hub.model.ImageClassifier`, the `ViTImageClassifier`
     we pluck out `cls_token` which is first seqence from the backbone.
 
     Args:

--- a/keras_hub/src/models/vit_det/vit_layers.py
+++ b/keras_hub/src/models/vit_det/vit_layers.py
@@ -463,7 +463,7 @@ class WindowedTransformerEncoder(keras.layers.Layer):
 
 class ViTDetPatchingAndEmbedding(keras.layers.Layer):
     """
-    Implements a image patch and embedding layer.
+    Implements an image patch and embedding layer.
 
     Image to Patch Embedding using only a conv layer (without
     layer normalization).The code has been adapted from [Segment Anything

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer.py
@@ -184,7 +184,7 @@ class BytePairTokenizerCache(_base_class):
 
     def _get_key(self, keys):
         """Get the hash key for given inputs."""
-        # `tf.fingerprint` converts token to a array of uint8 of length 8, we
+        # `tf.fingerprint` converts token to an array of uint8 of length 8, we
         # need to convert it to a uint64.
         return tf.squeeze(
             tf.matmul(

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
@@ -358,8 +358,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
                             val_list[i] = val_list[i].decode("utf-8")
                         elif not isinstance(val_list[i], str):
                             raise ValueError(
-                                "If a array is provided as input, all elements "
-                                f"must be strings. Received: {inputs}"
+                                "If an array is provided as input, all "
+                                f"elements must be strings. Received: {inputs}"
                             )
                     return val_list, True
                 else:


### PR DESCRIPTION
## Description of the change
This PR corrects several minor typos and grammatical errors found in docstrings, comments, and documentation across the repository to improve clarity and professional quality.

Summary of changes:
   * Duplicate words: Fixed instances of "and and" and "to to" in box_matcher.py, segformer_image_segmenter.py, and STYLE_GUIDE.md.
   * Article usage ("a" vs "an"): Corrected grammar for terms starting with vowel sounds (e.g., "an array", "an int", "an obscure bug") in sentence_piece_tokenizer.py, byte_pair_tokenizer.py, cached_multi_head_attention.py, and rotary_embedding.py.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
