### PR TITLE
[PyGrain Migration] Unpack (x, y, sample_weight) tuples in the preprocessing __call__ path

### DIFF
--- a/keras_hub/src/layers/preprocessing/preprocessing_layer.py
+++ b/keras_hub/src/layers/preprocessing/preprocessing_layer.py
@@ -20,6 +20,12 @@ class PreprocessingLayer(keras.layers.Layer):
         # Allow Python workflow. Historically, KerasHub preprocessing layers
         # required TF and TF text libraries.
         self._allow_python_workflow = _allow_python_workflow
+        # Whether `call` has the `(x, y, sample_weight)` signature. Keras has
+        # already inspected `self.call` in `Layer.__init__`, so this is safe.
+        params = inspect.signature(self.call).parameters
+        self._call_accepts_labels = all(
+            k in params for k in ("x", "y", "sample_weight")
+        )
         # Most pre-preprocessing has no build.
         if not hasattr(self, "build"):
             self.built = True
@@ -40,18 +46,6 @@ class PreprocessingLayer(keras.layers.Layer):
         ):
             args = args[0]
         return super().__call__(*args, **kwargs)
-
-    @property
-    def _call_accepts_labels(self):
-        """Whether `call` has the `(x, y, sample_weight)` signature."""
-        accepts_labels = getattr(self, "_call_accepts_labels_cache", None)
-        if accepts_labels is None:
-            params = inspect.signature(self.call).parameters
-            accepts_labels = all(
-                k in params for k in ("x", "y", "sample_weight")
-            )
-            self._call_accepts_labels_cache = accepts_labels
-        return accepts_labels
 
     def get_build_config(self):
         return None

--- a/keras_hub/src/layers/preprocessing/preprocessing_layer.py
+++ b/keras_hub/src/layers/preprocessing/preprocessing_layer.py
@@ -1,3 +1,5 @@
+import inspect
+
 import keras
 
 from keras_hub.src.utils.tensor_utils import assert_tf_libs_installed
@@ -21,6 +23,35 @@ class PreprocessingLayer(keras.layers.Layer):
         # Most pre-preprocessing has no build.
         if not hasattr(self, "build"):
             self.built = True
+
+    def __call__(self, *args, **kwargs):
+        # Mimic the `tf.data` behavior of unpacking `(x, y)` and
+        # `(x, y, sample_weight)` tuples when calling layers that accept
+        # labels. This allows layers to be mapped directly over datasets whose
+        # elements are tuples, e.g. `grain.MapDataset.source(...).map(layer)`,
+        # or to be called directly on a single dataset element.
+        if (
+            len(args) == 1
+            and type(args[0]) is tuple
+            and len(args[0]) in (2, 3)
+            and "y" not in kwargs
+            and "sample_weight" not in kwargs
+            and self._call_accepts_labels
+        ):
+            args = args[0]
+        return super().__call__(*args, **kwargs)
+
+    @property
+    def _call_accepts_labels(self):
+        """Whether `call` has the `(x, y, sample_weight)` signature."""
+        accepts_labels = getattr(self, "_call_accepts_labels_cache", None)
+        if accepts_labels is None:
+            params = inspect.signature(self.call).parameters
+            accepts_labels = all(
+                k in params for k in ("x", "y", "sample_weight")
+            )
+            self._call_accepts_labels_cache = accepts_labels
+        return accepts_labels
 
     def get_build_config(self):
         return None

--- a/keras_hub/src/layers/preprocessing/preprocessing_layer_test.py
+++ b/keras_hub/src/layers/preprocessing/preprocessing_layer_test.py
@@ -1,10 +1,15 @@
-import grain
 import numpy as np
+import pytest
 
 from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_hub.src.tests.test_case import TestCase
+
+try:
+    import grain
+except ImportError:
+    grain = None
 
 
 class LabelsLayer(PreprocessingLayer):
@@ -95,6 +100,7 @@ class PreprocessingLayerTest(TestCase):
         self.assertIs(output["x"], x)
         self.assertIsNone(output["y"])
 
