### PR TITLE
 CI : Extract CPU tests into reusable cpu_tests.yml workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
   pull_request:
-  workflow_call:
   release:
     types: [created]
 
@@ -15,71 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_tests:
-    name: Test the code (${{ matrix.backend }}, ${{ matrix.version }}, shard ${{ matrix.shard }})
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [tensorflow, jax, torch]
-        version: [keras-stable]
-        shard: [1, 2, 3, 4]
-        include:
-          - backend: jax
-            version: keras-3.14
-            shard: 1
-          - backend: jax
-            version: keras-nightly
-            shard: 1
-          - backend: openvino
-            version: keras-nightly
-            shard: 1
-
-    container:
-      image: python:3.11-slim
-
-    runs-on: linux-x86-n2-16
-    timeout-minutes: 120
-    env:
-      KERAS_BACKEND: ${{ matrix.backend }}
-    steps:
-    - name: Install binary dependencies
-      # build-essential for C extensions (tokenizers, torch)
-      # curl, git, gnupg for checkout and other actions
-      run: |
-        apt-get update
-        apt-get -y install build-essential curl git gnupg
-        git config --global --add safe.directory '*'
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-    - name: Install dependencies
-      run: |
-          pip install -r requirements.txt --progress-bar off
-          pip install --no-deps -e "." --progress-bar off
-    - name: Pin Keras 3.14
-      if: ${{ matrix.version == 'keras-3.14'}}
-      run: |
-        pip uninstall -y keras jaxlib jax
-        pip install keras==3.14.0 --progress-bar off
-        pip install jax==0.10.0 --progress-bar off
-    - name: Pin Keras Nightly
-      if: ${{ matrix.version == 'keras-nightly'}}
-      run: |
-        pip uninstall -y keras
-        pip install keras-nightly --no-cache-dir --progress-bar off
-    - name: Test with pytest
-      run: |
-        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits 4 --group ${{ matrix.shard }}
-    - name: Run integration tests
-      if: ${{ matrix.shard == 1 }}
-      run: |
-        python pip_build.py --install
-        cd integration_tests && pytest . -k "not NoTensorflow"
-    - name: Run no tensorflow integration test
-      if: ${{ matrix.backend != 'tensorflow' && matrix.shard == 1 }}
-      run: |
-        pip uninstall -y tensorflow-text tensorflow
-        cd integration_tests && pytest . -k "NoTensorflow"
+  cpu_tests:
+    uses: ./.github/workflows/cpu_tests.yml # zizmor: ignore[self-repository]
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -1,0 +1,87 @@
+name: CPU Tests
+
+on:
+  workflow_call:
+    inputs:
+      shards:
+        description: 'JSON array of shard indices to run'
+        type: string
+        default: '[1, 2, 3, 4]'
+      shard_count:
+        description: 'Total number of shards for pytest-split'
+        type: number
+        default: 4
+      timeout:
+        description: 'Timeout in minutes for each test job'
+        type: number
+        default: 120
+
+permissions:
+  contents: read
+
+jobs:
+  cpu_tests:
+    name: CPU Tests (${{ matrix.backend }}, ${{ matrix.version }}, shard ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax, torch]
+        version: [keras-stable]
+        shard: ${{ fromJSON(inputs.shards) }}
+        include:
+          - backend: jax
+            version: keras-3.14
+            shard: 1
+          - backend: jax
+            version: keras-nightly
+            shard: 1
+          - backend: openvino
+            version: keras-nightly
+            shard: 1
+
+    container:
+      image: python:3.11-slim
+
+    runs-on: linux-x86-n2-16
+    timeout-minutes: ${{ inputs.timeout }}
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
+    steps:
+    - name: Install binary dependencies
+      # build-essential for C extensions (tokenizers, torch)
+      # curl, git, gnupg for checkout and other actions
+      run: |
+        apt-get update
+        apt-get -y install build-essential curl git gnupg
+        git config --global --add safe.directory '*'
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: Install dependencies
+      run: |
+          pip install -r requirements.txt --progress-bar off
+          pip install --no-deps -e "." --progress-bar off
+    - name: Pin Keras 3.14
+      if: ${{ matrix.version == 'keras-3.14'}}
+      run: |
+        pip uninstall -y keras jaxlib jax
+        pip install keras==3.14.0 --progress-bar off
+        pip install jax==0.10.0 --progress-bar off
+    - name: Pin Keras Nightly
+      if: ${{ matrix.version == 'keras-nightly'}}
+      run: |
+        pip uninstall -y keras
+        pip install keras-nightly --no-cache-dir --progress-bar off
+    - name: Test with pytest
+      run: |
+        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits ${{ inputs.shard_count }} --group ${{ matrix.shard }}
+    - name: Run integration tests
+      if: ${{ matrix.shard == 1 }}
+      run: |
+        python pip_build.py --install
+        cd integration_tests && pytest . -k "not NoTensorflow"
+    - name: Run no tensorflow integration test
+      if: ${{ matrix.backend != 'tensorflow' && matrix.shard == 1 }}
+      run: |
+        pip uninstall -y tensorflow-text tensorflow
+        cd integration_tests && pytest . -k "NoTensorflow"

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -48,8 +48,6 @@ jobs:
       KERAS_BACKEND: ${{ matrix.backend }}
     steps:
     - name: Install binary dependencies
