### PR TITLE
[PyGrain Migration] Run RandomDeletion and RandomSwap in Grain pipelines

### DIFF
--- a/keras_hub/src/layers/preprocessing/random_deletion.py
+++ b/keras_hub/src/layers/preprocessing/random_deletion.py
@@ -4,7 +4,10 @@ from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
+from keras_hub.src.utils.random_utils import record_rng
+from keras_hub.src.utils.tensor_utils import canonicalize_python_inputs
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
 from keras_hub.src.utils.tensor_utils import is_string_dtype
 from keras_hub.src.utils.tensor_utils import preprocessing_function
@@ -31,6 +34,15 @@ class RandomDeletion(PreprocessingLayer):
     batched input, inputs should be a list of lists or a rank two tensor. For
     unbatched inputs, each element should be a list or a rank one tensor.
 
+    This layer runs on a pure Python/NumPy code path by default, so it works
+    inside a Grain pipeline and does not require TensorFlow. Randomness is
+    derived from `seed` together with a stable hash of the record being
+    augmented, so the output does not depend on how many Grain workers are
+    running or on the order records are seen in. The tradeoff is that an
+    identical record is augmented identically on every epoch. To vary the
+    augmentation per epoch, pass your own generator as `rng`, for example from
+    `grain.RandomMapTransform`, which derives one from the element index.
+
     Args:
         rate: The probability of a token being chosen for deletion.
         max_deletions: The maximum number of tokens to delete.
@@ -40,7 +52,9 @@ class RandomDeletion(PreprocessingLayer):
             returns as output a scalar tensor True/False value. A value of
             True indicates that the token should not be considered a
             candidate for deletion. This function must be tracable--it
-            should consist of tensorflow operations.
+            should consist of tensorflow operations. Setting this forces the
+            layer onto the TensorFlow code path, which cannot run in a Grain
+            worker; prefer `skip_py_fn`.
         skip_py_fn: A function that takes as input a python token value and
             returns as output `True` or `False`. A value of True
             indicates that should not be considered a candidate for deletion.
@@ -48,32 +62,38 @@ class RandomDeletion(PreprocessingLayer):
             tracable--it can be any python function.
         seed: A seed for the random number generator.
 
+    Call arguments:
+        inputs: The tokens to augment.
+        rng: Optional `np.random.Generator` used instead of the per record
+            generator derived from `seed`. Only supported on the pure Python
+            code path.
+
     Examples:
 
     Word level usage.
     >>> keras.utils.set_random_seed(1337)
     >>> x = ["Hey I like", "Keras and Tensorflow"]
     >>> x = list(map(lambda x: x.split(), x))
-    >>> augmenter = keras_hub.layers.RandomDeletion(rate=0.4, seed=42)
+    >>> augmenter = keras_hub.layers.RandomDeletion(rate=0.4, seed=1)
     >>> y = augmenter(x)
     >>> list(map(lambda y: " ".join(y), y))
-    ['I like', 'and']
+    ['Hey like', 'and Tensorflow']
 
     Character level usage.
     >>> keras.utils.set_random_seed(1337)
     >>> x = ["Hey Dude", "Speed Up"]
     >>> x = list(map(lambda x: list(x), x))
-    >>> augmenter = keras_hub.layers.RandomDeletion(rate=0.4, seed=42)
+    >>> augmenter = keras_hub.layers.RandomDeletion(rate=0.4, seed=3)
     >>> y = augmenter(x)
     >>> list(map(lambda y: "".join(y), y))
-    ['H Dude', 'pedUp']
+    ['HeyDue', 'ee Up']
 
     Usage with skip_list.
     >>> keras.utils.set_random_seed(1337)
     >>> x = ["Hey I like", "Keras and Tensorflow"]
     >>> x = list(map(lambda x: x.split(), x))
     >>> augmenter = keras_hub.layers.RandomDeletion(rate=0.4,
-    ...     skip_list=["Keras", "Tensorflow"], seed=42)
+    ...     skip_list=["Keras", "Tensorflow"], seed=9)
     >>> y = augmenter(x)
     >>> list(map(lambda y: " ".join(y), y))
     ['I like', 'Keras Tensorflow']
@@ -97,7 +117,7 @@ class RandomDeletion(PreprocessingLayer):
     >>> x = ["Hey I like", "Keras and Tensorflow"]
     >>> x = list(map(lambda x: x.split(), x))
     >>> augmenter = RandomDeletion(rate=0.4,
-    ...     skip_py_fn=skip_py_fn, seed=42)
+    ...     skip_py_fn=skip_py_fn, seed=14)
     >>> y = augmenter(x)
     >>> list(map(lambda y: " ".join(y), y))
     ['Hey I', 'and Tensorflow']
@@ -121,12 +141,22 @@ class RandomDeletion(PreprocessingLayer):
                 f"Received: dtype={dtype}"
             )
 
-        super().__init__(dtype=dtype, name=name, **kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            dtype=dtype,
+            name=name,
+            _allow_python_workflow=_allow_python_workflow,
+            **kwargs,
+        )
 
         self.rate = rate
         self.max_deletions = max_deletions
         self.seed = random.randint(1, int(1e9)) if seed is None else seed
