### PR TITLE
[PyGrain Migration] Return NumPy instead of backend tensors from preprocessing

### DIFF
--- a/keras_hub/src/layers/preprocessing/image_converter.py
+++ b/keras_hub/src/layers/preprocessing/image_converter.py
@@ -15,6 +15,8 @@ from keras_hub.src.utils.preset_utils import get_preset_loader
 from keras_hub.src.utils.preset_utils import get_preset_saver
 from keras_hub.src.utils.python_utils import classproperty
 from keras_hub.src.utils.tensor_utils import check_bounding_box_support
+from keras_hub.src.utils.tensor_utils import convert_preprocessing_outputs_grain
+from keras_hub.src.utils.tensor_utils import in_grain_data_pipeline
 from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
@@ -223,6 +225,10 @@ class ImageConverter(PreprocessingLayer):
             inputs["images"] = x
         else:
             inputs = x
+        if in_grain_data_pipeline():
+            # Grain pickles outputs across worker processes, so return NumPy
+            # arrays rather than backend tensors.
+            return convert_preprocessing_outputs_grain(inputs)
         return inputs
 
     @preprocessing_function

--- a/keras_hub/src/layers/preprocessing/image_converter_test.py
+++ b/keras_hub/src/layers/preprocessing/image_converter_test.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 
+import grain
 import keras
 import numpy as np
 import pytest
@@ -174,6 +175,28 @@ class ImageConverterTest(TestCase):
         restored = ImageConverter.from_preset(save_dir)
         test_image = np.random.rand(100, 100, 3) * 255
         self.assertAllClose(restored(test_image), converter(test_image))
+
+    def test_grain_outputs_numpy(self):
+        converter = ImageConverter(
+            image_size=(4, 4),
+            scale=1 / 255.0,
+        )
+        images = [
+            np.random.randint(0, 255, size=(6, 6, 3)).astype("uint8"),
+            np.random.randint(0, 255, size=(8, 8, 3)).astype("uint8"),
+        ]
+        # Direct call returns backend tensors.
+        self.assertNotIsInstance(converter(images[0]), np.ndarray)
+        # Grain returns numpy arrays.
+        ds = grain.MapDataset.source(images).map(converter)
+        for output in ds:
+            self.assertIsInstance(output, np.ndarray)
+            self.assertEqual(output.shape, (4, 4, 3))
+        (batch,) = list(ds.batch(2))
+        self.assertIsInstance(batch, np.ndarray)
+        self.assertEqual(batch.shape, (2, 4, 4, 3))
+        # Numerics match the direct call.
+        self.assertAllClose(batch[0], converter(images[0]))
 
     def test_inhomogeneous_batch(self):
         if not self._allow_python_workflow:

--- a/keras_hub/src/layers/preprocessing/start_end_packer.py
+++ b/keras_hub/src/layers/preprocessing/start_end_packer.py
@@ -263,7 +263,7 @@ class StartEndPacker(PreprocessingLayer):
                 else:
                     inputs = inputs.to_list()
                 return inputs, not unbatched
-            elif keras.ops.is_tensor(inputs):
+            elif isinstance(inputs, np.ndarray) or keras.ops.is_tensor(inputs):
                 inputs = convert_to_list(inputs)
                 if inputs and isinstance(inputs[0], (tuple, list)):
                     return inputs, True

--- a/keras_hub/src/layers/preprocessing/start_end_packer_test.py
+++ b/keras_hub/src/layers/preprocessing/start_end_packer_test.py
@@ -1,3 +1,5 @@
+import grain
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -433,3 +435,30 @@ class StartEndPackerTest(TestCase):
         ]
         self.assertAllEqual(output, expected_output)
         self.assertAllEqual(padding_mask, expected_padding_mask)