+    @pytest.mark.skipif(grain is None, reason="grain is not installed")
     def test_grain_map_over_tuple_elements(self):
         elements = [
             ("the quick brown fox", 1, 0.5),

--- a/keras_hub/src/layers/preprocessing/preprocessing_layer_test.py
+++ b/keras_hub/src/layers/preprocessing/preprocessing_layer_test.py
@@ -1,0 +1,115 @@
+import grain
+import numpy as np
+
+from keras_hub.src.layers.preprocessing.preprocessing_layer import (
+    PreprocessingLayer,
+)
+from keras_hub.src.tests.test_case import TestCase
+
+
+class LabelsLayer(PreprocessingLayer):
+    """A layer with the `(x, y, sample_weight)` call signature."""
+
+    def __init__(self, **kwargs):
+        super().__init__(_allow_python_workflow=True, **kwargs)
+
+    def call(self, x, y=None, sample_weight=None):
+        return {"x": x, "y": y, "sample_weight": sample_weight}
+
+
+class FeaturesLayer(PreprocessingLayer):
+    """A layer that takes a single input and no labels."""
+
+    def __init__(self, **kwargs):
+        super().__init__(_allow_python_workflow=True, **kwargs)
+
+    def call(self, inputs):
+        return {"inputs": inputs}
+
+
+class PreprocessingLayerTest(TestCase):
+    def setUp(self):
+        self.layer = LabelsLayer()
+
+    def test_dict_element(self):
+        element = {"text": "the quick brown fox", "images": np.ones((2, 2))}
+        output = self.layer(element)
+        self.assertIs(output["x"], element)
+        self.assertIsNone(output["y"])
+        self.assertIsNone(output["sample_weight"])
+
+    def test_string_element(self):
+        output = self.layer("the quick brown fox")
+        self.assertEqual(output["x"], "the quick brown fox")
+        self.assertIsNone(output["y"])
+        self.assertIsNone(output["sample_weight"])
+
+    def test_x_y_tuple(self):
+        output = self.layer(("the quick brown fox", 1))
+        self.assertEqual(output["x"], "the quick brown fox")
+        self.assertEqual(output["y"], 1)
+        self.assertIsNone(output["sample_weight"])
+
+    def test_x_y_sample_weight_tuple(self):
+        output = self.layer(("the quick brown fox", 1, 0.5))
+        self.assertEqual(output["x"], "the quick brown fox")
+        self.assertEqual(output["y"], 1)
+        self.assertEqual(output["sample_weight"], 0.5)
+
+    def test_tuple_of_features_x_with_explicit_labels(self):
+        # A tuple `x` (e.g. multiple text segments) must not be unpacked when
+        # `y` or `sample_weight` are passed explicitly.
+        x = ("first segment", "second segment")
+        output = self.layer(x, 1)
+        self.assertIs(output["x"], x)
+        self.assertEqual(output["y"], 1)
+        output = self.layer(x, y=1)
+        self.assertIs(output["x"], x)
+        self.assertEqual(output["y"], 1)
+        output = self.layer(x, sample_weight=0.5)
+        self.assertIs(output["x"], x)
+        self.assertIsNone(output["y"])
+        self.assertEqual(output["sample_weight"], 0.5)
+        output = self.layer(x=x)
+        self.assertIs(output["x"], x)
+        self.assertIsNone(output["y"])
+
+    def test_tuple_of_features_x_without_labels_signature(self):
+        # Layers that do not accept labels never unpack tuples.
+        layer = FeaturesLayer()
+        x = ("first segment", "second segment")
+        output = layer(x)
+        self.assertIs(output["inputs"], x)
+        x = ("first segment", "second segment", "third segment")
+        output = layer(x)
+        self.assertIs(output["inputs"], x)
+
+    def test_long_tuple_and_list_not_unpacked(self):
+        x = ("a", "b", "c", "d")
+        output = self.layer(x)
+        self.assertIs(output["x"], x)
+        self.assertIsNone(output["y"])
+        # Lists are data, not `(x, y)` structures.
+        x = ["the quick brown fox", "the earth is round"]
+        output = self.layer(x)
+        self.assertIs(output["x"], x)
+        self.assertIsNone(output["y"])
+
+    def test_grain_map_over_tuple_elements(self):
+        elements = [
+            ("the quick brown fox", 1, 0.5),
+            ("the earth is round", 0, 1.0),
+        ]
+        ds = grain.MapDataset.source(elements).map(self.layer)
+        outputs = list(ds)
+        self.assertEqual(outputs[0]["x"], "the quick brown fox")
+        self.assertEqual(outputs[0]["y"], 1)
+        self.assertEqual(outputs[0]["sample_weight"], 0.5)
+        self.assertEqual(outputs[1]["x"], "the earth is round")
+        self.assertEqual(outputs[1]["y"], 0)
+        self.assertEqual(outputs[1]["sample_weight"], 1.0)
+        # Dict elements pass through as `x`.
+        elements = [{"text": "the quick brown fox", "label": 1}]
+        (output,) = list(grain.MapDataset.source(elements).map(self.layer))
+        self.assertEqual(output["x"], elements[0])
+        self.assertIsNone(output["y"])

--- a/keras_hub/src/models/bert/bert_text_classifier_preprocessor_test.py
+++ b/keras_hub/src/models/bert/bert_text_classifier_preprocessor_test.py
@@ -1,3 +1,4 @@
+import grain
 import pytest
 
 from keras_hub.src.models.bert.bert_text_classifier_preprocessor import (
@@ -38,6 +39,24 @@ class BertTextClassifierPreprocessorTest(TestCase):
                 [1.0],  # Pass through sample_weights.
             ),
         )