-        self._generator = tf.random.Generator.from_seed(self.seed)
+        # `tf.random.Generator` is only built on demand by `_call_tf`. Building
+        # it here would require TensorFlow at construction time, and the
+        # generator would be pickled into every Grain worker, making all
+        # workers replay the same stream.
+        self._generator = None
         self.skip_list = skip_list
         self.skip_fn = skip_fn
         self.skip_py_fn = skip_py_fn
@@ -148,22 +178,33 @@ class RandomDeletion(PreprocessingLayer):
                 "provided."
             )
 
-        if self.skip_list:
-            self.StaticHashTable = tf.lookup.StaticHashTable(
+        self._skip_set = set(self.skip_list) if self.skip_list else None
+        # Built on demand by `_call_tf`; see the `_generator` comment above.
+        self._skip_table = None
+
+    def _tf_generator(self):
+        if self._generator is None:
+            self._generator = tf.random.Generator.from_seed(self.seed)
+        return self._generator
+
+    def _tf_skip_table(self):
+        if self._skip_table is None:
+            self._skip_table = tf.lookup.StaticHashTable(
                 tf.lookup.KeyValueTensorInitializer(
                     tf.convert_to_tensor(self.skip_list),
                     tf.convert_to_tensor([True] * len(self.skip_list)),
                 ),
                 default_value=False,
             )
+        return self._skip_table
 
     @preprocessing_function
-    def call(self, inputs):
+    def _call_tf(self, inputs):
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
 
         skip_masks = None
         if self.skip_list:
-            skip_masks = self.StaticHashTable.lookup(inputs.flat_values)
+            skip_masks = self._tf_skip_table().lookup(inputs.flat_values)
         elif self.skip_fn:
             skip_masks = tf.map_fn(
                 self.skip_fn, inputs.flat_values, fn_output_signature="bool"
@@ -197,7 +238,7 @@ class RandomDeletion(PreprocessingLayer):
         token_counts = tf.cast(positions.row_lengths(), "float32")
         num_to_select = tf.random.stateless_binomial(
             shape=tf.shape(token_counts),
-            seed=self._generator.make_seeds()[:, 0],
+            seed=self._tf_generator().make_seeds()[:, 0],
             counts=token_counts,
             probs=self.rate,
         )
@@ -238,6 +279,68 @@ class RandomDeletion(PreprocessingLayer):
             inputs = tf.squeeze(inputs, axis=0)
 
         return inputs
+
+    def _skip_mask_python(self, tokens):
+        """Return a bool per token, `True` if it cannot be deleted."""
+        if self._skip_set is not None:
+            return [token in self._skip_set for token in tokens]
+        if self.skip_py_fn is not None:
+            return [bool(self.skip_py_fn(token)) for token in tokens]
+        return [False] * len(tokens)
+
+    def _call_python(self, inputs, rng=None):
+        inputs, batched = canonicalize_python_inputs(inputs)
+
+        outputs = []
+        for row in inputs:
+            # `tf.RaggedTensor.to_list()` yields `bytes` for string data.
+            row = [
+                token.decode("utf-8") if isinstance(token, bytes) else token
+                for token in row
+            ]
+            row_rng = rng if rng is not None else record_rng(self.seed, row)
+            candidates = [
+                index
+                for index, skip in enumerate(self._skip_mask_python(row))
+                if not skip
+            ]
+            num_to_select = int(row_rng.binomial(len(candidates), self.rate))
+            if self.max_deletions is not None:
+                num_to_select = min(num_to_select, self.max_deletions)
+            deleted = set()
+            if num_to_select:
+                shuffled = row_rng.permutation(candidates)
+                deleted = set(shuffled[:num_to_select].tolist())
+            outputs.append(
+                [token for i, token in enumerate(row) if i not in deleted]
+            )
+
+        if not batched:
+            outputs = outputs[0]
+        # Deletion always produces ragged output, which the TensorFlow path
+        # also returns as nested python lists.
+        return outputs
+
+    def call(self, inputs, rng=None):
+        # `skip_fn` is documented to consist of TensorFlow ops, so a layer
+        # configured with it can only run on the TensorFlow path.
+        use_tf = (
+            not self._allow_python_workflow
+            or self.skip_fn is not None
+            or in_tf_function()
+        )
+        if use_tf:
+            if rng is not None:
+                raise ValueError(
+                    "`rng` is only supported on the pure python code path, "
+                    "but this layer is running on the TensorFlow code path. "
+                    "This happens when `skip_fn` is set or when the layer is "
+                    "called inside a `tf.function` such as `tf.data.Dataset."
+                    "map`. Use `skip_py_fn` instead of `skip_fn`, and Grain "
+                    "instead of `tf.data`, to pass an `rng`."
+                )
+            return self._call_tf(inputs)
+        return self._call_python(inputs, rng=rng)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/layers/preprocessing/random_deletion_test.py
+++ b/keras_hub/src/layers/preprocessing/random_deletion_test.py
@@ -1,5 +1,11 @@
+import sys
+
+import grain
 import keras
+import numpy as np
+import pytest
 import tensorflow as tf
+from absl import flags
 
 from keras_hub.src.layers.preprocessing.random_deletion import RandomDeletion
 from keras_hub.src.tests.test_case import TestCase
@@ -19,33 +25,33 @@ class RandomDeletionTest(TestCase):
         )
 
     def test_shape_and_output_from_word_deletion(self):
-        keras.utils.set_random_seed(1337)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
-        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=42)
+        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=1)
         augmented = augmenter(split)
         output = [
             tf.strings.reduce_join(x, separator=" ", axis=-1) for x in augmented
         ]
