### PR TITLE
fix(causal_lm): give the CausalLM.generate_step stub the signature it is called with

### DIFF
--- a/keras_hub/src/models/causal_lm.py
+++ b/keras_hub/src/models/causal_lm.py
@@ -123,7 +123,7 @@ class CausalLM(Task):
         # Clear the compiled generate function.
         self.generate_function = None
 
-    def generate_step(self):
+    def generate_step(self, *args, **kwargs):
         """Run generation on a single batch of input."""
         raise NotImplementedError
 


### PR DESCRIPTION
## Problem

`CausalLM.generate_step` is the abstract hook subclasses implement, and the base class calls it with two arguments:

```python
# keras_hub/src/models/causal_lm.py:135
self.generate_function = self.generate_step
...
# keras_hub/src/models/causal_lm.py:379
return generate_function(x, stop_token_ids=stop_token_ids)
```

The torch and jax wrappers in `make_generate_function` do the same (`self.generate_step(inputs, stop_token_ids)`).

But the stub is declared with no parameters:

```python
def generate_step(self):
    """Run generation on a single batch of input."""
    raise NotImplementedError
```

so reaching it raises an arity error rather than the intended `NotImplementedError`:

```
TypeError: generate_step() got an unexpected keyword argument 'stop_token_ids'
```

26 of the 27 `CausalLM` subclasses override `generate_step`, which is why this has gone unnoticed. The exception is `Seq2SeqLM` — itself exported as `keras_hub.models.Seq2SeqLM` and documented as a base class to subclass — which inherits the stub as-is. A `Seq2SeqLM` subclass that forgets to implement `generate_step` therefore gets a confusing signature error instead of "you must implement this".

## Verification

Replaying the real call site against the real stub definition, extracted from `causal_lm.py`:

| stub signature | result of `generate_step(x, stop_token_ids=None)` |
| --- | --- |
| `def generate_step(self):` (master) | `TypeError: generate_step() got an unexpected keyword argument 'stop_token_ids'` |
| `def generate_step(self, *args, **kwargs):` (this PR) | `NotImplementedError` |

## Fix

Use the same tolerant signature the three sibling base classes already use for exactly this hook:

```
keras_hub/src/models/text_to_image.py:119   def generate_step(self, *args, **kwargs):
keras_hub/src/models/image_to_image.py:127  def generate_step(self, *args, **kwargs):
keras_hub/src/models/inpaint.py:130         def generate_step(self, *args, **kwargs):
```

One line, signature only. No behaviour change for any subclass that implements the method — and `gemma4_assistant_causal_lm.py:246` already overrides it with the same `(*args, **kwargs)` form, so the shape is established in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
