### PR TITLE
Unpin Tensorflow-Text version cap (revert <2.21.0 restriction)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "kagglesdk==0.1.28",
     "sentencepiece",
     "tokenizers",
-    "tensorflow-text>=2.20.1,<2.21.0;platform_system != 'Windows'",
+    "tensorflow-text>=2.20.1;platform_system != 'Windows'",
 ]
 
 [project.urls]

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
 tensorflow-cpu
-tensorflow-text>=2.20.1,<2.21.0
+tensorflow-text>=2.20.1
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow with cuda support.
 tensorflow[and-cuda]
-tensorflow-text>=2.20.1,<2.21.0
+tensorflow-text>=2.20.1
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
 tensorflow-cpu
-tensorflow-text>=2.20.1,<2.21.0
+tensorflow-text>=2.20.1
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu126

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Tensorflow.
 tensorflow-cpu;sys_platform != 'darwin'
 tensorflow;sys_platform == 'darwin'
-tensorflow-text>=2.20.1,<2.21.0;platform_system != 'Windows'
+tensorflow-text>=2.20.1;platform_system != 'Windows'
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary

Removes the temporary `tensorflow-text<2.21.0` upper bound that was
introduced in #2979 to work around a breakage caused by the
`tensorflow-text==2.21.0` release.

The `tensorflow-text` team has resolved the compatibility issues, and
the new release has been tested and confirmed working across all
KerasHub backends (JAX, TF, PyTorch, OpenVINO).

## Changes

- `pyproject.toml`: `tensorflow-text>=2.20.1,<2.21.0` → `tensorflow-text>=2.20.1`
- `requirements.txt`: same
- `requirements-jax-cuda.txt`: same
- `requirements-tensorflow-cuda.txt`: same
- `requirements-torch-cuda.txt`: same

## Related PRs

- Pinned in: #2979 — _Pin tensorflow-text<2.21.0 to fix CI and Keras hub PyPi usage breakage_



## Colab Notebook

[Reference gist](https://colab.research.google.com/gist/laxmareddyp/a614a111dad2986cd2bf137c53a74830/bert_model.ipynb)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have read and followed the [PR contribution policy](https://github.com/keras-team/keras/issues/23601).
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