-        exp_output = ["I like", "and Tensorflow"]
+        exp_output = ["Hey like", "and Tensorflow"]
         self.assertAllEqual(output, exp_output)
+        # `max_deletions=1`, so each row loses at most one token.
+        for row, augmented_row in zip(split.to_list(), augmented):
+            self.assertLen(augmented_row, len(row) - 1)
 
     def test_shape_and_output_from_character_swaps(self):
-        keras.utils.set_random_seed(1337)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.unicode_split(inputs, "UTF-8")
-        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=42)
+        augmenter = RandomDeletion(rate=0.4, max_deletions=1, seed=1)
         augmented = augmenter(split)
         output = [tf.strings.reduce_join(x, axis=-1) for x in augmented]
-        exp_output = ["Hey I lie", "Keras and Tensoflow"]
+        exp_output = ["He I like", "Keras and Tensorflw"]
         self.assertAllEqual(output, exp_output)
 
     def test_with_integer_tokens(self):
-        keras.utils.set_random_seed(1337)
         inputs = tf.constant([[1, 2], [3, 4]])
-        augmenter = RandomDeletion(rate=0.4, max_deletions=4, seed=42)
+        augmenter = RandomDeletion(rate=0.4, max_deletions=4, seed=13)
         output = augmenter(inputs)
-        exp_output = [[2], [4]]
+        exp_output = [[2], [3]]
         self.assertAllEqual(output, exp_output)
 
     def test_skip_options(self):
@@ -141,3 +147,77 @@ class RandomDeletionTest(TestCase):
         output = ds.take(1).get_single_element()
         exp_output = [["Hey", "I", "like"], ["and", "Tensorflow"]]
         self.assertAllEqual(output, exp_output)
+
+    def test_grain_outputs_python_lists(self):
+        augmenter = RandomDeletion(rate=0.4, seed=42)
+        data = [["Hey", "I", "like"], ["Keras", "and", "Tensorflow"]]
+        ds = grain.MapDataset.source(data).map(augmenter)
+        output = list(ds)
+        self.assertLen(output, 2)
+        for row in output:
+            self.assertIsInstance(row, list)
+            for token in row:
+                self.assertIsInstance(token, str)
+
+    def test_output_independent_of_record_order(self):
+        # This is the property that makes the layer safe to run with any
+        # number of Grain workers: a record is augmented the same way no
+        # matter when, where, or in what batch it is seen.
+        augmenter = RandomDeletion(rate=0.5, seed=42)
+        data = [[f"tok{i}", "a", "b", "c", "d"] for i in range(8)]
+        forward = [augmenter(row) for row in data]
+        backward = [augmenter(row) for row in reversed(data)]
+        self.assertEqual(forward, list(reversed(backward)))
+        # Batched and unbatched calls agree too.
+        self.assertEqual(augmenter(data), forward)
+
+    @pytest.mark.large
+    def test_grain_multiprocessing_is_deterministic(self):
+        # Grain reads absl flags when it spawns workers, and pytest never
+        # parses them.
+        if not flags.FLAGS.is_parsed():
+            flags.FLAGS(sys.argv[:1])
+        augmenter = RandomDeletion(rate=0.5, seed=42)
+        data = [[f"tok{i}", "a", "b", "c", "d"] for i in range(16)]
+        expected = [augmenter(row) for row in data]
+        ds = grain.MapDataset.source(data).map(augmenter).to_iter_dataset()
+        for num_workers in (1, 2):
+            options = grain.MultiprocessingOptions(num_workers=num_workers)
+            self.assertEqual(list(ds.mp_prefetch(options)), expected)
+
+    def test_rng_argument(self):
+        augmenter = RandomDeletion(rate=0.5, seed=42)
+        row = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        # An explicit generator advances between calls, so augmentation
+        # varies, and replaying the generator reproduces the sequence.
+        rng = np.random.default_rng(0)
+        first = [tuple(augmenter(row, rng=rng)) for _ in range(8)]
+        rng = np.random.default_rng(0)
+        second = [tuple(augmenter(row, rng=rng)) for _ in range(8)]
+        self.assertGreater(len(set(first)), 1)
+        self.assertEqual(first, second)
+
+    def test_rng_rejected_on_tf_path(self):
+        def skip_fn(word):
+            return tf.strings.regex_full_match(word, r"\pP")
+
+        augmenter = RandomDeletion(rate=0.5, seed=42, skip_fn=skip_fn)
+        with self.assertRaisesRegex(ValueError, "`rng` is only supported"):
+            augmenter(["a", "b"], rng=np.random.default_rng(0))
+
+    def test_python_and_tf_paths_agree_on_structure(self):
+        inputs = [["Hey", "I", "like"], ["Keras", "and", "Tensorflow"]]
+        python_layer = RandomDeletion(rate=0.5, max_deletions=1, seed=42)
+        tf_layer = RandomDeletion(
+            rate=0.5, max_deletions=1, seed=42, _allow_python_workflow=False
+        )
+        python_output = python_layer(inputs)
+        tf_output = tf_layer(inputs)
+        self.assertLen(python_output, len(tf_output))
+        for row, python_row, tf_row in zip(inputs, python_output, tf_output):
+            # The two paths draw from different RNG streams, but both must
+            # delete at most `max_deletions` tokens and keep the original
+            # order of whatever survives.
+            for out_row in (python_row, tf_row):
+                self.assertGreaterEqual(len(out_row), len(row) - 1)
+                self.assertEqual(out_row, [t for t in row if t in out_row])