-      # build-essential for C extensions (tokenizers, torch)
-      # curl, git, gnupg for checkout and other actions
       run: |
         apt-get update
         apt-get -y install build-essential curl git gnupg
@@ -73,8 +71,11 @@ jobs:
         pip uninstall -y keras
         pip install keras-nightly --no-cache-dir --progress-bar off
     - name: Test with pytest
+      env:
+        SHARD_COUNT: ${{ inputs.shard_count }}
+        SHARD: ${{ matrix.shard }}
       run: |
-        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits ${{ inputs.shard_count }} --group ${{ matrix.shard }}
+        pytest keras_hub/ -n auto --dist loadfile --durations=50 --splits "$SHARD_COUNT" --group "$SHARD"
     - name: Run integration tests
       if: ${{ matrix.shard == 1 }}
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,11 +9,15 @@ permissions:
   contents: read
 
 jobs:
-  run-test-for-nightly:
-    uses: ./.github/workflows/actions.yml # zizmor: ignore[self-repository]
+  cpu_tests:
+    uses: ./.github/workflows/cpu_tests.yml # zizmor: ignore[self-repository]
+    with:
+      shards: '[1]'
+      shard_count: 1
+      timeout: 240
   nightly:
     name: Build Wheel file and upload
-    needs: [run-test-for-nightly]
+    needs: [cpu_tests]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Approved issue link
<!--- Link the approved issue that is assigned to you, e.g. "Fixes #123".
      An issue must be assigned to you and linked here before this PR can be
      marked "Ready for review". -->


## Description of the change

- Extracts the CPU test job from actions.yml into a standalone reusable workflow (cpu_tests.yml) and calls it from both actions.yml and nightly.yml. This eliminates the need for nightly.yml to call the entire actions.yml (which also includes format checks), and allows each caller to configure test behavior independently.

## Changes

- New: .github/workflows/cpu_tests.yml — Reusable workflow_call workflow with configurable inputs (shards, shard_count, timeout)
- Modified: .github/workflows/actions.yml — Now delegates CPU tests to cpu_tests.yml (default: 4 shards, 120 min timeout). Format check remains inline.
- Modified: .github/workflows/nightly.yml — Calls cpu_tests.yml directly with no sharding (shards: '[1]', shard_count: 1, timeout: 240) instead of going through actions.yml
## Motivation
- Single source of truth for CPU test logic — changes are made in one place
- Nightly doesn't need sharding — reduces from 15 jobs to 6, saving CI resources
- Consistent with gpu_tests.yml pattern already in progress


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