+
+    @parameterized.named_parameters(
+        ("allow_python_workflow", True),
+        ("disallow_python_workflow", False),
+    )
+    def test_grain_outputs_numpy(self, allow_python_workflow):
+        layer = StartEndPacker(
+            sequence_length=5,
+            start_value=1,
+            end_value=2,
+            return_padding_mask=True,
+            _allow_python_workflow=allow_python_workflow,
+        )
+        # Direct call returns backend tensors.
+        token_ids, padding_mask = layer([5, 6, 7])
+        self.assertNotIsInstance(token_ids, np.ndarray)
+        # Grain returns numpy arrays.
+        ds = grain.MapDataset.source([[5, 6, 7], [8, 9]]).map(layer)
+        for token_ids, padding_mask in ds:
+            self.assertIsInstance(token_ids, np.ndarray)
+            self.assertIsInstance(padding_mask, np.ndarray)
+        (token_ids, padding_mask) = list(ds.batch(2))[0]
+        self.assertAllEqual(token_ids, [[1, 5, 6, 7, 2], [1, 8, 9, 2, 0]])
+        self.assertAllEqual(
+            padding_mask,
+            [[1, 1, 1, 1, 1], [1, 1, 1, 1, 0]],
+        )

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer.py
@@ -280,9 +280,9 @@ class BytePairTokenizer(tokenizer.Tokenizer):
     ...     vocab, merge, sequence_length=2)
     >>> seq1, seq2 = tokenizer(["butterfly", "butter"])
     >>> np.array(seq1)
-    array([3, 8])
+    array([3, 8], dtype=int32)
     >>> np.array(seq2)
-    array([3, 0])
+    array([3, 0], dtype=int32)
 
     Detokenize
     >>> tokenizer = keras_hub.tokenizers.BytePairTokenizer(vocab, merge)

--- a/keras_hub/src/tokenizers/byte_pair_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_pair_tokenizer.py
@@ -817,6 +817,12 @@ class BytePairTokenizer(tokenizer.Tokenizer):
                 tokens + [pad_token_id] * (self.sequence_length - len(tokens))
                 for tokens in batched_tokens
             ]
+            if is_int_dtype(self.compute_dtype):
+                # Dense int outputs are arrays, so that direct calls return
+                # backend tensors and Grain pipelines return NumPy.
+                batched_tokens = np.array(
+                    batched_tokens, dtype=self.compute_dtype
+                )
 
         if not batched:
             batched_tokens = batched_tokens[0]

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer.py
@@ -402,6 +402,12 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
                 tokens + [pad_token_id] * (self.sequence_length - len(tokens))
                 for tokens in batched_tokens
             ]
+            if is_int_dtype(self.compute_dtype):
+                # Dense int outputs are arrays, so that direct calls return
+                # backend tensors and Grain pipelines return NumPy.
+                batched_tokens = np.array(
+                    batched_tokens, dtype=self.compute_dtype
+                )
 
         if not batched:
             batched_tokens = batched_tokens[0]

--- a/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/sentence_piece_tokenizer_test.py
@@ -2,6 +2,8 @@ import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import grain
+import numpy as np
 from keras.src.saving import serialization_lib
 
 from keras_hub.src.tests.test_case import TestCase
@@ -104,6 +106,28 @@ class SentencePieceTokenizerTest(TestCase):
         self.assertAllEqual(
             output_data, [["<s>", "▁the", "▁quick", "▁brown", "▁fox.", "</s>"]]
         )
+
+    def test_grain_outputs_numpy(self):
+        input_data = ["the quick brown fox.", "the quick"]
+        # Ragged outputs are python lists.
+        (outputs,) = list(
+            grain.MapDataset.source([input_data]).map(self.tokenizer)
+        )
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(outputs, [[6, 5, 3, 4], [6, 5]])
+        # Dense outputs are numpy arrays.
+        tokenizer = SentencePieceTokenizer(
+            proto=self.proto,
+            sequence_length=5,
+            _allow_python_workflow=self._allow_python_workflow,
+        )
+        outputs = list(grain.MapDataset.source(input_data).map(tokenizer))
+        for output in outputs:
+            self.assertIsInstance(output, np.ndarray)
+        (batch,) = list(
+            grain.MapDataset.source(input_data).map(tokenizer).batch(2)
+        )
+        self.assertAllEqual(batch, [[6, 5, 3, 4, 0], [6, 5, 0, 0, 0]])
 
     def test_detokenize(self):
         outputs = self.tokenizer.detokenize([6, 5, 3, 4])

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -8,6 +8,7 @@ import threading
 import keras
 import numpy as np
 from keras import ops
