### PR TITLE
[PyGrain Migration] Add pure Python paths to audio converters for Grain pipelines

### DIFF
--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -10,6 +10,7 @@ from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.gemma3n.gemma3n_backbone import Gemma3nBackbone
 from keras_hub.src.utils.audio_utils import frame_signal
+from keras_hub.src.utils.audio_utils import hann_window
 from keras_hub.src.utils.tensor_utils import (
     convert_preprocessing_outputs_python,
 )
@@ -178,9 +179,8 @@ class Gemma3nAudioConverter(AudioConverter):
         if self.fft_overdrive:
             fft_length *= 2
         self.fft_length = fft_length
-        hann_arange = np.arange(self.frame_length, dtype=self.compute_dtype)
-        self.window = 0.5 * (
-            1 - np.cos(2 * np.pi * hann_arange / self.frame_length)
+        self.window = hann_window(
+            self.frame_length, periodic=True, dtype=self.compute_dtype
         )
         self.mel_filters = self._create_filterbank_matrix(
             n_freqs=self.fft_length // 2 + 1,

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter.py
@@ -9,6 +9,13 @@ except ImportError:
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.gemma3n.gemma3n_backbone import Gemma3nBackbone
+from keras_hub.src.utils.audio_utils import frame_signal
+from keras_hub.src.utils.tensor_utils import (
+    convert_preprocessing_outputs_python,
+)
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
+from keras_hub.src.utils.tensor_utils import in_tf_function
+from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 
 @keras_hub_export("keras_hub.layers.Gemma3nAudioConverter")
@@ -144,7 +151,10 @@ class Gemma3nAudioConverter(AudioConverter):
         **kwargs,
     ):
         # === Config ===
-        super().__init__(**kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
         self.feature_size = feature_size
         self.sampling_rate = sampling_rate
         self.padding_value = padding_value
@@ -168,9 +178,9 @@ class Gemma3nAudioConverter(AudioConverter):
         if self.fft_overdrive:
             fft_length *= 2
         self.fft_length = fft_length
-        hann_arange = tf.range(self.frame_length, dtype=self.compute_dtype)
+        hann_arange = np.arange(self.frame_length, dtype=self.compute_dtype)
         self.window = 0.5 * (
-            1 - tf.cos(2 * np.pi * hann_arange / self.frame_length)
+            1 - np.cos(2 * np.pi * hann_arange / self.frame_length)
         )
         self.mel_filters = self._create_filterbank_matrix(
             n_freqs=self.fft_length // 2 + 1,
@@ -193,7 +203,7 @@ class Gemma3nAudioConverter(AudioConverter):
         sample_rate,
         fft_length,
     ):
-        all_freqs = tf.cast(tf.range(n_freqs), dtype=self.compute_dtype) * (
+        all_freqs = np.arange(n_freqs, dtype=self.compute_dtype) * (
             sample_rate / fft_length
         )
         # HTK mel-scale formula:
@@ -207,21 +217,20 @@ class Gemma3nAudioConverter(AudioConverter):
         m_max = 2595.0 * math.log10(1.0 + (f_max / 700.0))
         m_pts = np.linspace(m_min, m_max, n_mels + 2, dtype=np.float32)
         f_pts = 700.0 * (10 ** (m_pts / 2595.0) - 1.0)
-        f_pts = tf.constant(f_pts, dtype=self.compute_dtype)
+        f_pts = f_pts.astype(self.compute_dtype)
         f_diff = f_pts[1:] - f_pts[:-1]
-        slopes = tf.expand_dims(f_pts, 0) - tf.expand_dims(all_freqs, 1)
-        zero = tf.zeros(1, dtype=self.compute_dtype)
+        slopes = np.expand_dims(f_pts, 0) - np.expand_dims(all_freqs, 1)
         down_slopes = (-1.0 * slopes[:, :-2]) / f_diff[:-1]
         up_slopes = slopes[:, 2:] / f_diff[1:]
-        fb = tf.maximum(zero, tf.minimum(down_slopes, up_slopes))
-        return tf.constant(fb, dtype=self.compute_dtype)
+        fb = np.maximum(0.0, np.minimum(down_slopes, up_slopes))
+        return fb.astype(self.compute_dtype)
 
     def _extract_spectrogram(self, waveform, attention_mask):
-        waveform = tf.cast(waveform, dtype=self.compute_dtype)
+        waveform = np.asarray(waveform, dtype=self.compute_dtype)
         if self.dither > 0.0:
-            waveform = waveform + self.dither * tf.random.normal(
-                tf.shape(waveform), dtype=waveform.dtype
-            )
+            waveform = waveform + self.dither * np.random.default_rng(
+                None
+            ).standard_normal(waveform.shape).astype(waveform.dtype)
         if self.input_scale_factor != 1.0:
             waveform = waveform * self.input_scale_factor
         if self.preemphasis > 0.0:
@@ -230,47 +239,42 @@ class Gemma3nAudioConverter(AudioConverter):
                 rest_of_samples = (
                     waveform[:, 1:] - self.preemphasis * waveform[:, :-1]
                 )
-                waveform = tf.concat([first_sample, rest_of_samples], axis=-1)
+                waveform = np.concatenate(
+                    [first_sample, rest_of_samples], axis=-1
+                )
             else:
-                waveform = tf.concat(
+                waveform = np.concatenate(
                     [
                         waveform[:, :1],
                         waveform[:, 1:] - self.preemphasis * waveform[:, :-1],
                     ],
                     axis=-1,
                 )
-        frames = tf.signal.frame(
-            waveform,
-            frame_length=self.frame_length,
-            frame_step=self.hop_length,
-            pad_end=False,
-        )
+        frames = frame_signal(waveform, self.frame_length, self.hop_length)
         frames = frames * self.window
         pad_length = self.fft_length - self.frame_length
-        paddings = [[0, 0], [0, 0], [0, pad_length]]
-        frames = tf.pad(frames, paddings)
-        stft = tf.signal.rfft(frames)
-        magnitude_spec = tf.abs(stft)
-        mel_spec = tf.matmul(magnitude_spec, self.mel_filters)
-        mel_floor_tensor = tf.constant(self.mel_floor, dtype=self.compute_dtype)
-        log_mel_spec = tf.math.log(tf.maximum(mel_spec, mel_floor_tensor))
+        frames = np.pad(frames, ((0, 0), (0, 0), (0, pad_length)))
+        stft = np.fft.rfft(frames, n=self.fft_length, axis=-1)
+        magnitude_spec = np.abs(stft)
+        mel_spec = np.matmul(magnitude_spec, self.mel_filters)
+        log_mel_spec = np.log(np.maximum(mel_spec, self.mel_floor))
         if self.per_bin_mean is not None:
-            per_bin_mean_tensor = tf.constant(
-                self.per_bin_mean,
-                shape=(1, 1, self.feature_size),
-                dtype=self.compute_dtype,
+            per_bin_mean = np.reshape(
+                np.asarray(self.per_bin_mean, dtype=self.compute_dtype),
+                (1, 1, self.feature_size),
             )
-            log_mel_spec = log_mel_spec - per_bin_mean_tensor
+            log_mel_spec = log_mel_spec - per_bin_mean
         if self.per_bin_stddev is not None:
-            per_bin_stddev_tensor = tf.constant(
-                self.per_bin_stddev,
-                shape=(1, 1, self.feature_size),
-                dtype=self.compute_dtype,
+            per_bin_stddev = np.reshape(
+                np.asarray(self.per_bin_stddev, dtype=self.compute_dtype),
+                (1, 1, self.feature_size),
             )
-            log_mel_spec = log_mel_spec / per_bin_stddev_tensor
-        mel_spectrogram = tf.squeeze(log_mel_spec, axis=0)
-        mask = tf.cast(attention_mask[:: self.hop_length], dtype=tf.bool)
-        return mel_spectrogram, mask[: tf.shape(mel_spectrogram)[0]]
+            log_mel_spec = log_mel_spec / per_bin_stddev
+        mel_spectrogram = np.squeeze(log_mel_spec, axis=0).astype(
+            self.compute_dtype
+        )
+        mask = np.asarray(attention_mask[:: self.hop_length], dtype="bool")
+        return mel_spectrogram, mask[: mel_spectrogram.shape[0]]
 
     def _get_padding_strategies(self, padding=False, max_length=None):
         if padding is not False:
@@ -444,7 +448,76 @@ class Gemma3nAudioConverter(AudioConverter):
             return batch_outputs_features, None
         return batch_outputs_features, batch_outputs_masks
 
-    def call(
+    def _process_python(
+        self,
+        raw_speech,
+        padding="longest",
+        max_length=480000,
+        truncation=True,
+        pad_to_multiple_of=128,
+        return_attention_mask=True,
+    ):
+        """Run the full NumPy feature extraction pipeline.
+
+        Returns a `(input_features, input_features_mask)` tuple of NumPy
+        arrays, where the mask is a boolean array.
+        """
+        raw_speech_np = np.asarray(raw_speech)
+        is_batched = raw_speech_np.ndim > 1
+        if is_batched:
+            speech_list = [rs.reshape(-1, 1) for rs in raw_speech_np]
+        else:
+            raw_speech_np = np.atleast_1d(raw_speech_np)
+            speech_list = [raw_speech_np.reshape(-1, 1)]
+        input_features_list, attention_mask_list = self.pad(
+            speech_list,
+            padding=padding,
+            max_length=max_length,
+            truncation=truncation,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_attention_mask=return_attention_mask,
+        )
+        prepared_speech = []
+        prepared_speech_mask = []
+        for speech, mask in zip(input_features_list, attention_mask_list):
+            features, feature_mask = self._extract_spectrogram(
+                np.asarray(speech.T, dtype=self.compute_dtype),
+                np.asarray(mask, dtype="int32"),
+            )
+            prepared_speech.append(features)
+            prepared_speech_mask.append(feature_mask)
+        input_features = np.stack(prepared_speech)
+        input_features_mask = np.stack(prepared_speech_mask)
+        if not is_batched:
+            input_features = np.squeeze(input_features, axis=0)
+            input_features_mask = np.squeeze(input_features_mask, axis=0)
+        return input_features, input_features_mask
+
+    def _call_python(
+        self,
+        raw_speech,
+        padding="longest",
+        max_length=480000,
+        truncation=True,
+        pad_to_multiple_of=128,
+        return_attention_mask=True,
+    ):
+        raw_speech = convert_to_numpy(raw_speech)
+        input_features, input_features_mask = self._process_python(
+            raw_speech,
+            padding=padding,
+            max_length=max_length,
+            truncation=truncation,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_attention_mask=return_attention_mask,
+        )
+        input_features_mask = input_features_mask.astype("int32")
+        return convert_preprocessing_outputs_python(
+            (input_features, input_features_mask)
+        )
+
+    @preprocessing_function
+    def _call_tf(
         self,
         raw_speech,
         padding="longest",
@@ -454,37 +527,14 @@ class Gemma3nAudioConverter(AudioConverter):
         return_attention_mask=True,
     ):
         def _process_in_py(raw_speech_tensor):
-            raw_speech_np = raw_speech_tensor.numpy()
-            is_batched = raw_speech_np.ndim > 1
-            if is_batched:
-                speech_list = [rs.reshape(-1, 1) for rs in raw_speech_np]
-            else:
-                raw_speech_np = np.atleast_1d(raw_speech_np)
-                speech_list = [raw_speech_np.reshape(-1, 1)]
-            input_features_list, attention_mask_list = self.pad(
-                speech_list,
+            return self._process_python(
+                raw_speech_tensor.numpy(),
                 padding=padding,
                 max_length=max_length,
                 truncation=truncation,
                 pad_to_multiple_of=pad_to_multiple_of,
                 return_attention_mask=return_attention_mask,
             )
-            prepared_speech = []
-            prepared_speech_mask = []
-            for speech, mask in zip(input_features_list, attention_mask_list):
-                speech_tensor = tf.constant(speech.T, dtype=self.compute_dtype)
-                mask_tensor = tf.constant(mask, dtype=tf.int32)
-                features, feature_mask = self._extract_spectrogram(
-                    speech_tensor, mask_tensor
-                )
-                prepared_speech.append(features)
-                prepared_speech_mask.append(feature_mask)
-            input_features = tf.stack(prepared_speech)
-            input_features_mask = tf.stack(prepared_speech_mask)
-            if not is_batched:
-                input_features = tf.squeeze(input_features, axis=0)
-                input_features_mask = tf.squeeze(input_features_mask, axis=0)
-            return input_features, input_features_mask
 
         if not isinstance(raw_speech, (tf.Tensor, tf.RaggedTensor)):
             was_batched = isinstance(raw_speech, (list, tuple))
@@ -507,6 +557,27 @@ class Gemma3nAudioConverter(AudioConverter):
             input_features_mask.set_shape([num_frames])
         input_features_mask = tf.cast(input_features_mask, dtype="int32")
         return input_features, input_features_mask
+
+    def call(
+        self,
+        raw_speech,
+        padding="longest",
+        max_length=480000,
+        truncation=True,
+        pad_to_multiple_of=128,
+        return_attention_mask=True,
+    ):
+        kwargs = {
+            "padding": padding,
+            "max_length": max_length,
+            "truncation": truncation,
+            "pad_to_multiple_of": pad_to_multiple_of,
+            "return_attention_mask": return_attention_mask,
+        }
+        if not self._allow_python_workflow or in_tf_function():
+            return self._call_tf(raw_speech, **kwargs)
+        else:
+            return self._call_python(raw_speech, **kwargs)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
+++ b/keras_hub/src/models/gemma3n/gemma3n_audio_converter_test.py
@@ -1,3 +1,4 @@
+import grain
 import numpy as np
 
 from keras_hub.src.models.gemma3n.gemma3n_audio_converter import (
@@ -121,3 +122,26 @@ class Gemma3nAudioConverterTest(TestCase):
     def test_serialization(self):
         instance = Gemma3nAudioConverter(**self.init_kwargs)
         self.run_serialization_test(instance=instance)
+
+    def test_python_matches_tf(self):
+        converter = Gemma3nAudioConverter(**self.init_kwargs)
+        audio = self.input_data[0][:4000]
+        py_features, py_mask = converter._call_python(audio)
+        tf_features, tf_mask = converter._call_tf(audio)
+        self.assertAllClose(py_features, tf_features)
+        self.assertAllEqual(py_mask, tf_mask)
+
+    def test_grain_outputs_numpy(self):
+        converter = Gemma3nAudioConverter(**self.init_kwargs)
+        samples = [self.input_data[0][:4000], self.input_data[0][:8000]]
+        ds = grain.MapDataset.source(samples).map(converter)
+        for sample, output in zip(samples, ds):
+            self.assertIsInstance(output, tuple)
+            features, mask = output
+            self.assertIsInstance(features, np.ndarray)
+            self.assertIsInstance(mask, np.ndarray)
+            self.assertEqual(features.shape[-1], self.feature_size)
+            self.assertEqual(features.shape[0], mask.shape[0])
+            expected_features, expected_mask = converter(sample)
+            self.assertAllClose(features, expected_features)
+            self.assertAllEqual(mask, expected_mask)

--- a/keras_hub/src/models/gemma4/gemma4_audio_converter.py
+++ b/keras_hub/src/models/gemma4/gemma4_audio_converter.py
@@ -4,6 +4,12 @@ from keras import ops
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.utils.tensor_utils import (
+    convert_preprocessing_outputs_python,
+)
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
+from keras_hub.src.utils.tensor_utils import in_tf_function
+from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 
 @keras_hub_export("keras_hub.layers.Gemma4AudioConverter")
@@ -93,7 +99,10 @@ class Gemma4AudioConverter(AudioConverter):
         frame_length=320,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
 
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
@@ -121,17 +130,18 @@ class Gemma4AudioConverter(AudioConverter):
         # HTK mel filterbank: shape (num_fft_bins // 2 + 1, num_mels).
         self.mel_filters = self._get_mel_filters()
 
-        # Periodic Hann window matching HF
+        # Periodic Hann window matching HF. Kept as NumPy so the layer holds
+        # no backend tensors (Grain pickles layers into worker processes).
         length = self.frame_length + 1
         window = np.hanning(length)
-        self.window = ops.convert_to_tensor(window[:-1], dtype="float32")
+        self.window = window[:-1].astype("float32")
 
         # Precompute indices for manual framing
         num_frames = self.num_samples // self.stride
         one_frame_indices = np.arange(self.frame_length)
         start_indices = np.arange(num_frames) * self.stride
         indices = start_indices[:, None] + one_frame_indices[None, :]
-        self.indices = ops.convert_to_tensor(indices, dtype="int32")
+        self.indices = indices.astype("int32")
 
         self.built = True
 
@@ -187,13 +197,18 @@ class Gemma4AudioConverter(AudioConverter):
         paddings = [[0, 0], [pad_left, 0]]
         audio = ops.pad(audio, paddings, mode="constant")
 
+        # `self.indices` and `self.window` are NumPy constants; materialize
+        # them as tensors for the graph/backend path.
+        indices = ops.convert_to_tensor(self.indices)
+        window = ops.cast(
+            ops.convert_to_tensor(self.window), self.compute_dtype
+        )
+
         def true_fn():
             max_idx = ops.shape(audio)[1]
-            safe_indices = ops.minimum(
-                self.indices, ops.maximum(max_idx - 1, 0)
-            )
+            safe_indices = ops.minimum(indices, ops.maximum(max_idx - 1, 0))
             frames = ops.take(audio, safe_indices, axis=1)
-            out_of_bounds = self.indices >= max_idx
+            out_of_bounds = indices >= max_idx
             out_of_bounds = ops.expand_dims(out_of_bounds, axis=0)
             return ops.where(out_of_bounds, ops.cast(0.0, frames.dtype), frames)
 
@@ -208,7 +223,7 @@ class Gemma4AudioConverter(AudioConverter):
         frames = ops.cond(max_idx > 0, true_fn, false_fn)
 
         # Apply window
-        frames = frames * self.window
+        frames = frames * window
 
         # Zero-pad to fft_length
         padding = self.num_fft_bins - self.frame_length
@@ -267,17 +282,80 @@ class Gemma4AudioConverter(AudioConverter):
         num_frames = self.num_samples // self.stride
         return (num_frames, self.num_mels)
 
-    def call(self, audio):
-        """Convert raw waveform(s) to log-mel spectrogram features.
+    def _extract_audio_features_python(self, audio):
+        """NumPy equivalent of `_extract_audio_features`.
 
         Args:
-            audio: array of shape ``(num_samples,)`` or
-                ``(batch_size, num_samples)``.
+            audio: NumPy array of shape ``(batch_size, num_samples)``.
 
         Returns:
-            Log-mel spectrogram of shape ``(num_frames, num_mels)`` or
-            ``(batch_size, num_frames, num_mels)``.
+            NumPy array of shape ``(batch_size, num_frames, num_mels)``.
         """
+        # Pad left by frame_length // 2 for semicausal padding
+        pad_left = self.frame_length // 2
+        audio = np.pad(audio, ((0, 0), (pad_left, 0)), mode="constant")
+
+        # Framing with zeros for out of bounds indices.
+        max_idx = audio.shape[1]
+        safe_indices = np.minimum(self.indices, max(max_idx - 1, 0))
+        frames = audio[:, safe_indices]
+        frames = np.where(self.indices[None, ...] >= max_idx, 0.0, frames)
+
+        # Apply window
+        frames = frames * self.window
+
+        # Zero-pad to fft_length
+        padding = self.num_fft_bins - self.frame_length
+        if padding > 0:
+            frames = np.pad(frames, ((0, 0), (0, 0), (0, padding)))
+        else:
+            frames = frames[..., : self.num_fft_bins]
+
+        # Magnitude spectrum of the real FFT.
+        magnitudes = np.abs(np.fft.rfft(frames, n=self.num_fft_bins, axis=-1))
+
+        # Mel filterbank matmul: (batch, num_frames, fft_bins) @
+        #   (fft_bins, num_mels) → (batch, num_frames, num_mels)
+        mel_spec = np.matmul(magnitudes, self.mel_filters)
+
+        # Log compression.
+        log_spec = np.log(mel_spec + self.mel_floor)
+
+        # Optional per-bin mean / stddev normalisation.
+        if self.per_bin_mean is not None:
+            mean = np.array(self.per_bin_mean, dtype="float32").reshape(
+                1, 1, -1
+            )
+            log_spec = log_spec - mean
+        if self.per_bin_stddev is not None:
+            stddev = np.array(self.per_bin_stddev, dtype="float32").reshape(
+                1, 1, -1
+            )
+            log_spec = log_spec / stddev
+
+        return log_spec.astype(self.compute_dtype)
+
+    def _call_python(self, audio):
+        audio = convert_to_numpy(audio)
+        audio = np.asarray(audio, dtype=self.compute_dtype)
+        rank_1_input = audio.ndim == 1
+        if rank_1_input:
+            audio = np.expand_dims(audio, axis=0)
+
+        # Trim to num_samples, then zero-pad any remaining deficit.
+        audio = audio[:, : self.num_samples]
+        padding = self.num_samples - audio.shape[1]
+        audio = np.pad(audio, ((0, 0), (0, padding)))
+
+        log_spec = self._extract_audio_features_python(audio)
+
+        if rank_1_input:
+            log_spec = np.squeeze(log_spec, axis=0)
+
+        return convert_preprocessing_outputs_python(log_spec)
+
+    @preprocessing_function
+    def _call_tf(self, audio):
         audio = ops.convert_to_tensor(audio, dtype=self.compute_dtype)
         rank_1_input = len(ops.shape(audio)) == 1
         if rank_1_input:
@@ -295,6 +373,22 @@ class Gemma4AudioConverter(AudioConverter):
             log_spec = ops.squeeze(log_spec, axis=0)
 
         return log_spec
+
+    def call(self, audio):
+        """Convert raw waveform(s) to log-mel spectrogram features.
+
+        Args:
+            audio: array of shape ``(num_samples,)`` or
+                ``(batch_size, num_samples)``.
+
+        Returns:
+            Log-mel spectrogram of shape ``(num_frames, num_mels)`` or
+            ``(batch_size, num_frames, num_mels)``.
+        """
+        if not self._allow_python_workflow or in_tf_function():
+            return self._call_tf(audio)
+        else:
+            return self._call_python(audio)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/models/gemma4/gemma4_audio_converter.py
+++ b/keras_hub/src/models/gemma4/gemma4_audio_converter.py
@@ -4,6 +4,7 @@ from keras import ops
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+from keras_hub.src.utils.audio_utils import hann_window
 from keras_hub.src.utils.tensor_utils import (
     convert_preprocessing_outputs_python,
 )
@@ -132,9 +133,9 @@ class Gemma4AudioConverter(AudioConverter):
 
         # Periodic Hann window matching HF. Kept as NumPy so the layer holds
         # no backend tensors (Grain pickles layers into worker processes).
-        length = self.frame_length + 1
-        window = np.hanning(length)
-        self.window = window[:-1].astype("float32")
+        self.window = hann_window(
+            self.frame_length, periodic=True, dtype="float32"
+        )
 
         # Precompute indices for manual framing
         num_frames = self.num_samples // self.stride

--- a/keras_hub/src/models/gemma4/gemma4_audio_converter_test.py
+++ b/keras_hub/src/models/gemma4/gemma4_audio_converter_test.py
@@ -1,3 +1,4 @@
+import grain
 import numpy as np
 from keras import ops
 
@@ -183,3 +184,36 @@ class Gemma4AudioConverterTest(TestCase):
         # num_frames = (16000 * 30) // 160 = 3000
         self.assertEqual(out.shape[-1], 128)
         self.assertEqual(out.shape[-2], 3000)
+
+    def test_python_matches_tf(self):
+        converter = Gemma4AudioConverter(**self.init_kwargs)
+        waveform = (
+            np.random.default_rng(42)
+            .standard_normal((2, self.num_samples))
+            .astype("float32")
+        )
+        # Silent mel bins sit exactly at the log floor, where the float32 TF
+        # FFT and the float64 NumPy FFT differ in the last digits, so compare
+        # with a relaxed tolerance.
+        self.assertAllClose(
+            converter._call_python(waveform),
+            converter._call_tf(waveform),
+            atol=1e-2,
+        )
+
+    def test_grain_outputs_numpy(self):
+        converter = Gemma4AudioConverter(**self.init_kwargs)
+        rng = np.random.default_rng(42)
+        samples = [
+            rng.standard_normal(self.num_samples).astype("float32")
+            for _ in range(2)
+        ]
+        ds = grain.MapDataset.source(samples).map(converter)
+        for sample, output in zip(samples, ds):
+            self.assertIsInstance(output, np.ndarray)
+            self.assertEqual(output.shape, (self.num_frames, 8))
+            self.assertAllClose(output, converter(sample))
+        (batch,) = list(ds.batch(2))
+        self.assertIsInstance(batch, np.ndarray)
+        self.assertEqual(batch.shape, (2, self.num_frames, 8))
+        self.assertAllClose(batch, converter(np.stack(samples)))

--- a/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
+++ b/keras_hub/src/models/gemma4/gemma4_causal_lm_preprocessor.py
@@ -597,9 +597,10 @@ class Gemma4CausalLMPreprocessor(CausalLMPreprocessor):
 
         # The audio converter runs as a Keras layer and may return a CUDA
         # torch tensor on GPU. Move to CPU so subsequent TF ops can accept it
-        # (mirrors the same guard in _preprocess_images).
+        # (mirrors the same guard in _preprocess_images). The Python path
+        # already returns NumPy, which has no `.cpu()`.
         if keras.config.backend() == "torch":
-            if not isinstance(mel, tf.Tensor):
+            if hasattr(mel, "cpu"):
                 mel = mel.cpu()
 
         # Expand dims to model expectation of Clips step: (B, 1, Seq, Feat)

--- a/keras_hub/src/models/moonshine/moonshine_audio_converter.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_converter.py
@@ -1,4 +1,5 @@
 import keras
+import numpy as np
 
 try:
     import tensorflow as tf
@@ -8,6 +9,12 @@ except ImportError:
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.moonshine.moonshine_backbone import MoonshineBackbone
+from keras_hub.src.utils.tensor_utils import (
+    convert_preprocessing_outputs_python,
+)
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
+from keras_hub.src.utils.tensor_utils import in_tf_function
+from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 
 @keras_hub_export("keras_hub.layers.MoonshineAudioConverter")
@@ -87,14 +94,18 @@ class MoonshineAudioConverter(AudioConverter):
         do_normalize=False,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
         self.sampling_rate = sampling_rate
         self.padding_value = padding_value
         self.do_normalize = do_normalize
 
-    def call(
+    @preprocessing_function
+    def _call_tf(
         self,
         inputs,
         sampling_rate=None,
@@ -281,6 +292,93 @@ class MoonshineAudioConverter(AudioConverter):
             )
 
         return processed_inputs
+
+    def _call_python(
+        self,
+        inputs,
+        sampling_rate=None,
+        padding=None,
+        max_length=None,
+        pad_to_multiple_of=None,
+    ):
+        # Validate sampling rate.
+        if sampling_rate is not None and sampling_rate != self.sampling_rate:
+            raise ValueError(
+                f"Expected sampling_rate {self.sampling_rate}, got "
+                f"{sampling_rate}"
+            )
+
+        processed_inputs = np.asarray(convert_to_numpy(inputs))
+        # Ensure inputs are (batch_size, time_steps, 1).
+        if processed_inputs.ndim == 2:
+            processed_inputs = np.expand_dims(processed_inputs, axis=-1)
+        elif processed_inputs.ndim != 3:
+            raise ValueError(
+                "Inputs must be mono audio: (batch_size, time_steps, 1)"
+            )
+
+        # Get original length and validate duration.
+        original_length = processed_inputs.shape[1]
+        duration = original_length / self.sampling_rate
+        # Source: https://github.com/usefulsensors/moonshine/blob/4a000427bd36a1c2c6d20a86c672dbd850b44c88/moonshine/transcribe.py#L20
+        if duration < 0.1 or duration > 64.0:
+            import warnings
+
+            warnings.warn(
+                "Audio duration must be between 0.1 and 64 seconds. For "
+                "transcribing longer segments, pre-segment your audio and "
+                "provide shorter segments."
+            )
+
+        # Handle padding.
+        target_length = None
+        if padding == "longest":
+            target_length = original_length
+        elif padding == "max_length" and max_length is not None:
+            target_length = max_length
+        if target_length is not None and pad_to_multiple_of:
+            target_length = (
+                (target_length + pad_to_multiple_of - 1) // pad_to_multiple_of
+            ) * pad_to_multiple_of
+        if target_length is not None:
+            if original_length < target_length:
+                padding_amount = target_length - original_length
+                processed_inputs = np.pad(
+                    processed_inputs,
+                    ((0, 0), (0, padding_amount), (0, 0)),
+                    mode="constant",
+                    constant_values=self.padding_value,
+                )
+            elif original_length > target_length and padding == "max_length":
+                processed_inputs = processed_inputs[:, :target_length, :]
+
+        # Normalize if enabled.
+        if self.do_normalize:
+            mean = np.mean(processed_inputs, axis=1, keepdims=True)
+            var = np.var(processed_inputs, axis=1, keepdims=True)
+            processed_inputs = (processed_inputs - mean) / np.sqrt(var + 1e-7)
+
+        processed_inputs = processed_inputs.astype(self.compute_dtype)
+        return convert_preprocessing_outputs_python(processed_inputs)
+
+    def call(
+        self,
+        inputs,
+        sampling_rate=None,
+        padding=None,
+        max_length=None,
+        pad_to_multiple_of=None,
+    ):
+        kwargs = {
+            "sampling_rate": sampling_rate,
+            "padding": padding,
+            "max_length": max_length,
+            "pad_to_multiple_of": pad_to_multiple_of,
+        }
+        if not self._allow_python_workflow or in_tf_function():
+            return self._call_tf(inputs, **kwargs)
+        else:
+            return self._call_python(inputs, **kwargs)
 
     def compute_output_shape(self, input_shape):
         # [batch_size, time_steps] → [batch_size, time_steps, 1].

--- a/keras_hub/src/models/moonshine/moonshine_audio_converter_test.py
+++ b/keras_hub/src/models/moonshine/moonshine_audio_converter_test.py
@@ -1,3 +1,4 @@
+import grain
 import keras
 import numpy as np
 
@@ -95,3 +96,36 @@ class MoonshineAudioConverterTest(TestCase):
     def test_serialization(self):
         instance = MoonshineAudioConverter(**self.init_kwargs)
         self.run_serialization_test(instance=instance)
+
+    def test_python_matches_tf(self):
+        converter = MoonshineAudioConverter(
+            **{**self.init_kwargs, "do_normalize": True}
+        )
+        audio = (
+            np.random.default_rng(42)
+            .random((2, self.sampling_rate, 1))
+            .astype("float32")
+        )
+        self.assertAllClose(
+            converter._call_python(audio), converter._call_tf(audio)
+        )
+        self.assertAllClose(
+            converter._call_python(audio, padding="max_length", max_length=100),
+            converter._call_tf(audio, padding="max_length", max_length=100),
+        )
+
+    def test_grain_outputs_numpy(self):
+        converter = MoonshineAudioConverter(**self.init_kwargs)
+        rng = np.random.default_rng(42)
+        samples = [
+            rng.random((1, self.sampling_rate, 1)).astype("float32")
+            for _ in range(2)
+        ]
+        ds = grain.MapDataset.source(samples).map(converter)
+        for sample, output in zip(samples, ds):
+            self.assertIsInstance(output, np.ndarray)
+            self.assertEqual(output.shape, (1, self.sampling_rate, 1))
+            self.assertAllClose(output, converter(sample))
+        (batch,) = list(ds.batch(2))
+        self.assertIsInstance(batch, np.ndarray)
+        self.assertEqual(batch.shape, (2, 1, self.sampling_rate, 1))

--- a/keras_hub/src/models/whisper/whisper_audio_converter.py
+++ b/keras_hub/src/models/whisper/whisper_audio_converter.py
@@ -3,6 +3,14 @@ import numpy as np
 from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.audio_converter import AudioConverter
 from keras_hub.src.models.whisper.whisper_backbone import WhisperBackbone
+from keras_hub.src.utils.audio_utils import frame_signal
+from keras_hub.src.utils.audio_utils import hann_window
+from keras_hub.src.utils.tensor_utils import (
+    convert_preprocessing_outputs_python,
+)
+from keras_hub.src.utils.tensor_utils import convert_to_numpy
+from keras_hub.src.utils.tensor_utils import in_tf_function
+from keras_hub.src.utils.tensor_utils import preprocessing_function
 
 try:
     import tensorflow as tf
@@ -63,7 +71,10 @@ class WhisperAudioConverter(AudioConverter):
         max_audio_length=30,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            _allow_python_workflow=_allow_python_workflow, **kwargs
+        )
 
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
@@ -90,7 +101,8 @@ class WhisperAudioConverter(AudioConverter):
         (https://github.com/huggingface/transformers/blob/v4.27.1/src/transformers/models/whisper/feature_extraction_whisper.py#L86)
         """
 
-        # TODO: Convert to TensorFlow ops (if possible).
+        # This is deliberately computed with NumPy. The filterbank is a
+        # constant, and NumPy keeps it usable without TensorFlow installed.
 
         dtype = np.float32
         # Initialize the weights
@@ -145,7 +157,10 @@ class WhisperAudioConverter(AudioConverter):
         weights *= enorm[:, np.newaxis]
 
         weights = np.transpose(weights)
-        return tf.constant(weights, dtype=self.compute_dtype)
+        # Keep the filterbank as NumPy. Both the TF and the Python paths cast
+        # it to the compute dtype when it is used, and a NumPy array can be
+        # pickled into Grain worker processes.
+        return weights.astype(dtype)
 
     def _extract_audio_features(self, audio):
         audio = tf.cast(audio, self.compute_dtype)
@@ -168,7 +183,7 @@ class WhisperAudioConverter(AudioConverter):
 
         mel_spec = tf.matmul(
             magnitudes,
-            self.mel_filters,
+            tf.constant(self.mel_filters, dtype=self.compute_dtype),
         )
 
         def tf_log10(x):
@@ -208,7 +223,77 @@ class WhisperAudioConverter(AudioConverter):
 
         return log_spec
 
-    def call(self, audio):
+    def _extract_audio_features_python(self, audio):
+        """NumPy equivalent of `_extract_audio_features`."""
+        dtype = self.compute_dtype
+        # Use "reflection" padding - `tf.signal.stft` uses symmetric padding
+        # internally.
+        pad_width = self.num_fft_bins // 2
+        audio = np.pad(audio, ((0, 0), (pad_width, pad_width)), mode="reflect")
+
+        # Compute the mel spectrogram.
+        frames = frame_signal(audio, self.num_fft_bins, self.stride)
+        frames = frames * hann_window(self.num_fft_bins, dtype="float64")
+        stft = np.fft.rfft(frames, n=self.num_fft_bins, axis=-1)
+        magnitudes = np.square(np.abs(stft[:, :-1, :]))
+
+        mel_spec = np.matmul(magnitudes, self.mel_filters)
+
+        # Clamp the values to a minimum value of 1e-10. This is done to avoid
+        # taking the log of 0, i.e., for numerical stability.
+        mel_spec = np.maximum(mel_spec, 1e-10)
+
+        # Calculate the log mel spectrogram.
+        log_spec = np.log10(mel_spec)
+        # Dynamic range compression.
+        max_value_minus_eight = np.max(log_spec, axis=(1, 2), keepdims=True) - 8
+        log_spec = np.maximum(log_spec, max_value_minus_eight)
+        # Normalization.
+        log_spec = (log_spec + 4.0) / 4.0
+
+        return log_spec.astype(dtype)
+
+    def _to_batched_array(self, audio):
+        """Convert any supported input to a dense `(batch, num_samples)` array.
+
+        Returns the padded/trimmed waveform batch and whether the input was
+        unbatched.
+        """
+        if tf is not None and isinstance(audio, tf.RaggedTensor):
+            rows, unbatched = audio.to_list(), False
+        else:
+            try:
+                array = convert_to_numpy(audio)
+            except ValueError:
+                # A ragged list of waveforms cannot be made rectangular.
+                array = None
+            if array is None or array.dtype == object:
+                rows, unbatched = list(audio), False
+            elif array.ndim == 1:
+                rows, unbatched = [array], True
+            else:
+                rows, unbatched = list(array), False
+
+        batch = np.zeros(
+            (len(rows), self.num_samples), dtype=self.compute_dtype
+        )
+        for i, row in enumerate(rows):
+            row = np.reshape(convert_to_numpy(row), (-1,))
+            row = row[: self.num_samples]
+            batch[i, : row.shape[0]] = row
+        return batch, unbatched
+
+    def _call_python(self, audio):
+        audio, rank_1_input = self._to_batched_array(audio)
+
+        # Find the log mel spectrogram.
+        log_spec = self._extract_audio_features_python(audio)
+        if rank_1_input:
+            log_spec = np.squeeze(log_spec, 0)
+        return convert_preprocessing_outputs_python(log_spec)
+
+    @preprocessing_function
+    def _call_tf(self, audio):
         if not isinstance(audio, (tf.Tensor, tf.RaggedTensor)):
             audio = tf.convert_to_tensor(audio)
 
@@ -230,6 +315,12 @@ class WhisperAudioConverter(AudioConverter):
         if rank_1_input:
             log_spec = tf.squeeze(log_spec, 0)
         return log_spec
+
+    def call(self, audio):
+        if not self._allow_python_workflow or in_tf_function():
+            return self._call_tf(audio)
+        else:
+            return self._call_python(audio)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/models/whisper/whisper_audio_converter_test.py
+++ b/keras_hub/src/models/whisper/whisper_audio_converter_test.py
@@ -1,3 +1,5 @@
+import grain
+import numpy as np
 import tensorflow as tf
 
 from keras_hub.src.models.whisper.whisper_audio_converter import (
@@ -38,3 +40,36 @@ class WhisperAudioConverterTest(TestCase):
         # Verify output.
         expected = [1.1656, 1.0151, -0.8343, -0.8343, -0.8343]
         self.assertAllClose(outputs[:, 0], expected, atol=0.01, rtol=0.01)
+
+    def test_python_matches_tf(self):
+        converter = WhisperAudioConverter(**self.init_kwargs)
+        audio = np.random.default_rng(42).random((2, 300)).astype("float32")
+        self.assertAllClose(
+            converter._call_python(audio),
+            converter._call_tf(audio),
+            atol=1e-4,
+        )
+
+    def test_grain_outputs_numpy(self):
+        converter = WhisperAudioConverter(**self.init_kwargs)
+        rng = np.random.default_rng(42)
+        samples = [
+            rng.random((300,)).astype("float32"),
+            rng.random((120,)).astype("float32"),
+        ]
+        # Unbatched source. Grain returns numpy arrays, not backend tensors.
+        ds = grain.MapDataset.source(samples).map(converter)
+        for sample, output in zip(samples, ds):
+            self.assertIsInstance(output, np.ndarray)
+            self.assertEqual(output.shape, (5, 80))
+            self.assertAllClose(output, converter(sample))
+        # Batching after the map gives the same result as a batched call.
+        (batch,) = list(ds.batch(2))
+        self.assertIsInstance(batch, np.ndarray)
+        self.assertEqual(batch.shape, (2, 5, 80))
+        # Batched source.
+        batched = np.stack(
+            [np.pad(sample, (0, 300 - sample.shape[0])) for sample in samples]
+        )
+        (output,) = list(grain.MapDataset.source([batched]).map(converter))
+        self.assertAllClose(output, batch)

--- a/keras_hub/src/utils/audio_utils.py
+++ b/keras_hub/src/utils/audio_utils.py
@@ -1,0 +1,53 @@
+"""NumPy helpers shared by the pure Python paths of audio converters.
+
+`keras_hub.layers.AudioConverter` subclasses historically computed
+spectrograms with `tf.signal`. These helpers mirror the `tf.signal` semantics
+with NumPy so audio preprocessing can run inside Grain worker processes (and
+on Jax/Torch setups without TensorFlow installed).
+"""
+
+import numpy as np
+
+
+def hann_window(length, periodic=True, dtype="float32"):
+    """Return a Hann window matching `tf.signal.hann_window`.
+
+    Args:
+        length: int. The length of the window.
+        periodic: bool. If `True` (the default, and the `tf.signal` default),
+            generate a periodic window for use with spectral analysis. If
+            `False`, generate a symmetric window.
+        dtype: str. The dtype of the returned window.
+    """
+    if length <= 1:
+        return np.ones(max(length, 0), dtype=dtype)
+    denominator = length if periodic else length - 1
+    arange = np.arange(length, dtype="float64")
+    window = 0.5 - 0.5 * np.cos(2.0 * np.pi * arange / denominator)
+    return window.astype(dtype)
+
+
+def frame_signal(x, frame_length, frame_step):
+    """Slice `x` into overlapping frames, matching `tf.signal.frame`.
+
+    Framing happens along the last axis with `pad_end=False`, so incomplete
+    trailing frames are dropped.
+
+    Args:
+        x: NumPy array of shape `(..., samples)`.
+        frame_length: int. The size of each frame.
+        frame_step: int. The hop size between consecutive frames.
+
+    Returns:
+        A NumPy array of shape `(..., num_frames, frame_length)`.
+    """
+    num_samples = x.shape[-1]
+    if num_samples < frame_length:
+        num_frames = 0
+    else:
+        num_frames = 1 + (num_samples - frame_length) // frame_step
+    if num_frames <= 0:
+        return np.zeros(x.shape[:-1] + (0, frame_length), dtype=x.dtype)
+    starts = np.arange(num_frames) * frame_step
+    indices = starts[:, None] + np.arange(frame_length)[None, :]
+    return x[..., indices]

--- a/keras_hub/src/utils/audio_utils_test.py
+++ b/keras_hub/src/utils/audio_utils_test.py
@@ -1,0 +1,32 @@
+import numpy as np
+import tensorflow as tf
+
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils.audio_utils import frame_signal
+from keras_hub.src.utils.audio_utils import hann_window
+
+
+class AudioUtilsTest(TestCase):
+    def test_hann_window_matches_tf(self):
+        for length in (1, 2, 8, 400):
+            self.assertAllClose(
+                hann_window(length),
+                tf.signal.hann_window(length, periodic=True),
+            )
+            self.assertAllClose(
+                hann_window(length, periodic=False),
+                tf.signal.hann_window(length, periodic=False),
+            )
+
+    def test_frame_signal_matches_tf(self):
+        x = np.random.default_rng(42).random((2, 97)).astype("float32")
+        for frame_length, frame_step in ((10, 5), (16, 16), (32, 3)):
+            self.assertAllClose(
+                frame_signal(x, frame_length, frame_step),
+                tf.signal.frame(x, frame_length, frame_step, pad_end=False),
+            )
+
+    def test_frame_signal_shorter_than_frame(self):
+        x = np.ones((1, 3), dtype="float32")
+        frames = frame_signal(x, 8, 2)
+        self.assertEqual(frames.shape, (1, 0, 8))


### PR DESCRIPTION
Port the Whisper, Moonshine, Gemma3n and Gemma4 audio converters to NumPy so they can run inside Grain worker processes without TensorFlow, following the ImageConverter precedent.

- Add NumPy helpers mirroring tf.signal.frame / tf.signal.hann_window.
- Split each converter into _call_python (NumPy) and _call_tf, with call() dispatching on _allow_python_workflow / in_tf_function().
- Default _allow_python_workflow to True for all four converters.
- Store constants (mel filterbanks, windows, framing indices) as NumPy instead of backend or TF tensors so layers pickle into Grain workers.
- Return NumPy inside Grain via convert_preprocessing_outputs_python.
- Add Grain and TF/Python numeric parity tests.

<!--- Before opening a PR, please read the updated Keras PR contribution
      policy: https://github.com/keras-team/keras/issues/23601
      PRs that do not follow this policy may be closed without review. -->

## Approved issue link
<!--- Link the approved issue that is assigned to you, e.g. "Fixes #123".
      An issue must be assigned to you and linked here before this PR can be
      marked "Ready for review". See the PR contribution policy:
      https://github.com/keras-team/keras/issues/23601 -->


## Description of the change
<!--- Describe your changes in detail. -->


## Reference
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

## Colab Notebook
<!-- If adding any new API, attach a colab showing the high-level usage. If adding a model, please also include numerics verification against a reference implementation.-->

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have read and followed the [PR contribution policy](https://github.com/keras-team/keras/issues/23601).
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
