### PR TITLE
fix: replace keras-team-review-pending with gTech-team-review-pending in Gemini triage allow-list

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -42,5 +42,5 @@ jobs:
       GEMINI_API: '${{ secrets.GEMINI_API }}'
     with:
       issue_number: '${{ github.event.inputs.issue_number || inputs.issue_number }}'
-      allowed_labels: 'backend:jax,backend:tensorflow,backend:torch,backend:OpenVino,Gemma,layers,python,dependencies,Duplicate,stale,stat:awaiting response from contributor,stat:awaiting keras-eng,Good first issue,irrelevant issue'
+      allowed_labels: 'backend:jax,backend:tensorflow,backend:torch,backend:OpenVino,Gemma,layers,python,dependencies,Duplicate,stale,stat:awaiting response from contributor,Good first issue,irrelevant issue,gTech-team-review-pending'
       gemini_model: 'gemini-3.5-flash'


### PR DESCRIPTION
## Problem

The `gemini-automated-issue-triage` workflow was automatically applying
`keras-team-review-pending` (and falling back to `stat:awaiting keras-eng`) on every
newly opened issue. This caused noise because:

- These labels imply human review assignments but were being applied by a bot
- Removing one label caused Gemini to pick the next "review pending" label in the allow-list
- This happened across keras-hub, keras.

## Fix

Replace `keras-team-review-pending` and `stat:awaiting keras-eng` with
`gTech-team-review-pending` in the `allowed_labels` list.

This means:
-  Gemini correctly signals "this was auto-triaged by gTech tooling"
- `keras-team-review-pending` is never auto-applied (keeps human-only semantics)
- `stat:awaiting keras-eng` is never auto-applied (keeps human-only semantics)

## Related issues
- keras-team/keras-hub#3018
- keras-team/keras-hub#3010
- keras-team/keras#23587


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
