### PR TITLE
Update tokenizers to use grain

### DIFF
--- a/keras_hub/src/tokenizers/byte_tokenizer.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer.py
@@ -1,8 +1,15 @@
+import unicodedata
+
 import numpy as np
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.tokenizers import tokenizer
+from keras_hub.src.utils.tensor_utils import canonicalize_python_string_inputs
+from keras_hub.src.utils.tensor_utils import canonicalize_python_token_inputs
+from keras_hub.src.utils.tensor_utils import casefold_utf8
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import get_decode_errors_name
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
@@ -50,10 +57,11 @@ class ByteTokenizer(tokenizer.Tokenizer):
         normalization_form: string. One of the following values: (None, "NFC",
             "NFKC", "NFD", "NFKD"). If set, every UTF-8 string in the input
             tensor text will be normalized to the given form before tokenizing.
-        errors: One of ('replace', 'remove', 'strict'). Specifies the
+        errors: One of ('replace', 'ignore', 'strict'). Specifies the
             `detokenize()` behavior when an invalid tokenizer is encountered.
             The value of `'strict'` will cause the operation to produce a
-            `InvalidArgument` error on any invalid input formatting. A value of
+            `InvalidArgument` error (or a `ValueError` when running without
+            TensorFlow) on any invalid input formatting. A value of
             `'replace'` will cause the tokenizer to replace any invalid
             formatting in the input with the `replacement_char` codepoint.
             A value of `'ignore'` will cause the tokenizer to skip any invalid
@@ -170,7 +178,10 @@ class ByteTokenizer(tokenizer.Tokenizer):
                 f"Received: errors={errors}"
             )
 