--- a/keras_hub/src/layers/preprocessing/random_swap.py
+++ b/keras_hub/src/layers/preprocessing/random_swap.py
@@ -4,7 +4,10 @@ from keras_hub.src.api_export import keras_hub_export
 from keras_hub.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
+from keras_hub.src.utils.random_utils import record_rng
+from keras_hub.src.utils.tensor_utils import canonicalize_python_inputs
 from keras_hub.src.utils.tensor_utils import convert_to_ragged_batch
+from keras_hub.src.utils.tensor_utils import in_tf_function
 from keras_hub.src.utils.tensor_utils import is_int_dtype
 from keras_hub.src.utils.tensor_utils import is_string_dtype
 from keras_hub.src.utils.tensor_utils import preprocessing_function
@@ -31,6 +34,15 @@ class RandomSwap(PreprocessingLayer):
     batched input, inputs should be a list of lists or a rank two tensor. For
     unbatched inputs, each element should be a list or a rank one tensor.
 
+    This layer runs on a pure Python/NumPy code path by default, so it works
+    inside a Grain pipeline and does not require TensorFlow. Randomness is
+    derived from `seed` together with a stable hash of the record being
+    augmented, so the output does not depend on how many Grain workers are
+    running or on the order records are seen in. The tradeoff is that an
+    identical record is augmented identically on every epoch. To vary the
+    augmentation per epoch, pass your own generator as `rng`, for example from
+    `grain.RandomMapTransform`, which derives one from the element index.
+
     Args:
         rate: The probability of a given token being chosen to be swapped
             with another random token.
@@ -41,13 +53,21 @@ class RandomSwap(PreprocessingLayer):
             returns as output a scalar tensor True/False value. A value of
             True indicates that the token should not be considered a
             candidate for deletion. This function must be tracable--it
-            should consist of tensorflow operations.
+            should consist of tensorflow operations. Setting this forces the
+            layer onto the TensorFlow code path, which cannot run in a Grain
+            worker; prefer `skip_py_fn`.
         skip_py_fn: A function that takes as input a python token value and
             returns as output `True` or `False`. A value of True
             indicates that should not be considered a candidate for deletion.
             Unlike the `skip_fn` argument, this argument need not be
             tracable--it can be any python function.
         seed: A seed for the random number generator.
+
+    Call arguments:
+        inputs: The tokens to augment.
+        rng: Optional `np.random.Generator` used instead of the per record
+            generator derived from `seed`. Only supported on the pure Python
+            code path.
 
 
     Examples:
@@ -56,10 +76,10 @@ class RandomSwap(PreprocessingLayer):
     >>> keras.utils.set_random_seed(1337)
     >>> x = ["Hey I like", "Keras and Tensorflow"]
     >>> x = list(map(lambda x: x.split(), x))
-    >>> augmenter = keras_hub.layers.RandomSwap(rate=0.4, seed=42)
+    >>> augmenter = keras_hub.layers.RandomSwap(rate=0.4, seed=9)
     >>> y = augmenter(x)
     >>> list(map(lambda y: " ".join(y), y))
-    ['like I Hey', 'and Keras Tensorflow']
+    ['I Hey like', 'and Tensorflow Keras']
 
     Character level usage.
     >>> keras.utils.set_random_seed(1337)
@@ -68,17 +88,17 @@ class RandomSwap(PreprocessingLayer):
     >>> augmenter = keras_hub.layers.RandomSwap(rate=0.4, seed=42)
     >>> y = augmenter(x)
     >>> list(map(lambda y: "".join(y), y))
-    ['deD yuHe', 'SUede pp']
+    ['Heyu edD', ' eedpUpS']
 
     Usage with skip_list.
     >>> keras.utils.set_random_seed(1337)
     >>> x = ["Hey I like", "Keras and Tensorflow"]
     >>> x = list(map(lambda x: x.split(), x))
     >>> augmenter = keras_hub.layers.RandomSwap(rate=0.4,
-    ...     skip_list=["Keras"], seed=42)
+    ...     skip_list=["Keras"], seed=9)
     >>> y = augmenter(x)
     >>> list(map(lambda y: " ".join(y), y))
-    ['like I Hey', 'Keras and Tensorflow']
+    ['I Hey like', 'Keras Tensorflow and']
 
     Usage with skip_fn.
     >>> def skip_fn(word):
@@ -123,12 +143,22 @@ class RandomSwap(PreprocessingLayer):
                 f"Received: dtype={dtype}"
             )
 
-        super().__init__(name=name, dtype=dtype, **kwargs)
+        _allow_python_workflow = kwargs.pop("_allow_python_workflow", True)
+        super().__init__(
+            name=name,
+            dtype=dtype,
+            _allow_python_workflow=_allow_python_workflow,
+            **kwargs,
+        )
 
         self.rate = rate
         self.max_swaps = max_swaps
         self.seed = random.randint(1, int(1e9)) if seed is None else seed