+from keras.src.utils.backend_utils import in_grain_data_pipeline
 from packaging import version
 
 try:
@@ -188,6 +189,41 @@ def convert_preprocessing_inputs(x):
     return x
 
 
+def convert_preprocessing_outputs_grain(x):
+    """Convert outputs after preprocessing to NumPy arrays and Python objects.
+
+    Grain executes preprocessing in Python worker processes and pickles every
+    element across process boundaries. Backend tensors (`jax.Array`,
+    `torch.Tensor`, ...) pickle poorly and would initialize device state in
+    each worker, so inside a Grain pipeline preprocessing outputs are:
+
+    - `np.ndarray`s for dense numeric data.
+    - Python lists (of lists) for ragged and string data.
+    - Unchanged for Python scalars, strings, and `None`.
+
+    This is used automatically by `convert_preprocessing_outputs` and
+    `convert_preprocessing_outputs_python` when executing inside a Grain
+    pipeline.
+    """
+
+    def convert(x):
+        if x is None or isinstance(x, (str, bytes)):
+            return x
+        if tf is not None and isinstance(x, tf.RaggedTensor):
+            return tensor_to_list(x)
+        if tf is not None and isinstance(x, tf.Tensor):
+            if x.dtype == tf.string:
+                return tensor_to_list(x)
+            return x.numpy()
+        if isinstance(x, np.ndarray):
+            return x
+        if ops.is_tensor(x):
+            return ops.convert_to_numpy(x)
+        return x
+
+    return keras.tree.map_structure(convert, x)
+
+
 def convert_preprocessing_outputs(x):
     """Convert outputs after preprocessing to a backend agnostic format.
 
@@ -196,6 +232,10 @@ def convert_preprocessing_outputs(x):
 
     - The correct tensor type for the Keras backend framework.
     - Python lists, in the case of ragged and string data.
+
+    When called inside a Grain pipeline (e.g. `grain.MapDataset.map(layer)`),
+    dense outputs are instead returned as `np.ndarray`s so they can be pickled
+    across Grain worker processes. See `convert_preprocessing_outputs_grain`.
 
     This will automatically be called when on the output of preprocessing
     layers or `keras_hub.models.Task`s with preprocessing included. It could be
@@ -223,6 +263,8 @@ def convert_preprocessing_outputs(x):
     """
     if not tf.executing_eagerly() or in_no_convert_scope():
         return x
+    if in_grain_data_pipeline():
+        return convert_preprocessing_outputs_grain(x)
 
     def convert(x):
         if x is None:
@@ -252,6 +294,10 @@ def convert_preprocessing_outputs_python(x):
     - The correct tensor type for the Keras backend framework.
     - Python lists, in the case of string data.
 