-        super().__init__(dtype=dtype, **kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            dtype=dtype, _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
 
         self.lowercase = lowercase
         self.sequence_length = sequence_length
@@ -178,10 +189,14 @@ class ByteTokenizer(tokenizer.Tokenizer):
         self.errors = errors
         self.replacement_char = replacement_char
 
-        self._char_lst = tf.constant(
-            [i.tobytes() for i in np.arange(256, dtype=np.uint8)]
-        )
+        self._char_lst = None
         self._update_special_token_ids()
+
+    def _maybe_initialized_tf(self):
+        if self._char_lst is None:
+            self._char_lst = tf.constant(
+                [i.tobytes() for i in np.arange(256, dtype=np.uint8)]
+            )
 
     def vocabulary_size(self):
         """Get the integer size of the tokenizer vocabulary."""
@@ -194,7 +209,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
         return vocab
 
     @preprocessing_function
-    def tokenize(self, inputs):
+    def _tokenize_tf(self, inputs):
         unbatched = inputs.shape.rank == 0
         if unbatched:
             inputs = tf.expand_dims(inputs, 0)
@@ -224,8 +239,50 @@ class ByteTokenizer(tokenizer.Tokenizer):
             tokens = tf.squeeze(tokens, 0)
         return tokens
 
+    def _tokenize_python(self, inputs):
+        # Invalid UTF-8 in `bytes` inputs is passed through untouched, as in
+        # the TF path. `surrogateescape` round trips such bytes exactly.
+        inputs, batched = canonicalize_python_string_inputs(
+            inputs, errors="surrogateescape"
+        )
+
+        batched_tokens = []
+        for text in inputs:
+            # Optional: Lowercase the input.
+            if self.lowercase:
+                text = casefold_utf8(text)
+            # Optional: Normalize unicode.
+            if self.normalization_form is not None:
+                text = unicodedata.normalize(self.normalization_form, text)
+            # Tokenize input strings.
+            batched_tokens.append(
+                list(text.encode("utf-8", errors="surrogateescape"))
+            )
+
+        # Convert to a dense output if `sequence_length` is set.
+        if self.sequence_length:
+            batched_tokens = [
+                tokens[: self.sequence_length]
+                + [0] * (self.sequence_length - len(tokens))
+                for tokens in batched_tokens
+            ]
+            # Dense outputs are arrays, so that direct calls return backend
+            # tensors and Grain pipelines return NumPy.
+            batched_tokens = np.array(batched_tokens, dtype=self.compute_dtype)
+
+        if not batched:
+            batched_tokens = batched_tokens[0]
+        return batched_tokens
+
+    def tokenize(self, inputs):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._tokenize_tf(inputs)
+        else:
+            return self._tokenize_python(inputs)
+
     @preprocessing_function
-    def detokenize(self, inputs):
+    def _detokenize_tf(self, inputs):
+        self._maybe_initialized_tf()
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
         # Remove trailing padding tokens, so that trailing "\x00" bytes don't
         # show up in the detokenized output.
@@ -246,6 +303,34 @@ class ByteTokenizer(tokenizer.Tokenizer):
         if unbatched:
             outputs = tf.squeeze(outputs, 0)
         return outputs
+
+    def _detokenize_python(self, inputs):
+        inputs, batched = canonicalize_python_token_inputs(inputs)
+        errors = get_decode_errors_name(self.errors, self.replacement_char)
+        outputs = []
+        for token_ids in inputs:
+            # Remove padding tokens, so that "\x00" bytes don't show up in
+            # the detokenized output.
+            token_ids = [i for i in token_ids if i != 0]
+            if any(i < 0 or i >= 256 for i in token_ids):
+                raise ValueError(
+                    "All token ids must be in range [0, 256). "
+                    f"Received: {token_ids}"
+                )
+            # Handle errors if an invalid byte sequence is encountered.
+            outputs.append(bytes(token_ids).decode("utf-8", errors=errors))
+        if not batched:
+            outputs = outputs[0]
+        return outputs
+
+    def detokenize(self, inputs):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._detokenize_tf(inputs)
+        else:
+            return self._detokenize_python(inputs)
+
+    def call(self, inputs, *args, training=None, **kwargs):
+        return self.tokenize(inputs, *args, **kwargs)
 
     def id_to_token(self, id):
         """Convert an integer id to a string token."""

--- a/keras_hub/src/tokenizers/byte_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/byte_tokenizer_test.py
@@ -1,14 +1,36 @@
+import numpy as np
+import pytest
 import tensorflow as tf
 
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.tokenizers.byte_tokenizer import ByteTokenizer
 
+try:
+    import grain
+except ImportError:
+    grain = None
+try:
+    import tensorflow_text as tf_text
+except ImportError:
+    tf_text = None
+
 
 class ByteTokenizerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._allow_python_workflow = True
+
+    def make_tokenizer(self, **kwargs):
+        return ByteTokenizer(
+            _allow_python_workflow=self._allow_python_workflow, **kwargs
+        )
+
     def test_tokenizer_basics(self):
         self.run_preprocessing_layer_test(
             cls=ByteTokenizer,
-            init_kwargs={},
+            init_kwargs={
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
             input_data=["hello", "fun", "▀▁▂▃", "haha"],
             expected_output=[
                 [104, 101, 108, 108, 111],
@@ -24,7 +46,10 @@ class ByteTokenizerTest(TestCase):
         # through `detokenize`.
         self.run_preprocessing_layer_test(
             cls=ByteTokenizer,
-            init_kwargs={"sequence_length": 12},
+            init_kwargs={
+                "sequence_length": 12,
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
             input_data=["hello", "fun", "▀▁▂▃", "haha"],
             expected_output=[
                 [104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0],
@@ -36,7 +61,7 @@ class ByteTokenizerTest(TestCase):
 
     def test_tokenize_scalar(self):
         input_data = "hello"
-        tokenizer = ByteTokenizer()
+        tokenizer = self.make_tokenizer()
         call_output = tokenizer(input_data)
         tokenize_output = tokenizer.tokenize(input_data)
 
@@ -45,7 +70,7 @@ class ByteTokenizerTest(TestCase):
 
     def test_dense_output(self):
         input_data = ["hello", "fun", "▀▁▂▃"]
-        tokenizer = ByteTokenizer(sequence_length=10)
+        tokenizer = self.make_tokenizer(sequence_length=10)
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -63,7 +88,7 @@ class ByteTokenizerTest(TestCase):
             [226, 150, 128, 226, 150, 129, 226, 150, 130, 226, 150, 131],
         ]
 
-        tokenizer = ByteTokenizer()
+        tokenizer = self.make_tokenizer()
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, ["hello", "fun", "▀▁▂▃"])
 
@@ -71,31 +96,35 @@ class ByteTokenizerTest(TestCase):
         # 226 is an invalid UTF-8 byte.
         input_data = [[104, 101, 226, 150, 108, 108, 111]]
 
-        tokenizer = ByteTokenizer(errors="replace", replacement_char=341)
+        tokenizer = self.make_tokenizer(errors="replace", replacement_char=341)
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, [b"he\xc5\x95llo"])
 
     def test_detokenize_ignore_error(self):
         input_data = [[104, 101, 226, 150, 108, 108, 111]]
 
-        tokenizer = ByteTokenizer(errors="ignore")
+        tokenizer = self.make_tokenizer(errors="ignore")
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, [b"hello"])
 
     def test_detokenize_strict_error(self):
         input_data = [[104, 101, 226, 150, 108, 108, 111]]
 
-        tokenizer = ByteTokenizer(errors="strict")
-        with self.assertRaises(tf.errors.InvalidArgumentError):
+        tokenizer = self.make_tokenizer(errors="strict")
+        if self._allow_python_workflow:
+            error = ValueError
+        else:
+            error = tf.errors.InvalidArgumentError
+        with self.assertRaises(error):
             _ = tokenizer.detokenize(input_data)
 
     def test_vocab_size(self):
-        tokenizer = ByteTokenizer()
+        tokenizer = self.make_tokenizer()
         self.assertEqual(tokenizer.vocabulary_size(), 256)
 
     def test_lowercase(self):
         input_data = ["HeLlO wOrLd"]
-        tokenizer = ByteTokenizer()
+        tokenizer = self.make_tokenizer()
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -104,7 +133,7 @@ class ByteTokenizerTest(TestCase):
 
     def test_skip_lowercase(self):
         input_data = ["HeLlO wOrLd"]
-        tokenizer = ByteTokenizer(lowercase=False)
+        tokenizer = self.make_tokenizer(lowercase=False)
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output, [[72, 101, 76, 108, 79, 32, 119, 79, 114, 76, 100]]
@@ -113,13 +142,112 @@ class ByteTokenizerTest(TestCase):
     def test_token_to_id(self):
         input_tokens = ["f", "u", "n"]
         expected_ids = [102, 117, 110]
-        tokenizer = ByteTokenizer()
+        tokenizer = self.make_tokenizer()
         ids = [tokenizer.token_to_id(t) for t in input_tokens]
         self.assertAllEqual(ids, expected_ids)
 
     def test_id_to_token(self):
         input_ids = [102, 117, 110]
         expected_tokens = ["f", "u", "n"]
-        tokenizer = ByteTokenizer()
+        tokenizer = self.make_tokenizer()
         tokens = [tokenizer.id_to_token(i) for i in input_ids]
         self.assertAllEqual(tokens, expected_tokens)
+
+    def test_bytes_and_tensor_inputs(self):
+        if not self._allow_python_workflow:
+            self.skipTest("The TF path does not accept numpy string arrays.")
+        tokenizer = self.make_tokenizer()
+        expected = [[104, 101, 108, 108, 111], [102, 117, 110]]
+        self.assertAllEqual(tokenizer([b"hello", b"fun"]), expected)
+        self.assertAllEqual(tokenizer(np.array(["hello", "fun"])), expected)
+        self.assertAllEqual(tokenizer(tf.constant(["hello", "fun"])), expected)
+        self.assertAllEqual(tokenizer(b"hello"), expected[0])
+        self.assertAllEqual(tokenizer(tf.constant("hello")), expected[0])
+        # Invalid utf-8 bytes are passed through.
+        self.assertAllEqual(tokenizer(b"h\xffi"), [104, 255, 105])
+
+    def test_detokenize_inputs(self):
+        if not self._allow_python_workflow:
+            self.skipTest("The TF path does not accept int64 inputs.")
+        tokenizer = self.make_tokenizer()
+        ids = [[104, 101, 108, 108, 111, 0, 0], [102, 117, 110, 0, 0, 0, 0]]
+        self.assertAllEqual(tokenizer.detokenize(ids), ["hello", "fun"])
+        self.assertAllEqual(
+            tokenizer.detokenize(np.array(ids)), ["hello", "fun"]
+        )
+        self.assertAllEqual(
+            tokenizer.detokenize(tf.constant(ids)), ["hello", "fun"]
+        )
+        self.assertAllEqual(tokenizer.detokenize(ids[0]), "hello")
+        self.assertAllEqual(tokenizer.detokenize(np.array(ids[0])), "hello")
+
+    @pytest.mark.skipif(grain is None, reason="grain is not installed")
+    def test_grain_outputs_numpy(self):
+        input_data = ["hello", "fun"]
+        # Ragged outputs are python lists.
+        tokenizer = self.make_tokenizer()
+        (outputs,) = list(grain.MapDataset.source([input_data]).map(tokenizer))
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(outputs, [[104, 101, 108, 108, 111], [102, 117, 110]])
+        # Dense outputs are numpy arrays.
+        tokenizer = self.make_tokenizer(sequence_length=6)
+        outputs = list(grain.MapDataset.source(input_data).map(tokenizer))
+        for output in outputs:
+            self.assertIsInstance(output, np.ndarray)
+        (batch,) = list(
+            grain.MapDataset.source(input_data).map(tokenizer).batch(2)
+        )
+        self.assertAllEqual(
+            batch, [[104, 101, 108, 108, 111, 0], [102, 117, 110, 0, 0, 0]]
+        )
+        self.assertAllEqual(batch, tokenizer(input_data))
+
+    @pytest.mark.skipif(tf_text is None, reason="tensorflow-text not installed")
+    def test_python_path_matches_tf_path(self):
+        if not self._allow_python_workflow:
+            self.skipTest("Parity test only runs from the python path.")
+        corpus = [
+            "The quick brown fox.",
+            "ﬁsh ǅ ß İ Σ",
+            "á é í ó ú Ç",
+            "  leading and trailing  ",
+            "x\xa0y\u3000z\ty\nq",
+            "emoji 😀 test 한국어 テスト",
+            "",
+        ]
+        bad_ids = [
+            [104, 101, 226, 150, 108, 108, 111],
+            [255],
+            [226, 150, 128, 226],
+            [237, 160, 128],
+        ]
+        for kwargs in [
+            {},
+            {"lowercase": False},
+            {"normalization_form": "NFKD"},
+            {"lowercase": False, "normalization_form": "NFC"},
+            {"sequence_length": 8},
+            {"errors": "replace", "replacement_char": 88},
+            {"errors": "ignore"},
+        ]:
+            python_tokenizer = ByteTokenizer(**kwargs)
+            tf_tokenizer = ByteTokenizer(_allow_python_workflow=False, **kwargs)
+            python_ids = python_tokenizer(corpus)
+            tf_ids = tf_tokenizer(corpus)
+            self.assertAllEqual(python_ids, tf_ids)
+            self.assertAllEqual(
+                python_tokenizer.detokenize(python_ids),
+                tf_tokenizer.detokenize(tf_ids),
+            )
+            self.assertAllEqual(
+                python_tokenizer.detokenize(bad_ids),
+                tf_tokenizer.detokenize(bad_ids),
+            )
+
+
+class ByteTokenizerTFTest(ByteTokenizerTest):
+    """Set `_allow_python_workflow=False` to test TF execution."""
+
+    def setUp(self):
+        super().setUp()
+        self._allow_python_workflow = False

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer.py
@@ -1,6 +1,15 @@
+import codecs
+import unicodedata
+
+import numpy as np
+
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.tokenizers import tokenizer
+from keras_hub.src.utils.tensor_utils import canonicalize_python_string_inputs
+from keras_hub.src.utils.tensor_utils import canonicalize_python_token_inputs
+from keras_hub.src.utils.tensor_utils import casefold_utf8
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
 from keras_hub.src.utils.tensor_utils import preprocessing_function
 
@@ -12,6 +21,22 @@ try:
     import tensorflow_text as tf_text
 except ImportError:
     tf_text = None
+
+
+# When decoding `bytes` inputs on the Python path, each invalid sequence is
+# first replaced by this sentinel (a lone surrogate, which never occurs in
+# valid text and is untouched by case folding and normalization). It is then
+# mapped to `replacement_char` or dropped after lowercasing and normalization,
+# matching the TF path where `tf.strings.unicode_decode` runs last.
+_INVALID_SENTINEL = "\udc00"
+_INVALID_SENTINEL_ERRORS = "keras_hub_unicode_invalid_sentinel"
+
+
+def _invalid_sentinel_handler(exception):
+    return _INVALID_SENTINEL, exception.end
+
+
+codecs.register_error(_INVALID_SENTINEL_ERRORS, _invalid_sentinel_handler)
 
 
 @keras_hub_export("keras_hub.tokenizers.UnicodeCodepointTokenizer")
@@ -47,10 +72,11 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         normalization_form: One of the following string values (None, 'NFC',
             'NFKC', 'NFD', 'NFKD'). If set will normalize unicode to the given
             form before tokenizing.
-        errors: One of ('replace', 'remove', 'strict'). Specifies the
+        errors: One of ('replace', 'ignore', 'strict'). Specifies the
             `detokenize()` behavior when an invalid codepoint is encountered.
             The value of `'strict'` will cause the tokenizer to produce a
-            `InvalidArgument` error on any invalid input formatting. A value of
+            `InvalidArgument` error (or a `ValueError` when running without
+            TensorFlow) on any invalid input formatting. A value of
             `'replace'` will cause the tokenizer to replace any invalid
             formatting in the input with the replacement_char codepoint.
             A value of `'ignore'` will cause the tokenizer to skip any invalid
@@ -232,7 +258,10 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                     ""
                 )
 
-        super().__init__(dtype=dtype, **kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            dtype=dtype, _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
 
         self.sequence_length = sequence_length
         self.lowercase = lowercase
@@ -273,7 +302,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         return vocab
 
     @preprocessing_function
-    def tokenize(self, inputs):
+    def _tokenize_tf(self, inputs):
         unbatched = inputs.shape.rank == 0
         if unbatched:
             inputs = tf.expand_dims(inputs, 0)
@@ -309,8 +338,61 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
 
         return tokens
 
+    def _tokenize_python(self, inputs):
+        errors = _INVALID_SENTINEL_ERRORS
+        if self.errors == "strict":
+            errors = "strict"
+        inputs, batched = canonicalize_python_string_inputs(
+            inputs, encoding=self.input_encoding, errors=errors
+        )
+
+        batched_tokens = []
+        for text in inputs:
+            # Optionally lowercase the text
+            if self.lowercase:
+                text = casefold_utf8(text)
+            # Optionally normalize the text to a given form
+            if self.normalization_form:
+                text = unicodedata.normalize(self.normalization_form, text)
+            tokens = []
+            for c in text:
+                if c == _INVALID_SENTINEL:
+                    # Handle errors from decoding invalid `bytes` inputs.
+                    if self.errors == "replace":
+                        tokens.append(self.replacement_char)
+                else:
+                    tokens.append(ord(c))
+            # Optionally clamps the output code point values to be in the
+            # range [0, vocabulary_size)
+            if self._vocabulary_size:
+                tokens = [
+                    min(max(t, 0), self._vocabulary_size - 1) for t in tokens
+                ]
+            batched_tokens.append(tokens)
+
+        # Convert to a dense output if `sequence_length` is set.
+        if self.sequence_length:
+            batched_tokens = [
+                tokens[: self.sequence_length]
+                + [0] * (self.sequence_length - len(tokens))
+                for tokens in batched_tokens
+            ]
+            # Dense outputs are arrays, so that direct calls return backend
+            # tensors and Grain pipelines return NumPy.
+            batched_tokens = np.array(batched_tokens, dtype=self.compute_dtype)
+
+        if not batched:
+            batched_tokens = batched_tokens[0]
+        return batched_tokens
+
+    def tokenize(self, inputs):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._tokenize_tf(inputs)
+        else:
+            return self._tokenize_python(inputs)
+
     @preprocessing_function
-    def detokenize(self, inputs):
+    def _detokenize_tf(self, inputs):
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
         inputs = tf.ragged.boolean_mask(inputs, tf.not_equal(inputs, 0))
         outputs = tf.strings.unicode_encode(
@@ -322,6 +404,41 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         if unbatched:
             outputs = tf.squeeze(outputs, 0)
         return outputs
+
+    def _detokenize_python(self, inputs):
+        inputs, batched = canonicalize_python_token_inputs(inputs)
+        outputs = []
+        for token_ids in inputs:
+            chars = []
+            for token_id in token_ids:
+                # Remove padding tokens.
+                if token_id == 0:
+                    continue
+                is_valid = 0 <= token_id <= 0x10FFFF and not (
+                    0xD800 <= token_id <= 0xDFFF
+                )
+                if is_valid:
+                    chars.append(chr(token_id))
+                elif self.errors == "replace":
+                    chars.append(chr(self.replacement_char))
+                elif self.errors == "strict":
+                    raise ValueError(
+                        f"Invalid unicode codepoint: {token_id}. Received "
+                        f"token ids: {token_ids}"
+                    )
+            outputs.append("".join(chars))
+        if not batched:
+            outputs = outputs[0]
+        return outputs
+
+    def detokenize(self, inputs):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._detokenize_tf(inputs)
+        else:
+            return self._detokenize_python(inputs)
+
+    def call(self, inputs, *args, training=None, **kwargs):
+        return self.tokenize(inputs, *args, **kwargs)
 
     def id_to_token(self, id):
         """Convert an integer id to a string token."""

--- a/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pytest
 import tensorflow as tf
 
 from keras_hub.src.tests.test_case import TestCase
@@ -5,12 +7,32 @@ from keras_hub.src.tokenizers.unicode_codepoint_tokenizer import (
     UnicodeCodepointTokenizer,
 )
 
+try:
+    import grain
+except ImportError:
+    grain = None
+try:
+    import tensorflow_text as tf_text
+except ImportError:
+    tf_text = None
+
 
 class UnicodeCodepointTokenizerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._allow_python_workflow = True
+
+    def make_tokenizer(self, **kwargs):
+        return UnicodeCodepointTokenizer(
+            _allow_python_workflow=self._allow_python_workflow, **kwargs
+        )
+
     def test_tokenizer_basics(self):
         self.run_preprocessing_layer_test(
             cls=UnicodeCodepointTokenizer,
-            init_kwargs={},
+            init_kwargs={
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
             input_data=["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"],
             expected_output=[
                 [110, 105, 110, 106, 97],
@@ -26,7 +48,10 @@ class UnicodeCodepointTokenizerTest(TestCase):
         # the dense, padded output round-trips cleanly through `detokenize`.
         self.run_preprocessing_layer_test(
             cls=UnicodeCodepointTokenizer,
-            init_kwargs={"sequence_length": 10},
+            init_kwargs={
+                "sequence_length": 10,
+                "_allow_python_workflow": self._allow_python_workflow,
+            },
             input_data=["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"],
             expected_output=[
                 [110, 105, 110, 106, 97, 0, 0, 0, 0, 0],
@@ -47,6 +72,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
                 "errors": "ignore",
                 "replacement_char": 0,
                 "vocabulary_size": 100,
+                "_allow_python_workflow": self._allow_python_workflow,
             },
             input_data=["ninja", "samurai", "▀▁▂▃"],
             expected_output=[
@@ -59,7 +85,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_tokenize_scalar(self):
         input_data = "ninja"
-        tokenizer = UnicodeCodepointTokenizer()
+        tokenizer = self.make_tokenizer()
         call_output = tokenizer(input_data)
         tokenize_output = tokenizer.tokenize(input_data)
 
@@ -68,7 +94,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_dense_output(self):
         input_data = ["ninja", "samurai", "▀▁▂▃"]
-        tokenizer = UnicodeCodepointTokenizer(sequence_length=10)
+        tokenizer = self.make_tokenizer(sequence_length=10)
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -81,7 +107,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_tokenize_scalar_with_vocabulary_size(self):
         input_data = "ninja"
-        tokenizer = UnicodeCodepointTokenizer(vocabulary_size=105)
+        tokenizer = self.make_tokenizer(vocabulary_size=105)
         call_output = tokenizer(input_data)
         tokenize_output = tokenizer.tokenize(input_data)
 
@@ -90,9 +116,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_tokenize_dense_with_vocabulary_size(self):
         input_data = ["ninja", "samurai", "▀▁▂▃"]
-        tokenizer = UnicodeCodepointTokenizer(
-            sequence_length=10, vocabulary_size=105
-        )
+        tokenizer = self.make_tokenizer(sequence_length=10, vocabulary_size=105)
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -105,7 +129,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_tokenize_ragged_with_vocabulary_size(self):
         input_data = ["ninja", "samurai", "▀▁▂▃"]
-        tokenizer = UnicodeCodepointTokenizer(vocabulary_size=105)
+        tokenizer = self.make_tokenizer(vocabulary_size=105)
         call_output = tokenizer(input_data)
         tokenize_output = tokenizer.tokenize(input_data)
         exp_outputs = [
@@ -123,7 +147,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
             [9600, 9601, 9602, 9603],
         ]
 
-        tokenizer = UnicodeCodepointTokenizer()
+        tokenizer = self.make_tokenizer()
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(
             detokenize_output,
@@ -137,27 +161,29 @@ class UnicodeCodepointTokenizerTest(TestCase):
     def test_detokenize_replace_error(self):
         # 10000000 is an invalid value
         input_data = tf.ragged.constant([[110, 105, 10000000, 110, 106, 97]])
-        tokenizer = UnicodeCodepointTokenizer(
-            errors="replace", replacement_char=75
-        )
+        tokenizer = self.make_tokenizer(errors="replace", replacement_char=75)
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, [b"niKnja"])
 
     def test_detokenize_ignore_error(self):
         input_data = tf.ragged.constant([[110, 105, 10000000, 110, 106, 97]])
-        tokenizer = UnicodeCodepointTokenizer(errors="ignore")
+        tokenizer = self.make_tokenizer(errors="ignore")
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, [b"ninja"])
 
     def test_detokenize_strict_error(self):
         input_data = tf.ragged.constant([[110, 105, 10000000, 110, 106, 97]])
-        tokenizer = UnicodeCodepointTokenizer(errors="strict")
-        with self.assertRaises(tf.errors.InvalidArgumentError):
+        tokenizer = self.make_tokenizer(errors="strict")
+        if self._allow_python_workflow:
+            error = ValueError
+        else:
+            error = tf.errors.InvalidArgumentError
+        with self.assertRaises(error):
             _ = tokenizer.detokenize(input_data)
 
     def test_normalization_without_UTF8_valueerror(self):
         with self.assertRaises(ValueError):
-            _ = UnicodeCodepointTokenizer(
+            _ = self.make_tokenizer(
                 errors="strict",
                 input_encoding="UTF-16",
                 normalization_form="NFC",
@@ -165,7 +191,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_lowercase(self):
         input_data = tf.constant(["NiNJaS"])
-        tokenizer = UnicodeCodepointTokenizer()
+        tokenizer = self.make_tokenizer()
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -174,7 +200,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
 
     def test_skip_lowercase(self):
         input_data = tf.constant(["NiNJaS"])
-        tokenizer = UnicodeCodepointTokenizer(lowercase=False)
+        tokenizer = self.make_tokenizer(lowercase=False)
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -184,13 +210,124 @@ class UnicodeCodepointTokenizerTest(TestCase):
     def test_token_to_id(self):
         input_tokens = ["ب", "و", "خ"]
         expected_ids = [1576, 1608, 1582]
-        tokenizer = UnicodeCodepointTokenizer(vocabulary_size=2000)
+        tokenizer = self.make_tokenizer(vocabulary_size=2000)
         ids = [tokenizer.token_to_id(t) for t in input_tokens]
         self.assertAllEqual(ids, expected_ids)
 
     def test_id_to_token(self):
         input_ids = [1576, 1608, 1582]
         expected_tokens = ["ب", "و", "خ"]
-        tokenizer = UnicodeCodepointTokenizer(vocabulary_size=2000)
+        tokenizer = self.make_tokenizer(vocabulary_size=2000)
         tokens = [tokenizer.id_to_token(i) for i in input_ids]
         self.assertAllEqual(tokens, expected_tokens)
+
+    def test_bytes_and_tensor_inputs(self):
+        if not self._allow_python_workflow:
+            self.skipTest("The TF path does not accept numpy string arrays.")
+        tokenizer = self.make_tokenizer()
+        expected = [[110, 105, 110, 106, 97], [9600, 9601]]
+        self.assertAllEqual(tokenizer([b"ninja", "▀▁".encode()]), expected)
+        self.assertAllEqual(tokenizer(np.array(["ninja", "▀▁"])), expected)
+        self.assertAllEqual(tokenizer(tf.constant(["ninja", "▀▁"])), expected)
+        self.assertAllEqual(tokenizer(b"ninja"), expected[0])
+        self.assertAllEqual(tokenizer(tf.constant("ninja")), expected[0])
+
+    def test_tokenize_invalid_bytes(self):
+        input_data = [b"ni\xe2\x96ja", b"\xff", b"ok"]
+        tokenizer = self.make_tokenizer(errors="replace", replacement_char=75)
+        self.assertAllEqual(
+            tokenizer(input_data), [[110, 105, 75, 106, 97], [75], [111, 107]]
+        )
+        tokenizer = self.make_tokenizer(errors="ignore")
+        self.assertAllEqual(
+            tokenizer(input_data), [[110, 105, 106, 97], [], [111, 107]]
+        )
+
+    def test_detokenize_inputs(self):
+        if not self._allow_python_workflow:
+            self.skipTest("The TF path does not accept int64 inputs.")
+        tokenizer = self.make_tokenizer()
+        ids = [[110, 105, 110, 106, 97, 0, 0], [9600, 9601, 0, 0, 0, 0, 0]]
+        self.assertAllEqual(tokenizer.detokenize(ids), ["ninja", "▀▁"])
+        self.assertAllEqual(
+            tokenizer.detokenize(np.array(ids)), ["ninja", "▀▁"]
+        )
+        self.assertAllEqual(
+            tokenizer.detokenize(tf.constant(ids)), ["ninja", "▀▁"]
+        )
+        self.assertAllEqual(tokenizer.detokenize(ids[0]), "ninja")
+        self.assertAllEqual(tokenizer.detokenize(np.array(ids[0])), "ninja")
+
+    @pytest.mark.skipif(grain is None, reason="grain is not installed")
+    def test_grain_outputs_numpy(self):
+        input_data = ["ninja", "▀▁"]
+        # Ragged outputs are python lists.
+        tokenizer = self.make_tokenizer()
+        (outputs,) = list(grain.MapDataset.source([input_data]).map(tokenizer))
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(outputs, [[110, 105, 110, 106, 97], [9600, 9601]])
+        # Dense outputs are numpy arrays.
+        tokenizer = self.make_tokenizer(sequence_length=6)
+        outputs = list(grain.MapDataset.source(input_data).map(tokenizer))
+        for output in outputs:
+            self.assertIsInstance(output, np.ndarray)
+        (batch,) = list(
+            grain.MapDataset.source(input_data).map(tokenizer).batch(2)
+        )
+        self.assertAllEqual(
+            batch, [[110, 105, 110, 106, 97, 0], [9600, 9601, 0, 0, 0, 0]]
+        )
+        self.assertAllEqual(batch, tokenizer(input_data))
+
+    @pytest.mark.skipif(tf_text is None, reason="tensorflow-text not installed")
+    def test_python_path_matches_tf_path(self):
+        if not self._allow_python_workflow:
+            self.skipTest("Parity test only runs from the python path.")
+        corpus = [
+            "The quick brown fox.",
+            "ﬁsh ǅ ß İ Σ",
+            "á é í ó ú Ç",
+            "  leading and trailing  ",
+            "x\xa0y\u3000z\ty\nq",
+            "emoji 😀 test 한국어 テスト",
+            "",
+        ]
+        bad_ids = [[110, 105, 10000000, 110], [110, -1, 110], [110, 0, 110]]
+        bad_bytes = [b"ni\xe2\x96ja", b"\xff", b"HeLLo"]
+        for kwargs in [
+            {},
+            {"lowercase": False},
+            {"normalization_form": "NFKD"},
+            {"lowercase": False, "normalization_form": "NFC"},
+            {"sequence_length": 8},
+            {"vocabulary_size": 105},
+            {"errors": "replace", "replacement_char": 75},
+            {"errors": "ignore"},
+        ]:
+            python_tokenizer = UnicodeCodepointTokenizer(**kwargs)
+            tf_tokenizer = UnicodeCodepointTokenizer(
+                _allow_python_workflow=False, **kwargs
+            )
+            python_ids = python_tokenizer(corpus)
+            tf_ids = tf_tokenizer(corpus)
+            self.assertAllEqual(python_ids, tf_ids)
+            self.assertAllEqual(
+                python_tokenizer.detokenize(python_ids),
+                tf_tokenizer.detokenize(tf_ids),
+            )
+            self.assertAllEqual(
+                python_tokenizer(bad_bytes), tf_tokenizer(bad_bytes)
+            )
+            if "sequence_length" not in kwargs:
+                self.assertAllEqual(
+                    python_tokenizer.detokenize(bad_ids),
+                    tf_tokenizer.detokenize(tf.ragged.constant(bad_ids)),
+                )
+
+
+class UnicodeCodepointTokenizerTFTest(UnicodeCodepointTokenizerTest):
+    """Set `_allow_python_workflow=False` to test TF execution."""
+
+    def setUp(self):
+        super().setUp()
+        self._allow_python_workflow = False

--- a/keras_hub/src/tokenizers/word_piece_tokenizer.py
+++ b/keras_hub/src/tokenizers/word_piece_tokenizer.py
@@ -1,13 +1,22 @@
+import functools
 import os
 import re
+import unicodedata
 from typing import Iterable
 
 import keras
+import numpy as np
+import regex
 from keras.src.saving import serialization_lib
 
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.tokenizers import tokenizer
+from keras_hub.src.utils.tensor_utils import canonicalize_python_string_inputs
+from keras_hub.src.utils.tensor_utils import canonicalize_python_token_inputs
+from keras_hub.src.utils.tensor_utils import casefold_utf8
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
 from keras_hub.src.utils.tensor_utils import is_string_dtype
 from keras_hub.src.utils.tensor_utils import preprocessing_function
@@ -86,6 +95,124 @@ WHITESPACE_PUNCTUATION_AND_CJK_REGEX = r"|".join(
         CJK_REGEX,
     ]
 )
+
+
+# Python `regex` equivalents of the RE2 patterns above, used by the Python
+# (TensorFlow free) path. Note that RE2's `\s` only matches ASCII whitespace.
+PY_WHITESPACE_REGEX = r"|".join(
+    [
+        r"[ \t\n\r\f]",
+        r"\p{Cc}",
+        r"\p{Cf}",
+    ]
+)
+PY_PUNCTUATION_REGEX = r"|".join(
+    [
+        r"[!-/]",
+        r"[:-@]",
+        r"[\[-`]",
+        r"[{-~]",
+        r"[\p{P}]",
+    ]
+)
+PY_CJK_REGEX = r"|".join(
+    [
+        r"[\u4E00-\u9FFF]",
+        r"[\u3400-\u4DBF]",
+        r"[\U00020000-\U0002A6DF]",
+        r"[\U0002A700-\U0002B73F]",
+        r"[\U0002B740-\U0002B81F]",
+        r"[\U0002B820-\U0002CEAF]",
+        r"[\uF900-\uFAFF]",
+        r"[\U0002F800-\U0002FA1F]",
+    ]
+)
+
+# `tf_text.FastWordpieceTokenizer` maps words longer than this many bytes to
+# the unknown token.
+MAX_BYTES_PER_WORD = 100
+
+
+@functools.lru_cache(maxsize=32)
+def _get_split_patterns(split_on_cjk, special_tokens):
+    """Compiled `(delimiter, keep_delimiter)` regexes for word splitting."""
+    if split_on_cjk:
+        split_pattern = r"|".join(
+            [PY_WHITESPACE_REGEX, PY_PUNCTUATION_REGEX, PY_CJK_REGEX]
+        )
+        keep_split_pattern = r"|".join([PY_PUNCTUATION_REGEX, PY_CJK_REGEX])
+    else:
+        split_pattern = r"|".join([PY_WHITESPACE_REGEX, PY_PUNCTUATION_REGEX])
+        keep_split_pattern = PY_PUNCTUATION_REGEX
+    if special_tokens:
+        special_tokens_pattern = get_special_tokens_pattern(special_tokens)
+        split_pattern = r"|".join([special_tokens_pattern, split_pattern])
+        keep_split_pattern = r"|".join(
+            [special_tokens_pattern, keep_split_pattern]
+        )
+    return regex.compile(split_pattern), regex.compile(keep_split_pattern)
+
+
+def _regex_split(text, delimiter_pattern, keep_pattern):
+    """Python equivalent of `tf_text.regex_split` for a single string."""
+    words = []
+    position = 0
+    for match in delimiter_pattern.finditer(text):
+        if match.start() > position:
+            words.append(text[position : match.start()])
+        if keep_pattern.fullmatch(match.group()):
+            words.append(match.group())
+        position = match.end()
+    if position < len(text):
+        words.append(text[position:])
+    return words
+
+
+def pretokenize_python(
+    text,
+    lowercase=False,
+    strip_accents=True,
+    split=True,
+    split_on_cjk=True,
+    special_tokens=None,
+):
+    """Python equivalent of `pretokenize` for a single string.
+
+    Args:
+        text: str. Input to be pretokenized.
+        lowercase: bool. If True, the input text will be lowercased (with
+            unicode case folding) before tokenization.
+        strip_accents: bool. If `True`, all accent marks will be removed from
+            text before tokenization.
+        split: bool. If `True`, input will be split on whitespace and
+            punctuation marks, and all punctuation marks will be kept as
+            tokens. If `False`, `text` is treated as a single whole word.
+        split_on_cjk: bool. If `True`, input will be split on CJK characters.
+            Only applicable when `split` is `True`.
+        special_tokens: list of strings. Special tokens that will never be
+            split or lowercased.
+
+    Returns:
+        A list of pre-tokenized words.
+    """
+    if strip_accents:
+        # Normalize unicode to NFD, which splits out accent mark characters,
+        # then remove the accent marks.
+        text = unicodedata.normalize("NFD", text)
+        text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    special_tokens = tuple(special_tokens) if special_tokens else ()
+    if split:
+        delimiter_pattern, keep_pattern = _get_split_patterns(
+            split_on_cjk, special_tokens
+        )
+        words = _regex_split(text, delimiter_pattern, keep_pattern)
+    else:
+        words = [text]
+    if lowercase:
+        # Do not lowercase special tokens. They often contain capital
+        # letters, e.g. `"[CLS]"`.
+        words = [w if w in special_tokens else casefold_utf8(w) for w in words]
+    return words
 
 
 def get_special_tokens_pattern(special_tokens):
@@ -342,7 +469,10 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
                 f"Received: dtype={dtype}"
             )
 
-        super().__init__(dtype=dtype, **kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            dtype=dtype, _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
         if oov_token is None:
             raise ValueError("`oov_token` cannot be None.")
 
@@ -374,6 +504,7 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         if vocabulary is None:
             self.vocabulary = None
             self._fast_word_piece = None
+            self._token_to_id_map = None
             return
 
         if isinstance(vocabulary, str):
@@ -408,6 +539,18 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
                 "the `oov_token` argument when creating the tokenizer."
             )
 
+        self._token_to_id_map = {
+            token: i for i, token in enumerate(self.vocabulary)
+        }
+        # When using `WordPieceTokenizer` with `tf.data`, the tf-text
+        # tokenizer must be built outside the `tf.data` pipeline, so build it
+        # eagerly whenever tf-text is available.
+        self._fast_word_piece = None
+        if tf_text is not None:
+            self._set_vocabulary_tf()
+        self._update_special_token_ids()
+
+    def _set_vocabulary_tf(self):
         self._fast_word_piece = tf_text.FastWordpieceTokenizer(
             vocab=self.vocabulary,
             token_out_type=self.compute_dtype,
@@ -416,7 +559,10 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
             no_pretokenization=True,
             support_detokenization=True,
         )
-        self._update_special_token_ids()
+
+    def _maybe_initialized_tf(self):
+        if self._fast_word_piece is None:
+            self._set_vocabulary_tf()
 
     def get_vocabulary(self):
         """Get the tokenizer vocabulary as a list of strings tokens."""
@@ -440,11 +586,10 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
 
     def token_to_id(self, token):
         """Convert a string token to an integer id."""
-        # This will be slow, but keep memory usage down compared to building a
-        # . Assuming the main use case is looking up a few special tokens
-        # early in the vocab, this should be fine.
         self._check_vocabulary()
-        return self.vocabulary.index(token)
+        if token not in self._token_to_id_map:
+            raise ValueError(f"Token '{token}' is not in the vocabulary.")
+        return self._token_to_id_map[token]
 
     def get_config(self):
         config = super().get_config()
@@ -470,24 +615,29 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
                 "to pass a `vocabulary` argument when creating the layer."
             )
 
+    def _special_tokens_for_splitting(self):
+        if not (self.split and self.special_tokens_in_strings):
+            return None
+        special_tokens = self.special_tokens
+        if self._init_special_tokens:
+            special_tokens += self._init_special_tokens
+        return special_tokens
+
     @preprocessing_function
-    def tokenize(self, inputs):
-        self._check_vocabulary()
-        inputs = tf.convert_to_tensor(inputs)
+    def _tokenize_tf(self, inputs):
+        self._maybe_initialized_tf()
+        if not isinstance(inputs, tf.RaggedTensor):
+            inputs = tf.convert_to_tensor(inputs)
         unbatched = inputs.shape.rank == 0
-        pattern = None
-        if self.split and self.special_tokens_in_strings:
-            # the idea here is to pass the special tokens regex to the
-            # split function as delimiter regex pattern, so the input will
-            # be splitted by them, but also the function will treat each one
-            # of them as one entity that shouldn't be splitted even if they
-            # have other delimiter regex pattern inside them. then pass the
-            # special tokens regex also as keep delimiter regex
-            # pattern, so they will not be removed.
-            special_tokens = self.special_tokens
-            if self._init_special_tokens:
-                special_tokens += self._init_special_tokens
-            pattern = get_special_tokens_pattern(special_tokens)
+        # The idea here is to pass the special tokens regex to the split
+        # function as delimiter regex pattern, so the input will be splitted
+        # by them, but also the function will treat each one of them as one
+        # entity that shouldn't be splitted even if they have other delimiter
+        # regex pattern inside them. Then pass the special tokens regex also
+        # as keep delimiter regex pattern, so they will not be removed.
+        pattern = get_special_tokens_pattern(
+            self._special_tokens_for_splitting()
+        )
         inputs = pretokenize(
             inputs,
             self.lowercase,
@@ -516,14 +666,158 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
 
         return tokens
 
-    @preprocessing_function
-    def detokenize(self, inputs):
+    def _tokenize_word_python(self, word):
+        """Apply the WordPiece algorithm to a single pre-tokenized word.
+
+        This is a greedy longest-match-first lookup of subwords in the
+        vocabulary, where subwords after the first are prefixed with the
+        `suffix_indicator`. Words that cannot be fully tokenized, or that are
+        longer than `MAX_BYTES_PER_WORD`, map to the `oov_token`.
+        """
+        if not word:
+            return []
+        if len(word.encode("utf-8")) > MAX_BYTES_PER_WORD:
+            return [self.oov_token]
+        tokens = []
+        start = 0
+        while start < len(word):
+            end = len(word)
+            current = None
+            while start < end:
+                subword = word[start:end]
+                if start > 0:
+                    subword = self.suffix_indicator + subword
+                if subword in self._token_to_id_map:
+                    current = subword
+                    break
+                end -= 1
+            if current is None:
+                return [self.oov_token]
+            tokens.append(current)
+            start = end
+        return tokens
+
+    def _canonicalize_presplit_inputs(self, inputs):
+        """Canonicalize inputs for `split=False` to lists of words.
+
+        Returns a tuple `(inputs, batched)`, where `inputs` is a list of
+        samples, each a list of pre-split words.
+        """
+        if tf is not None and isinstance(inputs, tf.RaggedTensor):
+            inputs = inputs.to_list()
+        elif (
+            isinstance(inputs, np.ndarray)
+            or keras.ops.is_tensor(inputs)
+            or (tf is not None and isinstance(inputs, tf.Tensor))
+        ):
+            inputs = convert_to_numpy(inputs)
+            if inputs.ndim == 2:
+                inputs = inputs.tolist()
+        if isinstance(inputs, (tuple, list)) and (
+            not inputs or isinstance(inputs[0], (tuple, list))
+        ):
+            samples = []
+            for sample in inputs:
+                words, _ = canonicalize_python_string_inputs(list(sample))
+                samples.append(words)
+            return samples, True
+        words, _ = canonicalize_python_string_inputs(inputs)
+        return [words], False
+
+    def _tokenize_python(self, inputs):
+        special_tokens = self._special_tokens_for_splitting()
+        if self.split:
+            inputs, batched = canonicalize_python_string_inputs(inputs)
+            samples = [[text] for text in inputs]
+        else:
+            samples, batched = self._canonicalize_presplit_inputs(inputs)
+
+        batched_tokens = []
+        for sample in samples:
+            tokens = []
+            for text in sample:
+                words = pretokenize_python(
+                    text,
+                    self.lowercase,
+                    self.strip_accents,
+                    self.split,
+                    self.split_on_cjk,
+                    special_tokens,
+                )
+                for word in words:
+                    tokens.extend(self._tokenize_word_python(word))
+            if is_int_dtype(self.compute_dtype):
+                tokens = [self._token_to_id_map[token] for token in tokens]
+            batched_tokens.append(tokens)
+
+        # Convert to a dense output if `sequence_length` is set.
+        if self.sequence_length:
+            pad_value = 0 if is_int_dtype(self.compute_dtype) else ""
+            batched_tokens = [
+                tokens[: self.sequence_length]
+                + [pad_value] * (self.sequence_length - len(tokens))
+                for tokens in batched_tokens
+            ]
+            if is_int_dtype(self.compute_dtype):
+                # Dense int outputs are arrays, so that direct calls return
+                # backend tensors and Grain pipelines return NumPy.
+                batched_tokens = np.array(
+                    batched_tokens, dtype=self.compute_dtype
+                )
+
+        if not batched:
+            batched_tokens = batched_tokens[0]
+        return batched_tokens
+
+    def tokenize(self, inputs):
         self._check_vocabulary()
+        if not self._allow_python_workflow or in_tf_function():
+            return self._tokenize_tf(inputs)
+        else:
+            return self._tokenize_python(inputs)
+
+    @preprocessing_function
+    def _detokenize_tf(self, inputs):
+        self._maybe_initialized_tf()
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
         outputs = self._fast_word_piece.detokenize(inputs)
         if unbatched:
             outputs = tf.squeeze(outputs, 0)
         return outputs
+
+    def _detokenize_python(self, inputs):
+        inputs, batched = canonicalize_python_token_inputs(inputs)
+        outputs = []
+        suffix_length = len(self.suffix_indicator)
+        for token_ids in inputs:
+            words = []
+            for i, token_id in enumerate(token_ids):
+                token = self.id_to_token(token_id)
+                # Like tf-text, join suffix tokens to the previous word, but
+                # keep a leading suffix token (and a bare suffix indicator)
+                # as is.
+                if (
+                    i > 0
+                    and len(token) > suffix_length
+                    and token.startswith(self.suffix_indicator)
+                ):
+                    words[-1] += token[suffix_length:]
+                else:
+                    words.append(token)
+            outputs.append(" ".join(words))
+        if not batched:
+            outputs = outputs[0]
+        return outputs
+
+    def detokenize(self, inputs):
+        self._check_vocabulary()
+        if not self._allow_python_workflow or in_tf_function():
+            return self._detokenize_tf(inputs)
+        else:
+            return self._detokenize_python(inputs)
+
+    def call(self, inputs, *args, training=None, **kwargs):
+        return self.tokenize(inputs, *args, **kwargs)
 
     def compute_output_spec(self, input_spec):
         return keras.KerasTensor(

--- a/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_hub/src/tokenizers/word_piece_tokenizer_test.py
@@ -1,17 +1,38 @@
 import os
 
+import numpy as np
+import pytest
 import tensorflow as tf
 from keras.src.saving import serialization_lib
 
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.tokenizers.word_piece_tokenizer import WordPieceTokenizer
 
+try:
+    import grain
+except ImportError:
+    grain = None
+try:
+    import tensorflow_text as tf_text
+except ImportError:
+    tf_text = None
+
 
 class WordPieceTokenizerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._allow_python_workflow = True
+
+    def make_tokenizer(self, **kwargs):
+        return WordPieceTokenizer(
+            _allow_python_workflow=self._allow_python_workflow, **kwargs
+        )
+
     def test_tokenizer_basics(self):
         self.run_preprocessing_layer_test(
             cls=WordPieceTokenizer,
             init_kwargs={
+                "_allow_python_workflow": self._allow_python_workflow,
                 "vocabulary": [
                     "[UNK]",
                     "the",
@@ -21,7 +42,7 @@ class WordPieceTokenizerTest(TestCase):
                     "##own",
                     "fox",
                     ".",
-                ]
+                ],
             },
             input_data=["the quick brown fox."],
             expected_output=[[1, 2, 3, 4, 5, 6, 7]],
@@ -34,6 +55,7 @@ class WordPieceTokenizerTest(TestCase):
         self.run_preprocessing_layer_test(
             cls=WordPieceTokenizer,
             init_kwargs={
+                "_allow_python_workflow": self._allow_python_workflow,
                 "vocabulary": vocab_data,
                 "lowercase": True,
                 "oov_token": "@UNK@",
@@ -49,7 +71,7 @@ class WordPieceTokenizerTest(TestCase):
     def test_dense_output(self):
         input_data = ["the quick brown fox."]
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data, sequence_length=10
         )
         call_output = tokenizer(input_data)
@@ -58,7 +80,7 @@ class WordPieceTokenizerTest(TestCase):
     def test_string_tokenize(self):
         input_data = ["the quick brown fox"]
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, dtype="string")
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data, dtype="string")
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -67,7 +89,7 @@ class WordPieceTokenizerTest(TestCase):
 
     def test_detokenize(self):
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
         outputs = tokenizer.detokenize([1, 2, 3, 4, 5, 6])
         self.assertAllEqual(outputs, "the quick brown fox")
         outputs = tokenizer.detokenize([[1, 2, 3, 4, 5, 6], [1, 6]])
@@ -75,7 +97,7 @@ class WordPieceTokenizerTest(TestCase):
 
     def test_accessors(self):
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
         self.assertEqual(tokenizer.vocabulary_size(), 7)
         self.assertEqual(
             tokenizer.get_vocabulary(),
@@ -88,7 +110,7 @@ class WordPieceTokenizerTest(TestCase):
 
     def test_error_id_out_of_vocabulary(self):
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
         with self.assertRaises(ValueError):
             tokenizer.id_to_token(tokenizer.vocabulary_size())
         with self.assertRaises(ValueError):
@@ -98,7 +120,7 @@ class WordPieceTokenizerTest(TestCase):
         input_data = ["quick brown whale @MASK@"]
         vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox", "@MASK@"]
         special_tokens = ["@UNK@", "@MASK@"]
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data,
             oov_token="@UNK@",
             suffix_indicator="@@",
@@ -118,7 +140,7 @@ class WordPieceTokenizerTest(TestCase):
         vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
         vocab_data = [*special_tokens, *vocab_data]
 
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data,
             special_tokens=special_tokens,
             special_tokens_in_strings=True,
@@ -132,7 +154,7 @@ class WordPieceTokenizerTest(TestCase):
         vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
         vocab_data = [*special_tokens, *vocab_data]
 
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data,
             lowercase=True,
             special_tokens=special_tokens,
@@ -144,7 +166,7 @@ class WordPieceTokenizerTest(TestCase):
     def test_cjk_tokens(self):
         input_data = ["ah半推zz"]
         vocab_data = ["[UNK]", "推", "敐", "乐", "半", "偷", "匕", "ah", "zz"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, dtype="string")
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data, dtype="string")
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
@@ -154,21 +176,21 @@ class WordPieceTokenizerTest(TestCase):
     def test_lowercase(self):
         input_data = ["the QUicK brOWN FOX"]
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, lowercase=True)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data, lowercase=True)
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [[1, 2, 3, 4, 5, 6]])
 
     def test_skip_lowercase(self):
         input_data = ["the QUicK brOWN FOX"]
         vocab_data = ["[UNK]", "the", "QU", "##icK", "br", "##OWN", "fox"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, lowercase=False)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data, lowercase=False)
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [[1, 2, 3, 4, 5, 0]])
 
     def test_strip_accents(self):
         input_data = ["á é í ó ú"]
         vocab_data = ["[UNK]", "a", "e", "i", "o", "u"]
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data, strip_accents=True
         )
         call_output = tokenizer(input_data)
@@ -177,7 +199,7 @@ class WordPieceTokenizerTest(TestCase):
     def test_skip_strip_accents(self):
         input_data = ["á é í ó ú"]
         vocab_data = ["[UNK]", "á", "é", "í", "ó", "ú"]
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data, strip_accents=False
         )
         call_output = tokenizer(input_data)
@@ -186,14 +208,14 @@ class WordPieceTokenizerTest(TestCase):
     def test_no_splitting(self):
         input_data = ["t o k e n", "m i s s i n g", "t o k e n"]
         vocab_data = ["[UNK]", "t o k e n"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, split=False)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data, split=False)
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [1, 0, 1])
 
     def test_word_piece_only(self):
         input_data = ["the", "quíck", "Brówn", "Fóx"]
         vocab_data = ["[UNK]", "the", "qu", "##íck", "Br", "##ówn", "Fóx"]
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data,
             lowercase=False,
             strip_accents=False,