-        self._generator = tf.random.Generator.from_seed(self.seed)
+        # `tf.random.Generator` is only built on demand by `_call_tf`. Building
+        # it here would require TensorFlow at construction time, and the
+        # generator would be pickled into every Grain worker, making all
+        # workers replay the same stream.
+        self._generator = None
         self.skip_list = skip_list
         self.skip_fn = skip_fn
         self.skip_py_fn = skip_py_fn
@@ -144,22 +174,33 @@ class RandomSwap(PreprocessingLayer):
                 "provided."
             )
 
-        if self.skip_list:
-            self.StaticHashTable = tf.lookup.StaticHashTable(
+        self._skip_set = set(self.skip_list) if self.skip_list else None
+        # Built on demand by `_call_tf`; see the `_generator` comment above.
+        self._skip_table = None
+
+    def _tf_generator(self):
+        if self._generator is None:
+            self._generator = tf.random.Generator.from_seed(self.seed)
+        return self._generator
+
+    def _tf_skip_table(self):
+        if self._skip_table is None:
+            self._skip_table = tf.lookup.StaticHashTable(
                 tf.lookup.KeyValueTensorInitializer(
                     tf.convert_to_tensor(self.skip_list),
                     tf.convert_to_tensor([True] * len(self.skip_list)),
                 ),
                 default_value=False,
             )
+        return self._skip_table
 
     @preprocessing_function
-    def call(self, inputs):
+    def _call_tf(self, inputs):
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
 
         skip_masks = None
         if self.skip_list:
-            skip_masks = self.StaticHashTable.lookup(inputs.flat_values)
+            skip_masks = self._tf_skip_table().lookup(inputs.flat_values)
         elif self.skip_fn:
             skip_masks = tf.map_fn(
                 self.skip_fn, inputs.flat_values, fn_output_signature="bool"
@@ -192,7 +233,7 @@ class RandomSwap(PreprocessingLayer):
         token_counts = tf.cast(positions.row_lengths(), "float32")
         num_to_select = tf.random.stateless_binomial(
             shape=tf.shape(token_counts),
-            seed=self._generator.make_seeds()[:, 0],
+            seed=self._tf_generator().make_seeds()[:, 0],
             counts=token_counts,
             probs=self.rate,
         )
@@ -211,7 +252,7 @@ class RandomSwap(PreprocessingLayer):
                     minval=0,
                     maxval=tf.size(positions),
                     dtype="int32",
-                    seed=self._generator.make_seeds()[:, 0],
+                    seed=self._tf_generator().make_seeds()[:, 0],
                 )
                 index1, index2 = positions[index[0]], positions[index[1]]
                 # swap items at the sampled indices with each other
@@ -234,6 +275,71 @@ class RandomSwap(PreprocessingLayer):
         if unbatched:
             swapped = tf.squeeze(swapped, axis=0)
         return swapped
+
+    def _skip_mask_python(self, tokens):
+        """Return a bool per token, `True` if it cannot be swapped."""
+        if self._skip_set is not None:
+            return [token in self._skip_set for token in tokens]
+        if self.skip_py_fn is not None:
+            return [bool(self.skip_py_fn(token)) for token in tokens]
+        return [False] * len(tokens)
+
+    def _call_python(self, inputs, rng=None):
+        inputs, batched = canonicalize_python_inputs(inputs)
+
+        outputs = []
+        for row in inputs:
+            # `tf.RaggedTensor.to_list()` yields `bytes` for string data.
+            row = [
+                token.decode("utf-8") if isinstance(token, bytes) else token
+                for token in row
+            ]
+            row_rng = rng if rng is not None else record_rng(self.seed, row)
+            candidates = [
+                index
+                for index, skip in enumerate(self._skip_mask_python(row))
+                if not skip
+            ]
+            num_to_select = int(row_rng.binomial(len(candidates), self.rate))
+            if self.max_swaps is not None:
+                num_to_select = min(num_to_select, self.max_swaps)
+            num_to_select = min(num_to_select, len(candidates))
+            swapped = list(row)
+            for _ in range(num_to_select):
+                first, second = row_rng.integers(0, len(candidates), size=2)
+                index1, index2 = candidates[first], candidates[second]
+                swapped[index1], swapped[index2] = (
+                    swapped[index2],
+                    swapped[index1],
+                )
+            outputs.append(swapped)
+
+        if not batched:
+            outputs = outputs[0]
+        # Swapping preserves row lengths, but the TensorFlow path returns a
+        # `tf.RaggedTensor`, i.e. nested python lists, so match that.
+        return outputs
+
+    def call(self, inputs, rng=None):
+        # `skip_fn` is documented to consist of TensorFlow ops, so a layer
+        # configured with it can only run on the TensorFlow path.
+        use_tf = (
+            not self._allow_python_workflow
+            or self.skip_fn is not None
+            or in_tf_function()
+        )
+        if use_tf:
+            if rng is not None:
+                raise ValueError(
+                    "`rng` is only supported on the pure python code path, "
+                    "but this layer is running on the TensorFlow code path. "
+                    "This happens when `skip_fn` is set or when the layer is "
+                    "called inside a `tf.function` such as `tf.data.Dataset."
+                    "map`. Use `skip_py_fn` instead of `skip_fn`, and Grain "
+                    "instead of `tf.data`, to pass an `rng`."
+                )
+            return self._call_tf(inputs)
+        return self._call_python(inputs, rng=rng)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_hub/src/layers/preprocessing/random_swap_test.py
+++ b/keras_hub/src/layers/preprocessing/random_swap_test.py
@@ -1,5 +1,11 @@
+import sys
+
+import grain
 import keras
+import numpy as np
+import pytest
 import tensorflow as tf
+from absl import flags
 
 from keras_hub.src.layers.preprocessing.random_swap import RandomSwap
 from keras_hub.src.tests.test_case import TestCase
@@ -18,46 +24,53 @@ class RandomSwapTest(TestCase):
         )
 
     def test_shape_and_output_from_word_swap(self):
