### PR TITLE
[PyGrain Migration] Add Grain coverage to TestCase harness

### DIFF
--- a/keras_hub/src/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_hub/src/layers/preprocessing/masked_lm_mask_generator.py
@@ -1,6 +1,5 @@
 import random
 
-import keras
 import numpy as np
 
 from keras_hub.src.api_export import keras_hub_export
@@ -8,6 +7,9 @@ from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_hub.src.utils.tensor_utils import canonicalize_python_inputs
+from keras_hub.src.utils.tensor_utils import (
+    convert_preprocessing_outputs_python,
+)
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import preprocessing_function
@@ -300,11 +302,14 @@ class MaskedLMMaskGenerator(PreprocessingLayer):
             out_mask_weights = out_mask_weights[0]
 
         def _canonicalize_outputs(outputs, dtype=None):
+            # Ragged outputs stay as (lists of) python lists. Rectangular
+            # outputs are converted to backend tensors, or NumPy arrays inside
+            # a Grain pipeline.
             try:
                 arr = np.array(outputs, dtype=dtype or "int32")
                 if arr.dtype == object:
                     return outputs
-                return keras.ops.convert_to_tensor(arr)
+                return convert_preprocessing_outputs_python(arr)
             except (ValueError, TypeError):
                 return outputs
 

--- a/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3/gemma3_causal_lm_preprocessor.py
@@ -491,9 +491,9 @@ class Gemma3CausalLMPreprocessor(CausalLMPreprocessor):
         )
         images = self.image_converter(images)
 
-        if keras.config.backend() == "torch" and not isinstance(
-            images, tf.Tensor
-        ):
+        # Inside a Grain pipeline the image converter returns NumPy arrays,
+        # otherwise torch tensors which may live on an accelerator.
+        if keras.config.backend() == "torch" and keras.ops.is_tensor(images):
             images = images.cpu()
 
         # Recover the rank.

--- a/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_causal_lm_preprocessor.py
@@ -498,9 +498,9 @@ class Gemma3nCausalLMPreprocessor(CausalLMPreprocessor):
             ],
         )
         images = self.image_converter(images)