+    When called inside a Grain pipeline (e.g. `grain.MapDataset.map(layer)`),
+    dense outputs are instead returned as `np.ndarray`s so they can be pickled
+    across Grain worker processes. See `convert_preprocessing_outputs_grain`.
+
     Examples:
     ```python
     # A batch of three samples each with two string segments.
@@ -269,6 +315,8 @@ def convert_preprocessing_outputs_python(x):
     """
     if in_no_convert_scope():
         return x
+    if in_grain_data_pipeline():
+        return convert_preprocessing_outputs_grain(x)
 
     def convert(x):
         if x is None:

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -409,7 +409,7 @@ def canonicalize_python_inputs(inputs):
         else:
             inputs = inputs.to_list()
         return inputs, not unbatched
-    elif keras.ops.is_tensor(inputs):
+    elif isinstance(inputs, np.ndarray) or keras.ops.is_tensor(inputs):
         inputs = convert_to_list(inputs)
         if inputs and isinstance(inputs[0], (tuple, list)):
             return inputs, True

--- a/keras_hub/src/utils/tensor_utils_test.py
+++ b/keras_hub/src/utils/tensor_utils_test.py
@@ -1,3 +1,4 @@
+import grain
 import numpy as np
 import tensorflow as tf
 from keras import ops
@@ -7,7 +8,12 @@ from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.tensor_utils import any_equal
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_inputs
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_outputs
+from keras_hub.src.utils.tensor_utils import convert_preprocessing_outputs_grain
+from keras_hub.src.utils.tensor_utils import (
+    convert_preprocessing_outputs_python,
+)
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import in_grain_data_pipeline
 from keras_hub.src.utils.tensor_utils import is_float_dtype
 from keras_hub.src.utils.tensor_utils import is_tensor_type
 from keras_hub.src.utils.tensor_utils import preprocessing_function
@@ -113,6 +119,146 @@ class ConvertHelpers(TestCase):
             return inputs
 
         test(self, ([1, 2, 3], ["foo", "bar"], "foo"))
+
+
+class GrainOutputsTest(TestCase):
+    """Preprocessing outputs inside a Grain pipeline must be NumPy/lists.
+
+    Grain pickles elements across worker processes, so backend tensors are
+    never returned from a Grain `map`.
+    """
+
+    def assertNumpyOutputs(self, x):
+        for leaf in tree.flatten(x):
+            self.assertNotIsInstance(leaf, tf.Tensor)
+            self.assertNotIsInstance(leaf, tf.RaggedTensor)
+            if not isinstance(leaf, (str, bytes, int, float, bool)):
+                self.assertIsInstance(leaf, np.ndarray)
+
+    def run_grain(self, fn, elements):
+        return list(grain.MapDataset.source(elements).map(fn))
+
+    def test_in_grain_data_pipeline_detection(self):
+        seen = []
+        self.assertFalse(in_grain_data_pipeline())
+        self.run_grain(lambda x: seen.append(in_grain_data_pipeline()), [0])
+        self.assertEqual(seen, [True])
+        self.assertFalse(in_grain_data_pipeline())
+
+    def test_convert_preprocessing_outputs_grain(self):
+        inputs = {
+            "dense": tf.constant([[1, 2], [3, 4]]),
+            "ragged": tf.ragged.constant([[1, 2, 3], [4]]),
+            "strings": tf.constant(["one", "two"]),
+            "backend": ops.ones((2, 2)),
+            "numpy": np.zeros((2,)),
+            "scalar_string": "hi",
+            "python_list": [1, 2],
+            "none": None,
+        }
+        outputs = convert_preprocessing_outputs_grain(inputs)
+        self.assertIsInstance(outputs["dense"], np.ndarray)
+        self.assertAllEqual(outputs["dense"], [[1, 2], [3, 4]])
+        self.assertEqual(outputs["ragged"], [[1, 2, 3], [4]])
+        self.assertEqual(outputs["strings"], ["one", "two"])
+        self.assertIsInstance(outputs["backend"], np.ndarray)
+        self.assertIsInstance(outputs["numpy"], np.ndarray)
+        self.assertEqual(outputs["scalar_string"], "hi")
+        self.assertEqual(outputs["python_list"], [1, 2])
+        self.assertIsNone(outputs["none"])
+
+    def test_convert_preprocessing_outputs_in_grain(self):
+        # Outside grain: backend tensors.
+        outputs = convert_preprocessing_outputs(tf.constant([1, 2, 3]))
+        self.assertTrue(is_tensor_type(outputs))
+        self.assertNotIsInstance(outputs, np.ndarray)
+        # Inside grain: numpy.
+        (outputs,) = self.run_grain(
+            lambda x: convert_preprocessing_outputs(tf.constant(x)),
+            [[1, 2, 3]],
+        )
+        self.assertIsInstance(outputs, np.ndarray)
+        self.assertAllEqual(outputs, [1, 2, 3])
+        # Ragged and string outputs stay python lists.
+        (outputs,) = self.run_grain(
+            lambda x: convert_preprocessing_outputs(
+                (tf.ragged.constant(x), tf.constant(["a", "b"]))
+            ),
+            [[[1, 2], [3]]],
+        )
+        self.assertEqual(outputs, ([[1, 2], [3]], ["a", "b"]))
+
+    def test_convert_preprocessing_outputs_python_in_grain(self):
+        # Outside grain: backend tensors.
+        outputs = convert_preprocessing_outputs_python(np.array([1, 2, 3]))
+        self.assertTrue(is_tensor_type(outputs))
+        self.assertNotIsInstance(outputs, np.ndarray)
+        # Inside grain: numpy, lists stay lists.
+        (outputs,) = self.run_grain(
+            lambda x: convert_preprocessing_outputs_python(
+                (np.array(x), ops.array(x), [[1], [2, 3]], "hi")
+            ),
+            [[1, 2, 3]],
+        )
+        self.assertIsInstance(outputs[0], np.ndarray)
+        self.assertIsInstance(outputs[1], np.ndarray)
+        self.assertEqual(outputs[2], [[1], [2, 3]])
+        self.assertEqual(outputs[3], "hi")
+
+    def test_preprocessing_function_in_grain(self):
+        @preprocessing_function
+        def fn(self, x):
+            return x
+
+        @preprocessing_function
+        def fn_with_labels(self, x, y=None, sample_weight=None):
+            return x, y, sample_weight
+
+        elements = [
+            {"ints": [1, 2, 3], "text": "hello", "image": np.ones((2, 2, 3))}
+        ]
+        # Direct call: backend tensors.
+        outputs = fn(self, elements[0])
+        self.assertTrue(is_tensor_type(outputs["ints"]))
+        self.assertNotIsInstance(outputs["ints"], np.ndarray)
+        # Grain map: numpy and python types.
+        (outputs,) = self.run_grain(lambda x: fn(self, x), elements)
+        self.assertNumpyOutputs(outputs)
+        self.assertAllEqual(outputs["ints"], [1, 2, 3])
+        self.assertEqual(outputs["text"], "hello")
+        self.assertAllEqual(outputs["image"], np.ones((2, 2, 3)))
+        # Grain map with labels.
+        (outputs,) = self.run_grain(
+            lambda x: fn_with_labels(self, x, [1], [0.5]), elements
+        )
+        self.assertNumpyOutputs(outputs)
+        self.assertAllEqual(outputs[1], [1])
+        self.assertAllClose(outputs[2], [0.5])
+
+    def test_grain_batching(self):
+        # Grain batches by stacking numpy leaves; outputs must be stackable.
+        @preprocessing_function
+        def fn(self, x):
+            return {"ints": x, "text": tf.strings.upper("hello")}
+
+        ds = grain.MapDataset.source([[1, 2], [3, 4]]).map(
+            lambda x: fn(self, x)
+        )
+        (batch,) = list(ds.batch(2))
+        self.assertIsInstance(batch["ints"], np.ndarray)
+        self.assertAllEqual(batch["ints"], [[1, 2], [3, 4]])
+        self.assertEqual(batch["text"].tolist(), ["HELLO", "HELLO"])
+
+    def test_grain_iter_dataset(self):
+        @preprocessing_function
+        def fn(self, x):
+            return x
+
+        ds = grain.MapDataset.source([[1, 2], [3, 4]]).to_iter_dataset()
+        outputs = list(ds.map(lambda x: fn(self, x)))
+        self.assertLen(outputs, 2)
+        for output in outputs:
+            self.assertIsInstance(output, np.ndarray)
 
 
 class TensorToListTest(TestCase):

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -18,6 +18,7 @@ pytest-split
 build
 namex
 # Optional deps.
+grain
 rouge-score
 tensorflow-datasets
 safetensors


### PR DESCRIPTION
Return NumPy instead of backend tensors from preprocessing inside grain