-        keras.utils.set_random_seed(1337)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
-        augmenter = RandomSwap(rate=0.7, max_swaps=3, seed=42)
+        augmenter = RandomSwap(rate=0.7, max_swaps=3, seed=1)
         augmented = augmenter(split)
         output = [
             tf.strings.reduce_join(x, separator=" ", axis=-1) for x in augmented
         ]
-        exp_output = ["like I Hey", "Tensorflow Keras and"]
+        exp_output = ["like I Hey", "and Keras Tensorflow"]
         self.assertAllEqual(output, exp_output)
+        # Swapping is a permutation, so every row keeps its exact tokens.
+        for row, augmented_row in zip(split.to_list(), augmented):
+            self.assertEqual(
+                sorted(t.decode("utf-8") for t in row), sorted(augmented_row)
+            )
 
     def test_shape_and_output_from_character_swap(self):
-        keras.utils.set_random_seed(1337)
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.unicode_split(inputs, "UTF-8")
-        augmenter = RandomSwap(rate=0.7, max_swaps=6, seed=42)
+        augmenter = RandomSwap(rate=0.7, max_swaps=6, seed=1)
         augmented = augmenter(split)
         output = [tf.strings.reduce_join(x, axis=-1) for x in augmented]
-        exp_output = ["yli I eHke", "seaad rnK Tensolrfow"]
+        exp_output = ["H leIkyi e", "Kerasnanf eTosor ldw"]
         self.assertAllEqual(output, exp_output)
 
     def test_with_integer_tokens(self):
-        keras.utils.set_random_seed(1337)
         inputs = tf.constant([[1, 2, 3], [4, 5, 6]])
-        augmenter = RandomSwap(rate=0.7, max_swaps=6, seed=42)
+        augmenter = RandomSwap(rate=0.7, max_swaps=6, seed=1)
         output = augmenter(inputs)
-        exp_output = [[3, 2, 1], [6, 4, 5]]
+        exp_output = [[1, 3, 2], [5, 4, 6]]
         self.assertAllEqual(output, exp_output)
 
     def test_skip_options(self):
-        keras.utils.set_random_seed(1337)
-        augmenter = RandomSwap(
-            rate=0.9, max_swaps=3, seed=11, skip_list=["Tensorflow", "like"]
-        )
         inputs = ["Hey I like", "Keras and Tensorflow"]
         split = tf.strings.split(inputs)
+        # `skip_list` and `skip_py_fn` run on the python path and `skip_fn` on
+        # the TensorFlow path, so they draw from different RNG streams and
+        # need different seeds to produce a visible swap.
+        augmenter = RandomSwap(
+            rate=0.9, max_swaps=3, seed=3, skip_list=["Tensorflow", "like"]
+        )
         augmented = augmenter(split)
         output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-        exp_output = ["I Hey like", "Keras and Tensorflow"]
+        exp_output = ["I Hey like", "and Keras Tensorflow"]
         self.assertAllEqual(output, exp_output)
+        # Skipped tokens must stay at their original index.
+        self.assertEqual(augmented[0][2], "like")
+        self.assertEqual(augmented[1][2], "Tensorflow")
 
         def skip_fn(word):
             if word == "Tensorflow" or word == "like":
@@ -76,11 +89,11 @@ class RandomSwapTest(TestCase):
             return False
 
         augmenter = RandomSwap(
-            rate=0.9, max_swaps=3, seed=11, skip_py_fn=skip_py_fn
+            rate=0.9, max_swaps=3, seed=3, skip_py_fn=skip_py_fn
         )
         augmented = augmenter(split)
         output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-        exp_output = ["I Hey like", "Keras and Tensorflow"]
+        exp_output = ["I Hey like", "and Keras Tensorflow"]
         self.assertAllEqual(output, exp_output)
 
     def test_augment_first_batch_second(self):
@@ -154,3 +167,73 @@ class RandomSwapTest(TestCase):
             ["and", "Keras", "Tensorflow"],
         ]
         self.assertAllEqual(output, exp_output)
