### PR TITLE
 Run the full test suite for every backend on PRs and master merges

### DIFF
--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -21,23 +21,24 @@ permissions:
 
 jobs:
   cpu_tests:
-    name: CPU Tests (${{ matrix.backend }}, ${{ matrix.version }}, shard ${{ matrix.shard }})
+    name: CPU Tests (${{ matrix.config.backend }}, ${{ matrix.config.version }}, shard ${{ matrix.shard }})
     strategy:
       fail-fast: false
       matrix:
-        backend: [tensorflow, jax, torch]
-        version: [keras-stable]
-        shard: ${{ fromJSON(inputs.shards) }}
-        include:
+        config:
+          - backend: tensorflow
+            version: keras-stable
+          - backend: jax
+            version: keras-stable
+          - backend: torch
+            version: keras-stable
           - backend: jax
             version: keras-3.14
-            shard: 1
           - backend: jax
             version: keras-nightly
-            shard: 1
           - backend: openvino
             version: keras-nightly
-            shard: 1
+        shard: ${{ fromJSON(inputs.shards) }}
 
     container:
       image: python:3.11-slim
@@ -45,7 +46,7 @@ jobs:
     runs-on: linux-x86-n2-16
     timeout-minutes: ${{ inputs.timeout }}
     env:
-      KERAS_BACKEND: ${{ matrix.backend }}
+      KERAS_BACKEND: ${{ matrix.config.backend }}
     steps:
     - name: Install binary dependencies
       run: |
@@ -60,13 +61,13 @@ jobs:
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
     - name: Pin Keras 3.14
-      if: ${{ matrix.version == 'keras-3.14'}}
+      if: ${{ matrix.config.version == 'keras-3.14'}}
       run: |
         pip uninstall -y keras jaxlib jax
         pip install keras==3.14.0 --progress-bar off
         pip install jax==0.10.0 --progress-bar off
     - name: Pin Keras Nightly
-      if: ${{ matrix.version == 'keras-nightly'}}
+      if: ${{ matrix.config.version == 'keras-nightly'}}
       run: |
         pip uninstall -y keras
         pip install keras-nightly --no-cache-dir --progress-bar off
@@ -82,7 +83,7 @@ jobs:
         python pip_build.py --install
         cd integration_tests && pytest . -k "not NoTensorflow"
     - name: Run no tensorflow integration test
-      if: ${{ matrix.backend != 'tensorflow' && matrix.shard == 1 }}
+      if: ${{ matrix.config.backend != 'tensorflow' && matrix.shard == 1 }}
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"


### PR DESCRIPTION
## What this fixes

Three of the six CI configs run only **25% of the test suite** on PRs and
master merges. Regressions in those configs pass CI and are caught the next
morning by nightly, or not at all.

In `cpu_tests.yml`, the base matrix covers `tensorflow`/`jax`/`torch` on
keras-stable across all four shards. The other three configs are `include`
rows pinned to a single shard:


so those three resolve to `--splits 4 --group 1` — one quarter of the suite.
Groups 2, 3 and 4 are never executed for them.

`nightly.yml` overrides `shard_count: 1`, so every config runs 100% at night.
That mismatch is the bug: the check gating a PR is four times weaker than the
check gating the release, and the difference is invisible because each config
reports as a single green check.

### Observed impact

On a recent PR the OpenVINO check was green while every test it was meant to
validate had either been skipped or landed in a group that never ran. Nothing
in the job output distinguishes "passed" from "never executed".



### Coverage

| Config | Before (PR) | After (PR) | Nightly |
|---|---|---|---|
| tensorflow @ keras-stable | 100% | 100% | 100% |
| jax @ keras-stable | 100% | 100% | 100% |
| torch @ keras-stable | 100% | 100% | 100% |
| jax @ keras-3.14 | **25%** | **100%** | 100% |
| jax @ keras-nightly | **25%** | **100%** | 100% |
| openvino @ keras-nightly | **25%** | **100%** | 100% |

PR and master merges now match nightly exactly.

## Cost

PR job count goes from 15 to 24. Nightly is unchanged at 6.

Wall-clock is essentially flat: the nine added jobs each run 1/4 of the suite
in parallel, rather than making any single job longer. This deliberately
spends runner capacity instead of latency — the alternative of forcing the
three configs to `--splits 1` would have made them roughly 4x the duration of
every other job and become the critical path.

Integration-test gating is unchanged: `Run integration tests` and
`Run no tensorflow integration test` are still guarded on `matrix.shard == 1`,
so they continue to run exactly once per config.

This PR touches CI configuration only — no library or test code.

## Verification

- 24 `CPU Tests (...)` jobs on this PR; 6 on the next nightly.
- Every job's pytest line reads `--splits 4 --group N` for N in 1..4.
- `jax keras-3.14`, `jax keras-nightly` and `openvino` each show four jobs.
- Integration test steps run once per config, on shard 1 only.


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have read and followed the [PR contribution policy](https://github.com/keras-team/keras/issues/23601).
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