@@ -209,31 +231,31 @@ class WordPieceTokenizerTest(TestCase):
         with tf.io.gfile.GFile(vocab_path, "w") as file:
             for piece in vocab_data:
                 file.write(piece + "\n")
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_path)
+        tokenizer = self.make_tokenizer(vocabulary=vocab_path)
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [[1, 2, 3, 4, 5, 6, 7]])
 
     def test_no_oov_token_in_vocabulary(self):
         vocab_data = ["qu", "@@ick", "br", "@@OWN", "fox"]
         with self.assertRaises(ValueError):
-            WordPieceTokenizer(
+            self.make_tokenizer(
                 vocabulary=vocab_data,
             )
 
         vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@OWN", "fox"]
         with self.assertRaises(ValueError):
-            WordPieceTokenizer(
+            self.make_tokenizer(
                 vocabulary=vocab_data,
             )
 
         vocab_data = ["UNK", "qu", "@@ick", "br", "@@OWN", "fox"]
         with self.assertRaises(ValueError):
-            WordPieceTokenizer(
+            self.make_tokenizer(
                 vocabulary=vocab_data,
             )
 
         with self.assertRaises(ValueError):
-            WordPieceTokenizer(vocabulary=vocab_data, oov_token=None)
+            self.make_tokenizer(vocabulary=vocab_data, oov_token=None)
 
     def test_no_splitting_with_special_tokens(self):
         # When `split` is `False`, no special tokens tokenization will be done.
@@ -244,7 +266,7 @@ class WordPieceTokenizerTest(TestCase):
             "t o k e n",
         ]
         vocab_data = ["[UNK]", "[MASK]", "t o k e n"]
-        tokenizer = WordPieceTokenizer(
+        tokenizer = self.make_tokenizer(
             vocabulary=vocab_data, split=False, special_tokens=["[MASK]"]
         )
         output = tokenizer(input_data)
@@ -256,7 +278,7 @@ class WordPieceTokenizerTest(TestCase):
         with open(vocab_path, "w") as file:
             file.write("[UNK]\nthe\nquick\nbrown\nfox\n")
 
-        tokenizer = WordPieceTokenizer()
+        tokenizer = self.make_tokenizer()
         with serialization_lib.SafeModeScope(True):
             with self.assertRaisesRegex(
                 ValueError,
@@ -264,3 +286,168 @@ class WordPieceTokenizerTest(TestCase):
                 r"model archive.*Vocabulary file: .*vocab\.txt",
             ):
                 tokenizer.set_vocabulary(vocab_path)
+
+    def test_split_false_ragged_inputs(self):
+        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data, split=False)
+        # A batch of pre-split words.
+        input_data = tf.ragged.constant([["the", "quick"], ["Brown", "fox"]])
+        self.assertAllEqual(tokenizer(input_data), [[1, 2, 3], [0, 6]])
+        self.assertAllEqual(
+            tokenizer([["the", "quick"], ["Brown", "fox"]]), [[1, 2, 3], [0, 6]]
+        )
+        if self._allow_python_workflow:
+            # A single pre-split word. The TF path only supports batches of
+            # words when `split=False`.
+            self.assertAllEqual(tokenizer("quick"), [2, 3])
+
+    def test_bytes_and_tensor_inputs(self):
+        if not self._allow_python_workflow:
+            self.skipTest("The TF path does not accept numpy string arrays.")
+        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
+        expected = [[1, 2, 3], [4, 5, 6]]
+        self.assertAllEqual(tokenizer([b"the quick", b"brown fox"]), expected)
+        self.assertAllEqual(
+            tokenizer(np.array(["the quick", "brown fox"])), expected
+        )
+        self.assertAllEqual(
+            tokenizer(tf.constant(["the quick", "brown fox"])), expected
+        )
+        self.assertAllEqual(tokenizer(b"the quick"), expected[0])
+        self.assertAllEqual(tokenizer(tf.constant("the quick")), expected[0])
+
+    def test_detokenize_inputs(self):
+        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
+        ids = [[1, 2, 3], [4, 5, 6]]
+        expected = ["the quick", "brown fox"]
+        self.assertAllEqual(tokenizer.detokenize(ids), expected)
+        self.assertAllEqual(tokenizer.detokenize(np.array(ids)), expected)
+        self.assertAllEqual(
+            tokenizer.detokenize(tf.constant(ids, "int32")), expected
+        )
+        self.assertAllEqual(tokenizer.detokenize(ids[0]), expected[0])
+        self.assertAllEqual(tokenizer.detokenize(np.array(ids[0])), expected[0])
+        # Leading suffix tokens and bare suffix indicators are kept as is.
+        vocab_data = ["[UNK]", "the", "##", "##ick", "a##b"]
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
+        self.assertAllEqual(tokenizer.detokenize([3]), "##ick")
+        self.assertAllEqual(tokenizer.detokenize([3, 3]), "##ickick")
+        self.assertAllEqual(tokenizer.detokenize([1, 2]), "the ##")
+        self.assertAllEqual(tokenizer.detokenize([1, 4, 3]), "the a##bick")
+        self.assertAllEqual(tokenizer.detokenize([]), "")
+
+    def test_long_words_map_to_oov(self):
+        vocab_data = ["[UNK]", "a", "##a"]
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
+        self.assertAllEqual(tokenizer("a" * 100), [1] + [2] * 99)
+        self.assertAllEqual(tokenizer("a" * 101), [0])
+
+    @pytest.mark.skipif(grain is None, reason="grain is not installed")
+    def test_grain_outputs_numpy(self):
+        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
+        input_data = ["the quick", "brown fox"]
+        # Ragged outputs are python lists.
+        tokenizer = self.make_tokenizer(vocabulary=vocab_data)
+        (outputs,) = list(grain.MapDataset.source([input_data]).map(tokenizer))
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(outputs, [[1, 2, 3], [4, 5, 6]])
+        # Dense outputs are numpy arrays.
+        tokenizer = self.make_tokenizer(
+            vocabulary=vocab_data, sequence_length=4
+        )
+        outputs = list(grain.MapDataset.source(input_data).map(tokenizer))
+        for output in outputs:
+            self.assertIsInstance(output, np.ndarray)
+        (batch,) = list(
+            grain.MapDataset.source(input_data).map(tokenizer).batch(2)
+        )
+        self.assertAllEqual(batch, [[1, 2, 3, 0], [4, 5, 6, 0]])
+        self.assertAllEqual(batch, tokenizer(input_data))
+
+    @pytest.mark.skipif(tf_text is None, reason="tensorflow-text not installed")
+    def test_python_path_matches_tf_path(self):
+        if not self._allow_python_workflow:
+            self.skipTest("Parity test only runs from the python path.")
+        # NOTE: `tf_text.regex_split` truncates strings at "\x00" bytes, so
+        # the paths are only compared on inputs without them.
+        corpus = [
+            "The quick brown fox.",
+            "hi[MASK]there, you! [CLS]x",
+            "Hello,World.  多个 test\u200bab",
+            "á é í ó ú Ç",
+            "don't stop-me now...",
+            "a$b^c`d{e}~f",
+            "  leading and trailing  ",
+            "ﬁsh ǅ ß İ Σ",
+            "x\xa0y\u3000z\ty\nq",
+            "“quoted” — dash…",
+            "[MASK][MASK]x[MASK]",
+            "quickquick theq the##ick",
+            "emoji 😀 test 한국어",
+            "a" * 101,
+            "",
+        ]
+        vocab_data = [
+            "[PAD]", "[UNK]", "[CLS]", "[MASK]", "the", "qu", "##ick", "br",
+            "##own", "fox", ".", ",", "!", "'", "-", "a", "b", "c", "d", "e",
+            "x", "y", "z", "##h", "##ere", "t", "hi", "半", "推", "多", "个",
+            "test", "you", "now", "don", "##t", "stop", "me", "quick",
+            "##quick", "fi", "##sh", "ss", "i", "σ", "emoji", "한국어",
+            "leading", "and", "trailing", "“", "”", "—", "…", "dash",
+            "quoted", "$", "^", "`", "{", "}", "~", "##a",
+        ]  # fmt: skip
+        for kwargs in [
+            {},
+            {"lowercase": True},
+            {"strip_accents": True},
+            {"lowercase": True, "strip_accents": True, "split_on_cjk": False},
+            {
+                "lowercase": True,
+                "special_tokens": ["[MASK]", "[CLS]"],
+                "special_tokens_in_strings": True,
+            },
+            {"dtype": "string"},
+            {"dtype": "string", "lowercase": True, "split_on_cjk": False},
+            {"sequence_length": 8},
+        ]:
+            python_tokenizer = WordPieceTokenizer(
+                vocabulary=vocab_data, **kwargs
+            )
+            tf_tokenizer = WordPieceTokenizer(
+                vocabulary=vocab_data, _allow_python_workflow=False, **kwargs
+            )
+            python_output = python_tokenizer(corpus)
+            tf_output = tf_tokenizer(corpus)
+            self.assertAllEqual(python_output, tf_output)
+            for text in corpus:
+                self.assertAllEqual(python_tokenizer(text), tf_tokenizer(text))
+            if kwargs.get("dtype", "int32") != "string":
+                self.assertAllEqual(
+                    python_tokenizer.detokenize(python_output),
+                    tf_tokenizer.detokenize(tf_output),
+                )
+        # Pre-split inputs.
+        words = ["the", "quick", "Fox", "ǅ", "theq", "", "hi"]
+        ragged = tf.ragged.constant([["the", "quick"], ["Fox"], []])
+        for kwargs in [{}, {"lowercase": True, "strip_accents": True}]:
+            python_tokenizer = WordPieceTokenizer(
+                vocabulary=vocab_data, split=False, **kwargs
+            )
+            tf_tokenizer = WordPieceTokenizer(
+                vocabulary=vocab_data,
+                split=False,
+                _allow_python_workflow=False,
+                **kwargs,
+            )
+            self.assertAllEqual(python_tokenizer(words), tf_tokenizer(words))
+            self.assertAllEqual(python_tokenizer(ragged), tf_tokenizer(ragged))
+
+
+class WordPieceTokenizerTFTest(WordPieceTokenizerTest):
+    """Set `_allow_python_workflow=False` to test TF execution."""
+
+    def setUp(self):
+        super().setUp()
+        self._allow_python_workflow = False

--- a/keras_hub/src/utils/tensor_utils.py
+++ b/keras_hub/src/utils/tensor_utils.py
@@ -1,9 +1,11 @@
+import codecs
 import contextlib
 import functools
 import inspect
 import math
 import re
 import threading
+import unicodedata
 
 import keras
 import numpy as np
@@ -419,6 +421,163 @@ def canonicalize_python_inputs(inputs):
         raise ValueError(
             f"Input should be a list or a list of lists. Received: {inputs}"
         )
+
+
+def canonicalize_python_string_inputs(
+    inputs, encoding="utf-8", errors="strict"
+):
+    """Canonicalize string inputs for the Python path of a tokenizer.
+
+    Accepts a single string, a list/tuple of strings, or a rank 0 or rank 1
+    string tensor/array (backend, NumPy or TensorFlow). `bytes` are decoded
+    with `encoding` and `errors`.
+
+    Returns:
+        A tuple `(inputs, batched)`, where `inputs` is a list of Python
+        strings and `batched` is whether the input was a batch.
+    """
+
+    def to_str(x):
+        if isinstance(x, bytes):
+            return x.decode(encoding, errors=errors)
+        if isinstance(x, np.str_):
+            return str(x)
+        if isinstance(x, str):
+            return x
+        raise ValueError(
+            "If a list, tuple or array is provided as input, all elements "
+            f"must be strings. Received: {inputs}"
+        )
+
+    if isinstance(inputs, (str, bytes, np.str_)):
+        return [to_str(inputs)], False
+    if isinstance(inputs, (tuple, list)):
+        return [to_str(x) for x in inputs], True
+    if (
+        isinstance(inputs, np.ndarray)
+        or keras.ops.is_tensor(inputs)
+        or (tf is not None and isinstance(inputs, tf.Tensor))
+    ):
+        inputs = convert_to_numpy(inputs)
+        if inputs.ndim == 0:
+            return [to_str(inputs.item())], False
+        if inputs.ndim == 1:
+            return [to_str(x) for x in inputs.tolist()], True
+        raise ValueError(
+            f"Array must be 0 or 1 dimensional, got {inputs.shape}."
+        )
+    raise ValueError(
+        f"Input should be a string or a list of strings. Received: {inputs}"
+    )
+
+
+def canonicalize_python_token_inputs(inputs):
+    """Canonicalize token id inputs for the Python path of a tokenizer.
+
+    Accepts a single integer, a list of integers, a list of lists of integers,
+    or a rank 0, 1 or 2 integer tensor/array (backend, NumPy or TensorFlow,
+    ragged or dense).
+
+    Returns:
+        A tuple `(inputs, batched)`, where `inputs` is a list of lists of
+        Python integers and `batched` is whether the input was a batch.
+    """
+    if tf is not None and isinstance(inputs, (tf.Tensor, tf.RaggedTensor)):
+        if isinstance(inputs, tf.RaggedTensor):
+            inputs = inputs.to_list()
+        else:
+            inputs = np.array(inputs)
+    if isinstance(inputs, (int, np.integer)):
+        return [[int(inputs)]], False
+    if isinstance(inputs, (tuple, list)):
+        if not inputs or isinstance(inputs[0], (int, np.integer)):
+            # Unbatched list of ints.
+            return [[int(x) for x in inputs]], False
+        # Batched list of lists of ints.
+        return [[int(x) for x in convert_to_list(seq)] for seq in inputs], True
+    if isinstance(inputs, np.ndarray) or keras.ops.is_tensor(inputs):
+        inputs = convert_to_numpy(inputs)
+        if inputs.ndim == 0:
+            return [[inputs.item()]], False
+        if inputs.ndim == 1:
+            return [inputs.tolist()], False
+        if inputs.ndim == 2:
+            return inputs.tolist(), True
+        raise ValueError(
+            f"Array must be 0, 1 or 2 dimensional, got {inputs.shape}."
+        )
+    raise ValueError(
+        "Input should be an integer, a list of integers, backend "
+        f"tensor or numpy array. Received: {inputs}"
+    )
+
+
+# Unicode "Default_Ignorable_Code_Point" ranges. These are removed by
+# `tf_text.case_fold_utf8` (which applies NFKC_Casefold), so the Python case
+# folding below removes them too.
+_DEFAULT_IGNORABLE_RANGES = (
+    (0x00AD, 0x00AD),
+    (0x034F, 0x034F),
+    (0x061C, 0x061C),
+    (0x115F, 0x1160),
+    (0x17B4, 0x17B5),
+    (0x180B, 0x180F),
+    (0x200B, 0x200F),
+    (0x202A, 0x202E),
+    (0x2060, 0x206F),
+    (0x3164, 0x3164),
+    (0xFE00, 0xFE0F),
+    (0xFEFF, 0xFEFF),
+    (0xFFA0, 0xFFA0),
+    (0xFFF0, 0xFFF8),
+    (0x1BCA0, 0x1BCA3),
+    (0x1D173, 0x1D17A),
+    (0xE0000, 0xE0FFF),
+)
+
+
+def _is_default_ignorable(char):
+    cp = ord(char)
+    return any(lo <= cp <= hi for lo, hi in _DEFAULT_IGNORABLE_RANGES)
+
+
+def casefold_utf8(text):
+    """Python equivalent of `tf_text.case_fold_utf8`.
+
+    `tf_text.case_fold_utf8` applies the Unicode NFKC_Casefold mapping, which
+    is NFKC normalization plus full case folding, and drops default ignorable
+    code points (e.g. zero width spaces and soft hyphens).
+    """
+    text = unicodedata.normalize("NFKC", text).casefold()
+    if any(_is_default_ignorable(c) for c in text):
+        text = "".join(c for c in text if not _is_default_ignorable(c))
+    return text
+
+
+_REGISTERED_ERROR_HANDLERS = {}
+
+
+def get_decode_errors_name(errors, replacement_char=65533):
+    """Return a codecs error handler name for `str.encode`/`bytes.decode`.
+
+    Python equivalent of the `errors` and `replacement_char` arguments of
+    `tf.strings.unicode_decode`/`tf.strings.unicode_transcode`. `errors` is
+    one of `"strict"`, `"ignore"` or `"replace"`. For `"replace"`, a custom
+    handler replacing each invalid sequence with `chr(replacement_char)` is
+    registered with the `codecs` module and returned.
+    """
+    if errors != "replace" or replacement_char == 65533:
+        return errors
+    name = f"keras_hub_replace_{replacement_char}"
+    if name not in _REGISTERED_ERROR_HANDLERS:
+        replacement = chr(replacement_char)
+
+        def handler(exception):
+            return replacement, exception.end
+
+        codecs.register_error(name, handler)
+        _REGISTERED_ERROR_HANDLERS[name] = handler
+    return name
 
 
 def compute_padding_mask(token_ids, pad_token_id):

--- a/keras_hub/src/utils/tensor_utils_test.py
+++ b/keras_hub/src/utils/tensor_utils_test.py
@@ -6,6 +6,9 @@ from keras import tree
 
 from keras_hub.src.tests.test_case import TestCase
 from keras_hub.src.utils.tensor_utils import any_equal
+from keras_hub.src.utils.tensor_utils import canonicalize_python_string_inputs
+from keras_hub.src.utils.tensor_utils import canonicalize_python_token_inputs
+from keras_hub.src.utils.tensor_utils import casefold_utf8
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_inputs
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_outputs
 from keras_hub.src.utils.tensor_utils import convert_preprocessing_outputs_grain
@@ -13,6 +16,7 @@ from keras_hub.src.utils.tensor_utils import (
     convert_preprocessing_outputs_python,
 )
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import get_decode_errors_name
 from keras_hub.src.utils.tensor_utils import in_grain_data_pipeline
 from keras_hub.src.utils.tensor_utils import is_float_dtype
 from keras_hub.src.utils.tensor_utils import is_tensor_type
@@ -484,3 +488,111 @@ class IsFloatDtypeTest(TestCase):
         ]
         for dtype in non_float_dtypes:
             self.assertFalse(is_float_dtype(dtype))
+
+
+class CanonicalizePythonInputsTest(TestCase):
+    def test_string_inputs(self):
+        self.assertEqual(canonicalize_python_string_inputs("a"), (["a"], False))
+        self.assertEqual(
+            canonicalize_python_string_inputs(b"a"), (["a"], False)
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(np.str_("a")), (["a"], False)
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(["a", b"b"]), (["a", "b"], True)
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(("a", "b")), (["a", "b"], True)
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(np.array(["a", "b"])),
+            (["a", "b"], True),
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(np.array("a")), (["a"], False)
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(tf.constant(["a", "b"])),
+            (["a", "b"], True),
+        )
+        self.assertEqual(
+            canonicalize_python_string_inputs(tf.constant("a")), (["a"], False)
+        )
+        # Decoding options for bytes.
+        self.assertEqual(
+            canonicalize_python_string_inputs(b"a\xffb", errors="ignore"),
+            (["ab"], False),
+        )
+        with self.assertRaises(ValueError):
+            canonicalize_python_string_inputs(b"a\xffb")
+        with self.assertRaises(ValueError):
+            canonicalize_python_string_inputs([1, 2])
+        with self.assertRaises(ValueError):
+            canonicalize_python_string_inputs(np.array([["a"], ["b"]]))
+
+    def test_token_inputs(self):
+        self.assertEqual(canonicalize_python_token_inputs(1), ([[1]], False))
+        self.assertEqual(
+            canonicalize_python_token_inputs([1, 2]), ([[1, 2]], False)
+        )
+        self.assertEqual(canonicalize_python_token_inputs([]), ([[]], False))
+        self.assertEqual(
+            canonicalize_python_token_inputs([[1, 2], [3]]),
+            ([[1, 2], [3]], True),
+        )
+        self.assertEqual(
+            canonicalize_python_token_inputs(np.array(1)), ([[1]], False)
+        )
+        self.assertEqual(
+            canonicalize_python_token_inputs(np.array([1, 2])),
+            ([[1, 2]], False),
+        )
+        self.assertEqual(
+            canonicalize_python_token_inputs(np.array([[1, 2], [3, 4]])),
+            ([[1, 2], [3, 4]], True),
+        )
+        self.assertEqual(
+            canonicalize_python_token_inputs(ops.array([[1, 2], [3, 4]])),
+            ([[1, 2], [3, 4]], True),
+        )
+        self.assertEqual(
+            canonicalize_python_token_inputs(tf.constant([1, 2])),
+            ([[1, 2]], False),
+        )
+        self.assertEqual(
+            canonicalize_python_token_inputs(tf.ragged.constant([[1, 2], [3]])),
+            ([[1, 2], [3]], True),
+        )
+        with self.assertRaises(ValueError):
+            canonicalize_python_token_inputs(np.zeros((1, 1, 1)))
+        with self.assertRaises(ValueError):
+            canonicalize_python_token_inputs("a")
+
+
+class CasefoldUtf8Test(TestCase):
+    def test_matches_nfkc_casefold(self):
+        # NFKC normalization plus full case folding.
+        self.assertEqual(casefold_utf8("HeLlO"), "hello")
+        self.assertEqual(casefold_utf8("ß ẞ"), "ss ss")
+        self.assertEqual(casefold_utf8("ﬁsh ǅ"), "fish dž")
+        self.assertEqual(casefold_utf8("ΣΑΣ"), "σασ")
+        self.assertEqual(casefold_utf8("Ａ①"), "a1")
+        # Default ignorable code points are removed.
+        self.assertEqual(casefold_utf8("a\u200bb\u00adc\u200d d"), "abc d")
+        self.assertEqual(casefold_utf8("é"), "é")
+
+
+class GetDecodeErrorsNameTest(TestCase):
+    def test_builtin_handlers(self):
+        self.assertEqual(get_decode_errors_name("strict"), "strict")
+        self.assertEqual(get_decode_errors_name("ignore"), "ignore")
+        self.assertEqual(get_decode_errors_name("replace"), "replace")
+        self.assertEqual(get_decode_errors_name("replace", 65533), "replace")
+
+    def test_custom_replacement_char(self):
+        errors = get_decode_errors_name("replace", 88)
+        self.assertEqual(b"he\xe2\x96llo".decode("utf-8", errors), "heXllo")
+        self.assertEqual(b"\xff\xff".decode("utf-8", errors), "XX")
+        # The handler is registered once and reused.
+        self.assertEqual(get_decode_errors_name("replace", 88), errors)


### PR DESCRIPTION
**WordPieceTokenizer** - tokenize/detokenize path
In keras_hub/src/tokenizers/word_piece_tokenizer.py, implement _tokenize_python
Implement _detokenize_python
Constructor: don't require tf-text (_allow_python_workflow=True default, match byte_pair_tokenizer.py).

**ByteTokenizer**
Follow the pattern from byte_pair_tokenizer.py (_allow_python_workflow, in_tf_function() guard). Respect sequence_length (pad/truncate) and normalization_form (unicodedata.normalize) options.

**UnicodeCodepointTokenizer**
Same as ByteTokenizer. Python equivalent: [ord(c) for c in s] after the configured normalization .  detokenize via "".join(chr(i)) honoring errors/replacement_char, vocabulary_size clamping, and sequence_length.