+
+    def test_grain_outputs_python_lists(self):
+        augmenter = RandomSwap(rate=0.4, seed=42)
+        data = [["Hey", "I", "like"], ["Keras", "and", "Tensorflow"]]
+        ds = grain.MapDataset.source(data).map(augmenter)
+        output = list(ds)
+        self.assertLen(output, 2)
+        for row in output:
+            self.assertIsInstance(row, list)
+            for token in row:
+                self.assertIsInstance(token, str)
+
+    def test_output_independent_of_record_order(self):
+        # This is the property that makes the layer safe to run with any
+        # number of Grain workers: a record is augmented the same way no
+        # matter when, where, or in what batch it is seen.
+        augmenter = RandomSwap(rate=0.5, seed=42)
+        data = [[f"tok{i}", "a", "b", "c", "d"] for i in range(8)]
+        forward = [augmenter(row) for row in data]
+        backward = [augmenter(row) for row in reversed(data)]
+        self.assertEqual(forward, list(reversed(backward)))
+        # Batched and unbatched calls agree too.
+        self.assertEqual(augmenter(data), forward)
+
+    @pytest.mark.large
+    def test_grain_multiprocessing_is_deterministic(self):
+        # Grain reads absl flags when it spawns workers, and pytest never
+        # parses them.
+        if not flags.FLAGS.is_parsed():
+            flags.FLAGS(sys.argv[:1])
+        augmenter = RandomSwap(rate=0.5, seed=42)
+        data = [[f"tok{i}", "a", "b", "c", "d"] for i in range(16)]
+        expected = [augmenter(row) for row in data]
+        ds = grain.MapDataset.source(data).map(augmenter).to_iter_dataset()
+        for num_workers in (1, 2):
+            options = grain.MultiprocessingOptions(num_workers=num_workers)
+            self.assertEqual(list(ds.mp_prefetch(options)), expected)
+
+    def test_rng_argument(self):
+        augmenter = RandomSwap(rate=0.5, seed=42)
+        row = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        # An explicit generator advances between calls, so augmentation
+        # varies, and replaying the generator reproduces the sequence.
+        rng = np.random.default_rng(0)
+        first = [tuple(augmenter(row, rng=rng)) for _ in range(8)]
+        rng = np.random.default_rng(0)
+        second = [tuple(augmenter(row, rng=rng)) for _ in range(8)]
+        self.assertGreater(len(set(first)), 1)
+        self.assertEqual(first, second)
+
+    def test_rng_rejected_on_tf_path(self):
+        def skip_fn(word):
+            return tf.strings.regex_full_match(word, r"\pP")
+
+        augmenter = RandomSwap(rate=0.5, seed=42, skip_fn=skip_fn)
+        with self.assertRaisesRegex(ValueError, "`rng` is only supported"):
+            augmenter(["a", "b"], rng=np.random.default_rng(0))
+
+    def test_python_and_tf_paths_agree_on_structure(self):
+        inputs = [["Hey", "I", "like"], ["Keras", "and", "Tensorflow"]]
+        python_layer = RandomSwap(rate=0.5, max_swaps=2, seed=42)
+        tf_layer = RandomSwap(
+            rate=0.5, max_swaps=2, seed=42, _allow_python_workflow=False
+        )
+        for output in (python_layer(inputs), tf_layer(inputs)):
+            self.assertLen(output, len(inputs))
+            for row, out_row in zip(inputs, output):
+                # The two paths draw from different RNG streams, but both
+                # must permute each row without adding or losing tokens.
+                self.assertEqual(sorted(out_row), sorted(row))

--- a/keras_hub/src/utils/random_utils.py
+++ b/keras_hub/src/utils/random_utils.py
@@ -1,0 +1,57 @@
+"""Randomness helpers for TensorFlow-free preprocessing layers.
+
+Grain runs preprocessing inside worker processes and pickles the layer into
+each of them. Any random state stored on the layer is therefore *copied*, not
+shared, so a generator created in `__init__` would replay the exact same
+stream in every worker. The helpers here derive randomness from the record
+being augmented instead, which keeps outputs independent of how many workers
+are used and of the order records are seen in.
+"""
+
+import hashlib
+
+import numpy as np
+
+
+def stable_hash(tokens):
+    """Return a stable 64 bit integer hash for a sequence of tokens.
+
+    Unlike the builtin `hash()`, which is salted per process via
+    `PYTHONHASHSEED`, this hash is identical across processes and across runs.
+    That makes it safe to derive random seeds from inside Grain workers.
+
+    Args:
+        tokens: an iterable of `str`, `bytes`, or numbers.
+    """
+    hasher = hashlib.blake2b(digest_size=8)
+    for token in tokens:
+        if isinstance(token, bytes):
+            hasher.update(token)
+        elif isinstance(token, str):
+            hasher.update(token.encode("utf-8"))
+        else:
+            hasher.update(repr(token).encode("utf-8"))
+        # Separator, so `["ab", "c"]` and `["a", "bc"]` hash differently.
+        hasher.update(b"\x00")
+    return int.from_bytes(hasher.digest(), "big")
+
+
+def record_rng(seed, tokens):
+    """Create a `np.random.Generator` keyed to a seed and a record's content.
+
+    The returned generator depends only on `seed` and on the content of
+    `tokens`. It does not depend on the position of the record in the dataset,
+    on how many Grain workers are running, or on which worker happens to pick
+    the record up. Augmenting the same dataset with `num_workers=1` and
+    `num_workers=8` therefore gives identical results.
+
+    The tradeoff is that identical records are augmented identically. Callers
+    that want augmentation to vary per epoch should pass their own generator,
+    for example via `grain.RandomMapTransform`, which hands out a generator
+    derived from the element index.
+
+    Args:
+        seed: int. The layer level seed.
+        tokens: an iterable of `str`, `bytes`, or numbers.
+    """
+    return np.random.default_rng([seed, stable_hash(tokens)])