+
+    def test_grain_unpacks_tuple_elements(self):
+        preprocessor = BertTextClassifierPreprocessor(**self.init_kwargs)
+        expected = preprocessor(*self.input_data)
+        # Unbatched `(x, y, sample_weight)` elements.
+        elements = [("THE QUICK BROWN FOX.", 1, 1.0)]
+        ds = grain.MapDataset.source(elements).map(preprocessor).batch(1)
+        (output,) = list(ds)
+        self.assertAllClose(output, expected)
+        # Batched `(x, y, sample_weight)` elements.
+        ds = grain.MapDataset.source([self.input_data]).map(preprocessor)
+        (output,) = list(ds)
+        self.assertAllClose(output, expected)
+        # `(x, y)` elements.
+        expected = preprocessor(self.input_data[0], self.input_data[1])
+        ds = grain.MapDataset.source([self.input_data[:2]]).map(preprocessor)
+        (output,) = list(ds)
+        self.assertAllClose(output, expected)
 
     def test_errors_for_2d_list_input(self):
         preprocessor = BertTextClassifierPreprocessor(**self.init_kwargs)

--- a/keras_hub/src/models/bert/bert_text_classifier_preprocessor_test.py
+++ b/keras_hub/src/models/bert/bert_text_classifier_preprocessor_test.py
@@ -1,4 +1,3 @@
-import grain
 import pytest
 
 from keras_hub.src.models.bert.bert_text_classifier_preprocessor import (
@@ -6,6 +5,11 @@ from keras_hub.src.models.bert.bert_text_classifier_preprocessor import (
 )
 from keras_hub.src.models.bert.bert_tokenizer import BertTokenizer
 from keras_hub.src.tests.test_case import TestCase
+
+try:
+    import grain
+except ImportError:
+    grain = None
 
 
 class BertTextClassifierPreprocessorTest(TestCase):
@@ -40,6 +44,7 @@ class BertTextClassifierPreprocessorTest(TestCase):
             ),
         )
 
+    @pytest.mark.skipif(grain is None, reason="grain is not installed")
     def test_grain_unpacks_tuple_elements(self):
         preprocessor = BertTextClassifierPreprocessor(**self.init_kwargs)
         expected = preprocessor(*self.input_data)


### PR DESCRIPTION
In the preprocessing base __call__, when called with a single positional argument that is a tuple of length 2 or 3 and the wrapped fn accepts (x, y, sample_weight), unpack it before dispatch.
Add unit tests: dict element, (x, y), (x, y, sw), and a tuple-of-features x (regression guard against over-unpacking).
