### PR TITLE
 Fix all remaining zizmor audit failures

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -37,7 +37,7 @@ jobs:
           ))
         )
       )
-    uses: keras-team/shared-workflows/.github/workflows/gemini-issue-triage.yml@d9d8977425f512c21d72ace682b9fae6e4c5b901 # v1
+    uses: keras-team/shared-workflows/.github/workflows/gemini-issue-triage.yml@1ff60fd615b03a85abdffac6d7cbe390988bb305 # v1
     secrets:
       GEMINI_API: '${{ secrets.GEMINI_API }}'
     with:

--- a/.github/workflows/jules-review.yml
+++ b/.github/workflows/jules-review.yml
@@ -23,6 +23,6 @@ jobs:
       (github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request) &&
       contains(github.event.comment.body, '@jules') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: keras-team/shared-workflows/.github/workflows/jules-review.yml@d9d8977425f512c21d72ace682b9fae6e4c5b901 # v1
+    uses: keras-team/shared-workflows/.github/workflows/jules-review.yml@1ff60fd615b03a85abdffac6d7cbe390988bb305 # v1
     secrets:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   run-test-for-nightly:
-    uses: ./.github/workflows/actions.yml  # zizmor: ignore[self-repository]
+    uses: $/.github/workflows/actions.yml
   nightly:
     name: Build Wheel file and upload
     needs: [run-test-for-nightly]


### PR DESCRIPTION
## Description of the change

- **nightly.yml**: Use `$/` self-repository syntax instead of `./` (`self-repository` audit)
- **gemini-automated-issue-triage.yml**: Update `keras-team/shared-workflows` hash pin to match current `v1` tag (`mismatched-version-comment` audit)
- **jules-review.yml**: Update `keras-team/shared-workflows` hash pin to match current `v1` tag (`mismatched-version-comment` audit)


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
