### PR TITLE
Implement build on Task to prevent unbuilt state warning

### DIFF
--- a/keras_hub/src/models/task.py
+++ b/keras_hub/src/models/task.py
@@ -58,6 +58,9 @@ class Task(PipelineModel):
             # Default compilation.
             self.compile()
 
+    def build(self, input_shape=None):
+        self.built = True
+
     def preprocess_samples(self, x, y=None, sample_weight=None):
         # If `preprocessor` is `None`, return inputs unaltered.
         if self.preprocessor is None:

--- a/keras_hub/src/models/task_test.py
+++ b/keras_hub/src/models/task_test.py
@@ -354,3 +354,15 @@ class TestTask(TestCase):
         )
         with self.assertRaises(ValueError):
             causal_lm.export_to_transformers(export_path)
+
+    def test_no_unbuilt_state_warning_on_build(self):
+        import warnings
+
+        causal_lm, _ = self._create_gemma_for_export_tests()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            causal_lm.build()
+            unbuilt_warnings = [
+                w for w in caught if "unbuilt state" in str(w.message)
+            ]
+            self.assertEqual(len(unbuilt_warnings), 0)


### PR DESCRIPTION
### Problem

When loading any `Task` model (e.g. `Gemma3CausalLM`) from a preset, Keras emits a warning:

```
UserWarning: `build()` was called on layer '<task_name>', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.
```

### Root Cause

`Task` models construct a functional model DAG (`self.backbone` and task-specific heads), which is completely built during construction. However, `self.preprocessor` is also attached as an attribute on the `Task` instance and remains `built=False` until data is passed to it during generation or training.

When `build()` is invoked (e.g. during functional initialization), Keras inspects `self._layers`. Because `preprocessor.built` is `False` and `Task` did not explicitly override `build()`, Keras's default `Layer.build` assumes an unbuilt layer state was overlooked and raises a warning.

**Manual verification:**

```
# Repro error
>>> import keras_hub
model = keras_hub.models.Qwen2CausalLM.from_preset("qwen2.5_coder_instruct_1.5b", load_weights=False)
>>> model = keras_hub.models.Qwen2CausalLM.from_preset("qwen2.5_coder_instruct_1.5b", load_weights=False)
/Users/jeffcarp/gh/keras-team/keras/keras/src/layers/layer.py:444: UserWarning: `build()` was called on layer 'qwen_causal_lm', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.
  warnings.warn(
  
# Monkey patch with fix - no error afterwards
>>> def causal_lm_build(self, input_shape=None):
...     if self.backbone is not None and not self.backbone.built:
...         self.backbone.build(input_shape)
...     self.built = True
...
>>> keras_hub.models.CausalLM.build = causal_lm_build
>>> model2 = keras_hub.models.Qwen2CausalLM.from_preset("qwen2.5_coder_instruct_1.5b", load_weights=False)
```

### Solution

Implement `build(self, input_shape=None)` directly on `Task`:
```python
def build(self, input_shape=None):
    self.built = True
```

This explicitly marks the task as built and suppresses the false-positive warning. A test has also been added to `task_test.py` to verify that calling `build()` on a `Task` emits no unbuilt state warnings.