-        if keras.config.backend() == "torch" and not isinstance(
-            images, tf.Tensor
-        ):
+        # Inside a Grain pipeline the image converter returns NumPy arrays,
+        # otherwise torch tensors which may live on an accelerator.
+        if keras.config.backend() == "torch" and keras.ops.is_tensor(images):
             images = images.cpu()
         # Recover the rank.
         images = tf.reshape(

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
@@ -546,10 +546,12 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
         pixel_values = images_dict["pixel_values"]
         pixel_position_ids = images_dict["pixel_position_ids"]
 
+        # Inside a Grain pipeline the image converter returns NumPy arrays,
+        # otherwise torch tensors which may live on an accelerator.
         if keras.config.backend() == "torch":
-            if not isinstance(pixel_values, tf.Tensor):
+            if keras.ops.is_tensor(pixel_values):
                 pixel_values = pixel_values.cpu()
-            if not isinstance(pixel_position_ids, tf.Tensor):
+            if keras.ops.is_tensor(pixel_position_ids):
                 pixel_position_ids = pixel_position_ids.cpu()
 
         pixel_values = tf.reshape(
@@ -598,9 +600,8 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
         # The audio converter runs as a Keras layer and may return a CUDA
         # torch tensor on GPU. Move to CPU so subsequent TF ops can accept it
         # (mirrors the same guard in _preprocess_images).
-        if keras.config.backend() == "torch":
-            if not isinstance(mel, tf.Tensor):
-                mel = mel.cpu()
+        if keras.config.backend() == "torch" and keras.ops.is_tensor(mel):
+            mel = mel.cpu()
 
         # Expand dims to model expectation of Clips step: (B, 1, Seq, Feat)
         mel = tf.expand_dims(mel, axis=1)
@@ -645,10 +646,12 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
         pixel_values = videos_dict["pixel_values"]
         pixel_position_ids = videos_dict["pixel_position_ids"]
 
+        # Inside a Grain pipeline the image converter returns NumPy arrays,
+        # otherwise torch tensors which may live on an accelerator.
         if keras.config.backend() == "torch":
-            if not isinstance(pixel_values, tf.Tensor):
+            if keras.ops.is_tensor(pixel_values):
                 pixel_values = pixel_values.cpu()
-            if not isinstance(pixel_position_ids, tf.Tensor):
+            if keras.ops.is_tensor(pixel_position_ids):
                 pixel_position_ids = pixel_position_ids.cpu()
 
         return {

--- a/keras_hub/src/models/parseq/parseq_tokenizer.py
+++ b/keras_hub/src/models/parseq/parseq_tokenizer.py
@@ -199,7 +199,6 @@ class PARSeqTokenizer(tokenizer.Tokenizer):
         )
         if unbatched:
             token_ids = tf.squeeze(token_ids, 0)
-            tf.ensure_shape(token_ids, shape=[self.max_label_length])
         return token_ids
 
     @preprocessing_function

--- a/keras_hub/src/models/sam3/sam3_pc_image_segmenter_preprocessor.py
+++ b/keras_hub/src/models/sam3/sam3_pc_image_segmenter_preprocessor.py
@@ -270,9 +270,7 @@ class SAM3PromptableConceptImageSegmenterPreprocessor(Preprocessor):
 
         # Resize and normalize the images.
         pixel_values = self.image_converter(images)
-        if keras.config.backend() == "torch" and not isinstance(
-            images, tf.Tensor
-        ):
+        if keras.config.backend() == "torch" and keras.ops.is_tensor(images):
             images = images.cpu()
 
         # Normalize the boxes.

--- a/keras_hub/src/models/whisper/whisper_audio_converter.py
+++ b/keras_hub/src/models/whisper/whisper_audio_converter.py
@@ -3,6 +3,7 @@ import numpy as np
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.whisper.whisper_backbone import WhisperBackbone
+from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 try:
     import tensorflow as tf
@@ -208,6 +209,7 @@ class WhisperAudioConverter(AudioConverter):
 
         return log_spec
 
+    @preprocessing_function
     def call(self, audio):
         if not isinstance(audio, (tf.Tensor, tf.RaggedTensor)):
             audio = tf.convert_to_tensor(audio)

--- a/keras_hub/src/tests/test_case.py
+++ b/keras_hub/src/tests/test_case.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 import tempfile
 
+import grain
 import keras
 import numpy as np
 import tensorflow as tf
@@ -35,6 +36,112 @@ def convert_to_comparible_type(x):
     if hasattr(x, "__array__"):
         return ops.convert_to_numpy(x)
     return x
+
+
+def _to_grain_leaf(x):
+    """Convert a single data leaf to a Grain friendly Python/NumPy object."""
+    if isinstance(x, tf.RaggedTensor):
+        x = x.to_list()
+    elif isinstance(x, tf.Tensor):
+        x = x.numpy()
+    elif not isinstance(x, (list, np.ndarray)) and ops.is_tensor(x):
+        x = ops.convert_to_numpy(x)
+    if isinstance(x, np.ndarray) and x.dtype.kind in ("S", "U", "O"):
+        x = x.tolist()
+    if isinstance(x, list):
+        x = tree.map_structure(
+            lambda e: e.decode("utf-8") if isinstance(e, bytes) else e, x
+        )
+    return x
+
+
+def _map_leaves(fn, *structures):
+    """Like `tree.map_structure`, but only dicts and tuples are structures.
+
+    This mirrors `tf.data.Dataset.from_tensor_slices`, where lists, arrays and
+    tensors are data leaves. Treating lists as leaves also allows zipping
+    ragged lists of differing lengths across `structures`.
+    """
+    x = structures[0]
+    if isinstance(x, dict):
+        return {
+            k: _map_leaves(fn, *(s[k] for s in structures)) for k in x.keys()
+        }
+    if isinstance(x, tuple):
+        return tuple(_map_leaves(fn, *vs) for vs in zip(*structures))
+    return fn(*structures)
+
+
+def _flatten_leaves(x):
+    """Like `tree.flatten`, but only dicts and tuples are structures."""
+    if isinstance(x, dict):
+        return [e for v in x.values() for e in _flatten_leaves(v)]
+    if isinstance(x, tuple):
+        return [e for v in x for e in _flatten_leaves(v)]
+    return [x]
+
+
+def grain_source_from_tensor_slices(input_data):
+    """`grain.MapDataset` analog of `tf.data.Dataset.from_tensor_slices`.
+
+    Every data leaf in `input_data` is sliced along its first axis, and each
+    element of the returned dataset has the same nested structure as
+    `input_data` with one slice per leaf. Elements are plain Python objects and
+    NumPy arrays, never tf or backend tensors.
+    """
+    input_data = _map_leaves(_to_grain_leaf, input_data)
+    lengths = set(len(x) for x in _flatten_leaves(input_data))
+    if len(lengths) != 1:
+        raise ValueError(
+            "All leaves of `input_data` must have the same first dimension. "
+            f"Received lengths: {sorted(lengths)}"
+        )
+    records = [
+        _map_leaves(lambda x: x[i], input_data) for i in range(lengths.pop())
+    ]
+    return grain.MapDataset.source(records)
+
+
+def grain_ragged_batch(elements):
+    """A Grain `batch_fn` that stacks dense leaves and lists ragged ones.
+
+    This is the Grain analog of `tf.data.Dataset.ragged_batch`. Leaves whose
+    shapes agree across elements are stacked into a NumPy array. All other
+    leaves (ragged lists, strings) are collected in a Python list, matching the
+    lists-of-lists convention of the Python preprocessing path.
+    """
+
+    def batch(*leaves):
+        if all(isinstance(x, np.ndarray) for x in leaves):
+            if len(set(x.shape for x in leaves)) == 1:
+                return np.stack(leaves)
+            return [x.tolist() for x in leaves]
+        if all(isinstance(x, (int, float, bool, np.generic)) for x in leaves):
+            return np.array(leaves)
+        return list(leaves)
+
+    return _map_leaves(batch, *elements)
+
+
+def assert_grain_safe_types(x):
+    """Assert `x` only contains NumPy arrays and plain Python objects.
+
+    Grain pickles every element across worker process boundaries, so
+    preprocessing outputs inside a Grain pipeline must never be tf or backend
+    tensors.
+    """
+
+    def check(leaf):
+        if leaf is None or isinstance(leaf, (str, bytes, int, float, bool)):
+            return
+        if isinstance(leaf, (np.ndarray, np.generic)):
+            return
+        raise AssertionError(
+            "Preprocessing outputs inside a Grain pipeline must be NumPy "
+            f"arrays or plain Python objects. Received: {type(leaf)}"
+        )
+
+    tree.map_structure(check, x)
 
 
 class TestCase(tf.test.TestCase, parameterized.TestCase):
@@ -228,11 +335,45 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         output_ds = ds.batch(1_000).map(layer)
         self.assertAllClose(output, output_ds.get_single_element())
 
+        # Check Grain parity with the direct call and the tf.data path.
+        self.run_grain_preprocessing_test(layer, input_data, output)
+
         if expected_output:
             self.assertAllClose(output, expected_output)
 
         if return_output:
             return output
+
+    def run_grain_preprocessing_test(self, layer, input_data, expected_output):
+        """Check a preprocessing layer runs in Grain and matches direct calls.
+
+        Runs the layer inside a `grain.MapDataset` both on an unbatched source
+        (one record per sample, followed by a ragged-aware batch) and on a
+        batched source (the full `input_data` as a single record). Both must
+        match `expected_output`, and every Grain output must be a NumPy array
+        or plain Python object so it can be pickled across Grain workers.
+        """
+        if isinstance(input_data, tuple):
+            # Mimic tf.data unpacking behavior for preprocessing layers.
+            def map_fn(x):
+                return layer(*x)
+        else:
+            map_fn = layer
+
+        # Run with an unbatched dataset.
+        ds = grain_source_from_tensor_slices(input_data)
+        output_ds = ds.map(map_fn)
+        for element in output_ds:
+            assert_grain_safe_types(element)
+        output_ds = output_ds.batch(len(ds), batch_fn=grain_ragged_batch)
+        (grain_output,) = list(output_ds)
+        self.assertAllClose(expected_output, grain_output)
+
+        # Run with a batched dataset.
+        ds = grain.MapDataset.source([_map_leaves(_to_grain_leaf, input_data)])
+        (grain_output,) = list(ds.map(map_fn))
+        assert_grain_safe_types(grain_output)
+        self.assertAllClose(expected_output, grain_output)
 
     def run_preprocessor_test(
         self,
@@ -269,6 +410,21 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         output, _, _ = keras.utils.unpack_x_y_sample_weight(output)
         shape = ops.shape(output[token_id_key])
         self.assertEqual(shape[-1], 17)
+
+        # Check the updated sequence length is respected inside Grain, and that
+        # (x, y, sample_weight) outputs come back as Grain safe NumPy/Python
+        # types after batching.
+        if isinstance(input_data, tuple):
+
+            def map_fn(x):
+                return layer(*x)
+        else:
+            map_fn = layer
+        ds = grain_source_from_tensor_slices(input_data).map(map_fn)
+        (grain_output,) = list(ds.batch(len(ds), batch_fn=grain_ragged_batch))
+        assert_grain_safe_types(grain_output)
+        grain_output, _, _ = keras.utils.unpack_x_y_sample_weight(grain_output)
+        self.assertEqual(np.shape(grain_output[token_id_key])[-1], 17)
 
     def run_serialization_test(self, instance):
         """Check idempotency of serialize/deserialize.

--- a/keras_hub/src/tests/test_case_test.py
+++ b/keras_hub/src/tests/test_case_test.py
@@ -1,0 +1,118 @@
+import grain
+import keras
+import numpy as np
+import tensorflow as tf
+from keras import ops
+
+from keras_hub.src.layers.preprocessing.start_end_packer import StartEndPacker
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.tests.test_case import assert_grain_safe_types
+from keras_hub.src.tests.test_case import grain_ragged_batch
+from keras_hub.src.tests.test_case import grain_source_from_tensor_slices
+
+
+class GrainSourceFromTensorSlicesTest(TestCase):
+    def test_list_of_strings(self):
+        ds = grain_source_from_tensor_slices(["a", "bb"])
+        self.assertEqual(list(ds), ["a", "bb"])
+
+    def test_dict_and_tuple_structure(self):
+        input_data = (
+            {"text": ["a", "bb"], "ids": np.array([[1, 2], [3, 4]])},
+            [0, 1],
+            ops.convert_to_tensor([0.5, 1.0]),
+        )
+        ds = grain_source_from_tensor_slices(input_data)
+        self.assertEqual(len(ds), 2)
+        x, y, sw = ds[1]
+        self.assertEqual(x["text"], "bb")
+        self.assertAllEqual(x["ids"], [3, 4])
+        self.assertIsInstance(x["ids"], np.ndarray)
+        self.assertEqual(y, 1)
+        self.assertEqual(float(sw), 1.0)
+        assert_grain_safe_types(ds[1])
+
+    def test_ragged_and_string_tensors(self):
+        ragged = tf.ragged.constant([[1, 2, 3], [4]])
+        strings = tf.constant(["a", "bb"])
+        ds = grain_source_from_tensor_slices({"x": ragged, "s": strings})
+        self.assertEqual(
+            list(ds), [{"x": [1, 2, 3], "s": "a"}, {"x": [4], "s": "bb"}]
+        )
+
+    def test_mismatched_lengths(self):
+        with self.assertRaisesRegex(ValueError, "same first dimension"):
+            grain_source_from_tensor_slices((["a", "b"], [1]))
+
+
+class GrainRaggedBatchTest(TestCase):
+    def test_stacks_dense_leaves(self):
+        elements = [
+            {"a": np.array([1, 2]), "b": 1.0},
+            {"a": np.array([3, 4]), "b": 2.0},
+        ]
+        batch = grain_ragged_batch(elements)
+        self.assertAllEqual(batch["a"], [[1, 2], [3, 4]])
+        self.assertAllClose(batch["b"], [1.0, 2.0])
+
+    def test_lists_ragged_leaves(self):
+        elements = [
+            ([1, 2, 3], np.array([1, 2, 3]), "a"),
+            ([4], np.array([4]), "bb"),
+        ]
+        batch = grain_ragged_batch(elements)
+        self.assertEqual(
+            batch, ([[1, 2, 3], [4]], [[1, 2, 3], [4]], ["a", "bb"])
+        )
+
+
+class AssertGrainSafeTypesTest(TestCase):
+    def test_accepts_numpy_and_python(self):
+        assert_grain_safe_types(
+            {"a": np.ones(2), "b": [[1, 2], [3]], "c": "str", "d": None, "e": 1}
+        )
+
+    def test_rejects_backend_and_tf_tensors(self):
+        with self.assertRaisesRegex(AssertionError, "NumPy arrays"):
+            assert_grain_safe_types({"a": ops.ones(2)})
+        with self.assertRaisesRegex(AssertionError, "NumPy arrays"):
+            assert_grain_safe_types((tf.ones(2),))
+
+
+class LeakyLayer(keras.layers.Layer):
+    """A layer that returns backend tensors regardless of the pipeline."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    def call(self, inputs):
+        return ops.convert_to_tensor(np.asarray(inputs, dtype="int32"))
+
+
+class GrainHarnessTest(TestCase):
+    def test_grain_checks_pass_for_grain_safe_layer(self):
+        layer = StartEndPacker(
+            sequence_length=4, start_value=1, end_value=2, pad_value=0
+        )
+        input_data = tf.ragged.constant([[5, 6], [7]])
+        expected = [[1, 5, 6, 2], [1, 7, 2, 0]]
+        self.run_grain_preprocessing_test(layer, input_data, expected)
+
+    def test_grain_checks_catch_backend_tensor_outputs(self):
+        layer = LeakyLayer()
+        input_data = np.array([[1, 2], [3, 4]])
+        # Sanity check the layer does leak backend tensors inside Grain.
+        (element,) = list(grain.MapDataset.source([input_data]).map(layer))
+        self.assertTrue(ops.is_tensor(element))
+        with self.assertRaisesRegex(AssertionError, "NumPy arrays"):
+            self.run_grain_preprocessing_test(layer, input_data, input_data)
+
+    def test_grain_checks_catch_output_mismatch(self):
+        layer = StartEndPacker(sequence_length=3, start_value=1)
+        input_data = [[5, 6], [7, 8]]
+        with self.assertRaises(AssertionError):
+            self.run_grain_preprocessing_test(
+                layer, input_data, [[1, 5, 6], [1, 7, 7]]
+            )


### PR DESCRIPTION
TestCase.run_preprocessing_layer_test should check for Grain parity
In run_preprocessing_layer_test, after the tf.data checks, add:
grain.MapDataset.source(...) unbatched → .map(layer) → batch → compare to output.
batched source → .map(layer) → compare.
Do the same for run_preprocessor_test
