### PR TITLE
Use keras.random.uniform instead of ops.random.uniform in Mixtral dec…

### DIFF
--- a/keras_hub/src/models/mixtral/mixtral_decoder.py
+++ b/keras_hub/src/models/mixtral/mixtral_decoder.py
@@ -230,7 +230,7 @@ class MixtralSparseMoeBlock(keras.layers.Layer):
 
         # Apply jitter noise during training if specified
         if training and self.router_jitter_noise > 0:
-            random_factors = ops.random.uniform(
+            random_factors = keras.random.uniform(
                 shape=ops.shape(hidden_states_flattened),
                 minval=1.0 - self.router_jitter_noise,
                 maxval=1.0 + self.router_jitter_noise,


### PR DESCRIPTION

## Summary
This PR changes `ops.random.uniform()` to `keras.random.uniform()` in 
the Mixtral decoder's router jitter noise implementation.

Per Keras maintainer clarification (keras-team/keras#23575), 
`keras.random` is the intended public API for random operations. 
`keras.ops.random` was never intended to be exposed.


## Approved issue link
<!--- Link the approved issue that is assigned to you, e.g. "Fixes #123".
      An issue must be assigned to you and linked here before this PR can be
      marked "Ready for review". -->
Fixes #3044 

## Description of the change
<!--- Describe your changes in detail. -->
- `keras_hub/src/models/mixtral/mixtral_decoder.py`: Replace 
  `ops.random.uniform()` with `keras.random.uniform()` in 
  `MixtralSparseMoeBlock.call()`

## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->
- Keras maintainer clarification on keras.random vs keras.ops.random: 
  https://github.com/keras-team/keras/issues/23575#issuecomment-5589477195
## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->
N/A - This is a one-line API fix, no new API or model added.
## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [✓ ] I have added all the necessary unit tests for my change.
- [x ] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [✓ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [✓ ] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [✓ ] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [✓ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