--- a/keras_hub/src/utils/random_utils_test.py
+++ b/keras_hub/src/utils/random_utils_test.py
@@ -1,0 +1,76 @@
+import hashlib
+import os
+import subprocess
+import sys
+
+import numpy as np
+
+from keras_hub.src.tests.test_case import TestCase
+from keras_hub.src.utils import random_utils as random_utils_module
+from keras_hub.src.utils.random_utils import record_rng
+from keras_hub.src.utils.random_utils import stable_hash
+
+
+class StableHashTest(TestCase):
+    def test_hash_is_deterministic(self):
+        self.assertEqual(stable_hash(["a", "b"]), stable_hash(["a", "b"]))
+
+    def test_hash_distinguishes_token_boundaries(self):
+        self.assertNotEqual(stable_hash(["ab", "c"]), stable_hash(["a", "bc"]))
+
+    def test_hash_handles_bytes_ints_and_strings(self):
+        self.assertEqual(stable_hash([b"a", b"b"]), stable_hash(["a", "b"]))
+        self.assertNotEqual(stable_hash([1, 2]), stable_hash([2, 1]))
+
+    def test_hash_is_stable_across_processes(self):
+        # `PYTHONHASHSEED` is randomized per process by default, which is
+        # exactly what would break Grain worker determinism if we used the
+        # builtin `hash()`.
+        module_path = random_utils_module.__file__
+        script = (
+            "import importlib.util;"
+            f"spec = importlib.util.spec_from_file_location('ru', "
+            f"{module_path!r});"
+            "module = importlib.util.module_from_spec(spec);"
+            "spec.loader.exec_module(module);"
+            "print(module.stable_hash(['Hey', 'I', 'like']))"
+        )
+        env = dict(os.environ, PYTHONHASHSEED="random")
+        outputs = set()
+        for _ in range(2):
+            outputs.add(
+                subprocess.check_output(
+                    [sys.executable, "-c", script], env=env
+                ).strip()
+            )
+        self.assertLen(outputs, 1)
+        self.assertEqual(
+            outputs.pop().decode("utf-8"),
+            str(stable_hash(["Hey", "I", "like"])),
+        )
+
+    def test_hash_matches_blake2b(self):
+        expected = hashlib.blake2b(b"a\x00b\x00", digest_size=8).digest()
+        self.assertEqual(
+            stable_hash(["a", "b"]), int.from_bytes(expected, "big")
+        )
+
+
+class RecordRngTest(TestCase):
+    def test_same_record_same_stream(self):
+        first = record_rng(42, ["a", "b"]).integers(0, 1000, size=8)
+        second = record_rng(42, ["a", "b"]).integers(0, 1000, size=8)
+        self.assertAllEqual(first, second)
+
+    def test_different_record_different_stream(self):
+        first = record_rng(42, ["a", "b"]).integers(0, 1000, size=8)
+        second = record_rng(42, ["a", "c"]).integers(0, 1000, size=8)
+        self.assertNotAllEqual(first, second)
+
+    def test_different_seed_different_stream(self):
+        first = record_rng(42, ["a", "b"]).integers(0, 1000, size=8)
+        second = record_rng(43, ["a", "b"]).integers(0, 1000, size=8)
+        self.assertNotAllEqual(first, second)
+
+    def test_returns_numpy_generator(self):
+        self.assertIsInstance(record_rng(42, ["a"]), np.random.Generator)


### PR DESCRIPTION
This Fixes #2952 

Add a pure Python/NumPy execution path to both layers so they can run in Grain worker processes without TensorFlow, following the existing `_call_python` / `_call_tf` dispatch pattern. `_allow_python_workflow` now defaults to `True`.

Both layers previously built a `tf.random.Generator` in `__init__`. Grain pickles the layer into every worker, so that generator is copied and each worker would replay the same stream. Randomness is now derived per record from the layer seed plus a stable content hash, so output is independent of worker count, worker assignment and record position. The hash uses blake2b rather than the builtin `hash()`, which is salted per process by `PYTHONHASHSEED`.

Content derived seeding augments an identical record identically on every epoch, so `call` also accepts an optional `rng` generator. Users can wrap the layer in `grain.RandomMapTransform` to get per epoch varying and worker independent randomness. Passing `rng` on the TensorFlow path raises instead of silently ignoring it.

`tf.random.Generator` and `tf.lookup.StaticHashTable` are now built lazily by the TensorFlow path only, so construction no longer requires TensorFlow. `skip_list` is also kept as a Python set for the NumPy path. `skip_fn` requires traceable TF ops, so it keeps dispatching to the TensorFlow path.

The NumPy path cannot reproduce TensorFlow's RNG stream, so the RNG dependent docstring and test expectations are regenerated. Seeds were changed where the previous seed produced a vacuous example. Tests also assert invariants now rather than only exact strings.


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have read and followed the [PR contribution policy](https://github.com/keras-team/keras/issues/23601).
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and works with all backends (TensorFlow, JAX, and PyTorch).
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have followed the Keras Hub [Model contribution guidelines](https://github.com/keras-team/keras-hub/blob/master/CONTRIBUTING_MODELS.md) in making these changes.
- [x] I have followed the Keras Hub [API design guidelines](https://github.com/keras-team/keras-hub/blob/master/API_DESIGN_GUIDE.md) in making these changes.
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
